### PR TITLE
feat: stamp message nodes with a creation timestamp

### DIFF
--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import binascii
 import hashlib
 import json
+import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -73,6 +74,12 @@ class MessageNode(StrictBaseModel):
     """True iff a model call produced this message (the response passed to `commit`); False for
     every prompt-supplied message — including assistant/tool messages fabricated as context
     the model never generated, which role alone can't tell apart from real turns."""
+    timestamp: float = Field(default_factory=time.time)
+    """Wall-clock epoch seconds when this node was created. Nodes materialize at turn commit,
+    so a turn's new input nodes and its assistant node carry (near-)identical stamps and the
+    delta between consecutive sampled nodes is that turn's harness + inference wall-clock.
+    Reused prefix nodes keep the stamp from the turn that first created them. Serialized, so
+    a dump re-validated from wire/disk keeps the original times."""
     token_ids: list[int] = Field(default_factory=list)
     """This message's delta contribution to the cumulative token sequence: its leading
     template scaffold + its own tokens — for an assistant, the generation-prompt scaffold


### PR DESCRIPTION
## Summary
- Add a `timestamp` field to `MessageNode` — wall-clock epoch seconds auto-stamped at node creation (`default_factory=time.time`), matching the float-epoch convention of the trace's `Timing`/`TimeSpan` fields
- Nodes materialize at turn commit, so a turn's new input nodes and its assistant node share a stamp and the delta between consecutive sampled nodes measures that turn's harness + inference wall-clock; reused prefix nodes keep the stamp from the turn that first created them
- Serialized like any other node field: rides the env-server wire and `traces.jsonl` (`to_record`), and a re-validated dump keeps the original times

## Verification
- `uv run ruff check` and `uv run pytest tests/v1/test_graph.py tests/v1/test_trace.py` pass
- End-to-end: ran Terminal-Bench 2 `fix-git` via the harbor taskset on a Prime sandbox (reward 1.0, 11 turns, 62s generation span) — nodes committed together share a stamp, consecutive turn commits are spaced by real tool-execution + inference time (+2.0s … +10.8s), and all stamps fall inside `timing.generation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional metadata on MessageNode with no changes to commit, dedup, or token attribution logic.
> 
> **Overview**
> Adds a **`timestamp`** field on **`MessageNode`** — wall-clock epoch seconds set at node creation via `default_factory=time.time`, aligned with trace **`Timing`** / **`TimeSpan`** float-epoch style.
> 
> New nodes get stamped when turns commit in **`_commit_turn`** (including paths that use **`model_construct`** without an explicit value). Nodes created in the same commit share nearly the same stamp; spacing between consecutive sampled nodes reflects per-turn harness + inference time, while prefix-reused nodes keep the stamp from the turn that first materialized them. The field is part of the normal Pydantic model, so it flows through env-server serialization and **`traces.jsonl`** and is preserved on reload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1504965d738428591d185d0dfce5b458fb89b91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add creation timestamp to `MessageNode`
> Adds a `timestamp` field (float, epoch seconds) to the `MessageNode` Pydantic model in [graph.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1960/files#diff-64c9d635eb215902a512c9e8ab316fd9b9967c36db03d4049aacc812cdfbd740), populated automatically via `default_factory=time.time`. The field is included in serialization and deserialization.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e150496. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->