### PR TITLE
v1 eval dashboard: wrap the output path instead of truncating it

### DIFF
--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -204,7 +204,7 @@ def Overview(config: EvalConfig) -> Table:
     limits, timeouts = _aligned([_limits(config), _timeouts(config)])
     grid.add_row("limits", limits)
     grid.add_row("timeouts", timeouts)
-    grid.add_row("output", str(output_path(config)))
+    grid.add_row("output", Text(str(output_path(config)), overflow="fold"))
     return grid
 
 


### PR DESCRIPTION
The Overview's output row used rich's default ellipsis overflow, which cut off exactly the part that distinguishes one run from another (the trailing uuid) on narrow terminals. Fold it onto the next line(s) instead so the full path is always readable (and copyable, e.g. for --resume).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single display tweak in the Rich eval dashboard; no runtime, auth, or data-path changes.
> 
> **Overview**
> The eval `--rich` dashboard **Overview** row for **output** no longer uses Rich’s default ellipsis truncation on narrow terminals.
> 
> The value is rendered as `Text(..., overflow="fold")` so long `output_path` strings wrap onto additional lines, keeping the trailing run-identifying segment visible and easier to copy (e.g. for `--resume`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 108e5474e4579bb647cb16c0f3abb924bea7c25b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wrap long output paths in the v1 eval dashboard Overview table
> Changes the 'output' cell in the Overview table to use a Rich `Text` object with `overflow='fold'` instead of a plain string, so long output paths wrap rather than overflow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 108e547.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->