### PR TITLE
Fix dash-prefixed prompts in CLI harnesses

### DIFF
--- a/verifiers/v1/harnesses/codex/harness.py
+++ b/verifiers/v1/harnesses/codex/harness.py
@@ -105,6 +105,7 @@ class CodexHarness(Harness[CodexHarnessConfig]):
             "-c",
             f"model_providers.{PROVIDER}.requires_openai_auth=false",
             *tool_config,
+            "--",
             prompt,
         ]
         return await runtime.run_program(argv, env)

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -140,7 +140,7 @@ class RLMHarness(Harness[RLMHarnessConfig]):
             env["RLM_MCP_CONFIG"] = json.dumps(
                 {"mcpServers": {name: {"url": url} for name, url in mcp_urls.items()}}
             )
-        return await runtime.run_program([RLM_BIN, prompt], env)
+        return await runtime.run_program([RLM_BIN, "--", prompt], env)
 
     @metric
     async def rlm(self, trace: Trace, runtime: Runtime) -> dict[str, float]:


### PR DESCRIPTION
## Overview

This updates the CLI harness launch argv for agents that pass the task prompt as a positional argument, so prompts that begin with `-` are treated as prompt text instead of CLI flags.

## Details

Codex and RLM both invoke their underlying CLIs with the task prompt as a positional argument. Adding the standard `--` delimiter before the prompt preserves normal prompt behavior while making dash-prefixed task instructions parse correctly. The other built-in harnesses were checked and either pass prompts through named options or `--key=value` arguments, so they do not need the same positional delimiter change.

A focused regression test covers the Codex and RLM argv shape for dash-prefixed prompts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small argv-shape change for two harness launch paths; no auth, data, or API contract changes.
> 
> **Overview**
> **Codex** and **RLM** launch CLIs with the task prompt as a trailing positional argument. Without a delimiter, prompts that start with `-` can be parsed as options instead of prompt text.
> 
> Both harnesses now insert the standard `--` immediately before the prompt in `run_program` argv (`codex exec` … `--`, prompt; `rlm` `--`, prompt). Other built-in harnesses already pass prompts via named flags or `--key=value` forms and are unchanged.
> 
> A parametrized test records argv for dash-prefixed prompts and asserts the last two elements are `["--", prompt]` for Codex and RLM.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddc529addb9a4a31527d715e8cc05b0971a51db4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix dash-prefixed prompts in CLI harnesses by inserting `--` separator
> Adds an explicit `--` argument before the prompt in both [CodexHarness](https://github.com/PrimeIntellect-ai/verifiers/pull/1957/files#diff-904c37fe437bb3b42e0238258ed85a8c6cede02461216bcf9c7417c5f3b72b7b) and [RLMHarness](https://github.com/PrimeIntellect-ai/verifiers/pull/1957/files#diff-3955da24b5fd88f62482297bbda7ba0936f633927f15576db27fed6e58f668ec) `launch` methods. This prevents prompts starting with a dash from being misinterpreted as CLI flags by the underlying binaries.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b9d3308.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->