### PR TITLE
feat(v1): Environment consumes the Agent — single-agent as the default program

### DIFF
--- a/docs/agent-programs.md
+++ b/docs/agent-programs.md
@@ -111,6 +111,15 @@ themselves, via the lineage stamps.
 
 Reward/metric handlers are `async def` — a sync handler fails at scoring time.
 
+## The eval runs on the same primitive
+
+An eval is already an agent program — the simplest one. `Environment` builds every
+episode's rollouts through an internal `Agent` (`Agent.rollout`, the resolve-only half
+of `run`), so placement, stage timeouts, and pairing validation resolve identically
+whether a run came from a config-driven eval or a hand-written program. Provenance is
+stamped by the rollout itself, so *every* trace — eval or program — carries
+`info["agent"]`.
+
 ## Placement rules
 
 - A **fresh box** per run is the default: the agent's runtime policy, resolved per task

--- a/verifiers/v1/ARCHITECTURE.md
+++ b/verifiers/v1/ARCHITECTURE.md
@@ -13,9 +13,10 @@ A rollout is the composition of three independently-swappable pieces, each loade
 - **Harness** — the program that drives the model turn to turn.
 - **Runtime** — *where* that program (and the taskset's tools / user simulator) executes.
 
-`Environment` (`env.py`) wires them together for an eval; `Rollout` (`rollout.py`) runs one
-trajectory; `Episode` (`episode.py`) runs a task's N rollouts and applies cross-rollout
-scoring. The single artifact every layer produces and consumes is a **`Trace`** — a typed
+`Environment` (`env.py`) wires them together for an eval, building every episode's
+rollouts through an internal `Agent` (`agent.py`) — the same primitive agent programs
+use; `Rollout` (`rollout.py`) runs one trajectory; `Episode` (`episode.py`) runs a
+task's N rollouts and applies cross-rollout scoring. The single artifact every layer produces and consumes is a **`Trace`** — a typed
 message graph (`graph.py`, `trace.py`).
 
 The load-bearing design idea: **a harness only ever points its model SDK at a localhost

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -25,7 +25,6 @@ from verifiers.v1.env import (
     EnvServerConfig,
     Environment,
     StaticPoolConfig,
-    TimeoutConfig,
     pool_serve_kwargs,
 )
 from verifiers.v1.episode import Episode
@@ -77,6 +76,7 @@ from verifiers.v1.scoring import (
     read_answer_file_or_last_reply as read_answer_file_or_last_reply,
     verify_boxed_math_answer as verify_boxed_math_answer,
 )
+from verifiers.v1.resolve import TimeoutConfig
 from verifiers.v1.retries import RetryConfig, RolloutRetryConfig
 from verifiers.v1.rollout import Rollout
 from verifiers.v1.runtimes import (

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -30,7 +30,7 @@ from typing import AsyncIterator
 from verifiers.v1.clients import (
     ModelContext,
 )
-from verifiers.v1.env import (
+from verifiers.v1.resolve import (
     TimeoutConfig,
     cap_remote_harness_timeout,
     resolve_runtime_config,
@@ -147,6 +147,24 @@ class Agent:
         from the agent's runtime policy. `ctx` replaces the agent's model context for
         this run — `dataclasses.replace(agent.ctx, model=...)` for a judge sweeping
         models."""
+        return await self.rollout(task, taskset=taskset, runtime=runtime, ctx=ctx).run()
+
+    def rollout(
+        self,
+        task: Task,
+        *,
+        taskset: Taskset | None = None,
+        runtime: Runtime | None = None,
+        ctx: ModelContext | None = None,
+        shared_urls: dict[str, str] | None = None,
+        interception: InterceptionPool | None = None,
+    ) -> Rollout:
+        """Resolve one run of this agent into a `Rollout`, without running it — placement
+        (task-resolved runtime, or the borrowed box), stage timeouts (agent > task, capped
+        for remote sandboxes), pairing validation. `run()` is this plus the await; the
+        `Environment` builds its episodes' rollouts here, injecting its eval-level
+        `shared_urls` / `interception` pool (left None, the agent's own entered pool
+        serves interception when reachable)."""
         ctx = ctx if ctx is not None else self.ctx
         taskset = taskset if taskset is not None else _NULL_TASKSET
         if runtime is not None:
@@ -158,7 +176,7 @@ class Agent:
             )
             run_is_local = runtime_is_local(runtime_config)
         validate_pairing(self.harness, taskset, runtime_config)
-        rollout = Rollout(
+        return Rollout(
             task=task,
             taskset=taskset,
             harness=self.harness,
@@ -173,22 +191,14 @@ class Agent:
             finalize_timeout=_merge(self.timeout.finalize, task.timeout.finalize),
             scoring_timeout=_merge(self.timeout.scoring, task.timeout.scoring),
             limits=self.limits,
-            interception=self._interception_for(run_is_local),
+            shared_urls=shared_urls,
+            interception=(
+                interception
+                if interception is not None
+                else self._interception_for(run_is_local)
+            ),
             runtime=runtime,
         )
-        trace = await rollout.run()
-        # Who produced this trace — so a program's traces stay attributable after the
-        # Agent objects are gone. Resolved per run: overrides and the live box win.
-        trace.info["agent"] = {
-            "harness": self.harness.config.id,
-            "model": ctx.model,
-            "runtime": {
-                "type": runtime_config.type,
-                "descriptor": rollout.runtime.descriptor if rollout.runtime else None,
-                "borrowed": runtime is not None,
-            },
-        }
-        return trace
 
     @asynccontextmanager
     async def provision(self, task: Task | None = None) -> AsyncIterator[Runtime]:

--- a/verifiers/v1/cli/debug.py
+++ b/verifiers/v1/cli/debug.py
@@ -25,7 +25,7 @@ from verifiers.v1.cli.resolve import (
 )
 from verifiers.v1.configs.debug import DebugConfig
 from verifiers.v1.decorators import invoke
-from verifiers.v1.env import resolve_runtime_config
+from verifiers.v1.resolve import resolve_runtime_config
 from verifiers.v1.runtimes import ProgramResult, Runtime, make_runtime
 from verifiers.v1.state import state_cls
 from verifiers.v1.taskset import Taskset

--- a/verifiers/v1/cli/validate.py
+++ b/verifiers/v1/cli/validate.py
@@ -31,7 +31,7 @@ from verifiers.v1.cli.resolve import (
 )
 from verifiers.v1.configs.validate import ValidateConfig
 from verifiers.v1.decorators import invoke
-from verifiers.v1.env import resolve_runtime_config
+from verifiers.v1.resolve import resolve_runtime_config
 from verifiers.v1.runtimes import make_runtime
 from verifiers.v1.state import state_cls
 from verifiers.v1.taskset import Taskset

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -1,14 +1,16 @@
-"""The environment: a taskset composed with an harness and a runtime.
+"""The environment: a program of agent interactions over a taskset.
 
-The Environment is the eval-level composition and *resolver* — it does not itself run
-rollouts. It holds the taskset, harness, runtime config, and timeouts; lists the tasks;
-and turns one task into a runnable `Episode` of `n` `Rollout`s, resolving per task the
-runtime (image + resources, with cli/task/default precedence) and the timeouts. Execution
-lives one level down: an `Episode` runs `n` `Rollout`s of a task and scores them
-(per-rollout `@reward`/`@metric`, then cross-rollout `@group_reward`); each `Rollout`
-runs one trajectory. The taskset's `@reward`/`@metric` get the rollout's runtime
-(read/exec inside it), so a task scores correctly under any harness; `@group_reward`s
-compare a task's rollouts.
+The Environment is the eval-level composition — it does not itself run rollouts. It
+holds the taskset and the timeouts/limits config, lists the tasks, and turns one task
+into a runnable `Episode`. Its program is the simplest one: a single `Agent` (the
+configured harness, the caller's model context, the harness's runtime policy) run `n`
+times on the task — every episode's rollouts are built through that internal Agent, so
+an eval run and a hand-written agent program resolve placement, timeouts, and pairing
+identically. Execution lives one level down: an `Episode` runs `n` `Rollout`s of a task
+and scores them (per-rollout `@reward`/`@metric`, then cross-rollout `@group_reward`);
+each `Rollout` runs one trajectory. The taskset's `@reward`/`@metric` get the rollout's
+runtime (read/exec inside it), so a task scores correctly under any harness;
+`@group_reward`s compare a task's rollouts.
 """
 
 import contextlib
@@ -18,37 +20,22 @@ from typing import Annotated, Literal
 from pydantic import Field, SerializeAsAny, model_validator
 from pydantic_config import BaseConfig
 
-from verifiers.v1.harness import Harness, HarnessConfig
+from verifiers.v1.agent import Agent
+from verifiers.v1.harness import HarnessConfig
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.decorators import discover_decorated
 from verifiers.v1.episode import Episode
 from verifiers.v1.types import ID
 from verifiers.v1.interception import InterceptionPool, RolloutLimits
+from verifiers.v1.resolve import TimeoutConfig, validate_pairing
 from verifiers.v1.retries import RetryConfig
-from verifiers.v1.rollout import Rollout
 from verifiers.v1.runtimes import (
-    RuntimeConfig,
     SubprocessConfig,
     runtime_is_local,
 )
 from verifiers.v1.task import Task
-from verifiers.v1.taskset import Taskset, TasksetConfig
+from verifiers.v1.taskset import TasksetConfig
 from verifiers.v1.mcp import serve_shared
-
-
-class TimeoutConfig(BaseConfig):
-    """Framework-enforced wall-clock timeouts per rollout stage, in seconds (None = no
-    limit). Each bounds one stage of `Rollout.run`: the taskset's `setup` hook, the harness
-    run, the taskset's `finalize` hook, then scoring."""
-
-    setup: float | None = None
-    """Max wall-clock for the taskset's `setup` hook (per-task runtime prep)."""
-    rollout: float | None = None
-    """Max wall-clock for the rollout (the harness run)."""
-    finalize: float | None = None
-    """Max wall-clock for the taskset's `finalize` hook (post-run work, before scoring)."""
-    scoring: float | None = None
-    """Max wall-clock for scoring — verify + rewards/metrics."""
 
 
 class StaticPoolConfig(BaseConfig):
@@ -185,100 +172,6 @@ class EnvServerConfig(EnvConfig):
 logger = logging.getLogger(__name__)
 
 
-def resolve_runtime_config(
-    base: RuntimeConfig, task: Task, warned: set[tuple[str, str]] | None = None
-) -> RuntimeConfig:
-    """Resolve a task's runtime config from a `base`: inject the task's `image` (a task with
-    an image must run in a container — refuse subprocess), and apply its `workdir` and
-    requested `resources` to the fields the runtime supports. Precedence is cli/toml > task >
-    default; a resource the runtime doesn't support warns once (deduped via `warned`). Shared
-    by `Environment.runtime_for` (rollouts) and the `validate` entrypoint."""
-    config = base
-    updates: dict = {}
-    if task.image is not None:
-        if isinstance(config, SubprocessConfig):
-            raise ValueError(
-                f"task {task.idx!r} requires image {task.image!r}, but the subprocess "
-                "runtime has no container; use the docker or prime runtime"
-            )
-        updates["image"] = task.image
-    workdir_spec = type(config).model_fields.get("workdir")
-    if (
-        task.workdir is not None
-        and workdir_spec is not None
-        and getattr(config, "workdir") == workdir_spec.default
-    ):
-        updates["workdir"] = task.workdir
-    for field, value in task.resources.model_dump(exclude_none=True).items():
-        spec = type(config).model_fields.get(field)
-        if spec is None:
-            key = (config.type, field)
-            if warned is not None and key not in warned:
-                warned.add(key)
-                logger.warning(
-                    "runtime %r doesn't support resource %r; ignoring it",
-                    config.type,
-                    field,
-                )
-        elif (
-            getattr(config, field) == spec.default
-        ):  # still the default → task may set it
-            updates[field] = value
-        # else: cli/toml changed it from the default → it wins over the task
-    return config.model_copy(update=updates) if updates else config
-
-
-def validate_pairing(
-    harness: Harness, taskset: Taskset, runtime_config: RuntimeConfig
-) -> None:
-    """Refuse a harness/taskset/runtime combination that cannot work: a taskset whose
-    tools (MCP) or user simulator the harness doesn't drive would run to completion with
-    the model never seeing them, and a `NEEDS_CONTAINER` taskset's world hooks would run
-    on the host under the subprocess runtime. Shared by `Environment` (once, at init)
-    and `Agent.run` (per run, against the resolved runtime)."""
-    if not harness.SUPPORTS_MCP and type(taskset).tools is not Taskset.tools:
-        raise ValueError(
-            f"Harness {harness.config.id!r} does not support MCP tools, but taskset "
-            f"{taskset.config.id!r} exposes tool servers (MCP). Run it with a harness "
-            f"that supports MCP (e.g. the default harness), or use a taskset without tools."
-        )
-    if not harness.SUPPORTS_USER_SIM and type(taskset).user is not Taskset.user:
-        raise ValueError(
-            f"Harness {harness.config.id!r} does not drive a user simulator, but taskset "
-            f"{taskset.config.id!r} defines one (Taskset.user). Run it with a harness that "
-            f"supports user simulation (e.g. the default harness), or use a taskset without one."
-        )
-    if taskset.NEEDS_CONTAINER and isinstance(runtime_config, SubprocessConfig):
-        raise ValueError(
-            f"Taskset {taskset.config.id!r} needs a container runtime "
-            "(NEEDS_CONTAINER), but this run resolves to the subprocess runtime; "
-            "use a docker or prime runtime."
-        )
-
-
-def cap_remote_harness_timeout(
-    harness_timeout: float | None, runtime_config: RuntimeConfig, task: Task
-) -> float | None:
-    """Remote sandboxes have a maximum lifetime of 24 hours: cap the harness timeout
-    there (with a warning) so a long run times out cleanly in the framework instead of
-    the provider killing the box mid-run. Shared by `Environment.episode` and
-    `Agent.run`."""
-    if (
-        harness_timeout is not None
-        and harness_timeout > 24 * 60 * 60
-        and not runtime_is_local(runtime_config)
-    ):
-        logger.warning(
-            "task %r resolves to a %.1f-hour harness timeout, but %s sandboxes have a "
-            "maximum lifetime of 24 hours; capping it at 24 hours",
-            task.idx,
-            harness_timeout / (60 * 60),
-            runtime_config.type,
-        )
-        return 24 * 60 * 60
-    return harness_timeout
-
-
 class Environment:
     def __init__(self, config: EnvConfig) -> None:
         from verifiers.v1.loaders import load_harness, load_taskset
@@ -301,35 +194,39 @@ class Environment:
                 "run.",
                 self.harness.config.id,
             )
-        self.setup_timeout = config.timeout.setup
-        self.harness_timeout = config.timeout.rollout
-        self.finalize_timeout = config.timeout.finalize
-        self.scoring_timeout = config.timeout.scoring
         self.limits = RolloutLimits(
             max_turns=config.max_turns,
             max_input_tokens=config.max_input_tokens,
             max_output_tokens=config.max_output_tokens,
             max_total_tokens=config.max_total_tokens,
         )
-        self._warned_resources: set[tuple[str, str]] = set()
+        self._agent: Agent | None = None
+        """The env's internal Agent — the single-agent program every episode runs. Built
+        on the first `episode()` (an Agent binds a `ModelContext` at construction, and the
+        env only sees one then); each episode passes its own `ctx` per rollout, so a cached
+        agent never pins a stale model."""
         self._shared_urls: dict[str, str] = {}
         self._interception: InterceptionPool | None = None
         """Eval-level serving resources, live only inside `serving()`: shared tool servers
         ({name: url}) and the interception pool. `episode()` injects them into every rollout
         so neither runner has to thread them through `Episode.run`/`Rollout.run`."""
 
-    def runtime_for(self, task: Task) -> RuntimeConfig:
-        """Resolve the runtime config for a task off the harness's runtime (see
-        `resolve_runtime_config`)."""
-        return resolve_runtime_config(
-            self.harness.config.runtime, task, self._warned_resources
-        )
+    def agent(self, ctx: ModelContext) -> Agent:
+        """The env's Agent: the configured harness with the harness's runtime policy and
+        the env's timeouts/limits. One instance backs every episode (its resolution state —
+        e.g. warn dedup — spans the eval); `ctx` only seeds the first construction."""
+        if self._agent is None:
+            self._agent = Agent(
+                self.harness, ctx, limits=self.limits, timeout=self.config.timeout
+            )
+        return self._agent
 
     def episode(self, task: Task, ctx: ModelContext, n: int = 1) -> Episode:
-        """Resolve `task` into a runnable episode of `n` rollouts: pick its runtime
-        (image + resources) and its timeouts (cli/toml > task > default, None = no limit),
-        build one `Rollout` per sample sharing them, and wrap them in an `Episode` (which
-        runs them and applies the taskset's `@group_reward`s across their traces).
+        """Resolve `task` into a runnable episode of `n` rollouts of the env's agent —
+        each rollout resolved by `Agent.rollout` (runtime from image/resources, timeouts
+        cli/toml > task > default, pairing validation) with the env's serving resources
+        injected — and wrap them in an `Episode` (which runs them and applies the
+        taskset's `@group_reward`s across their traces).
 
         A taskset with `@group_reward`s compares a task's rollouts, so it needs >=2 of
         them — refuse `n < 2` there (rather than silently scoring a group of one)."""
@@ -338,47 +235,18 @@ class Environment:
                 f"taskset defines @group_reward(s), which compare a task's rollouts and "
                 f"need >=2; got n={n} (pass -r/--num-rollouts >= 2)"
             )
-        runtime_config = self.runtime_for(task)
-        setup_timeout = (
-            self.setup_timeout if self.setup_timeout is not None else task.timeout.setup
-        )
-        harness_timeout = (
-            self.harness_timeout
-            if self.harness_timeout is not None
-            else task.timeout.harness
-        )
-        harness_timeout = cap_remote_harness_timeout(
-            harness_timeout, runtime_config, task
-        )
-        finalize_timeout = (
-            self.finalize_timeout
-            if self.finalize_timeout is not None
-            else task.timeout.finalize
-        )
-        scoring_timeout = (
-            self.scoring_timeout
-            if self.scoring_timeout is not None
-            else task.timeout.scoring
-        )
-        retries = self.config.retries
+        agent = self.agent(ctx)
         rollouts = [
-            Rollout(
-                task=task,
+            agent.rollout(
+                task,
                 taskset=self.taskset,
-                harness=self.harness,
                 ctx=ctx,
-                runtime_config=runtime_config,
-                setup_timeout=setup_timeout,
-                harness_timeout=harness_timeout,
-                finalize_timeout=finalize_timeout,
-                scoring_timeout=scoring_timeout,
-                limits=self.limits,
                 shared_urls=self._shared_urls,
                 interception=self._interception,
             )
             for _ in range(n)
         ]
-        return Episode(rollouts, self.taskset, retry=retries.rollout)
+        return Episode(rollouts, self.taskset, retry=self.config.retries.rollout)
 
     @contextlib.asynccontextmanager
     async def serving(self, tasks: list[Task]):

--- a/verifiers/v1/resolve.py
+++ b/verifiers/v1/resolve.py
@@ -1,0 +1,131 @@
+"""Per-run resolution: what a run may cost, where it runs, and whether the pairing works.
+
+These are the rules that turn "this harness, this taskset, this task" into one runnable
+placement — stage timeouts, the task-resolved runtime config, pairing validation, and
+the remote-lifetime cap. They live below both consumers: `Agent` (the program surface)
+resolves through them per run, and `Environment` (the eval surface) applies the same
+rules through its internal Agent — so a run behaves identically however it was reached.
+"""
+
+import logging
+
+from pydantic_config import BaseConfig
+
+from verifiers.v1.harness import Harness
+from verifiers.v1.runtimes import (
+    RuntimeConfig,
+    SubprocessConfig,
+    runtime_is_local,
+)
+from verifiers.v1.task import Task
+from verifiers.v1.taskset import Taskset
+
+logger = logging.getLogger(__name__)
+
+
+class TimeoutConfig(BaseConfig):
+    """Framework-enforced wall-clock timeouts per rollout stage, in seconds (None = no
+    limit). Each bounds one stage of `Rollout.run`: the taskset's `setup` hook, the harness
+    run, the taskset's `finalize` hook, then scoring."""
+
+    setup: float | None = None
+    """Max wall-clock for the taskset's `setup` hook (per-task runtime prep)."""
+    rollout: float | None = None
+    """Max wall-clock for the rollout (the harness run)."""
+    finalize: float | None = None
+    """Max wall-clock for the taskset's `finalize` hook (post-run work, before scoring)."""
+    scoring: float | None = None
+    """Max wall-clock for scoring — verify + rewards/metrics."""
+
+
+def resolve_runtime_config(
+    base: RuntimeConfig, task: Task, warned: set[tuple[str, str]] | None = None
+) -> RuntimeConfig:
+    """Resolve a task's runtime config from a `base`: inject the task's `image` (a task with
+    an image must run in a container — refuse subprocess), and apply its `workdir` and
+    requested `resources` to the fields the runtime supports. Precedence is cli/toml > task >
+    default; a resource the runtime doesn't support warns once (deduped via `warned`). Shared
+    by `Agent` (rollouts) and the `validate` entrypoint."""
+    config = base
+    updates: dict = {}
+    if task.image is not None:
+        if isinstance(config, SubprocessConfig):
+            raise ValueError(
+                f"task {task.idx!r} requires image {task.image!r}, but the subprocess "
+                "runtime has no container; use the docker or prime runtime"
+            )
+        updates["image"] = task.image
+    workdir_spec = type(config).model_fields.get("workdir")
+    if (
+        task.workdir is not None
+        and workdir_spec is not None
+        and getattr(config, "workdir") == workdir_spec.default
+    ):
+        updates["workdir"] = task.workdir
+    for field, value in task.resources.model_dump(exclude_none=True).items():
+        spec = type(config).model_fields.get(field)
+        if spec is None:
+            key = (config.type, field)
+            if warned is not None and key not in warned:
+                warned.add(key)
+                logger.warning(
+                    "runtime %r doesn't support resource %r; ignoring it",
+                    config.type,
+                    field,
+                )
+        elif (
+            getattr(config, field) == spec.default
+        ):  # still the default → task may set it
+            updates[field] = value
+        # else: cli/toml changed it from the default → it wins over the task
+    return config.model_copy(update=updates) if updates else config
+
+
+def validate_pairing(
+    harness: Harness, taskset: Taskset, runtime_config: RuntimeConfig
+) -> None:
+    """Refuse a harness/taskset/runtime combination that cannot work: a taskset whose
+    tools (MCP) or user simulator the harness doesn't drive would run to completion with
+    the model never seeing them, and a `NEEDS_CONTAINER` taskset's world hooks would run
+    on the host under the subprocess runtime. Applied by `Environment` (once, at init)
+    and by every `Agent` rollout (against the resolved runtime)."""
+    if not harness.SUPPORTS_MCP and type(taskset).tools is not Taskset.tools:
+        raise ValueError(
+            f"Harness {harness.config.id!r} does not support MCP tools, but taskset "
+            f"{taskset.config.id!r} exposes tool servers (MCP). Run it with a harness "
+            f"that supports MCP (e.g. the default harness), or use a taskset without tools."
+        )
+    if not harness.SUPPORTS_USER_SIM and type(taskset).user is not Taskset.user:
+        raise ValueError(
+            f"Harness {harness.config.id!r} does not drive a user simulator, but taskset "
+            f"{taskset.config.id!r} defines one (Taskset.user). Run it with a harness that "
+            f"supports user simulation (e.g. the default harness), or use a taskset without one."
+        )
+    if taskset.NEEDS_CONTAINER and isinstance(runtime_config, SubprocessConfig):
+        raise ValueError(
+            f"Taskset {taskset.config.id!r} needs a container runtime "
+            "(NEEDS_CONTAINER), but this run resolves to the subprocess runtime; "
+            "use a docker or prime runtime."
+        )
+
+
+def cap_remote_harness_timeout(
+    harness_timeout: float | None, runtime_config: RuntimeConfig, task: Task
+) -> float | None:
+    """Remote sandboxes have a maximum lifetime of 24 hours: cap the harness timeout
+    there (with a warning) so a long run times out cleanly in the framework instead of
+    the provider killing the box mid-run."""
+    if (
+        harness_timeout is not None
+        and harness_timeout > 24 * 60 * 60
+        and not runtime_is_local(runtime_config)
+    ):
+        logger.warning(
+            "task %r resolves to a %.1f-hour harness timeout, but %s sandboxes have a "
+            "maximum lifetime of 24 hours; capping it at 24 hours",
+            task.idx,
+            harness_timeout / (60 * 60),
+            runtime_config.type,
+        )
+        return 24 * 60 * 60
+    return harness_timeout

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -314,6 +314,17 @@ class Rollout:
                     logger.warning(
                         "runtime teardown failed (rollout %s)", trace.id, exc_info=True
                     )
+        # Who produced this trace — so it stays attributable (to an agent program's
+        # Agents, or an eval's env) after the objects are gone.
+        trace.info["agent"] = {
+            "harness": self.harness.config.id,
+            "model": ctx.model,
+            "runtime": {
+                "type": self.runtime_config.type,
+                "descriptor": runtime.descriptor,
+                "borrowed": not owns_runtime,
+            },
+        }
         logger.info(
             "rollout done: id=%s task=%s reward=%.3f turns=%d stop=%s",
             trace.id,


### PR DESCRIPTION
## What

Stacked on #1939. The `Environment` becomes the first consumer of the `Agent`: it is now a *program of agent interactions over a taskset*, running the simplest program — a single agent on the task, `n` times. Every episode's rollouts are built through an internal `Agent`, so a config-driven eval and a hand-written agent program resolve placement, stage timeouts, and pairing validation through one path. This is the substrate for pattern envs (proposer→solver, same-box judging, debate) as `Environment` subclasses that contribute only their role bindings and a program body — the machinery (episodes, serving, scoring, provenance) stays in the base.

## Changes

- **`verifiers/v1/resolve.py` (new)**: per-run resolution — `TimeoutConfig`, `resolve_runtime_config`, `validate_pairing`, `cap_remote_harness_timeout` — moved out of `env.py` to sit below both consumers (also breaks the `agent ← env` import cycle). Pure move, no behavior change.
- **`Agent.rollout()`**: the resolve-only half of `run()` — placement (task-resolved runtime or borrowed box), timeouts (agent > task, remote cap), pairing validation — returning the un-run `Rollout`. `run()` is now `rollout(...)` + await. The eval's serving resources (`shared_urls`, interception pool) inject here, so they never appear on the program-facing `run()`.
- **`Rollout.run()` stamps provenance itself**: `trace.info["agent"]` (harness, model, runtime type + descriptor, borrowed flag) moves from `Agent.run` into the rollout — **every** trace, eval or program, now carries it. One descriptor per rollout, queryable after the objects are gone.
- **`Environment`**: drops its mirrored resolution (`runtime_for`, the four per-stage timeout fields); `episode()` builds rollouts via `Environment.agent(ctx)` — one cached internal Agent per env (resolution state spans the eval; `ctx` still passes per rollout, so the env-server's per-request contexts keep working).
- Docs: env module docstring, `ARCHITECTURE.md` wiring sentence, and an "the eval runs on the same primitive" section in `docs/agent-programs.md`.

Net: 9 files, +224/−194 — mostly the move; `Environment.episode` shrinks from ~55 lines of resolution to a list comprehension.

## Not in this PR (deliberately)

The pattern-env contract itself — role bindings as config (`--solver.model ...`), an overridable program hook, `trainable`-trace marking for training one role of a multi-agent program. Those decisions overlap with #1941's topology tier and should land after that synthesis; this PR only puts the seam in place so they become subclass surface, not new machinery.

## Validation

- `ruff` + `pytest tests/v1` (non-e2e) pass.
- Live e2e matrix on the subprocess runtime (`-m "e2e and not docker and not prime and not modal"`): **19 passed** in `test_e2e.py` (incl. the shared-tool cases that run through the env-server worker pool — prime-rl's path) and all of `test_envs.py` — real model calls end-to-end through the rewired `Environment`.
- Live eval spot-check: both rollouts of an `echo-v1` eval return `reward=1.0` with per-rollout provenance stamps on their traces.
- `examples/agent_programs/smoke.py` re-run live: the agent-program path unchanged, stamp intact (now emitted by the rollout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make Environment consume an internal Agent for building episode rollouts
> - `Environment` now lazily constructs and caches an internal `Agent` (via `Environment.agent`), and delegates rollout construction to `Agent.rollout` rather than handling it directly. This aligns episode resolution behavior with agent programs.
> - `Agent` gains a new `rollout` method that returns a configured `Rollout` object without executing it, accepting optional `shared_urls` and `interception` overrides. `Agent.run` now delegates to this method.
> - Provenance stamping (`trace.info["agent"]`) moves from `Agent.run` to `Rollout.run`, so all rollouts (including env-internal ones) carry consistent harness, model, and runtime metadata.
> - `TimeoutConfig`, `resolve_runtime_config`, `validate_pairing`, and `cap_remote_harness_timeout` are extracted from [env.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1946/files#diff-69be10bd5960e88d88f219d4f261d0bdd16586857f9126451b04d05bac4c2cbb) into a new [resolve.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1946/files#diff-f08c899ac94aa963af53f5ee8a51a9dc4e532b19d4ae658c6644a37ecd7bbad1) module, and imports across the codebase are updated accordingly.
> - Behavioral Change: `Environment` no longer exposes per-timeout attributes or a `runtime_for(task)` method; callers needing per-task runtime resolution must use `resolve_runtime_config` from `verifiers.v1.resolve` directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 59b2ca1. 6 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->