### PR TITLE
fix v1 aux headers and replay scores

### DIFF
--- a/verifiers/v1/cli/replay.py
+++ b/verifiers/v1/cli/replay.py
@@ -93,14 +93,21 @@ async def run_replay(config: ReplayConfig, source: Path, out: Path) -> list[Trac
                 st.state, st.detail, st.end = "skipped", "rollout errored", time.time()
             else:
                 st.state = "running"
-                # Clear prior scores so a changed/removed judge leaves no stale (double-summed) entry.
+                prior_rewards = dict(trace.rewards)
+                prior_metrics = dict(trace.metrics)
+                # Clear before re-scoring so recomputed keys replace prior values without warning.
+                # Keys that offline scoring skips (runtime-dependent signals) are restored below.
                 if isinstance(trace.info, dict):
                     trace.info.pop("judge", None)
                 trace.rewards, trace.metrics, trace.extra_usage = {}, {}, []
                 try:
                     await taskset.score(trace)
+                    trace.rewards = {**prior_rewards, **trace.rewards}
+                    trace.metrics = {**prior_metrics, **trace.metrics}
                     st.state, st.detail = "scored", f"reward {trace.reward:.3f}"
                 except Exception as exc:
+                    trace.rewards = {**prior_rewards, **trace.rewards}
+                    trace.metrics = {**prior_metrics, **trace.metrics}
                     st.state, st.detail = "error", type(exc).__name__
                     trace.capture_error(
                         exc

--- a/verifiers/v1/clients/client.py
+++ b/verifiers/v1/clients/client.py
@@ -67,7 +67,13 @@ class Client(ABC):
         generates and cannot stream."""
         raise NotImplementedError(f"{type(self).__name__} does not support streaming")
 
-    async def relay_aux(self, dialect: Dialect, route: str, body: dict) -> dict:
+    async def relay_aux(
+        self,
+        dialect: Dialect,
+        route: str,
+        body: dict,
+        headers: Mapping[str, str] | None = None,
+    ) -> dict:
         """Relay a non-model-turn side request (an `aux_route`, e.g. Anthropic's `count_tokens`)
         verbatim to the provider and return its JSON. Only the relay (eval) client supports it."""
         raise NotImplementedError(f"{type(self).__name__} does not relay aux routes")

--- a/verifiers/v1/clients/eval.py
+++ b/verifiers/v1/clients/eval.py
@@ -205,12 +205,18 @@ class EvalClient(Client):
             close=resp.aclose,
         )
 
-    async def relay_aux(self, dialect: Dialect, route: str, body: dict) -> dict:
+    async def relay_aux(
+        self,
+        dialect: Dialect,
+        route: str,
+        body: dict,
+        headers: Mapping[str, str] | None = None,
+    ) -> dict:
         # A side request (e.g. count_tokens): relay its native JSON and return the provider JSON.
         resp = await self._request(
             self.base_url + route,
             body,
-            self._headers(dialect, None, None),
+            self._headers(dialect, headers, None),
         )
         return from_json(resp.content)
 

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -543,7 +543,7 @@ class InterceptionServer:
         logger.debug("intercept aux %s: id=%s", route, session.trace.id)
         try:
             result = await session.ctx.client.relay_aux(
-                dialect, route, await request.json()
+                dialect, route, await request.json(), headers=request.headers
             )
         except RolloutError as e:
             # An aux call isn't a model turn, so don't clobber a pending turn error.


### PR DESCRIPTION
## Summary

This PR fixes two issues found during the daily bug scan. It intentionally includes only the implementation fixes and this write-up; regression test files are excluded per request.

## Fixes

1. Preserve provider feature headers on aux relays.

   `EvalClient._headers()` was updated in #1930 to preserve provider feature headers such as `anthropic-beta`, but aux-route handling still called `relay_aux()` without the intercepted request headers. As a result, Anthropic side requests like `/v1/messages/count_tokens` could silently drop feature headers even though normal model turns preserved them.

   This patch threads optional headers through `Client.relay_aux()`, passes `request.headers` from the interception server, and reuses the existing `_headers()` filtering/auth logic in `EvalClient.relay_aux()`.

2. Preserve replay scores that cannot be recomputed offline.

   The replay entrypoint documents that runtime-dependent scoring signals are skipped offline and left as originally recorded. `run_replay()` cleared all prior rewards and metrics before calling `Taskset.score(trace)` without a runtime, so skipped runtime-dependent rewards/metrics were lost.

   This patch snapshots existing rewards and metrics, clears before re-scoring to avoid double counting recomputed keys, then restores any prior keys that offline scoring did not overwrite.

## Impact

- Aux provider requests now carry the same eligible feature headers as model-turn requests while still replacing localhost auth with provider auth.
- Replay preserves runtime-dependent score data when those signals cannot run without a live runtime.

## Validation

- `UV_FROZEN=1 git commit` pre-commit hooks passed: `ruff check`, `ruff format`.
- `UV_FROZEN=1 git push` pre-push hooks passed: `ruff check`, `ruff format`, generated docs check, `ty check verifiers`.

Tests are not included in this PR by request.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix aux header forwarding and preserve prior rewards/metrics on replay rescoring
> - `InterceptionServer.handle_aux` now passes `request.headers` to `EvalClient.relay_aux`, which forwards them to the provider instead of always sending `None`.
> - `run_replay.rescore` snapshots `prior_rewards` and `prior_metrics` before clearing the trace, then merges them back after rescoring so keys not recomputed by offline scoring are preserved; newly computed keys take precedence.
> - On scoring errors, prior rewards and metrics are also restored before the error state is recorded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e8236c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->