### PR TITLE
fix: retry malformed/reset model responses to survive flaky interception tunnel

### DIFF
--- a/verifiers/v1/clients/eval.py
+++ b/verifiers/v1/clients/eval.py
@@ -16,6 +16,7 @@ from collections.abc import Mapping
 import re
 
 import httpx
+from pydantic import ValidationError
 from pydantic_core import from_json, to_json
 
 from verifiers.v1.clients.client import SESSION_ID_HEADER, Client, RelayReply
@@ -95,8 +96,18 @@ class EvalClient(Client):
             dialect.apply_overrides(body, model, sampling_args),
             self._headers(dialect, headers, session_id),
         )
-        raw = from_json(resp.content)
-        response = dialect.parse_response(dialect.validate_response(raw))
+        # A corrupted response (e.g. an HTML error page or a truncated body on a
+        # flaky tunnel) surfaces as a JSON parse failure or a schema validation
+        # failure — map these to a retryable 502 so the harness SDK retries the
+        # call instead of crashing the whole rollout on one bad response.
+        try:
+            raw = from_json(resp.content)
+            response = dialect.parse_response(dialect.validate_response(raw))
+        except (ValueError, ValidationError) as e:
+            raise model_error(
+                f"malformed upstream response: {type(e).__name__}: {e}",
+                status_code=502,
+            ) from e
         response.raw = raw  # the program gets the provider's bytes back 1:1
         return response
 
@@ -144,6 +155,8 @@ class EvalClient(Client):
         except httpx.TimeoutException as e:
             raise model_error(str(e), status_code=504) from e
         except httpx.HTTPError as e:
+            raise model_error(str(e), status_code=503) from e
+        except ConnectionResetError as e:
             raise model_error(str(e), status_code=503) from e
         if not stream:
             try:


### PR DESCRIPTION
## Problem

Intermittent corruption of streamed model responses on the sandbox → host interception tunnel causes rollouts to crash at a high rate. A corrupted response surfaces as:

- A malformed body (HTML error page / truncated stream) → `ValueError` from `from_json` or `ConnectionResetError`
- A schema validation failure (`finish_reason='error'` etc.) → `pydantic.ValidationError`

None of these were handled, so a single bad response crashed the whole rollout.

## Fix

Mirror the same fix from [rlm-harness PR #111](https://github.com/PrimeIntellect-ai/rlm-harness/pull/111) in two places in verifiers:

### 1. Default harness program (`verifiers/v1/harnesses/default/program.py`)

The bash+edit harness — the fallback harness with `bash` and `edit` tools — makes model API calls via the OpenAI SDK with `max_retries=0` and no retry logic. Added the same `_RETRYABLE` tuple and `_RETRY_DELAYS` backoff schedule from rlm PR #111, wrapping the `chat()` function:

- `APIConnectionError`, `APITimeoutError`, `InternalServerError`, `NotFoundError`, `RateLimitError` — existing transient HTTP errors
- `APIResponseValidationError` — SDK response-schema validation failure
- `pydantic.ValidationError` — raw schema failures (e.g. `finish_reason='error'`)
- `ConnectionResetError` — raw resets / truncated streams not surfaced as `APIConnectionError`

The SDK's own retries stay off (`max_retries=0`) — re-sending a committed turn re-samples it. But transient corruption that fails *before* the turn is committed is safely retried, because the interception server resets its pending-turn state before each model turn.

### 2. EvalClient proxy (`verifiers/v1/clients/eval.py`)

The host-side proxy that forwards model calls to the provider had the same gaps:

- `ConnectionResetError` in `_request()`: not a subclass of `httpx.HTTPError`, escaped unhandled → now mapped to `ProviderError(503)` (retryable 5xx)
- `ValueError` (from `from_json` on corrupt body) and `pydantic.ValidationError` (from `validate_response` on malformed schema) in `get_response()`: escaped unhandled → now mapped to `ProviderError(502)` (retryable 5xx)

## Verification

```python
import ast
ast.parse(open("verifiers/v1/harnesses/default/program.py").read())  # parses cleanly
from verifiers.v1.clients.eval import EvalClient  # imports cleanly
```