### PR TITLE
feat: default prime runtime idle timeout to 1h

### DIFF
--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -47,6 +47,9 @@ class PrimeConfig(BaseConfig):
     """GPU spec, e.g. "A100" or "A100:2" (a bare count = provider-chosen type)."""
     disk: float = 5.0
     """Disk in GB."""
+    idle_timeout_minutes: int | None = 60
+    """Delete the sandbox after this many minutes with no activity (None disables it). Defaults
+    to 1h so a leaked sandbox self-terminates well before its 24h max lifetime."""
     creates_per_min: int | None = None
     """Pace sandbox creation to this many per minute, enforced host-wide across every
     env-server worker process (None/<= 0 disables it). (Tunnel creation is limited separately
@@ -85,6 +88,7 @@ class PrimeRuntime(Runtime):
             "disk_size_gb": self.config.disk,
             "gpu_count": gpu_count,
             "timeout_minutes": 24 * 60,  # Maximum lifetime of any sandbox.
+            "idle_timeout_minutes": self.config.idle_timeout_minutes,
             "gpu_type": gpu_type,
             "region": self.config.region,
         }

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -15,6 +15,7 @@ import tempfile
 from pathlib import Path, PurePosixPath
 from typing import ClassVar, Literal
 
+from pydantic import model_validator
 from pydantic_config import BaseConfig
 
 from verifiers.v1.errors import SandboxError
@@ -22,6 +23,9 @@ from verifiers.v1.runtimes.base import SERVICE_PORT, ProgramResult, Runtime, par
 from verifiers.v1.runtimes.limiters import creation_limiter
 
 logger = logging.getLogger(__name__)
+
+MAX_LIFETIME_MINUTES = 24 * 60
+"""Prime's fixed cap on any sandbox's total lifetime; the idle timeout must fit within it."""
 
 
 class PrimeConfig(BaseConfig):
@@ -54,6 +58,16 @@ class PrimeConfig(BaseConfig):
     """Pace sandbox creation to this many per minute, enforced host-wide across every
     env-server worker process (None/<= 0 disables it). (Tunnel creation is limited separately
     and globally — see limiters.TUNNEL_LIMITER.)"""
+
+    @model_validator(mode="after")
+    def _validate_idle_timeout(self) -> "PrimeConfig":
+        max_seconds = MAX_LIFETIME_MINUTES * 60
+        if self.idle_timeout is not None and self.idle_timeout > max_seconds:
+            raise ValueError(
+                f"idle_timeout ({self.idle_timeout}s) must not exceed the "
+                f"{max_seconds}s ({MAX_LIFETIME_MINUTES // 60}h) max sandbox lifetime"
+            )
+        return self
 
 
 class PrimeRuntime(Runtime):
@@ -94,7 +108,7 @@ class PrimeRuntime(Runtime):
             "memory_gb": self.config.memory,
             "disk_size_gb": self.config.disk,
             "gpu_count": gpu_count,
-            "timeout_minutes": 24 * 60,  # Maximum lifetime of any sandbox.
+            "timeout_minutes": MAX_LIFETIME_MINUTES,
             "idle_timeout_minutes": idle_minutes,
             "gpu_type": gpu_type,
             "region": self.config.region,

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -48,8 +48,7 @@ class PrimeConfig(BaseConfig):
     disk: float = 5.0
     """Disk in GB."""
     idle_timeout: float | None = 3600
-    """Seconds of inactivity before the sandbox self-deletes (None disables). Default 1h,
-    well under the 24h max lifetime."""
+    """Seconds of inactivity before the sandbox self-deletes (None disables)."""
     creates_per_min: int | None = None
     """Pace sandbox creation to this many per minute, enforced host-wide across every
     env-server worker process (None/<= 0 disables it). (Tunnel creation is limited separately

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -24,8 +24,8 @@ from verifiers.v1.runtimes.limiters import creation_limiter
 
 logger = logging.getLogger(__name__)
 
-MAX_LIFETIME_MINUTES = 24 * 60
-"""Prime's fixed cap on any sandbox's total lifetime; the idle timeout must fit within it."""
+MAX_LIFETIME = 24 * 60 * 60
+"""Prime's fixed cap (seconds) on any sandbox's total lifetime; the idle timeout must fit within it."""
 
 
 class PrimeConfig(BaseConfig):
@@ -61,11 +61,10 @@ class PrimeConfig(BaseConfig):
 
     @model_validator(mode="after")
     def _validate_idle_timeout(self) -> "PrimeConfig":
-        max_seconds = MAX_LIFETIME_MINUTES * 60
-        if self.idle_timeout is not None and self.idle_timeout > max_seconds:
+        if self.idle_timeout is not None and self.idle_timeout > MAX_LIFETIME:
             raise ValueError(
                 f"idle_timeout ({self.idle_timeout}s) must not exceed the "
-                f"{max_seconds}s ({MAX_LIFETIME_MINUTES // 60}h) max sandbox lifetime"
+                f"{MAX_LIFETIME}s ({MAX_LIFETIME // 3600}h) max sandbox lifetime"
             )
         return self
 
@@ -108,7 +107,7 @@ class PrimeRuntime(Runtime):
             "memory_gb": self.config.memory,
             "disk_size_gb": self.config.disk,
             "gpu_count": gpu_count,
-            "timeout_minutes": MAX_LIFETIME_MINUTES,
+            "timeout_minutes": MAX_LIFETIME // 60,
             "idle_timeout_minutes": idle_minutes,
             "gpu_type": gpu_type,
             "region": self.config.region,

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -25,7 +25,7 @@ from verifiers.v1.runtimes.limiters import creation_limiter
 logger = logging.getLogger(__name__)
 
 MAX_LIFETIME = 24 * 60 * 60
-"""Prime's fixed cap (seconds) on any sandbox's total lifetime; the idle timeout must fit within it."""
+"""Prime's fixed cap (seconds) on any sandbox's total lifetime."""
 
 
 class PrimeConfig(BaseConfig):

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -47,9 +47,9 @@ class PrimeConfig(BaseConfig):
     """GPU spec, e.g. "A100" or "A100:2" (a bare count = provider-chosen type)."""
     disk: float = 5.0
     """Disk in GB."""
-    idle_timeout_minutes: int | None = 60
-    """Delete the sandbox after this many minutes with no activity (None disables it). Defaults
-    to 1h so a leaked sandbox self-terminates well before its 24h max lifetime."""
+    idle_timeout: float | None = 3600
+    """Seconds of inactivity before the sandbox self-deletes (None disables). Default 1h,
+    well under the 24h max lifetime."""
     creates_per_min: int | None = None
     """Pace sandbox creation to this many per minute, enforced host-wide across every
     env-server worker process (None/<= 0 disables it). (Tunnel creation is limited separately
@@ -82,13 +82,20 @@ class PrimeRuntime(Runtime):
         # Map the resources onto prime's API (minutes, split GPU; memory/disk are already
         # GB). gpu_type/region are only sent when set (else provider-chosen).
         gpu_type, gpu_count = parse_gpu(self.config.gpu)
+        # prime's idle timeout is in whole minutes; convert from the seconds config surface
+        # (floored to the SDK's 1-minute minimum).
+        idle_minutes = (
+            max(1, round(self.config.idle_timeout / 60))
+            if self.config.idle_timeout is not None
+            else None
+        )
         options = {
             "cpu_cores": self.config.cpu,
             "memory_gb": self.config.memory,
             "disk_size_gb": self.config.disk,
             "gpu_count": gpu_count,
             "timeout_minutes": 24 * 60,  # Maximum lifetime of any sandbox.
-            "idle_timeout_minutes": self.config.idle_timeout_minutes,
+            "idle_timeout_minutes": idle_minutes,
             "gpu_type": gpu_type,
             "region": self.config.region,
         }

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -9,6 +9,7 @@ direction (a program in the sandbox reaching a host service) is the shared host-
 import asyncio
 import contextlib
 import logging
+import math
 import shlex
 import tempfile
 from pathlib import Path, PurePosixPath
@@ -84,7 +85,7 @@ class PrimeRuntime(Runtime):
         # prime's idle timeout is in whole minutes; convert from the seconds config surface
         # (floored to the SDK's 1-minute minimum).
         idle_minutes = (
-            max(1, round(self.config.idle_timeout / 60))
+            max(1, math.ceil(self.config.idle_timeout / 60))
             if self.config.idle_timeout is not None
             else None
         )


### PR DESCRIPTION
## Summary

- Add `idle_timeout` to `PrimeConfig` (seconds, default `3600` = 1h) and thread it through `PrimeRuntime.start` into `CreateSandboxRequest`.
- Prime sandboxes now self-terminate after 1h of inactivity by default, so a leaked sandbox is reclaimed well before its 24h max lifetime (`timeout_minutes`) instead of costing a full day.
- The config surface is in seconds to match how time is expressed everywhere else in v1 (`TimeoutConfig`, task timeouts); it's converted to prime's whole-minute API in `start` (ceil'd, floored to the SDK's 1-minute minimum).
- Reject an `idle_timeout` above the 24h max sandbox lifetime at config time (via a shared `MAX_LIFETIME_MINUTES` constant), instead of letting it fail at sandbox creation when the derived minutes exceed `timeout_minutes`.
- Set `tools.runtime.idle_timeout = null` to disable, or to any positive number of seconds up to 24h to tune it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default Prime sandbox lifecycle (idle self-delete after 1h), which can terminate long-idle evals unless tuned or disabled via `idle_timeout = null`.
> 
> **Overview**
> Prime sandboxes now get a configurable **idle timeout** so leaked sandboxes are reclaimed after inactivity instead of running until the 24h max lifetime.
> 
> `PrimeConfig` gains `idle_timeout` in **seconds** (default **3600**, `None` disables). A validator rejects values above the shared **`MAX_LIFETIME`** (24h) cap. `PrimeRuntime.start` maps seconds to Prime’s whole-minute API (`idle_timeout_minutes`, ceil with a 1-minute floor) and uses `MAX_LIFETIME` for `timeout_minutes` instead of an inline constant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f7c169dd793d0d398396f084f4eaa128610b4e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default prime runtime idle timeout to 1 hour
> - Adds an `idle_timeout` field to `PrimeConfig` (default 3600s) that is passed to sandbox creation as `idle_timeout_minutes`, causing sandboxes to self-delete after 60 minutes of inactivity by default.
> - A model-level validator enforces that `idle_timeout` does not exceed the 24h `MAX_LIFETIME` constant; set `idle_timeout=None` to disable idle timeout entirely.
> - Risk: existing sandboxes that relied on no idle timeout will now be terminated after 1 hour of inactivity unless `idle_timeout` is explicitly set to `None`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7f7c169.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->