### PR TITLE
feat(v1): persist advertised tool defs on the Trace for tool-use SFT

### DIFF
--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -74,6 +74,11 @@ async def test_tool(run_v1, harness_runtime, tool_runtime, tmp_path):
     assert trace.errors == []
     assert trace.num_turns >= 2  # tool call + answer
     assert trace.reward == 1.0
+    # The interception server captured the advertised tools onto the trace (for tool-use SFT):
+    # the null harness offered the task's MCP tool as `echo_back`, schema included.
+    assert trace.tools is not None
+    (echo_tool,) = [t for t in trace.tools if t.name == "echo_back"]
+    assert "message" in echo_tool.parameters.get("properties", {})
 
 
 @pytest.mark.e2e

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -60,6 +60,7 @@ def test_wire_trace_round_trip():
     # carry node `parent` links for `num_branches` to survive.
     tr = vf.Trace[MyTask, vf.State](
         task=vf.TraceTask(type="MyTask", data=MyTask(idx=0, prompt="q", answer="a")),
+        tools=[vf.Tool(name="echo", description="", parameters={"type": "object"})],
         nodes=[
             MessageNode(parent=None, message=UserMessage(content="q"), sampled=False),
             MessageNode(parent=0, message=AssistantMessage(content="a1"), sampled=True),
@@ -80,6 +81,9 @@ def test_wire_trace_round_trip():
     assert rt.reward == 1.0  # property recomputed from `rewards`
     assert rt.stop_condition == "done"
     assert rt.info == {"build": "ok"}
+    assert (
+        rt.tools == tr.tools
+    )  # the advertised tools persist (tool-use SFT reads them)
     assert rt.task.data.model_extra == {
         "answer": "a"
     }  # taskset extras preserved on WireTaskData

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -96,6 +96,9 @@ def parse_message(raw: dict) -> Message:
 
 
 def parse_tools(raw: list[dict] | None) -> list[Tool] | None:
+    # `or None` so a tools array with no function entries (e.g. only `custom`/built-in
+    # tools) parses to None, not [] — the same contract as the anthropic/responses
+    # dialects, and what keeps an empty parse from clearing `Trace.tools`.
     if not raw:
         return None
     return [
@@ -107,7 +110,7 @@ def parse_tools(raw: list[dict] | None) -> list[Tool] | None:
         )
         for t in raw
         if t.get("type", "function") == "function"
-    ]
+    ] or None
 
 
 # --- vf -> chat wire ----------------------------------------------------------

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -43,7 +43,7 @@ from verifiers.v1.errors import (
     UserError,
 )
 from verifiers.v1.trace import Trace
-from verifiers.v1.types import Messages
+from verifiers.v1.types import Messages, Tool
 
 if TYPE_CHECKING:
     from verifiers.v1.mcp import Respond
@@ -259,7 +259,10 @@ class InterceptionServer:
         # dialect's typed view for building the trace; the renderer re-derives its own from `body`.
         # A user simulator extends both each turn (`dialect.extend` for wire, `prompt` for trace).
         prompt: Messages
-        prompt, _ = dialect.parse_request(body)
+        # `tools` is recorded onto the trace only when a turn commits (below / in `_stream`):
+        # the request is ground truth for what the model saw, but a refused or failed request
+        # was never seen at all.
+        prompt, tools = dialect.parse_request(body)
         # Cache the opening so retries do not advance the simulator twice.
         if (
             session.user is not None
@@ -273,7 +276,7 @@ class InterceptionServer:
             # If the simulator ended at the open (its task's `@stop` now fires), the loop's
             # `refused()` below halts the harness before any model call — no special-casing here.
         if dialect.streaming(body):
-            return await self._stream(request, session, dialect, body, prompt)
+            return await self._stream(request, session, dialect, body, prompt, tools)
         headers = request.headers.copy()
         # A user simulator turns one program request into a multi-turn exchange: after each
         # model turn the simulator's reply is injected as a user turn and the model is
@@ -356,6 +359,12 @@ class InterceptionServer:
             )
             turn.commit(response)  # one node per new message;
             # branches fall out of walking the graph (see Trace.branches / verifiers.v1.graph)
+            if tools:
+                # Persist the advertised tools now that the model actually saw them (see
+                # `Trace.tools`). Only a tools-bearing turn updates it (truthy, so an empty
+                # parse or a trailing tool-less call never erases the schemas the recorded
+                # tool calls need).
+                session.trace.tools = tools
             # Hand back to the program when the model wants a tool (the program runs it) or
             # when there's no user simulator to keep the conversation going.
             if response.message.tool_calls or session.user is None:
@@ -389,6 +398,7 @@ class InterceptionServer:
         dialect: Dialect,
         body: dict,
         prompt: Messages,
+        tools: list[Tool] | None = None,
     ) -> web.StreamResponse:
         """A streamed (SSE) model turn: relay the provider's stream through to the program,
         incrementally assembling the response to record on the trace. Single-shot — a streamed
@@ -502,6 +512,8 @@ class InterceptionServer:
             if parser_error is not None:
                 raise parser_error
             turn.commit(parser.finish())
+            if tools:  # record only on commit, like the non-streaming path
+                session.trace.tools = tools
             logger.debug("intercept stream turn: id=%s", session.trace.id)
         finally:
             # Release the withheld events only now — after the commit — then close.

--- a/verifiers/v1/legacy.py
+++ b/verifiers/v1/legacy.py
@@ -20,6 +20,7 @@ from typing import Any
 
 import zmq
 import zmq.asyncio
+from pydantic import ValidationError
 
 from verifiers.v1.clients.config import ClientConfig, TrainClientConfig
 from verifiers.v1.serve.server import EnvServer
@@ -37,6 +38,7 @@ from verifiers.v1.types import (
     Response,
     SamplingConfig,
     SystemMessage,
+    Tool,
     ToolCall,
     ToolMessage,
     TurnTokens,
@@ -59,6 +61,22 @@ def _as_dict(obj: Any) -> Any:
     if hasattr(obj, "model_dump"):
         return obj.model_dump()
     return obj
+
+
+def _to_v1_tools(raw: Any) -> list[Tool] | None:
+    """Map v0 ``RolloutOutput.tool_defs`` onto ``Trace.tools``. The v0 and v1 ``Tool``
+    shapes are identical (name/description/parameters/strict), so this is a re-validation;
+    malformed entries are dropped rather than failing the whole trace mapping."""
+    defs: list[Tool] = []
+    for t in raw or []:
+        t = _as_dict(t)
+        if not isinstance(t, dict):
+            continue
+        try:
+            defs.append(Tool.model_validate(t))
+        except ValidationError:
+            continue
+    return defs or None
 
 
 def _text(content: Any) -> str:
@@ -234,6 +252,7 @@ def rollout_output_to_trace(out: dict, task_idx: int) -> Trace:
             type="Task",
             data=_to_wire_task(task_idx, out.get("prompt"), out.get("answer")),
         ),
+        tools=_to_v1_tools(out.get("tool_defs")),
         rewards={"reward": float(out.get("reward") or 0.0)},
         metrics={k: float(v) for k, v in (out.get("metrics") or {}).items()},
         is_completed=bool(out.get("is_completed", True)),

--- a/verifiers/v1/push.py
+++ b/verifiers/v1/push.py
@@ -56,6 +56,12 @@ def trace_to_sample(trace: Trace, rollout_number: int = 1) -> dict[str, Any]:
         "prompt": [],
         "completion": dump(branches[-1].messages) if branches else [],
         "answer": task.get("answer"),
+        # The tools advertised to the model (`Trace.tools`); keyed `tool_defs` because the
+        # v0 sample format already carries it there, so bridged and native rollouts render
+        # the same on the platform.
+        "tool_defs": [t.model_dump(mode="json", exclude_none=True) for t in trace.tools]
+        if trace.tools
+        else None,
         "reward": trace.reward,
         "timing": trace.timing.model_dump(mode="json", exclude_none=True),
         "is_completed": trace.is_completed,

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -24,6 +24,7 @@ from verifiers.v1.types import (
     AssistantMessage,
     Messages,
     StrictBaseModel,
+    Tool,
     ToolMessage,
     Usage,
     content_text,
@@ -200,6 +201,11 @@ class Trace(StrictBaseModel, Generic[DataT, StateT]):
     """The runtime's full config plus its provisioned resource ID."""
     nodes: list[MessageNode] = Field(default_factory=list)
     """The message graph; branches are derived views and storage stays linear in turns."""
+    tools: list[Tool] | None = None
+    """The tools advertised to the model, recorded when an intercepted turn commits (last
+    committed turn wins) — never from a refused/failed request the model never saw. The full
+    advertised list (not just tools called), so tool-use SFT can re-render the exact prompt;
+    a trace-level snapshot: mid-rollout changes collapse to the last set the model saw."""
 
     rewards: dict[str, float] = Field(default_factory=dict)
     """Weighted contributions from task rewards, group rewards, and judges."""


### PR DESCRIPTION
# feat(v1): persist the advertised tools on the Trace (for tool-use SFT)

Closes #1945

## Problem

The v1 `Trace` records the message graph (tool calls, tool results) but not the tool **schemas** the model was shown, so v1 `traces.jsonl` can't feed tool-use SFT: prime-rl re-renders each conversation through a chat template, and the template needs the tool list to reproduce the prompt the model was conditioned on. The classic path already persists this (`state["tool_defs"]` → `RolloutOutput.tool_defs`); v1 had no equivalent.

## Approach

Capture at the interception server, not from the environment (what the issue sketched). In v1 the harness program composes the final tool list — local tools (`bash`/`edit`), MCP tools renamed to `<server>_<tool>`, framework built-ins — so the taskset can't know it. Every harness's model calls flow through one choke point, and `dialect.parse_request` already returns the parsed tools there (previously discarded). The intercepted request is ground truth for what the model saw. Works across all three dialects (chat / responses / anthropic).

Recording happens **when the turn commits**, not at parse time: a request refused by a `@stop`/limit, or failing on `OverlongPromptError` before any provider call, was never seen by the model and must not overwrite the tools of the turns that actually happened. A rollout refused before any turn keeps `tools=None` by construction.

## Changes

- **`Trace.tools: list[Tool] | None`** — the advertised tools, set at each committed model turn (last committed turn wins). Round-trips through `traces.jsonl` / `WireTrace` like `info`; old dumps load as `None`.
- **Interception server** — keep the tools half of `parse_request` and record it at the two commit sites (turn loop + `_stream`, which now receives the parsed tools). Only a tools-bearing turn updates the field (truthy guard), so a trailing tool-less call (e.g. a summarization turn) can't erase the schemas the recorded tool calls reference.
- **Chat dialect** — `parse_tools` normalizes an empty parse to `None` (a tools array with only non-`function` entries), matching the anthropic/responses dialects' existing `] or None` contract.
- **Legacy bridge** — map v0 `RolloutOutput.tool_defs` onto `Trace.tools` (identical shape, re-validated; malformed entries dropped) so bridged v0 runs carry the same field.
- **Platform push** — `trace_to_sample` carries the tools, keyed `tool_defs` to match the v0 sample schema the platform already renders, so bridged and native rollouts look the same.

## Design notes

- **Full advertised list, not just tools called**: SFT must re-render the prompt the model saw, and tool *selection* is only learnable when the unchosen options are present.
- **Trace-level snapshot, not per-node** (the tradeoff #1945 asks to decide): per-node capture would repeat the tool list on every record line; a snapshot is sufficient for SFT. Mid-rollout tool changes collapse to the last set the model saw (documented on the field).
- **Forward-compat caveat**: `Trace` is `extra="forbid"`, so an older verifiers reading a *new* dump rejects the unknown key — same as any additive Trace field; wire producer/consumer share a verifiers install.

## Tests

- `test_wire_trace_round_trip` now carries `tools` through the dump/load round trip.
- `tests/v1/test_e2e.py::test_tool` asserts the captured `echo_back` schema on `trace.tools` across the harness × tool-runtime matrix.

## Validation (live)

20-task `wiki-search-v1` run on this branch (default harness, reward 0.75, err 0.00, platform push OK):

```
$ jq '.tools | length' traces.jsonl | sort | uniq -c
     20 5
$ jq -r '[.tools[].name] | join(",")' traces.jsonl | uniq -c
     20 bash,edit,wiki_read_section,wiki_search_pages,wiki_view_sections
$ jq 'has("tool_defs")' traces.jsonl | uniq -c
     20 false
```

`bash`/`edit` are harness-local tools the environment never sees — the capture point is why they're recorded. Downstream, the prime-rl export script (companion PR) built a 15-row `['messages', 'tools']` dataset from this run and `uv run sft` trained on it through the primary `tools` column path (loss 0.96 → 0.20, no tokenizer/loss-mask warnings). E2e matrix: 12 passed, 3 skipped (prime port exposure); the local cells re-pass after the commit-time-recording change.

> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 572bc29a470980ab74f0e4ca7acac0adf938609c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist advertised tool definitions on `Trace` for tool-use SFT
> - Adds an optional `tools: list[Tool] | None` field to the [`Trace`](https://github.com/PrimeIntellect-ai/verifiers/pull/1963/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e) model to store tools advertised to the model during a rollout.
> - Updates [`InterceptionServer`](https://github.com/PrimeIntellect-ai/verifiers/pull/1963/files#diff-84e2f8d027d609e8760ef6d533535ec9d99dfc6384d5ddb6111b4001b2010f35) to extract tools from each request and write them to `session.trace.tools` on commit, for both streaming and non-streaming paths.
> - Adds [`_to_v1_tools`](https://github.com/PrimeIntellect-ai/verifiers/pull/1963/files#diff-96c5091f7d2968ddfbe984f433163f21cab745ea95174158e924984d55abbfed) to normalize legacy `tool_defs` into validated `Tool` objects, and wires it into `rollout_output_to_trace`.
> - Updates [`trace_to_sample`](https://github.com/PrimeIntellect-ai/verifiers/pull/1963/files#diff-c5f6c769d7b0eae44c38fc5ada1ba8094390535c93bd137ec41c5d0e014b133f) to emit a `tool_defs` key in exported samples, matching the v0 format.
> - `parse_tools` in [`chat.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1963/files#diff-5d2fcbf59a03489b63b0626038a853eee89543b591074597161ee29aab901280) now returns `None` instead of `[]` when no function-type tools are present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d6a519.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->