### PR TITLE
chore(v1): rename RolloutContext to ModelContext

### DIFF
--- a/environments/compact/compact/harness.py
+++ b/environments/compact/compact/harness.py
@@ -12,7 +12,7 @@ import json
 from pathlib import Path
 
 from verifiers.v1.harness import Harness, HarnessConfig
-from verifiers.v1.clients import RolloutContext
+from verifiers.v1.clients import ModelContext
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.trace import Trace
 
@@ -32,7 +32,7 @@ class CompactingHarness(Harness[CompactingHarnessConfig]):
 
     async def launch(
         self,
-        ctx: RolloutContext,
+        ctx: ModelContext,
         trace: Trace,
         runtime: Runtime,
         endpoint: str,

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -12,7 +12,7 @@ from verifiers.v1.clients import (
     BaseClientConfig,
     Client,
     ClientConfig,
-    RolloutContext,
+    ModelContext,
     resolve_client,
 )
 from verifiers.v1.decorators import group_reward, metric, reward, stop, tool
@@ -188,7 +188,7 @@ __all__ = [
     "BaseConfig",
     "Harness",
     "HarnessConfig",
-    "RolloutContext",
+    "ModelContext",
     "Runtime",
     "RuntimeConfig",
     "ProgramResult",

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -6,7 +6,7 @@ import logging
 import random
 import time
 
-from verifiers.v1.clients import RolloutContext, resolve_client
+from verifiers.v1.clients import ModelContext, resolve_client
 from verifiers.v1.configs.eval import EvalConfig
 from verifiers.v1.cli.eval import resume
 from verifiers.v1.cli.dashboard import dashboard
@@ -29,7 +29,7 @@ async def run_eval(env: Environment, config: EvalConfig) -> list[Trace]:
     if config.shuffle:
         random.Random(_SHUFFLE_SEED).shuffle(tasks)
     tasks = tasks if config.num_tasks is None else tasks[: config.num_tasks]
-    ctx = RolloutContext(client=client, model=config.model, sampling=config.sampling)
+    ctx = ModelContext(client=client, model=config.model, sampling=config.sampling)
     # One episode of `num_rollouts` rollouts per task; the shared semaphore bounds total
     # concurrent rollouts (across episodes), so group rewards still see their whole episode.
     semaphore = (

--- a/verifiers/v1/cli/init.py
+++ b/verifiers/v1/cli/init.py
@@ -192,7 +192,7 @@ class {prefix}Harness(vf.Harness[{prefix}HarnessConfig]):
 
     async def launch(
         self,
-        ctx: vf.RolloutContext,
+        ctx: vf.ModelContext,
         trace: vf.Trace,
         runtime: vf.Runtime,
         endpoint: str,

--- a/verifiers/v1/clients/__init__.py
+++ b/verifiers/v1/clients/__init__.py
@@ -1,6 +1,6 @@
 """The client abstraction and its OpenAI-compatible + renderer implementations."""
 
-from verifiers.v1.clients.client import Client, RolloutContext
+from verifiers.v1.clients.client import Client, ModelContext
 from verifiers.v1.clients.config import (
     BaseClientConfig,
     ClientConfig,
@@ -13,7 +13,7 @@ from verifiers.v1.clients.train import TrainClient
 
 __all__ = [
     "Client",
-    "RolloutContext",
+    "ModelContext",
     "BaseClientConfig",
     "ClientConfig",
     "EvalClientConfig",

--- a/verifiers/v1/clients/client.py
+++ b/verifiers/v1/clients/client.py
@@ -77,7 +77,7 @@ class Client(ABC):
 
 
 @dataclass(frozen=True)
-class RolloutContext:
+class ModelContext:
     """The collaborators a single rollout needs (client + model + sampling), bundled
     so harnesses hold no rollout state. Built by the Environment."""
 

--- a/verifiers/v1/clients/client.py
+++ b/verifiers/v1/clients/client.py
@@ -78,8 +78,8 @@ class Client(ABC):
 
 @dataclass(frozen=True)
 class ModelContext:
-    """The collaborators a single rollout needs (client + model + sampling), bundled
-    so harnesses hold no rollout state. Built by the Environment."""
+    """The model-side collaborators a harness talks to (client + model + sampling),
+    bundled so harnesses hold no rollout state. Built by the Environment."""
 
     model: str
     client: Client

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -19,7 +19,7 @@ from pydantic import Field, SerializeAsAny, model_validator
 from pydantic_config import BaseConfig
 
 from verifiers.v1.harness import HarnessConfig
-from verifiers.v1.clients import RolloutContext
+from verifiers.v1.clients import ModelContext
 from verifiers.v1.decorators import discover_decorated
 from verifiers.v1.episode import Episode
 from verifiers.v1.types import ID
@@ -300,7 +300,7 @@ class Environment:
             self.harness.config.runtime, task, self._warned_resources
         )
 
-    def episode(self, task: Task, ctx: RolloutContext, n: int = 1) -> Episode:
+    def episode(self, task: Task, ctx: ModelContext, n: int = 1) -> Episode:
         """Resolve `task` into a runnable episode of `n` rollouts: pick its runtime
         (image + resources) and its timeouts (cli/toml > task > default, None = no limit),
         build one `Rollout` per sample sharing them, and wrap them in an `Episode` (which

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -16,7 +16,7 @@ from typing import ClassVar, Generic, TypeVar
 from pydantic import Field
 from pydantic_config import BaseConfig
 
-from verifiers.v1.clients import RolloutContext
+from verifiers.v1.clients import ModelContext
 from verifiers.v1.decorators import discover_decorated, invoke
 from verifiers.v1.errors import HarnessError, boundary
 from verifiers.v1.utils.install import env_name
@@ -131,7 +131,7 @@ class Harness(ABC, Generic[ConfigT]):
 
     async def run(
         self,
-        ctx: RolloutContext,
+        ctx: ModelContext,
         trace: Trace,
         runtime: Runtime,
         endpoint: str,
@@ -176,7 +176,7 @@ class Harness(ABC, Generic[ConfigT]):
     @abstractmethod
     async def launch(
         self,
-        ctx: RolloutContext,
+        ctx: ModelContext,
         trace: Trace,
         runtime: Runtime,
         endpoint: str,

--- a/verifiers/v1/harnesses/codex/harness.py
+++ b/verifiers/v1/harnesses/codex/harness.py
@@ -10,7 +10,7 @@ session secret) is read from an env var.
 import logging
 import shlex
 
-from verifiers.v1.clients import RolloutContext
+from verifiers.v1.clients import ModelContext
 from verifiers.v1.harness import Harness, HarnessConfig
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.trace import Trace
@@ -65,7 +65,7 @@ class CodexHarness(Harness[CodexHarnessConfig]):
 
     async def launch(
         self,
-        ctx: RolloutContext,
+        ctx: ModelContext,
         trace: Trace,
         runtime: Runtime,
         endpoint: str,

--- a/verifiers/v1/harnesses/default/harness.py
+++ b/verifiers/v1/harnesses/default/harness.py
@@ -14,7 +14,7 @@ import os
 from pathlib import Path
 
 from verifiers.v1.harness import Harness, HarnessConfig
-from verifiers.v1.clients import RolloutContext
+from verifiers.v1.clients import ModelContext
 from verifiers.v1.dialects.chat import message_to_wire
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.trace import Trace
@@ -61,7 +61,7 @@ class DefaultHarness(Harness[DefaultHarnessConfig]):
 
     async def launch(
         self,
-        ctx: RolloutContext,
+        ctx: ModelContext,
         trace: Trace,
         runtime: Runtime,
         endpoint: str,

--- a/verifiers/v1/harnesses/kimi_code/harness.py
+++ b/verifiers/v1/harnesses/kimi_code/harness.py
@@ -9,7 +9,7 @@ import json
 import logging
 import shlex
 
-from verifiers.v1.clients import RolloutContext
+from verifiers.v1.clients import ModelContext
 from verifiers.v1.harness import Harness, HarnessConfig
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.trace import Trace
@@ -64,7 +64,7 @@ class KimiCodeHarness(Harness[KimiCodeHarnessConfig]):
 
     async def launch(
         self,
-        ctx: RolloutContext,
+        ctx: ModelContext,
         trace: Trace,
         runtime: Runtime,
         endpoint: str,

--- a/verifiers/v1/harnesses/mini_swe_agent/harness.py
+++ b/verifiers/v1/harnesses/mini_swe_agent/harness.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from verifiers.v1.clients import RolloutContext
+from verifiers.v1.clients import ModelContext
 from verifiers.v1.harness import Harness, HarnessConfig
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.trace import Trace
@@ -27,7 +27,7 @@ class MiniSWEAgentHarness(Harness[MiniSWEAgentHarnessConfig]):
 
     async def launch(
         self,
-        ctx: RolloutContext,
+        ctx: ModelContext,
         trace: Trace,
         runtime: Runtime,
         endpoint: str,

--- a/verifiers/v1/harnesses/null/harness.py
+++ b/verifiers/v1/harnesses/null/harness.py
@@ -11,7 +11,7 @@ import json
 from pathlib import Path
 
 from verifiers.v1.harness import Harness, HarnessConfig
-from verifiers.v1.clients import RolloutContext
+from verifiers.v1.clients import ModelContext
 from verifiers.v1.dialects.chat import message_to_wire
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.trace import Trace
@@ -35,7 +35,7 @@ class NullHarness(Harness[NullHarnessConfig]):
 
     async def launch(
         self,
-        ctx: RolloutContext,
+        ctx: ModelContext,
         trace: Trace,
         runtime: Runtime,
         endpoint: str,

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -18,7 +18,7 @@ from typing import Literal
 from pydantic import model_validator
 
 from verifiers.v1.harness import Harness, HarnessConfig
-from verifiers.v1.clients import RolloutContext
+from verifiers.v1.clients import ModelContext
 from verifiers.v1.decorators import metric
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.trace import Trace
@@ -115,7 +115,7 @@ class RLMHarness(Harness[RLMHarnessConfig]):
 
     async def launch(
         self,
-        ctx: RolloutContext,
+        ctx: ModelContext,
         trace: Trace,
         runtime: Runtime,
         endpoint: str,

--- a/verifiers/v1/harnesses/terminus_2/harness.py
+++ b/verifiers/v1/harnesses/terminus_2/harness.py
@@ -3,7 +3,7 @@
 import logging
 from pathlib import Path
 
-from verifiers.v1.clients import RolloutContext
+from verifiers.v1.clients import ModelContext
 from verifiers.v1.harness import Harness, HarnessConfig
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.trace import Trace
@@ -39,7 +39,7 @@ class Terminus2Harness(Harness[Terminus2HarnessConfig]):
 
     async def launch(
         self,
-        ctx: RolloutContext,
+        ctx: ModelContext,
         trace: Trace,
         runtime: Runtime,
         endpoint: str,

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -32,7 +32,7 @@ from aiohttp import web
 from pydantic import TypeAdapter, ValidationError
 from pydantic_core import PydanticSerializationError, from_json, to_json
 
-from verifiers.v1.clients import RolloutContext
+from verifiers.v1.clients import ModelContext
 from verifiers.v1.dialects import DIALECTS, Dialect
 from verifiers.v1.dialects.base import is_sse_done_event
 from verifiers.v1 import graph
@@ -129,7 +129,7 @@ class RolloutSession:
     checked before each turn, and (optionally) a user simulator the rollout sets before the
     harness runs."""
 
-    ctx: RolloutContext
+    ctx: ModelContext
     trace: Trace
     stops: list[Callable[[Trace], Awaitable[bool]]] = field(default_factory=list)
     limits: RolloutLimits = field(default_factory=RolloutLimits)

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -19,7 +19,7 @@ from contextlib import asynccontextmanager
 from enum import StrEnum
 
 from verifiers.v1.harness import Harness
-from verifiers.v1.clients import RolloutContext
+from verifiers.v1.clients import ModelContext
 from verifiers.v1.decorators import discover_decorated, invoke
 from verifiers.v1.errors import (
     HarnessError,
@@ -69,7 +69,7 @@ class Rollout:
         task: Task,
         taskset: Taskset,
         harness: Harness,
-        ctx: RolloutContext,
+        ctx: ModelContext,
         runtime_config: RuntimeConfig,
         setup_timeout: float | None = None,
         harness_timeout: float | None = None,

--- a/verifiers/v1/serve/server.py
+++ b/verifiers/v1/serve/server.py
@@ -6,7 +6,7 @@ loads it. A caller (e.g. the orchestrator) stays env-agnostic: it asks `info` fo
 the task count + whether group scoring is needed, then `run_rollout` / `run_group`
 by task index. Per request the server resolves a `Client` from the request's
 `client` config (cached, so a renderer's tokenizer is built once), wraps it in a
-`RolloutContext`, and runs `env.episode(task, ctx, n).run()`, returning each
+`ModelContext`, and runs `env.episode(task, ctx, n).run()`, returning each
 `Trace` as a JSON dict (with its computed `branches`).
 
 Minimal port of `verifiers.serve` (ROUTER + msgpack), single async process: each
@@ -26,7 +26,7 @@ import zmq.asyncio
 
 from verifiers.utils.process_utils import use_threading_tqdm_lock
 from verifiers.utils.serve_utils import msgpack_encoder
-from verifiers.v1.clients import RolloutContext, resolve_client
+from verifiers.v1.clients import ModelContext, resolve_client
 from verifiers.v1.clients.client import Client
 from verifiers.v1.clients.config import ClientConfig
 from verifiers.v1.decorators import discover_decorated
@@ -106,8 +106,8 @@ class EnvServer:
 
     def _context(
         self, client_config: ClientConfig, model: str, sampling: SamplingConfig
-    ) -> RolloutContext:
-        return RolloutContext(
+    ) -> ModelContext:
+        return ModelContext(
             client=self._client(client_config, model), model=model, sampling=sampling
         )
 


### PR DESCRIPTION
Renames the `RolloutContext` dataclass to `ModelContext`.

The type bundles `model` + `client` + `sampling` — collaborators that are stable across a rollout, not rollout-scoped state. The name `RolloutContext` was misleading; `ModelContext` reflects what it actually holds.

Pure rename, no behavior change: 37 occurrences across 18 files, including the public re-exports in `verifiers/v1/__init__.py` and `verifiers/v1/clients/__init__.py`. Verified all modules import cleanly and `vf.ModelContext` resolves.

No downstream prime-rl source changes needed — prime-rl never referenced `RolloutContext`. After merge, prime-rl's `deps/verifiers` submodule pin gets bumped to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename `RolloutContext` to `ModelContext` across the v1 verifiers codebase
> Pure rename with no functional changes. The `RolloutContext` dataclass in [client.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1940/files#diff-03d8d18cf21766007d7efc7af13862dcd1d58ab1a1374aef2efdd4ba59c69e2e) is renamed to `ModelContext`, and all type annotations, imports, and exports across harnesses, rollout, interception, and serve modules are updated to match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized adc8e2f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical identifier rename with no logic changes; risk is limited to downstream imports of the old name.
> 
> **Overview**
> Renames the **`RolloutContext`** frozen dataclass to **`ModelContext`** everywhere in v1 — definition in `verifiers/v1/clients/client.py`, with an updated docstring that describes it as model-side collaborators (`client`, `model`, `sampling`) rather than rollout-scoped state.
> 
> **Imports, type hints, and public exports** are updated across harnesses (base + built-ins + compact example), `Rollout`, `Environment.episode`, interception `RolloutSession`, eval runner, env server, and `verifiers/v1/__init__.py` / `clients/__init__.py`. The **`init` harness scaffold** now generates `vf.ModelContext` for new environments.
> 
> **No field or behavior changes** — callers still build the same bundle and pass it through the rollout path; only the public name changes (breaking for code that imported `RolloutContext`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adc8e2f903de6bfa049952b93f01a9ddadb455e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->