### PR TITLE
fix v1 aux header forwarding

### DIFF
--- a/verifiers/v1/clients/client.py
+++ b/verifiers/v1/clients/client.py
@@ -67,7 +67,13 @@ class Client(ABC):
         generates and cannot stream."""
         raise NotImplementedError(f"{type(self).__name__} does not support streaming")
 
-    async def relay_aux(self, dialect: Dialect, route: str, body: dict) -> dict:
+    async def relay_aux(
+        self,
+        dialect: Dialect,
+        route: str,
+        body: dict,
+        headers: Mapping[str, str] | None = None,
+    ) -> dict:
         """Relay a non-model-turn side request (an `aux_route`, e.g. Anthropic's `count_tokens`)
         verbatim to the provider and return its JSON. Only the relay (eval) client supports it."""
         raise NotImplementedError(f"{type(self).__name__} does not relay aux routes")

--- a/verifiers/v1/clients/eval.py
+++ b/verifiers/v1/clients/eval.py
@@ -205,12 +205,18 @@ class EvalClient(Client):
             close=resp.aclose,
         )
 
-    async def relay_aux(self, dialect: Dialect, route: str, body: dict) -> dict:
+    async def relay_aux(
+        self,
+        dialect: Dialect,
+        route: str,
+        body: dict,
+        headers: Mapping[str, str] | None = None,
+    ) -> dict:
         # A side request (e.g. count_tokens): relay its native JSON and return the provider JSON.
         resp = await self._request(
             self.base_url + route,
             body,
-            self._headers(dialect, None, None),
+            self._headers(dialect, headers, None),
         )
         return from_json(resp.content)
 

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -543,7 +543,7 @@ class InterceptionServer:
         logger.debug("intercept aux %s: id=%s", route, session.trace.id)
         try:
             result = await session.ctx.client.relay_aux(
-                dialect, route, await request.json()
+                dialect, route, await request.json(), headers=request.headers
             )
         except RolloutError as e:
             # An aux call isn't a model turn, so don't clobber a pending turn error.


### PR DESCRIPTION
## Summary

Fix aux-route provider forwarding so eligible request headers are preserved the same way model-turn requests preserve them.

## Root Cause

#1930 updated `EvalClient._headers()` to preserve provider feature headers such as `anthropic-beta` across all dialects. Normal model turns passed intercepted request headers into `_headers()`, but aux routes still called `relay_aux()` without `request.headers`.

That meant Anthropic side requests like `/v1/messages/count_tokens` could silently drop provider feature headers even though normal model requests kept them.

## Changes

- Add optional `headers` to `Client.relay_aux()`.
- Pass intercepted aux request headers from `InterceptionServer.handle_aux()`.
- Reuse `EvalClient._headers()` for aux requests so localhost auth/transport headers are filtered and provider auth is still applied last.

## Impact

Aux provider requests now carry the same eligible feature headers as model-turn requests while still replacing localhost auth with real provider auth.

## Validation

- `UV_FROZEN=1 uv run ruff check --fix`
- `UV_FROZEN=1 uv run ruff format`
- `UV_FROZEN=1 git commit` pre-commit hooks: `ruff check`, `ruff format`
- `UV_FROZEN=1 git push` pre-push hooks: `ruff check`, `ruff format`, generated docs check, `ty check verifiers`

Tests are not included in this PR by request.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix aux header forwarding in v1 interception server
> Inbound HTTP request headers were not being forwarded to the upstream provider on aux routes. The fix threads headers through three layers: `InterceptionServer.handle_aux` now passes `request.headers` to `relay_aux`, `EvalClient.relay_aux` accepts the optional `headers` parameter and passes it to `_request`, and the base `Client.relay_aux` signature is updated to match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ce7c661.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to eval proxy header forwarding on aux routes; reuses the existing `_headers` filtering used for model turns, with no new auth or data paths.
> 
> **Overview**
> **Aux routes** (e.g. Anthropic `count_tokens`) now forward the same eligible inbound headers to the provider as normal model turns, instead of building upstream requests with no intercepted headers.
> 
> `InterceptionServer.handle_aux` passes `request.headers` into `relay_aux`. The base `Client.relay_aux` API gains an optional `headers` argument, and `EvalClient.relay_aux` feeds those through `self._headers(dialect, headers, None)` so provider feature headers like `anthropic-beta` are kept while localhost auth and transport headers are still stripped and real provider auth is applied last.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce7c661ccbbcf334502205c2b9e7430f21228f0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->