### PR TITLE
v1 eval dashboard: wrap around when paging with the arrows

### DIFF
--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -513,9 +513,10 @@ class Pager:
     whenever everything fits on one page, so paging re-anchors and re-opens on page 1 if rollouts
     overflow again after a resize. `count` (the page count, set each render by `_paginate`) gates the
     arrows: they're inert while a single page fits, so a stray press before rollouts overflow can't
-    switch off auto-advance or offset the starting page once paging begins. The chosen page is
-    clamped to `count` (it can shrink on a resize; it otherwise only grows, as rollouts are never
-    removed)."""
+    switch off auto-advance or offset the starting page once paging begins. The arrows wrap around
+    (left on the first page lands on the last, right on the last lands on the first), so the pages
+    form a circle rather than dead-ending. The chosen page is still clamped to `count` between
+    presses (it can shrink on a resize; it otherwise only grows, as rollouts are never removed)."""
 
     def __init__(self) -> None:
         self.page = 0
@@ -526,7 +527,7 @@ class Pager:
     def on_key(self, key: str) -> None:
         if key in ("left", "right") and self.count > 1:
             self.manual = True
-            self.page += 1 if key == "right" else -1
+            self.page = (self.page + (1 if key == "right" else -1)) % self.count
 
     def index(self, now: float) -> int:
         # Track the auto page while it drives, so the first arrow continues from what's on screen


### PR DESCRIPTION
Left on the first page lands on the last and right on the last lands on the first, so the pages form a circle rather than dead-ending at either edge. Auto-advance and the single-page arrow gating are unchanged; the clamp in manual mode still covers a page count that shrinks on a resize.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only pager behavior in the eval dashboard; no auth, data, or eval execution paths touched.
> 
> **Overview**
> Manual **left/right** paging in the v1 eval rich dashboard now **wraps**: from page 1, left goes to the last page; from the last page, right goes to page 1.
> 
> Implementation is a one-line change in `Pager.on_key` — page updates use modulo by `count` instead of `+= 1` / `-= 1`. **Auto-advance**, single-page arrow gating, and **manual-mode clamping** on resize in `index()` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0afac361cb3157a0342aa983b65c51bf3e750d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wrap left/right arrow paging in the v1 eval dashboard
> Updates `Pager.on_key` in [eval.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1951/files#diff-0a27b905958929f3ae9e01937dd7e3cf97a60dec137caddcbf87792784fc9035) to use modulo arithmetic `(page + delta) % count` so navigating past the last page jumps to the first, and vice versa.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c0afac3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->