### PR TITLE
fix: precise eval resuming — reload finished traces so a resumed run matches the uninterrupted one

### DIFF
--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -231,15 +231,11 @@ def Progress(
     rollouts: list[Rollout],
     start: float,
     page: tuple[int, int] | None = None,
-    finished: list[Trace] | None = None,
 ) -> Group:
-    # On resume, `finished` holds the kept on-disk rollouts (reloaded as finished traces); count
-    # them alongside this session's so progress, reward, err, and the breakdown cover the whole
-    # run. `rollouts` is only this session's (owed) work, so the total adds the kept ones back.
-    done = (finished or []) + [
-        r.trace for r in rollouts if r.phase == Phase.DONE
-    ]  # fully scored
-    total = len(finished or []) + len(rollouts)
+    # On resume, `rollouts` includes the previous session's kept rollouts (as `Finished`), so
+    # progress, reward, err, and the breakdown cover the whole run, not just this session's.
+    done = [r.trace for r in rollouts if r.phase == Phase.DONE]  # fully scored
+    total = len(rollouts)
     # Headline reward = mean over non-errored; when any errored, `format_mean` appends the
     # global avg (errored count as 0) in parens. `err` is the share that errored.
     reward = format_mean(done, lambda t: t.reward)
@@ -594,7 +590,6 @@ def _render(
     config: EvalConfig,
     start: float,
     pager: Pager,
-    finished: list[Trace] | None = None,
     push: "PushState | None" = None,
 ) -> Group:
     now = time.time()
@@ -606,7 +601,7 @@ def _render(
     # rows fill what's left; page through them (timer / arrows) when they'd overflow (else rich
     # truncates).
     footer = _push_footer(push)
-    top = Group(header, Progress(rollouts, start, finished=finished), Rule(style="dim"))
+    top = Group(header, Progress(rollouts, start), Rule(style="dim"))
     reserved = len(_CONSOLE.render_lines(top))
     if footer is not None:
         reserved += len(_CONSOLE.render_lines(footer))
@@ -616,7 +611,6 @@ def _render(
         rollouts,
         start,
         page=(index + 1, count) if count > 1 else None,
-        finished=finished,
     )
     parts = [
         header,
@@ -634,18 +628,17 @@ async def dashboard(
     rollouts: list[Rollout],
     config: EvalConfig,
     start: float,
-    finished: list[Trace] | None = None,
     push: "PushState | None" = None,
 ):
     """Refresh the live eval view until the `with` block exits, then a final frame. Left/right
-    arrows page through rollout rows when they overflow the screen. On resume, `finished` carries
-    the kept on-disk rollouts (reloaded as finished traces) so the counts and scores cover the
-    whole run, not just this session's re-run rollouts. `push` is the shared `--push` status the
-    view renders as a line under the rollouts once the upload starts (dim -> white URL / red error),
-    updated by the caller as the inline upload runs and lands."""
+    arrows page through rollout rows when they overflow the screen. On resume, `rollouts`
+    includes the previous session's kept rollouts (as finished ones), so the rows, counts, and
+    scores cover the whole run, not just this session's re-run rollouts. `push` is the shared
+    `--push` status the view renders as a line under the rollouts once the upload starts (dim ->
+    white URL / red error), updated by the caller as the inline upload runs and lands."""
     pager = Pager()
     async with live_view(
-        lambda: _render(rollouts, config, start, pager, finished, push),
+        lambda: _render(rollouts, config, start, pager, push),
         on_key=pager.on_key,
     ):
         yield

--- a/verifiers/v1/cli/eval/resume.py
+++ b/verifiers/v1/cli/eval/resume.py
@@ -1,27 +1,27 @@
-"""Resume an interrupted eval: re-run only the rollouts a previous run didn't finish.
+"""Resume an interrupted eval: reload its finished rollouts and run only the rest.
 
 A run writes `config.toml` + `traces.jsonl` into its output dir. `--resume <dir>` reloads
-that config verbatim (so it takes no other flags) and writes back into the same dir, running
-only the rollouts still owed: the *missing* ones (never written — the run was interrupted) and
-the *errored* ones (written with an error). Good rollouts are kept; errored ones are dropped
-and redone. A group-scored taskset is resumed a whole task at a time (its rollouts are scored
-together), so any task that isn't fully complete is redone from scratch.
+that config verbatim (so it takes no other flags) and writes back into the same dir. `load`
+brings the good saved rollouts back into memory and re-runs only what's still owed: the
+*missing* rollouts (never written — the run was interrupted) and the *errored* ones (written
+with an error; dropped and redone). The loaded traces rejoin the run everywhere — counted,
+displayed, pushed, and printed alongside this session's — so a resumed run picks up exactly
+where the interrupted one stopped. A group-scored taskset is resumed a whole task at a time
+(its rollouts are scored together), so any task that isn't fully complete is redone from
+scratch.
 """
 
 import json
 import tomllib
 from collections import defaultdict
-from collections.abc import Iterator
 from pathlib import Path
 
 from pydantic_core import from_json
 
-from verifiers.v1.cli.output import CONFIG_FILE, TRACES_FILE, read_traces
+from verifiers.v1.cli.output import CONFIG_FILE, TRACES_FILE
 from verifiers.v1.configs.eval import EvalConfig
-from verifiers.v1.state import state_cls
-from verifiers.v1.task import WireTask
-from verifiers.v1.taskset import Taskset
-from verifiers.v1.trace import Trace
+from verifiers.v1.rollout import Phase, Rollout
+from verifiers.v1.trace import Trace, WireTrace
 
 
 def split_resume(argv: list[str]) -> tuple[Path | None, list[str]]:
@@ -53,80 +53,61 @@ def load_resume_config(resume_dir: Path) -> EvalConfig:
     return config
 
 
-def _read_results(results_path: Path) -> Iterator[tuple[int, int, bool]]:
-    """Stream `(file reference, task idx, errored)` without retaining decoded traces."""
-    if not results_path.exists():
-        return
-    with results_path.open("rb") as results:
-        while True:
-            offset = results.tell()
-            line = results.readline()
-            if not line:
-                break
-            if line.strip():
+class Finished(Rollout):
+    """A finished rollout reloaded from a previous session (see `load`): carries just the
+    surface the dashboard reads (`trace`/`task`/`phase`/`runtime`), so a resumed run's kept
+    rollouts render exactly like this session's."""
+
+    def __init__(self, trace: Trace) -> None:
+        self.trace = trace
+        self.task = trace.task
+        self.phase = Phase.DONE
+        self.runtime = None
+
+
+def load(
+    resume_dir: Path, selected_idxs: list[int], num_rollouts: int, group: bool
+) -> tuple[list[Trace], dict[int, int]]:
+    """Load the good saved rollouts back into memory as finished traces and diff them against
+    the run's target (`num_rollouts` per selected task): returns (the kept traces, rollouts
+    owed per task idx). An errored trace is dropped and re-run; a group-scored task is kept
+    only if fully complete, else its whole group is redone. Rewrites `traces.jsonl` to just
+    the kept rows — verbatim, via a temp file + atomic rename, so an interrupted resume can't
+    corrupt the prior good results — and the resumed rollouts then append. `WireTrace` reads
+    any taskset's saved traces without importing it."""
+    path = resume_dir / TRACES_FILE
+    selected = set(selected_idxs)
+    good: dict[int, list[bytes]] = defaultdict(list)
+    if path.exists():
+        with path.open("rb") as results:
+            for line in results:
+                if not line.strip():
+                    continue
                 try:
                     row = from_json(line)
                 except ValueError:
                     row = json.loads(line)
-                yield offset, row["task"]["idx"], bool(row.get("errors"))
-
-
-def plan(
-    resume_dir: Path, selected_idxs: list[int], num_rollouts: int, group: bool
-) -> tuple[list[int], dict[int, int]]:
-    """Diff the saved results against the run's target (`num_rollouts` per selected task).
-    Returns (byte offsets of rows to keep, rollouts owed per task idx). An errored trace is
-    dropped and re-run; a group-scored task is kept only if fully complete, else its whole group
-    is redone."""
-    # Retain only the offsets resume can reuse; trace payloads stay on disk.
-    selected = set(selected_idxs)
-    by_idx: dict[int, list[int]] = defaultdict(list)
-    for offset, idx, errored in _read_results(resume_dir / TRACES_FILE):
-        if idx in selected and not errored and len(by_idx[idx]) < num_rollouts:
-            by_idx[idx].append(offset)
-    keep: list[int] = []
+                idx = row["task"]["idx"]
+                if (
+                    idx in selected
+                    and not row.get("errors")
+                    and len(good[idx]) < num_rollouts
+                ):
+                    good[idx].append(line if line.endswith(b"\n") else line + b"\n")
+    keep: list[bytes] = []
     owed: dict[int, int] = {}
     for idx in selected_idxs:
-        good = by_idx.get(idx, [])
-        if group:
-            if len(good) >= num_rollouts:
-                keep.extend(good)
-            else:
-                owed[idx] = num_rollouts  # re-run the whole group; keep none of it
-        else:
-            keep.extend(good)
-            missing = num_rollouts - len(good)
-            if missing:
-                owed[idx] = missing
-    return keep, owed
-
-
-def rewrite_results(resume_dir: Path, keep: list[int]) -> None:
-    """Replace `traces.jsonl` with just the kept (good) traces; resumed rollouts append. Via a
-    temp file + atomic rename, so an interrupted resume can't corrupt the prior good results."""
-    path = resume_dir / TRACES_FILE
+        rows = good.get(idx, [])
+        if group and len(rows) < num_rollouts:
+            owed[idx] = num_rollouts  # re-run the whole group; keep none of it
+            continue
+        keep.extend(rows)
+        if missing := num_rollouts - len(rows):
+            owed[idx] = missing
     tmp = path.with_suffix(".jsonl.tmp")
-    if not keep:
-        tmp.write_bytes(b"")
-        tmp.replace(path)
-        return
-    # Re-read retained rows by offset while building the atomic replacement.
-    with path.open("rb") as results, tmp.open("wb") as output:
-        for offset in keep:
-            results.seek(offset)
-            raw = results.readline()
-            output.write(raw)
-            if not raw.endswith(b"\n"):
-                output.write(b"\n")
+    tmp.write_bytes(b"".join(keep))
     tmp.replace(path)
-
-
-def load_kept(resume_dir: Path, taskset: Taskset) -> list[Trace]:
-    """Reload the kept (good) traces as finished `Trace`s, so a resumed run's live dashboard counts
-    them toward the whole run (progress, reward, err, and the usage/time breakdown). Call *after*
-    `rewrite_results`, which leaves only the kept rows on disk. `WireTask` reads any taskset's saved
-    task without a runtime or its `Task` type (mirrors `replay`)."""
-    return read_traces(resume_dir, Trace[WireTask, state_cls(type(taskset))])
+    return [WireTrace.model_validate_json(line) for line in keep], owed
 
 
 def nothing_to_resume_msg(resume_dir: Path, num_tasks: int, num_rollouts: int) -> str:

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -37,26 +37,22 @@ async def run_eval(env: Environment, config: EvalConfig) -> list[Trace]:
     )
     out = output_path(config)
     # Write config.toml up front, then persist each trace as it completes (so the results are
-    # durable mid-run, not only at the end). On resume, keep the saved config + good traces and
-    # run only the owed rollouts. One lock serializes worker-thread appends from concurrent
-    # rollouts while keeping large trace serialization off the event loop.
+    # durable mid-run, not only at the end). One lock serializes worker-thread appends from
+    # concurrent rollouts while keeping large trace serialization off the event loop.
     owed: dict[str, int] | None = None
-    # On resume, the kept (good) on-disk rollouts, reloaded as finished traces so the live
-    # dashboard counts the whole run (progress, reward, err, usage/time) rather than only this
-    # session's re-run rollouts. Only the --rich dashboard reads them, so skip the load otherwise.
+    # On resume, the kept (good) on-disk rollouts rejoin the run as finished traces: displayed,
+    # returned, pushed, and printed alongside this session's, with only the owed rollouts re-run
+    # — so the resumed run is indistinguishable from one that was never interrupted.
     finished: list[Trace] = []
     if config.resume is not None:
         group = bool(discover_decorated(env.taskset, "group_reward"))
-        keep, owed = resume.plan(
+        finished, owed = resume.load(
             out, [t.idx for t in tasks], config.num_rollouts, group
         )
         if not owed:  # already complete - report it and exit successfully
             print(resume.nothing_to_resume_msg(out, len(tasks), config.num_rollouts))
             raise SystemExit(0)
         tasks = [task for task in tasks if owed.get(task.idx)]
-        resume.rewrite_results(out, keep)
-        if config.rich:
-            finished = resume.load_kept(out, env.taskset)
         logger.info(
             "resuming %s: %d task(s), %d rollout(s) owed",
             out,
@@ -88,7 +84,9 @@ async def run_eval(env: Environment, config: EvalConfig) -> list[Trace]:
             env.episode(task, ctx, n=owed[task.idx] if owed else config.num_rollouts)
             for task in tasks
         ]
-        rollouts = [rollout for episode in episodes for rollout in episode.rollouts]
+        rollouts = [resume.Finished(trace) for trace in finished] + [
+            rollout for episode in episodes for rollout in episode.rollouts
+        ]
         # --push in the live dashboard: share a status the dashboard renders as a line under the
         # rollouts once the run finishes and the upload begins (dim -> green URL / red error), and
         # do the upload inline below so it resolves on screen. Only the rich path has a dashboard;
@@ -99,7 +97,7 @@ async def run_eval(env: Environment, config: EvalConfig) -> list[Trace]:
 
             push_state = PushState()
         display = (
-            dashboard(rollouts, config, start, finished=finished, push=push_state)
+            dashboard(rollouts, config, start, push=push_state)
             if config.rich
             else contextlib.nullcontext()
         )
@@ -107,7 +105,9 @@ async def run_eval(env: Environment, config: EvalConfig) -> list[Trace]:
             results = await asyncio.gather(
                 *(episode.run(semaphore, on_complete) for episode in episodes)
             )
-            traces = [trace for episode_traces in results for trace in episode_traces]
+            traces = finished + [
+                trace for episode_traces in results for trace in episode_traces
+            ]
             if (
                 push_state is not None
             ):  # upload off the event loop so the view keeps refreshing
@@ -178,14 +178,14 @@ async def run_eval_server(config: EvalConfig) -> list[Trace]:
         if config.num_tasks is not None:
             idxs = idxs[: config.num_tasks]
         out = output_path(config)
+        finished: list[Trace] = []
         if config.resume is not None:
-            keep, owed = resume.plan(
+            finished, owed = resume.load(
                 out, idxs, config.num_rollouts, info.requires_group_scoring
             )
             if not owed:  # already complete - report it and exit successfully
                 print(resume.nothing_to_resume_msg(out, len(idxs), config.num_rollouts))
                 raise SystemExit(0)
-            resume.rewrite_results(out, keep)
             idxs = [idx for idx in idxs if owed.get(idx)]
             logger.info(
                 "resuming %s: %d task(s), %d rollout(s) owed",
@@ -248,7 +248,7 @@ async def run_eval_server(config: EvalConfig) -> list[Trace]:
             units = [run_rollout_unit(i) for i in idxs for _ in range(owed[i])]
         results = await asyncio.gather(*units)
         await client.close()
-        return [trace for unit_traces in results for trace in unit_traces]
+        return finished + [trace for unit_traces in results for trace in unit_traces]
     finally:
         proc.terminate()
         with contextlib.suppress(Exception):


### PR DESCRIPTION
## Summary

- `--resume` now reloads the previous session's good traces into memory (`resume.load`) and they rejoin the run everywhere: the returned trace set, the `--push` upload (metrics + samples), the non-rich final stdout dump, and the `--rich` dashboard. The state just after resume matches the state just before the stop.
- The dashboard renders kept rollouts as per-rollout rows, not just in the aggregates: they enter the same `rollouts` list as `Finished` (a display-only `Rollout` reloaded from disk), so `Progress`/`Rows` treat them like any completed rollout and the separate `finished` plumbing is gone.
- Collapses the resume machinery (`_read_results` byte-offset streaming, `plan`, `rewrite_results`, `load_kept`) into a single `load` that reads `traces.jsonl` once, rewrites it to the kept rows (verbatim bytes, temp file + atomic rename, as before), and returns the kept traces plus the owed counts. Net −26 LOC.
- Loading is no longer gated on `--rich`, and the `--server` path gets the same semantics (kept traces merged into its returned set). `WireTrace` reads any taskset's saved traces, so `load` needs no taskset.

Closes #1961.

## Verification

gsm8k-v1, 8 tasks x 1 rollout, non-rich, SIGTERM once 3 traces had landed, then `uv run eval --resume <dir>`:

- **Before**: the resumed process's final trace dump contained only the 5 re-run traces — the 3 pre-stop traces were never loaded into memory (so `--push` would have uploaded a 5-trace run).
- **After**: the final dump contains all 8 traces; `traces.jsonl` holds 8 unique rollouts (no duplicates); rendering the dashboard from the reloaded traces shows all 8 as `[success]` rows with progress `8/8` and the full reward/usage/time breakdown.
- Resuming an already-complete run still prints `nothing to resume ...` and exits 0 without touching the results.
- `uv run ruff check`, `uv run --python 3.13 ty check verifiers`, and `uv run pytest tests/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches eval resume persistence and trace ordering for push/outputs; behavior change is intentional but affects all resume paths including server mode.
> 
> **Overview**
> **`--resume` now loads good `traces.jsonl` rows into memory** via a single `resume.load` (replacing offset-based `plan` / `rewrite_results` / `load_kept`). Kept traces are prepended to returned results, `--push`, stdout, and the **`--server`** path—not only when `--rich` is on.
> 
> The **rich dashboard** drops the separate `finished` argument: kept rollouts join the main `rollouts` list as `resume.Finished` display-only rollouts, so **per-row progress** and aggregates cover the full run.
> 
> `load` still atomically rewrites `traces.jsonl` to kept verbatim bytes, then parses kept lines with **`WireTrace`** (no taskset import).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b01c5972ba4fc92604d19032dcba13043dad367. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix eval resuming to reload finished traces so resumed runs match uninterrupted ones
> - Rewrites [resume.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1962/files#diff-fa57536955ac6c644296a0f3317271ffdc94b2611e7ad3d0c2266c436b96a4f8) to load and return previously completed traces directly (via a new `load` function), replacing the old offset-based `plan`/`rewrite_results`/`load_kept` workflow.
> - Introduces a `Finished` rollout subclass that wraps a saved `Trace` with `Phase.DONE`, allowing finished rollouts to be included in the live dashboard and returned traces.
> - Updates [runner.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1962/files#diff-65be4a576330571f2729a3bbcdbe92ac81bbcba450c313597c1bdca3a1c3f2e4) to prepend `Finished` rollouts to the dashboard rollout list and include them in push uploads; only owed rollouts are re-executed.
> - Simplifies [eval.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1962/files#diff-0a27b905958929f3ae9e01937dd7e3cf97a60dec137caddcbf87792784fc9035) by removing the separate `finished` parameter from the dashboard — callers now pass finished rollouts directly in the `rollouts` list.
> - Behavioral Change: resumed eval runs now display previously finished rollouts in the live dashboard and include them in the final result set, matching the output of an uninterrupted run.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 1b01c59. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->