### PR TITLE
feat: improvements to rubric judge

### DIFF
--- a/tests/v1/test_judges.py
+++ b/tests/v1/test_judges.py
@@ -29,9 +29,9 @@ class QATask(vf.Task):
     answer: str = ""
 
 
-def make_trace(reply: str = "It is Paris.") -> vf.Trace:
+def make_trace(reply: str = "It is Paris.", answer: str = "Paris") -> vf.Trace:
     return vf.Trace(
-        task=QATask(idx=0, prompt="Capital of France?", answer="Paris"),
+        task=QATask(idx=0, prompt="Capital of France?", answer=answer),
         nodes=[
             MessageNode(
                 parent=None,
@@ -573,6 +573,19 @@ def test_rubric_choices_validation(tmp_path):
             tmp_path,
             body='[[criteria]]\nname = "x"\ntext = "t"\nchoices = ["a", "a"]\n',
         ).criteria
+
+
+async def test_rubric_reference_answer_optional(tmp_path, fake_judge_model):
+    # off by default: no reference block in the prompt.
+    t = make_trace()
+    await rubric_judge(tmp_path).score(t.task, t)
+    assert "Reference solution" not in fake_judge_model[-1]
+
+    # answer_field set: the task's gold answer is shown to the judge.
+    t = make_trace(answer="ZEBRA-GOLD")
+    await rubric_judge(tmp_path, answer_field="answer").score(t.task, t)
+    assert "Reference solution" in fake_judge_model[-1]
+    assert "ZEBRA-GOLD" in fake_judge_model[-1]
 
 
 # --- Taskset.score integration -------------------------------------------------------------

--- a/tests/v1/test_judges.py
+++ b/tests/v1/test_judges.py
@@ -533,12 +533,12 @@ async def test_rubric_verdict_mismatch_raises(tmp_path, monkeypatch):
 
 CHOICES_TOML = (
     '[[criteria]]\nname = "depth"\ntext = "How thorough?"\n'
-    'choices = ["good", "partial", "none"]\n'
+    'choices = ["none", "partial", "good"]\n'
 )
 
 
 async def test_rubric_choices_normalize(tmp_path, monkeypatch):
-    # Ordered choices (best→worst) score by rank: "partial" of ["good","partial","none"] -> 0.5.
+    # Ordered choices (worst→best) score by rank: "partial" of ["none","partial","good"] -> 0.5.
     async def graded(self, messages, *, trace=None, schema=None, parse=None, **s):
         v = {"verdicts": [{"name": "depth", "reason": "r", "verdict": "partial"}]}
         return JudgeResponse(text=json.dumps(v), parsed=None)

--- a/tests/v1/test_judges.py
+++ b/tests/v1/test_judges.py
@@ -47,23 +47,31 @@ def make_trace(reply: str = "It is Paris.") -> vf.Trace:
 
 @pytest.fixture
 def fake_judge_model(monkeypatch):
-    """Fake the judge's model call, recording each prompt for assertions. Text calls reply
-    "yes" iff "Paris" appears in the response block of the rendered prompt; structured
-    (`schema`) calls verdict each `- name: text` criteria line "yes" iff it mentions Paris."""
+    """Fake the judge's model call, recording each prompt for assertions. Rubric calls (a JSON
+    `verdicts` instruction or a `schema`) reply one reasoned verdict per `- name: text` criterion,
+    "yes" iff it mentions Paris; other judges reply plain "yes"/"no" by the response block."""
     prompts: list[str] = []
 
     async def fake_complete(
         self, messages, *, trace=None, schema=None, parse=None, **sampling
     ):
         prompts.append(messages)
-        if schema is not None:
+        # Rubric calls carry criteria lines + a JSON `verdicts` instruction; reply one verdict per
+        # criterion (yes iff its text mentions Paris) with a reason. Other judges get plain yes/no.
+        if schema is not None or '"verdicts"' in messages:
             verdicts = [
-                {"name": name, "verdict": "yes" if "Paris" in text else "no"}
+                {
+                    "name": name,
+                    "reason": "cites Paris" if "Paris" in text else "no Paris",
+                    "verdict": "yes" if "Paris" in text else "no",
+                }
                 for name, text in re.findall(r"^- ([^:]+): (.+)$", messages, re.M)
             ]
             response = JudgeResponse(
-                text=json.dumps(verdicts),
-                parsed=schema.model_validate({"verdicts": verdicts}),
+                text=json.dumps({"verdicts": verdicts}),
+                parsed=schema.model_validate({"verdicts": verdicts})
+                if schema
+                else None,
             )
         else:
             response = JudgeResponse(
@@ -501,7 +509,7 @@ def test_rubric_rejects_bad_files(tmp_path):
 
 async def test_rubric_score(tmp_path, fake_judge_model):
     # verdicts: mentions_paris=1 (w=3), is_polite=0 (w=1) -> weighted mean 0.75, from ONE
-    # structured judge call; each verdict lands as a `<name>/<criterion>` metric.
+    # judge call; each verdict lands as a `<name>/<criterion>` metric.
     judge = rubric_judge(tmp_path)
     trace = make_trace()
     assert await judge.score(trace.task, trace) == 0.75
@@ -513,13 +521,13 @@ async def test_rubric_verdict_mismatch_raises(tmp_path, monkeypatch):
     # A reply that doesn't verdict exactly the rubric's criteria is a judge failure: raise
     # (-> rollout error), don't guess or silently score 0.
     async def wrong_names(self, messages, *, trace=None, schema=None, parse=None, **s):
-        verdicts = {"verdicts": [{"name": "typo", "verdict": "yes"}]}
-        return JudgeResponse(text="", parsed=schema.model_validate(verdicts))
+        verdicts = {"verdicts": [{"name": "typo", "reason": "x", "verdict": "yes"}]}
+        return JudgeResponse(text=json.dumps(verdicts), parsed=None)
 
     monkeypatch.setattr(Judge, "complete", wrong_names)
     judge = rubric_judge(tmp_path)
     trace = make_trace()
-    with pytest.raises(ValueError, match="expected the rubric"):
+    with pytest.raises(ValueError, match="expected the batch"):
         await judge.score(trace.task, trace)
 
 

--- a/tests/v1/test_judges.py
+++ b/tests/v1/test_judges.py
@@ -531,6 +531,50 @@ async def test_rubric_verdict_mismatch_raises(tmp_path, monkeypatch):
         await judge.score(trace.task, trace)
 
 
+CHOICES_TOML = (
+    '[[criteria]]\nname = "depth"\ntext = "How thorough?"\n'
+    'choices = ["good", "partial", "none"]\n'
+)
+
+
+async def test_rubric_choices_normalize(tmp_path, monkeypatch):
+    # Ordered choices (best→worst) score by rank: "partial" of ["good","partial","none"] -> 0.5.
+    async def graded(self, messages, *, trace=None, schema=None, parse=None, **s):
+        v = {"verdicts": [{"name": "depth", "reason": "r", "verdict": "partial"}]}
+        return JudgeResponse(text=json.dumps(v), parsed=None)
+
+    monkeypatch.setattr(Judge, "complete", graded)
+    judge = rubric_judge(tmp_path, body=CHOICES_TOML, name="q")
+    trace = make_trace()
+    assert await judge.score(trace.task, trace) == 0.5
+    assert trace.metrics == {"q/depth": 0.5}
+
+
+async def test_rubric_off_menu_answer_raises(tmp_path, monkeypatch):
+    # A verdict that isn't one of the criterion's choices is a judge failure, not a 0.
+    async def off_menu(self, messages, *, trace=None, schema=None, parse=None, **s):
+        v = {"verdicts": [{"name": "depth", "reason": "r", "verdict": "maybe"}]}
+        return JudgeResponse(text=json.dumps(v), parsed=None)
+
+    monkeypatch.setattr(Judge, "complete", off_menu)
+    judge = rubric_judge(tmp_path, body=CHOICES_TOML)
+    trace = make_trace()
+    with pytest.raises(ValueError, match="expected one of"):
+        await judge.score(trace.task, trace)
+
+
+def test_rubric_choices_validation(tmp_path):
+    with pytest.raises(ValueError, match="at least two"):
+        rubric_judge(
+            tmp_path, body='[[criteria]]\nname = "x"\ntext = "t"\nchoices = ["only"]\n'
+        ).criteria
+    with pytest.raises(ValueError, match="duplicate options"):
+        rubric_judge(
+            tmp_path,
+            body='[[criteria]]\nname = "x"\ntext = "t"\nchoices = ["a", "a"]\n',
+        ).criteria
+
+
 # --- Taskset.score integration -------------------------------------------------------------
 
 

--- a/verifiers/v1/judges/rubric.py
+++ b/verifiers/v1/judges/rubric.py
@@ -46,17 +46,10 @@ RUBRIC_PROMPT = (Path(__file__).resolve().parent / "rubric.txt").read_text(
     encoding="utf-8"
 )
 
-# Appended to the prompt when `structured_output` is off, so the reply is JSON we can parse.
+# Appended to the prompt when `structured_output` is off, so the reply is JSON we can parse. Each
+# criterion carries a one-sentence `reason` written *before* the verdict (chain-of-thought), so the
+# verdict follows from it and the reasoning is auditable in `trace.info["judge"]`.
 JSON_SUFFIX = (
-    "\n\nRespond with ONLY a JSON object and nothing else, in exactly this shape:\n"
-    '{"verdicts": [{"name": "<criterion name>", "verdict": "<yes or no>"}, ...]}\n'
-    "with one entry per criterion, using each criterion's exact name and a verdict of "
-    '"yes" or "no".'
-)
-
-# The `reason`-on variant: one short justification per criterion, written *before* the verdict so
-# the verdict follows from it (chain-of-thought), and recorded verbatim in `trace.info["judge"]`.
-JSON_SUFFIX_REASON = (
     "\n\nRespond with ONLY a JSON object and nothing else, in exactly this shape:\n"
     '{"verdicts": [{"name": "<criterion name>", "reason": "<one sentence citing specific '
     'evidence from the response>", "verdict": "<yes or no>"}, ...]}\n'
@@ -120,26 +113,20 @@ class RubricJudgeConfig(JudgeConfig):
     whose structured decoding is flaky (e.g. GLM-5.2 and other non-OpenAI models on some providers
     return empty completions for structured calls, especially over long transcripts); OpenAI models
     handle either. Transient HTTP failures are already retried by the OpenAI client."""
-    reason: bool = False
-    """Ask the judge to write a one-sentence justification for each criterion *before* its verdict
-    (chain-of-thought). Improves calibration and makes every verdict auditable — the reasons are
-    recorded verbatim in `trace.info["judge"]`. Off by default (verdict only). Applies to the
-    plain-text JSON path; harmless with `structured_output` (the schema carries an optional
-    `reason`)."""
 
 
 class CriterionVerdict(StrictBaseModel):
-    """One criterion's verdict in the judge's reply, matched back to the rubric by `name`. `reason`
-    is a short justification the judge writes *before* the verdict when the judge's `reason` option
-    is on (chain-of-thought; auditable in `trace.info["judge"]`); empty otherwise."""
+    """One criterion's reply, matched back to the rubric by `name`: a short `reason`
+    (chain-of-thought, always recorded for auditability in `trace.info["judge"]`) written *before*
+    the yes/no `verdict`, so the verdict follows from it."""
 
     name: str
-    reason: str = ""
+    reason: str
     verdict: Literal["yes", "no"]
 
 
 class RubricVerdicts(StrictBaseModel):
-    """The judge's structured reply: one verdict per rubric criterion."""
+    """The judge's reply: one reasoned verdict per rubric criterion."""
 
     verdicts: list[CriterionVerdict]
 
@@ -205,8 +192,7 @@ class RubricJudge(Judge[RubricVerdicts, RubricJudgeConfig]):
             result = await self.evaluate(trace=trace, **fields)
             verdicts = cast(RubricVerdicts, result.parsed).verdicts
         else:
-            suffix = JSON_SUFFIX_REASON if self.config.reason else JSON_SUFFIX
-            messages = cast(str, self.build_messages(**fields)) + suffix
+            messages = cast(str, self.build_messages(**fields)) + JSON_SUFFIX
             result = await self.complete(
                 messages, trace=trace
             )  # no schema -> plain text

--- a/verifiers/v1/judges/rubric.py
+++ b/verifiers/v1/judges/rubric.py
@@ -1,8 +1,8 @@
 """rubric — an off-the-shelf rubric judge, plugged from config alone.
 
 Reads a rubric — a list of criteria — from a JSON or TOML file and asks the judge model to grade
-each by picking one of its ordered `choices` (default `["yes", "no"]`, a binary check), scored to
-[0, 1] by rank — best → worst, so the first choice is 1.0 and the last 0.0 (all in one call by
+each by picking one of its ordered `choices` (default `["no", "yes"]`, a binary check), scored to
+[0, 1] by rank — worst → best, so the first choice is 0.0 and the last 1.0 (all in one call by
 default, or batched `max_criteria`-at-a-time). Grading uses plain-text JSON by default, or
 structured output when `structured_output=true` (see `RubricJudgeConfig`). The reward is the
 weighted mean of the per-criterion scores (`sum(w*v) / sum(w)`, so it stays in [0, 1]); each score
@@ -22,8 +22,8 @@ with `rubrics/quality.toml` listing the criteria (JSON takes `{"criteria": [...]
     name = "cites_sources"
     text = "The response cites at least one specific source."
     weight = 1.0
-    # choices default to ["yes", "no"]; give an ordered best→worst list for a graded criterion:
-    # choices = ["thorough", "partial", "none"]   # -> 1.0, 0.5, 0.0
+    # choices default to ["no", "yes"]; give an ordered worst→best list for a graded criterion:
+    # choices = ["none", "partial", "thorough"]   # -> 0.0, 0.5, 1.0
 """
 
 import asyncio
@@ -66,10 +66,9 @@ JSON_SUFFIX = (
 
 
 def normalize_choice(choice: str, choices: list[str]) -> float:
-    """Score a chosen option to [0, 1] by rank. `choices` are ordered best → worst, so the first
-    scores 1.0, the last 0.0, and the rest evenly spaced (`choices` always has >= 2 entries)."""
-    rank = choices.index(choice)
-    return (len(choices) - 1 - rank) / (len(choices) - 1)
+    """Score a chosen option to [0, 1] by rank. `choices` are ordered worst → best, so the first
+    scores 0.0, the last 1.0, and the rest evenly spaced (`choices` always has >= 2 entries)."""
+    return choices.index(choice) / (len(choices) - 1)
 
 
 def first_verdicts_object(text: str) -> dict | None:
@@ -100,9 +99,9 @@ class Criterion(StrictBaseModel):
     """The check itself, phrased so the first (best) choice means satisfied."""
     weight: float = 1.0
     """The criterion's share of the reward (overridable per name via `weights` in config)."""
-    choices: list[str] = ["yes", "no"]
-    """Allowed answers, ordered **best → worst**: the first scores 1.0, the last 0.0, the rest
-    evenly spaced by rank. Default `["yes", "no"]` is a binary check. Needs >= 2, no duplicates."""
+    choices: list[str] = ["no", "yes"]
+    """Allowed answers, ordered **worst → best**: the first scores 0.0, the last 1.0, the rest
+    evenly spaced by rank. Default `["no", "yes"]` is a binary check. Needs >= 2, no duplicates."""
 
     @field_validator("choices")
     @classmethod
@@ -223,8 +222,8 @@ class RubricJudge(Judge[RubricVerdicts, RubricJudgeConfig]):
         ) -> str:  # every criterion states its own allowed answers inline
             opts = (
                 "yes or no"
-                if c.choices == ["yes", "no"]
-                else "one of, best to worst: " + ", ".join(c.choices)
+                if c.choices == ["no", "yes"]
+                else "one of, worst to best: " + ", ".join(c.choices)
             )
             return f"- {c.name}: {c.text} (answer {opts})"
 

--- a/verifiers/v1/judges/rubric.py
+++ b/verifiers/v1/judges/rubric.py
@@ -1,7 +1,9 @@
 """rubric — an off-the-shelf rubric judge, plugged from config alone.
 
 Reads a rubric — a list of yes/no criteria — from a JSON or TOML file and asks the judge model
-to grade all criteria in one structured-output call, scoring each 1/0. The reward is the weighted
+to grade the criteria, scoring each 1/0 (all in one call by default, or batched
+`max_criteria`-at-a-time). Grading uses plain-text JSON by default, or structured output when
+`structured_output=true` (see `RubricJudgeConfig`). The reward is the weighted
 mean of the verdicts (`sum(w*v) / sum(w)`, so it stays in [0, 1]); each verdict is also recorded
 as a `<name>/<criterion>` metric. Criterion weights come from the rubric file and are overridable
 from config (`weights`); the aggregate weighs into `trace.reward` via the judge's `weight`:
@@ -20,6 +22,7 @@ with `rubrics/quality.toml` listing the criteria (JSON takes `{"criteria": [...]
     weight = 1.0
 """
 
+import asyncio
 import json
 import math
 import tomllib
@@ -41,6 +44,14 @@ from verifiers.v1.types import ID, StrictBaseModel
 # A sibling text file so it doubles as a starting point for a config `prompt_file`.
 RUBRIC_PROMPT = (Path(__file__).resolve().parent / "rubric.txt").read_text(
     encoding="utf-8"
+)
+
+# Appended to the prompt when `structured_output` is off, so the reply is JSON we can parse.
+JSON_SUFFIX = (
+    "\n\nRespond with ONLY a JSON object and nothing else, in exactly this shape:\n"
+    '{"verdicts": [{"name": "<criterion name>", "verdict": "<yes or no>"}, ...]}\n'
+    "with one entry per criterion, using each criterion's exact name and a verdict of "
+    '"yes" or "no".'
 )
 
 
@@ -70,6 +81,17 @@ class RubricJudgeConfig(JudgeConfig):
     """How much of the rollout fills `{response}` (see `JudgeView`). Defaults to the whole
     transcript — rubric criteria typically grade the process (tool use, citations,
     intermediate steps), not just the final answer."""
+    max_criteria: int | None = None
+    """How many criteria to grade per judge call. `None` (default) grades all criteria in one
+    call. `1` sends one call per criterion (n independent judges); `k` batches them k-at-a-time.
+    Batches are graded concurrently and merged. Smaller batches trade more calls for focus/
+    robustness. Must be >= 1."""
+    structured_output: bool = False
+    """Grade via JSON-schema structured output (`response_format`) when `True`; grade via plain-text
+    output parsed as JSON when `False` (the default). Plain text is far more reliable on endpoints
+    whose structured decoding is flaky (e.g. GLM-5.2 and other non-OpenAI models on some providers
+    return empty completions for structured calls, especially over long transcripts); OpenAI models
+    handle either. Transient HTTP failures are already retried by the OpenAI client."""
 
 
 class CriterionVerdict(StrictBaseModel):
@@ -86,8 +108,8 @@ class RubricVerdicts(StrictBaseModel):
 
 
 class RubricJudge(Judge[RubricVerdicts, RubricJudgeConfig]):
-    """Scores every rubric criterion 1/0 in one structured judge call; rewards their
-    weighted mean."""
+    """Scores every rubric criterion 1/0 (in one judge call, or batched `max_criteria` at a
+    time) and rewards their weighted mean."""
 
     prompt = RUBRIC_PROMPT
     schema = RubricVerdicts
@@ -131,23 +153,68 @@ class RubricJudge(Judge[RubricVerdicts, RubricJudgeConfig]):
             raise ValueError(f"rubric '{path}' has no positive criterion weight")
         return criteria
 
-    async def score(self, task: Task, trace: Trace) -> float:
-        criteria = self.criteria
-        result = await self.evaluate(
-            trace=trace,
+    async def grade_batch(
+        self, task: Task, trace: Trace, batch: list[Criterion]
+    ) -> dict[str, float]:
+        """Grade one batch of criteria in a single judge call — structured output, or plain-text
+        JSON when `structured_output` is off (which avoids flaky structured decoding). Returns
+        `{name: 1.0/0.0}`, matched back to the batch by name. `score` fans this out per batch."""
+        fields = dict(
             question=judge_question(task, self.config.question_field),
             response=judge_response(trace, self.config.view),
-            criteria="\n".join(f"- {c.name}: {c.text}" for c in criteria),
+            criteria="\n".join(f"- {c.name}: {c.text}" for c in batch),
         )
-        verdicts = cast(RubricVerdicts, result.parsed).verdicts
-        # Exactly one verdict per criterion, matched by name — anything else is a judge
-        # failure and must error the rollout, not score the model (see `judge_verdict`).
-        if sorted(v.name for v in verdicts) != sorted(c.name for c in criteria):
+        if self.config.structured_output:
+            result = await self.evaluate(trace=trace, **fields)
+            verdicts = cast(RubricVerdicts, result.parsed).verdicts
+        else:
+            messages = cast(str, self.build_messages(**fields)) + JSON_SUFFIX
+            result = await self.complete(
+                messages, trace=trace
+            )  # no schema -> plain text
+            start = result.text.find("{")
+            if start == -1:
+                raise ValueError(f"judge returned no JSON object: {result.text!r}")
+            # Decode the first balanced JSON object, tolerating any prose/braces after it.
+            obj, _ = json.JSONDecoder().raw_decode(result.text[start:])
+            verdicts = RubricVerdicts.model_validate(obj).verdicts
+        # Exactly one verdict per criterion in the batch, matched by name — anything else is a
+        # judge failure and must error the rollout, not score the model (see `judge_verdict`).
+        if sorted(v.name for v in verdicts) != sorted(c.name for c in batch):
             raise ValueError(
                 f"judge verdicts name {sorted(v.name for v in verdicts)}, expected the "
-                f"rubric's {sorted(c.name for c in criteria)}"
+                f"batch's {sorted(c.name for c in batch)}"
             )
-        by_name = {v.name: float(v.verdict == "yes") for v in verdicts}
+        return {v.name: float(v.verdict == "yes") for v in verdicts}
+
+    async def score(self, task: Task, trace: Trace) -> float:
+        criteria = self.criteria
+        # Split into batches of `max_criteria` (None = one batch of all), then grade the batches
+        # concurrently (one judge call each) and merge.
+        k = self.config.max_criteria
+        if k is not None and k < 1:
+            raise ValueError(f"`max_criteria` must be >= 1 or None, got {k}")
+        batches = (
+            [criteria]
+            if k is None
+            else [criteria[i : i + k] for i in range(0, len(criteria), k)]
+        )
+        # Fan out one call per batch; if any fails, cancel the siblings so a judge failure
+        # doesn't keep billing the remaining batches.
+        tasks = [
+            asyncio.ensure_future(self.grade_batch(task, trace, batch))
+            for batch in batches
+        ]
+        try:
+            results = await asyncio.gather(*tasks)
+        except BaseException:
+            for t in tasks:
+                t.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            raise
+        by_name: dict[str, float] = {}
+        for batch_verdicts in results:
+            by_name.update(batch_verdicts)
         for criterion in criteria:
             trace.record_metric(
                 f"{self.reward_name}/{criterion.name}", by_name[criterion.name]

--- a/verifiers/v1/judges/rubric.py
+++ b/verifiers/v1/judges/rubric.py
@@ -55,6 +55,24 @@ JSON_SUFFIX = (
 )
 
 
+def first_verdicts_object(text: str) -> dict | None:
+    """The first balanced JSON object in `text` that carries a `verdicts` key. Scanning for the
+    key (not just the first `{`) skips prose and, crucially, an echoed format example — the one
+    in `JSON_SUFFIX` fails to parse (its trailing `...` isn't JSON) and is passed over rather
+    than mistaken for the answer. Returns `None` if no such object is found."""
+    decoder = json.JSONDecoder()
+    idx = text.find("{")
+    while idx != -1:
+        try:
+            obj, _ = decoder.raw_decode(text[idx:])
+        except json.JSONDecodeError:
+            obj = None
+        if isinstance(obj, dict) and "verdicts" in obj:
+            return obj
+        idx = text.find("{", idx + 1)
+    return None
+
+
 class Criterion(StrictBaseModel):
     """One rubric entry: a yes/no check the judge scores 1/0."""
 
@@ -172,11 +190,11 @@ class RubricJudge(Judge[RubricVerdicts, RubricJudgeConfig]):
             result = await self.complete(
                 messages, trace=trace
             )  # no schema -> plain text
-            start = result.text.find("{")
-            if start == -1:
-                raise ValueError(f"judge returned no JSON object: {result.text!r}")
-            # Decode the first balanced JSON object, tolerating any prose/braces after it.
-            obj, _ = json.JSONDecoder().raw_decode(result.text[start:])
+            obj = first_verdicts_object(result.text)
+            if obj is None:
+                raise ValueError(
+                    f"judge returned no verdicts JSON object: {result.text!r}"
+                )
             verdicts = RubricVerdicts.model_validate(obj).verdicts
         # Exactly one verdict per criterion in the batch, matched by name — anything else is a
         # judge failure and must error the rollout, not score the model (see `judge_verdict`).

--- a/verifiers/v1/judges/rubric.py
+++ b/verifiers/v1/judges/rubric.py
@@ -1,12 +1,14 @@
 """rubric — an off-the-shelf rubric judge, plugged from config alone.
 
-Reads a rubric — a list of yes/no criteria — from a JSON or TOML file and asks the judge model
-to grade the criteria, scoring each 1/0 (all in one call by default, or batched
-`max_criteria`-at-a-time). Grading uses plain-text JSON by default, or structured output when
-`structured_output=true` (see `RubricJudgeConfig`). The reward is the weighted
-mean of the verdicts (`sum(w*v) / sum(w)`, so it stays in [0, 1]); each verdict is also recorded
-as a `<name>/<criterion>` metric. Criterion weights come from the rubric file and are overridable
-from config (`weights`); the aggregate weighs into `trace.reward` via the judge's `weight`:
+Reads a rubric — a list of criteria — from a JSON or TOML file and asks the judge model to grade
+each by picking one of its ordered `choices` (default `["yes", "no"]`, a binary check), scored to
+[0, 1] by rank — best → worst, so the first choice is 1.0 and the last 0.0 (all in one call by
+default, or batched `max_criteria`-at-a-time). Grading uses plain-text JSON by default, or
+structured output when `structured_output=true` (see `RubricJudgeConfig`). The reward is the
+weighted mean of the per-criterion scores (`sum(w*v) / sum(w)`, so it stays in [0, 1]); each score
+is also recorded as a `<name>/<criterion>` metric. Criterion weights come from the rubric file and
+are overridable from config (`weights`); the aggregate weighs into `trace.reward` via the judge's
+`weight`:
 
     [[env.taskset.judges]]
     id = "rubric"
@@ -20,6 +22,8 @@ with `rubrics/quality.toml` listing the criteria (JSON takes `{"criteria": [...]
     name = "cites_sources"
     text = "The response cites at least one specific source."
     weight = 1.0
+    # choices default to ["yes", "no"]; give an ordered best→worst list for a graded criterion:
+    # choices = ["thorough", "partial", "none"]   # -> 1.0, 0.5, 0.0
 """
 
 import asyncio
@@ -28,7 +32,9 @@ import math
 import tomllib
 from functools import cached_property
 from pathlib import Path
-from typing import Literal, cast
+from typing import cast
+
+from pydantic import field_validator
 
 from verifiers.v1.judge import (
     Judge,
@@ -52,10 +58,18 @@ RUBRIC_PROMPT = (Path(__file__).resolve().parent / "rubric.txt").read_text(
 JSON_SUFFIX = (
     "\n\nRespond with ONLY a JSON object and nothing else, in exactly this shape:\n"
     '{"verdicts": [{"name": "<criterion name>", "reason": "<one sentence citing specific '
-    'evidence from the response>", "verdict": "<yes or no>"}, ...]}\n'
+    'evidence from the response>", "verdict": "<answer>"}, ...]}\n'
     "with one entry per criterion, using each criterion's exact name. For each, first write the "
-    'one-sentence reason grounded in the response, then the "yes" or "no" verdict it implies.'
+    'one-sentence reason grounded in the response, then the verdict: "yes" or "no", or — for a '
+    "criterion that lists allowed answers — exactly one of those answers."
 )
+
+
+def normalize_choice(choice: str, choices: list[str]) -> float:
+    """Score a chosen option to [0, 1] by rank. `choices` are ordered best → worst, so the first
+    scores 1.0, the last 0.0, and the rest evenly spaced (`choices` always has >= 2 entries)."""
+    rank = choices.index(choice)
+    return (len(choices) - 1 - rank) / (len(choices) - 1)
 
 
 def first_verdicts_object(text: str) -> dict | None:
@@ -77,14 +91,27 @@ def first_verdicts_object(text: str) -> dict | None:
 
 
 class Criterion(StrictBaseModel):
-    """One rubric entry: a yes/no check the judge scores 1/0."""
+    """One rubric entry the judge grades by picking one of `choices`, scored to [0, 1] by rank.
+    Defaults to a binary yes/no check (1/0)."""
 
     name: str
     """Key for the criterion's metric (`<judge name>/<name>`) and its `weights` override."""
     text: str
-    """The check itself, phrased so "yes" means satisfied."""
+    """The check itself, phrased so the first (best) choice means satisfied."""
     weight: float = 1.0
     """The criterion's share of the reward (overridable per name via `weights` in config)."""
+    choices: list[str] = ["yes", "no"]
+    """Allowed answers, ordered **best → worst**: the first scores 1.0, the last 0.0, the rest
+    evenly spaced by rank. Default `["yes", "no"]` is a binary check. Needs >= 2, no duplicates."""
+
+    @field_validator("choices")
+    @classmethod
+    def _check_choices(cls, v: list[str]) -> list[str]:
+        if len(v) < 2:
+            raise ValueError(f"`choices` needs at least two options, got {v}")
+        if len(set(v)) != len(v):
+            raise ValueError(f"`choices` has duplicate options: {v}")
+        return v
 
 
 class RubricJudgeConfig(JudgeConfig):
@@ -118,11 +145,12 @@ class RubricJudgeConfig(JudgeConfig):
 class CriterionVerdict(StrictBaseModel):
     """One criterion's reply, matched back to the rubric by `name`: a short `reason`
     (chain-of-thought, always recorded for auditability in `trace.info["judge"]`) written *before*
-    the yes/no `verdict`, so the verdict follows from it."""
+    the `verdict`, so the verdict follows from it. `verdict` is one of the criterion's `choices`
+    (validated per criterion in `grade_batch`, since choices vary by criterion)."""
 
     name: str
     reason: str
-    verdict: Literal["yes", "no"]
+    verdict: str
 
 
 class RubricVerdicts(StrictBaseModel):
@@ -182,11 +210,21 @@ class RubricJudge(Judge[RubricVerdicts, RubricJudgeConfig]):
     ) -> dict[str, float]:
         """Grade one batch of criteria in a single judge call — structured output, or plain-text
         JSON when `structured_output` is off (which avoids flaky structured decoding). Returns
-        `{name: 1.0/0.0}`, matched back to the batch by name. `score` fans this out per batch."""
+        `{name: score}`, each the chosen option normalized to [0, 1] by rank (best → worst),
+        matched back to the batch by name. `score` fans this out per batch."""
+
+        def render(
+            c: Criterion,
+        ) -> str:  # show non-default choices inline so the judge can pick
+            line = f"- {c.name}: {c.text}"
+            if c.choices != ["yes", "no"]:
+                line += f" (answer one of, best to worst: {', '.join(c.choices)})"
+            return line
+
         fields = dict(
             question=judge_question(task, self.config.question_field),
             response=judge_response(trace, self.config.view),
-            criteria="\n".join(f"- {c.name}: {c.text}" for c in batch),
+            criteria="\n".join(render(c) for c in batch),
         )
         if self.config.structured_output:
             result = await self.evaluate(trace=trace, **fields)
@@ -204,12 +242,23 @@ class RubricJudge(Judge[RubricVerdicts, RubricJudgeConfig]):
             verdicts = RubricVerdicts.model_validate(obj).verdicts
         # Exactly one verdict per criterion in the batch, matched by name — anything else is a
         # judge failure and must error the rollout, not score the model (see `judge_verdict`).
-        if sorted(v.name for v in verdicts) != sorted(c.name for c in batch):
+        by_criterion = {c.name: c for c in batch}
+        if sorted(v.name for v in verdicts) != sorted(by_criterion):
             raise ValueError(
                 f"judge verdicts name {sorted(v.name for v in verdicts)}, expected the "
-                f"batch's {sorted(c.name for c in batch)}"
+                f"batch's {sorted(by_criterion)}"
             )
-        return {v.name: float(v.verdict == "yes") for v in verdicts}
+        scores: dict[str, float] = {}
+        for v in verdicts:
+            choices = by_criterion[v.name].choices
+            if (
+                v.verdict not in choices
+            ):  # an off-menu answer is a judge failure, not a 0
+                raise ValueError(
+                    f"judge answered {v.verdict!r} for '{v.name}', expected one of {choices}"
+                )
+            scores[v.name] = normalize_choice(v.verdict, choices)
+        return scores
 
     async def score(self, task: Task, trace: Trace) -> float:
         criteria = self.criteria

--- a/verifiers/v1/judges/rubric.py
+++ b/verifiers/v1/judges/rubric.py
@@ -54,6 +54,16 @@ JSON_SUFFIX = (
     '"yes" or "no".'
 )
 
+# The `reason`-on variant: one short justification per criterion, written *before* the verdict so
+# the verdict follows from it (chain-of-thought), and recorded verbatim in `trace.info["judge"]`.
+JSON_SUFFIX_REASON = (
+    "\n\nRespond with ONLY a JSON object and nothing else, in exactly this shape:\n"
+    '{"verdicts": [{"name": "<criterion name>", "reason": "<one sentence citing specific '
+    'evidence from the response>", "verdict": "<yes or no>"}, ...]}\n'
+    "with one entry per criterion, using each criterion's exact name. For each, first write the "
+    'one-sentence reason grounded in the response, then the "yes" or "no" verdict it implies.'
+)
+
 
 def first_verdicts_object(text: str) -> dict | None:
     """The first balanced JSON object in `text` that carries a `verdicts` key. Scanning for the
@@ -110,12 +120,21 @@ class RubricJudgeConfig(JudgeConfig):
     whose structured decoding is flaky (e.g. GLM-5.2 and other non-OpenAI models on some providers
     return empty completions for structured calls, especially over long transcripts); OpenAI models
     handle either. Transient HTTP failures are already retried by the OpenAI client."""
+    reason: bool = False
+    """Ask the judge to write a one-sentence justification for each criterion *before* its verdict
+    (chain-of-thought). Improves calibration and makes every verdict auditable — the reasons are
+    recorded verbatim in `trace.info["judge"]`. Off by default (verdict only). Applies to the
+    plain-text JSON path; harmless with `structured_output` (the schema carries an optional
+    `reason`)."""
 
 
 class CriterionVerdict(StrictBaseModel):
-    """One criterion's verdict in the judge's reply, matched back to the rubric by `name`."""
+    """One criterion's verdict in the judge's reply, matched back to the rubric by `name`. `reason`
+    is a short justification the judge writes *before* the verdict when the judge's `reason` option
+    is on (chain-of-thought; auditable in `trace.info["judge"]`); empty otherwise."""
 
     name: str
+    reason: str = ""
     verdict: Literal["yes", "no"]
 
 
@@ -186,7 +205,8 @@ class RubricJudge(Judge[RubricVerdicts, RubricJudgeConfig]):
             result = await self.evaluate(trace=trace, **fields)
             verdicts = cast(RubricVerdicts, result.parsed).verdicts
         else:
-            messages = cast(str, self.build_messages(**fields)) + JSON_SUFFIX
+            suffix = JSON_SUFFIX_REASON if self.config.reason else JSON_SUFFIX
+            messages = cast(str, self.build_messages(**fields)) + suffix
             result = await self.complete(
                 messages, trace=trace
             )  # no schema -> plain text

--- a/verifiers/v1/judges/rubric.py
+++ b/verifiers/v1/judges/rubric.py
@@ -237,11 +237,11 @@ class RubricJudge(Judge[RubricVerdicts, RubricJudgeConfig]):
                 )
             if isinstance(answer, (list, tuple)):
                 answer = "\n".join(str(item) for item in answer)
-            # A self-contained, clearly-announced section; the trailing blank line separates it
-            # from the Response. Absent entirely when `answer_field` is unset (`{reference}` → "").
+            # A clearly-announced section (leading blank separates it from the Task block; the
+            # template's newline before Response closes it). Absent when `answer_field` is unset.
             reference = (
-                "Reference solution (a correct implementation of this task, for comparison):\n"
-                f"```\n{answer}\n```\n\n"
+                "\nReference solution (a correct implementation of this task, for comparison):\n"
+                f"```\n{answer}\n```\n"
             )
 
         fields = dict(

--- a/verifiers/v1/judges/rubric.py
+++ b/verifiers/v1/judges/rubric.py
@@ -237,8 +237,11 @@ class RubricJudge(Judge[RubricVerdicts, RubricJudgeConfig]):
                 )
             if isinstance(answer, (list, tuple)):
                 answer = "\n".join(str(item) for item in answer)
+            # A self-contained, clearly-announced section; the trailing blank line separates it
+            # from the Response. Absent entirely when `answer_field` is unset (`{reference}` → "").
             reference = (
-                f"\nReference solution (the task's gold answer):\n```\n{answer}\n```\n"
+                "Reference solution (a correct implementation of this task, for comparison):\n"
+                f"```\n{answer}\n```\n\n"
             )
 
         fields = dict(

--- a/verifiers/v1/judges/rubric.py
+++ b/verifiers/v1/judges/rubric.py
@@ -60,8 +60,8 @@ JSON_SUFFIX = (
     '{"verdicts": [{"name": "<criterion name>", "reason": "<one sentence citing specific '
     'evidence from the response>", "verdict": "<answer>"}, ...]}\n'
     "with one entry per criterion, using each criterion's exact name. For each, first write the "
-    'one-sentence reason grounded in the response, then the verdict: "yes" or "no", or — for a '
-    "criterion that lists allowed answers — exactly one of those answers."
+    "one-sentence reason grounded in the response, then set verdict to exactly one of the options "
+    "listed in parentheses after that criterion."
 )
 
 
@@ -125,6 +125,11 @@ class RubricJudgeConfig(JudgeConfig):
     question_field: str = ""
     """Task field to fill the prompt's `{question}`; empty = the task's prompt rendered as
     text (`Task.prompt_text`)."""
+    answer_field: str = ""
+    """Optional task field holding a reference answer (e.g. a gold patch) to show the judge, like
+    the reference judge. Empty (default) shows none — `{reference}` renders blank. A list-valued
+    field is joined one item per line. Needs `{reference}` in the prompt (the built-in `rubric.txt`
+    has it)."""
     view: JudgeView = "full_trace"
     """How much of the rollout fills `{response}` (see `JudgeView`). Defaults to the whole
     transcript — rubric criteria typically grade the process (tool use, citations,
@@ -215,16 +220,33 @@ class RubricJudge(Judge[RubricVerdicts, RubricJudgeConfig]):
 
         def render(
             c: Criterion,
-        ) -> str:  # show non-default choices inline so the judge can pick
-            line = f"- {c.name}: {c.text}"
-            if c.choices != ["yes", "no"]:
-                line += f" (answer one of, best to worst: {', '.join(c.choices)})"
-            return line
+        ) -> str:  # every criterion states its own allowed answers inline
+            opts = (
+                "yes or no"
+                if c.choices == ["yes", "no"]
+                else "one of, best to worst: " + ", ".join(c.choices)
+            )
+            return f"- {c.name}: {c.text} (answer {opts})"
+
+        reference = ""  # optional gold answer shown to the judge; blank unless `answer_field` set
+        if self.config.answer_field:
+            answer = getattr(task, self.config.answer_field, None)
+            if answer is None:
+                raise ValueError(
+                    f"rubric judge found no {self.config.answer_field!r} field on the task; "
+                    "point `answer_field` at the task's reference-answer field or leave it empty"
+                )
+            if isinstance(answer, (list, tuple)):
+                answer = "\n".join(str(item) for item in answer)
+            reference = (
+                f"\nReference solution (the task's gold answer):\n```\n{answer}\n```\n"
+            )
 
         fields = dict(
             question=judge_question(task, self.config.question_field),
             response=judge_response(trace, self.config.view),
             criteria="\n".join(render(c) for c in batch),
+            reference=reference,
         )
         if self.config.structured_output:
             result = await self.evaluate(trace=trace, **fields)

--- a/verifiers/v1/judges/rubric.py
+++ b/verifiers/v1/judges/rubric.py
@@ -29,6 +29,7 @@ with `rubrics/quality.toml` listing the criteria (JSON takes `{"criteria": [...]
 import asyncio
 import json
 import math
+import re
 import tomllib
 from functools import cached_property
 from pathlib import Path
@@ -220,12 +221,7 @@ class RubricJudge(Judge[RubricVerdicts, RubricJudgeConfig]):
         def render(
             c: Criterion,
         ) -> str:  # every criterion states its own allowed answers inline
-            opts = (
-                "yes or no"
-                if c.choices == ["no", "yes"]
-                else "one of, worst to best: " + ", ".join(c.choices)
-            )
-            return f"- {c.name}: {c.text} (answer {opts})"
+            return f"- {c.name}: {c.text} (answer one of, worst to best: {', '.join(c.choices)})"
 
         reference = ""  # optional gold answer shown to the judge; blank unless `answer_field` set
         if self.config.answer_field:
@@ -239,9 +235,14 @@ class RubricJudge(Judge[RubricVerdicts, RubricJudgeConfig]):
                 answer = "\n".join(str(item) for item in answer)
             # A clearly-announced section (leading blank separates it from the Task block; the
             # template's newline before Response closes it). Absent when `answer_field` is unset.
+            # Fence longer than any backtick run in the answer, so a patch/markdown containing ```
+            # can't close it early and spill into the prompt as instructions.
+            fence = "`" * (
+                max((len(m) for m in re.findall(r"`+", answer)), default=2) + 1
+            )
             reference = (
                 "\nReference solution (a correct implementation of this task, for comparison):\n"
-                f"```\n{answer}\n```\n"
+                f"{fence}\n{answer}\n{fence}\n"
             )
 
         fields = dict(

--- a/verifiers/v1/judges/rubric.txt
+++ b/verifiers/v1/judges/rubric.txt
@@ -4,8 +4,8 @@ Task:
 ```
 {question}
 ```
-{reference}
-Response:
+
+{reference}Response:
 ```
 {response}
 ```

--- a/verifiers/v1/judges/rubric.txt
+++ b/verifiers/v1/judges/rubric.txt
@@ -4,7 +4,7 @@ Task:
 ```
 {question}
 ```
-
+{reference}
 Response:
 ```
 {response}
@@ -13,4 +13,4 @@ Response:
 Criteria:
 {criteria}
 
-For each criterion, give a "yes" or "no" verdict under its exact name.
+For each criterion, answer under its exact name with exactly one of the options given in parentheses after it.

--- a/verifiers/v1/judges/rubric.txt
+++ b/verifiers/v1/judges/rubric.txt
@@ -4,8 +4,8 @@ Task:
 ```
 {question}
 ```
-
-{reference}Response:
+{reference}
+Response:
 ```
 {response}
 ```


### PR DESCRIPTION
## Summary

Makes the built-in `rubric` judge configurable + reliable enough to plug across tasksets. Knobs on
`RubricJudgeConfig` (all default to the prior behavior):

- **`structured_output`** (default **False**): grade via **plain-text output parsed as JSON**
  instead of `response_format`. Structured decoding is flaky on some endpoints — GLM-5.2 and other
  non-OpenAI models frequently return **empty completions** for structured calls over long
  transcripts (measured: 75% empty on a 269K-char transcript vs 0% plain-text), which the judge
  treats as fatal. Plain text is reliable and produces the same verdicts (~91% agreement); OpenAI
  models handle either. Parsing scans for the first balanced JSON object carrying a `verdicts` key,
  so a preamble or an echoed format example is skipped rather than mistaken for the answer.
- **`max_criteria`** (default None = all in one call): grade N criteria per call — `1` = per-criterion
  (n independent judges), `k` = batches of k; graded concurrently and merged. (Suggested by Will Brown.)
- **Always-on per-criterion `reason`**: each verdict carries a one-sentence justification written
  *before* the verdict (chain-of-thought), recorded verbatim in `trace.info["judge"]` for
  auditability. Applies to both JSON and structured paths. No config flag — always on.
- **`choices`** (per criterion, default `["no", "yes"]`): discrete, ordered **worst → best**; the
  chosen option is scored to [0, 1] by rank (first = 0.0, last = 1.0, evenly spaced). Subsumes
  binary / ternary / N-ary / named grades (`["none","partial","thorough"]` → 0.0/0.5/1.0). Each
  criterion states its own allowed answers inline in the prompt, and the global instruction defers
  to them (no yes/no default that could collide with a criterion's options). An off-menu answer is
  a judge failure (errors the rollout), not a silent 0.
- **`answer_field`** (default `""` = off): optionally show the judge a reference answer (e.g. a gold
  patch) pulled from a task field, like the reference judge — rendered into the prompt's
  `{reference}` slot (blank when off). List-valued fields are joined one item per line.

`grade_batch` runs one judge call over a batch (structured or plain-text), validates each verdict
against its criterion's `choices`, and normalizes by rank; `score` fans it out over the batches and
aggregates the weighted mean (stays in [0, 1]). Combines the former split PRs for JSON mode +
batching. Tests cover each knob (`tests/v1/test_judges.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout scoring and judge-call behavior (new default JSON path, batching, stricter verdict validation); failures still error rollouts rather than silent zeros, but misconfigured rubrics or model format drift could increase judge failures.
> 
> **Overview**
> **Rubric judge** now grades criteria by picking from per-criterion **ordered `choices`** (default `["no","yes"]`), mapping the pick to **[0, 1] by rank** instead of hardcoded yes/no. Each reply must include a **`reason`** before the verdict (always recorded for audit).
> 
> **Default grading** is **plain-text JSON** (`structured_output=false`): the prompt appends a format suffix and **`first_verdicts_object`** extracts the answer, avoiding flaky structured decoding on some models. Opt in with `structured_output=true` for schema-based calls.
> 
> New config: **`max_criteria`** splits criteria into concurrent **`grade_batch`** calls (with sibling cancel on failure); **`answer_field`** optionally injects a fenced **reference solution** into `{reference}` in the prompt template.
> 
> Tests and the fake judge were updated for JSON `verdicts` + reasons; added coverage for choice normalization, off-menu verdict errors, choice validation, and optional reference blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47c02791486f80bf934d9190fa5f3f6cdc9879ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add JSON output mode and batched criteria evaluation to `RubricJudge`
> - `RubricJudge` now defaults to plain-text JSON parsing instead of structured output, appending a `JSON_SUFFIX` prompt segment that asks the model to return a `verdicts` array with `name`, `reason`, and `verdict` fields per criterion.
> - Criteria can now be evaluated in concurrent batches controlled by the new `max_criteria` config field, with sibling batch calls cancelled on failure.
> - `Criterion` now accepts an ordered `choices` list (defaulting to `["no", "yes"]`); verdicts are normalized to a `[0,1]` score by rank, enabling multi-grade rubrics beyond binary yes/no.
> - The rubric prompt template optionally injects a reference solution section via the new `answer_field` config option.
> - Behavioral Change: `CriterionVerdict` now requires a `reason` field and accepts arbitrary verdict strings validated against criterion choices at runtime rather than enforcing `Literal['yes','no']` in the schema.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 47c0279.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->