### PR TITLE
feat(v1): support multi-type tasksets

### DIFF
--- a/assets/lab/environments/AGENTS.md
+++ b/assets/lab/environments/AGENTS.md
@@ -27,37 +27,51 @@ However, for most environments, building a taskset should be enough.
 
 ## A minimal environment
 
+A task is split into data and behavior. `vf.TaskData` is one row's pure data — the wire
+shape saved on every trace; subclass it to add typed fields (the reference answer, ground
+truths). `vf.Task` is the behavior — `@vf.reward` / `@vf.metric` scoring methods, lifecycle
+hooks, and tool/user declarations — reading the row off `self.data`. The `vf.Taskset` is
+the loader and factory: `Taskset[...]` declares every task type it owns, and `load()`
+constructs its initial tasks.
+
 ```python
-import verifiers.v1 as vf 
+import verifiers.v1 as vf
 
 
-# A task defines a single problem and is defined as a subclass of vf.Task
-class AdditionTask(vf.Task):
+# One row's data: the wire shape (what traces store).
+class AdditionData(vf.TaskData):
     answer: int
 
 
-# The taskset defines the dataset (collection of tasks) and needs a vf.TasksetConfig, which can be empty.
+# The behavior: how a row is scored. @vf.reward receives whatever it declares by
+# parameter name (`trace`, `runtime`); the row is `self.data`. The trace contains
+# the whole message graph, including function calls and user messages.
+class AdditionTask(vf.Task[AdditionData]):
+    @vf.reward
+    async def exact_match(self, trace: vf.Trace) -> float:
+        return float(trace.last_reply == str(self.data.answer))
+
+
+# The taskset is the loader: it builds the tasks from their rows.
 class AdditionTaskset(vf.Taskset[AdditionTask, vf.TasksetConfig]):
-    def load_tasks(self) -> list[AdditionTask]:
-        # Load the dataset, in this case we built it on the initial load
+    def load(self) -> list[AdditionTask]:
+        # Load the dataset, in this case we build it on the initial load
         return [
-            AdditionTask(idx=i, prompt=f"What is {i} + {i}?", answer=2 * i)
+            AdditionTask(
+                AdditionData(idx=i, prompt=f"What is {i} + {i}?", answer=2 * i),
+                self.config.task,
+            )
             for i in range(100)
         ]
-
-    # @vf.reward denotes the scoring function for the environment.
-    # It needs the actual task (defined earlier) as well as the trace, which contains the whole message graph, including function calls, user messages etc.
-    # It returns the reward for the rollout based on this function.
-    @vf.reward
-    async def exact_match(self, task: AdditionTask, trace: vf.Trace) -> float:
-        return float(trace.last_reply == str(task.answer))
 
 
 # Export the Taskset for verifiers to find it when loading
 __all__ = ["AdditionTaskset"]
 ```
 
-You can also use `@vf.metric` to record non-scored values and `@vf.group_reward` for group rewards, which might be useful for training.
+You can also use `@vf.metric` to record non-scored values, `@vf.group_reward` for group
+rewards (comparing a task's rollouts, useful for training), and `@vf.stop` for stop
+conditions. Lifecycle hooks (`setup`, `finalize`, `validate`) are methods on the task too.
 
 ## Making values configurable
 
@@ -69,25 +83,90 @@ class AdditionConfig(vf.TasksetConfig):
     num_tasks: int = 100
 
 class AdditionTaskset(vf.Taskset[AdditionTask, AdditionConfig]):
-    def load_tasks(self) -> list[AdditionTask]:
+    def load(self) -> list[AdditionTask]:
         return [
-            AdditionTask(idx=i, prompt=f"What is {i} + {i}?", answer=2 * i)
+            AdditionTask(
+                AdditionData(idx=i, prompt=f"What is {i} + {i}?", answer=2 * i),
+                self.config.task,
+            )
             for i in range(self.config.num_tasks) # <- re-use the value here
         ]
-
 ```
-Common usages for `vf.TasksetConfig` are settings like splits (e.g., train/test), difficulty settings, judge model names, etc.
+
+Common usages for `vf.TasksetConfig` are **load-time** settings: splits (e.g., train/test),
+dataset names, sample counts, rng seeds.
+
+Knobs the *task itself* reads — scoring parameters, judge endpoints, server placement — go
+on a `vf.TaskConfig`, nested on the taskset config under `task` for a single task type and
+passed to every constructed task. The task reads them off `self.config`, typed by
+parameterizing the task:
+
+```python
+class AdditionTaskConfig(vf.TaskConfig):
+    tolerance: float = 0.0
+
+class AdditionTask(vf.Task[AdditionData, vf.State, AdditionTaskConfig]):
+    @vf.reward
+    async def exact_match(self, trace: vf.Trace) -> float:
+        tolerance = self.config.tolerance  # a config knob, not a per-row field
+        ...
+
+class AdditionConfig(vf.TasksetConfig):
+    num_tasks: int = 100                              # load-time: --taskset.num-tasks
+    task: AdditionTaskConfig = AdditionTaskConfig()   # task-facing: --taskset.task.tolerance
+```
+
+The boundary: per-row data (the question, the reference answer) lives on `TaskData` fields;
+values uniform across the taskset live on the config — load-time ones directly on the
+`TasksetConfig`, task-facing ones under `task` for a single type or under explicit per-type
+fields for a task family. A task can also be constructed directly —
+`AdditionTask(data, config=AdditionTaskConfig(...))` — and an omitted config defaults to
+the declared type's defaults, so a standalone task works out of the box. Overriding
+`from_trace(trace)` (not implemented by default) opts a task into being derived from a
+finished rollout's bare `Trace` — how a multi-agent step spawns a follow-up task. The task
+data rides the wire as `trace.task`; `trace.task_class` records which declared behavior to
+re-attach during replay.
+
+A task family uses a distinct config type and explicit field for each task type. `load()`
+may return only seed tasks; a taskset-specific factory can construct a later type when the
+orchestrator has the preceding trace:
+
+```python
+class ProposerConfig(vf.TaskConfig): ...
+class SolvedConfig(vf.TaskConfig): ...
+
+class WorkflowConfig(vf.TasksetConfig):
+    proposer: ProposerConfig = ProposerConfig()
+    solved: SolvedConfig = SolvedConfig()
+
+class WorkflowTaskset(
+    vf.Taskset[ProposerTask | SolvedTask, WorkflowConfig]
+):
+    def load(self) -> list[ProposerTask | SolvedTask]:
+        return [ProposerTask(row, self.config.proposer) for row in load_rows()]
+
+    def solved_task(self, trace: vf.Trace) -> SolvedTask:
+        return SolvedTask.from_trace(trace, config=self.config.solved)
+```
 
 ## Adding Tools
 
 Some environments require custom tools, which are bundled as a `vf.Toolset` (similar to how a `vf.Taskset` bundles `vf.Task`).
 Tools are exposed as MCP servers to the given harness and thus need a harness which exposes MCP support (via `SUPPORTS_MCP`).
 
-You can create them like this (remember the bootstrapping with `uv run init MY_ENV -T`):
+Where you register a toolset decides its **scope** — per rollout, or shared across the eval:
+
+- **On the Task** (`Task.tools`): one server per rollout, in the harness's runtime
+  (`colocated`) or its own (`vf.ToolsetConfig`). For tools that see per-task data.
+- **On the Taskset** (`Taskset.tools`): ONE server for the whole eval, shared by every
+  rollout (`vf.SharedToolsetConfig` — own runtime or a remote `url`, no `colocated`). For
+  an expensive, task-agnostic resource (a corpus, an index) built once. Per-rollout writes
+  stay isolated via `self.state`.
+
 ```python
 DATABASE = None
 
-class SearchToolset(vf.Toolset[vf.ToolsetConfig]):
+class SearchToolset(vf.Toolset[vf.ToolsetConfig]):          # task-scoped
     TOOL_PREFIX = "search"
 
     @vf.tool
@@ -95,15 +174,30 @@ class SearchToolset(vf.Toolset[vf.ToolsetConfig]):
         """Search the task corpus."""
         return DATABASE.search(text)
 
-# User-configurable knobs
-class SearchConfig(vf.TasksetConfig):
-    tools: vf.ToolsetConfig = vf.ToolsetConfig()
+class CorpusToolset(vf.Toolset[vf.SharedToolsetConfig]):    # taskset-scoped (shared)
+    TOOL_PREFIX = "corpus"
+    ...
 
-class SearchTaskset(vf.Taskset[vf.Task, SearchConfig]):
-    # Launch the tools during setup
-    def tools(self, task: vf.Task) -> list[vf.Toolset]:
-        return [SearchToolset(self.config.tools)]
+class SearchTaskConfig(vf.TaskConfig):
+    tools: vf.ToolsetConfig = vf.ToolsetConfig()             # --taskset.task.tools.*
+
+class SearchTask(vf.Task[vf.TaskData, vf.State, SearchTaskConfig]):
+    tools = (SearchToolset,)                                 # per rollout
+
+class SearchConfig(vf.TasksetConfig):
+    tools: vf.SharedToolsetConfig = vf.SharedToolsetConfig() # --taskset.tools.*
+    task: SearchTaskConfig = SearchTaskConfig()
+
+class SearchTaskset(vf.Taskset[SearchTask, SearchConfig]):
+    tools = (CorpusToolset,)                                 # once per eval
 ```
+
+The framework builds each declared server with the matching config off the declaring
+scope's config — the field whose type is the server's declared config type, falling back
+to a default-constructed one. Override `server_config` (on `Task` or `Taskset`) if you
+need explicit pairing (e.g. two servers sharing one config type). User simulators are
+task-scoped only — they drive one rollout's conversation: `user = MyUser` on the task, a
+`vf.UserConfig` field on the task config.
 
 ## Using Judges
 
@@ -111,10 +205,6 @@ If your reward is semantic, use an LLM judge.
 
 ```python
 import verifiers.v1 as vf
-from functools import cached_property
-
-class Task(vf.Task):
-    answer: str
 
 class CorrectnessJudge(vf.Judge[bool]):
     # The rubric for the judge
@@ -128,31 +218,44 @@ class CorrectnessJudge(vf.Judge[bool]):
         return "yes" in response.text
 
 
-class Config(vf.TasksetConfig):
+class Config(vf.TaskConfig):
     # The judge inherits base_url and api keys from the client config (env vars, with the Prime CLI config as a fallback)
     judge: vf.JudgeConfig = vf.JudgeConfig(model="openai/gpt-5-mini")
 
 
-class JudgeTraceTaskset(vf.Taskset[Task, Config]):
-    # Build the judge lazily from config — no Taskset.__init__ override needed.
-    @cached_property
-    def judge(self) -> CorrectnessJudge:
-        return CorrectnessJudge(self.config.judge)
-
-    def load_tasks(self) -> list[Task]:
-        return [Task(idx=0, prompt="What is 2+2?", answer="4")]
+class JudgedTask(vf.Task[vf.State, Config]):
+    answer: str
 
     @vf.reward()
-    async def correct(self, task, trace) -> float:
-        result = await self.judge.evaluate(
-            trace=trace, 
-            question=task.prompt, 
-            answer=task.answer, 
+    async def correct(self, trace: vf.Trace) -> float:
+        judge = CorrectnessJudge(self.config.judge)  # config knobs stay CLI-tunable
+        result = await judge.evaluate(
+            trace=trace,
+            question=self.prompt,
+            answer=self.answer,
             # give the last assistant message to the judge
-            response=trace.last_reply
+            response=trace.last_reply,
         )
         return 1.0 if result.parsed else 0.0
+
+
+class SetConfig(vf.TasksetConfig):
+    task: Config = Config()
+
+
+class JudgeTraceTaskset(vf.Taskset[JudgedTask, SetConfig]):
+    def load(self) -> list[JudgedTask]:
+        return [JudgedTask(idx=0, prompt="What is 2+2?", answer="4")]
 ```
 
-To override the judge model, set `taskset.judge.model` in your config (it is a string).
-Sampling knobs live under `taskset.judge.sampling` — e.g. `taskset.judge.sampling.max_tokens`.
+To override the judge model, set `taskset.task.judge.model` in your config (it is a string).
+Sampling knobs live under `taskset.task.judge.sampling` — e.g.
+`taskset.task.judge.sampling.max_tokens`.
+
+Judges can also be plugged **from config alone** — no judge-calling code: the base
+`TaskConfig.judges` list on the corresponding task-config field (for example,
+`--taskset.task.judges` or `--taskset.proposer.judges`) plugs judge plugins (built-ins like
+`reference` / `rubric`, or hub packages) into each task using that config, and `Task.score`
+resolves and runs them after the task's own `@reward`s. Judges are config, never row data — the run's
+`config.toml` records what judged it, and `replay`'s layered config re-runs (or re-tunes)
+exactly those judges.

--- a/assets/lab/environments/AGENTS.md
+++ b/assets/lab/environments/AGENTS.md
@@ -149,6 +149,11 @@ class WorkflowTaskset(
         return SolvedTask.from_trace(trace, config=self.config.solved)
 ```
 
+See [`proposer_solver_v1`](https://github.com/PrimeIntellect-ai/verifiers/tree/main/environments/proposer_solver_v1)
+for a concrete task family; its taskset builds the handoff, while an orchestrator schedules
+the derived task on the next agent. It executes proposed verification code, so select an
+isolated harness runtime with `--harness.runtime.type docker` (or `prime`).
+
 ## Adding Tools
 
 Some environments require custom tools, which are bundled as a `vf.Toolset` (similar to how a `vf.Taskset` bundles `vf.Task`).

--- a/docs/v1/environments.md
+++ b/docs/v1/environments.md
@@ -142,6 +142,11 @@ class WorkflowTaskset(
         return SolvedTask.from_trace(trace, config=self.config.solved)
 ```
 
+See [`proposer_solver_v1`](https://github.com/PrimeIntellect-ai/verifiers/tree/main/environments/proposer_solver_v1)
+for a concrete task family; its taskset builds the handoff, while an orchestrator schedules
+the derived task on the next agent. It executes proposed verification code, so select an
+isolated harness runtime with `--harness.runtime.type docker` (or `prime`).
+
 ## Adding Tools
 
 Some environments require custom tools, which are bundled as a `vf.Toolset` (similar to how a `vf.Taskset` bundles `vf.Task`).

--- a/docs/v1/environments.md
+++ b/docs/v1/environments.md
@@ -24,8 +24,8 @@ A task is split into data and behavior. `vf.TaskData` is one row's pure data —
 shape saved on every trace; subclass it to add typed fields (the reference answer, ground
 truths). `vf.Task` is the behavior — `@vf.reward` / `@vf.metric` scoring methods, lifecycle
 hooks, and tool/user declarations — reading the row off `self.data`. The `vf.Taskset` is
-the loader: its `load()` builds each row's data and constructs the task around it (one
-task type per taskset).
+the loader and factory: `Taskset[...]` declares every task type it owns, and `load()`
+constructs its initial tasks.
 
 ```python
 import verifiers.v1 as vf
@@ -90,8 +90,9 @@ Common usages for `vf.TasksetConfig` are **load-time** settings: splits (e.g., t
 dataset names, sample counts, rng seeds.
 
 Knobs the *task itself* reads — scoring parameters, judge endpoints, server placement — go
-on a `vf.TaskConfig`, nested on the taskset config under `task` and passed to every
-constructed task. The task reads them off `self.config`, typed by parameterizing the task:
+on a `vf.TaskConfig`, nested on the taskset config under `task` for a single task type and
+passed to every constructed task. The task reads them off `self.config`, typed by
+parameterizing the task:
 
 ```python
 class AdditionTaskConfig(vf.TaskConfig):
@@ -110,13 +111,36 @@ class AdditionConfig(vf.TasksetConfig):
 
 The boundary: per-row data (the question, the reference answer) lives on `TaskData` fields;
 values uniform across the taskset live on the config — load-time ones directly on the
-`TasksetConfig`, task-facing ones under `task`. A task can also be constructed directly —
+`TasksetConfig`, task-facing ones under `task` for a single type or under explicit per-type
+fields for a task family. A task can also be constructed directly —
 `AdditionTask(data, config=AdditionTaskConfig(...))` — and an omitted config defaults to
 the declared type's defaults, so a standalone task works out of the box. Overriding
 `from_trace(trace)` (not implemented by default) opts a task into being derived from a
-finished rollout's bare `Trace` — how a multi-agent step spawns a follow-up task. Only the data rides the wire:
-`trace.task` is the `TaskData`, and behavior re-attaches by constructing the task class
-around it.
+finished rollout's bare `Trace` — how a multi-agent step spawns a follow-up task. The task
+data rides the wire as `trace.task`; `trace.task_class` records which declared behavior to
+re-attach during replay.
+
+A task family uses a distinct config type and explicit field for each task type. `load()`
+may return only seed tasks; a taskset-specific factory can construct a later type when the
+orchestrator has the preceding trace:
+
+```python
+class ProposerConfig(vf.TaskConfig): ...
+class SolvedConfig(vf.TaskConfig): ...
+
+class WorkflowConfig(vf.TasksetConfig):
+    proposer: ProposerConfig = ProposerConfig()
+    solved: SolvedConfig = SolvedConfig()
+
+class WorkflowTaskset(
+    vf.Taskset[ProposerTask | SolvedTask, WorkflowConfig]
+):
+    def load(self) -> list[ProposerTask | SolvedTask]:
+        return [ProposerTask(row, self.config.proposer) for row in load_rows()]
+
+    def solved_task(self, trace: vf.Trace) -> SolvedTask:
+        return SolvedTask.from_trace(trace, config=self.config.solved)
+```
 
 ## Adding Tools
 
@@ -222,8 +246,9 @@ Sampling knobs live under `taskset.task.judge.sampling` — e.g.
 `taskset.task.judge.sampling.max_tokens`.
 
 Judges can also be plugged **from config alone** — no judge-calling code: the base
-`TaskConfig.judges` list (`--taskset.task.judges`) plugs judge plugins (built-ins like
-`reference` / `rubric`, or hub packages) into every task, and `Task.score` resolves and
-runs them after the task's own `@reward`s. Judges are config, never row data — the run's
+`TaskConfig.judges` list on the corresponding task-config field (for example,
+`--taskset.task.judges` or `--taskset.proposer.judges`) plugs judge plugins (built-ins like
+`reference` / `rubric`, or hub packages) into each task using that config, and `Task.score`
+resolves and runs them after the task's own `@reward`s. Judges are config, never row data — the run's
 `config.toml` records what judged it, and `replay`'s layered config re-runs (or re-tunes)
 exactly those judges.

--- a/docs/v1/overview.md
+++ b/docs/v1/overview.md
@@ -14,7 +14,7 @@ An environment combines a _taskset_ and a _harness_. Often, it is sufficient to 
 
 ## Taskset
 
-A taskset is a collection of tasks, i.e., the _what_. A task is a prompt, a set of files, etc. — and it carries its own scoring (rewards, metrics) and lifecycle hooks: each dataset's task class defines how it is graded. The taskset is the loader that yields them; every taskset yields exactly one task type.
+A taskset is a collection of tasks, i.e., the _what_. A task is a prompt, a set of files, etc. — and it carries its own scoring (rewards, metrics) and lifecycle hooks: each dataset's task class defines how it is graded. A taskset declares the closed set of task types it can construct: one class for an ordinary taskset, or a union such as `ProposerTask | SolvedTask` for a task family.
 
 ## Harness
 

--- a/environments/AGENTS.md
+++ b/environments/AGENTS.md
@@ -148,6 +148,11 @@ class WorkflowTaskset(
         return SolvedTask.from_trace(trace, config=self.config.solved)
 ```
 
+See [`proposer_solver_v1`](https://github.com/PrimeIntellect-ai/verifiers/tree/main/environments/proposer_solver_v1)
+for a concrete task family; its taskset builds the handoff, while an orchestrator schedules
+the derived task on the next agent. It executes proposed verification code, so select an
+isolated harness runtime with `--harness.runtime.type docker` (or `prime`).
+
 ## Adding Tools
 
 Some environments require custom tools, which are bundled as a `vf.Toolset` (similar to how a `vf.Taskset` bundles `vf.Task`).

--- a/environments/AGENTS.md
+++ b/environments/AGENTS.md
@@ -26,37 +26,51 @@ However, for most environments, building a taskset should be enough.
 
 ## A minimal environment
 
+A task is split into data and behavior. `vf.TaskData` is one row's pure data — the wire
+shape saved on every trace; subclass it to add typed fields (the reference answer, ground
+truths). `vf.Task` is the behavior — `@vf.reward` / `@vf.metric` scoring methods, lifecycle
+hooks, and tool/user declarations — reading the row off `self.data`. The `vf.Taskset` is
+the loader and factory: `Taskset[...]` declares every task type it owns, and `load()`
+constructs its initial tasks.
+
 ```python
-import verifiers.v1 as vf 
+import verifiers.v1 as vf
 
 
-# A task defines a single problem and is defined as a subclass of vf.Task
-class AdditionTask(vf.Task):
+# One row's data: the wire shape (what traces store).
+class AdditionData(vf.TaskData):
     answer: int
 
 
-# The taskset defines the dataset (collection of tasks) and needs a vf.TasksetConfig, which can be empty.
+# The behavior: how a row is scored. @vf.reward receives whatever it declares by
+# parameter name (`trace`, `runtime`); the row is `self.data`. The trace contains
+# the whole message graph, including function calls and user messages.
+class AdditionTask(vf.Task[AdditionData]):
+    @vf.reward
+    async def exact_match(self, trace: vf.Trace) -> float:
+        return float(trace.last_reply == str(self.data.answer))
+
+
+# The taskset is the loader: it builds the tasks from their rows.
 class AdditionTaskset(vf.Taskset[AdditionTask, vf.TasksetConfig]):
-    def load_tasks(self) -> list[AdditionTask]:
-        # Load the dataset, in this case we built it on the initial load
+    def load(self) -> list[AdditionTask]:
+        # Load the dataset, in this case we build it on the initial load
         return [
-            AdditionTask(idx=i, prompt=f"What is {i} + {i}?", answer=2 * i)
+            AdditionTask(
+                AdditionData(idx=i, prompt=f"What is {i} + {i}?", answer=2 * i),
+                self.config.task,
+            )
             for i in range(100)
         ]
-
-    # @vf.reward denotes the scoring function for the environment.
-    # It needs the actual task (defined earlier) as well as the trace, which contains the whole message graph, including function calls, user messages etc.
-    # It returns the reward for the rollout based on this function.
-    @vf.reward
-    async def exact_match(self, task: AdditionTask, trace: vf.Trace) -> float:
-        return float(trace.last_reply == str(task.answer))
 
 
 # Export the Taskset for verifiers to find it when loading
 __all__ = ["AdditionTaskset"]
 ```
 
-You can also use `@vf.metric` to record non-scored values and `@vf.group_reward` for group rewards, which might be useful for training.
+You can also use `@vf.metric` to record non-scored values, `@vf.group_reward` for group
+rewards (comparing a task's rollouts, useful for training), and `@vf.stop` for stop
+conditions. Lifecycle hooks (`setup`, `finalize`, `validate`) are methods on the task too.
 
 ## Making values configurable
 
@@ -68,25 +82,90 @@ class AdditionConfig(vf.TasksetConfig):
     num_tasks: int = 100
 
 class AdditionTaskset(vf.Taskset[AdditionTask, AdditionConfig]):
-    def load_tasks(self) -> list[AdditionTask]:
+    def load(self) -> list[AdditionTask]:
         return [
-            AdditionTask(idx=i, prompt=f"What is {i} + {i}?", answer=2 * i)
+            AdditionTask(
+                AdditionData(idx=i, prompt=f"What is {i} + {i}?", answer=2 * i),
+                self.config.task,
+            )
             for i in range(self.config.num_tasks) # <- re-use the value here
         ]
-
 ```
-Common usages for `vf.TasksetConfig` are settings like splits (e.g., train/test), difficulty settings, judge model names, etc.
+
+Common usages for `vf.TasksetConfig` are **load-time** settings: splits (e.g., train/test),
+dataset names, sample counts, rng seeds.
+
+Knobs the *task itself* reads — scoring parameters, judge endpoints, server placement — go
+on a `vf.TaskConfig`, nested on the taskset config under `task` for a single task type and
+passed to every constructed task. The task reads them off `self.config`, typed by
+parameterizing the task:
+
+```python
+class AdditionTaskConfig(vf.TaskConfig):
+    tolerance: float = 0.0
+
+class AdditionTask(vf.Task[AdditionData, vf.State, AdditionTaskConfig]):
+    @vf.reward
+    async def exact_match(self, trace: vf.Trace) -> float:
+        tolerance = self.config.tolerance  # a config knob, not a per-row field
+        ...
+
+class AdditionConfig(vf.TasksetConfig):
+    num_tasks: int = 100                              # load-time: --taskset.num-tasks
+    task: AdditionTaskConfig = AdditionTaskConfig()   # task-facing: --taskset.task.tolerance
+```
+
+The boundary: per-row data (the question, the reference answer) lives on `TaskData` fields;
+values uniform across the taskset live on the config — load-time ones directly on the
+`TasksetConfig`, task-facing ones under `task` for a single type or under explicit per-type
+fields for a task family. A task can also be constructed directly —
+`AdditionTask(data, config=AdditionTaskConfig(...))` — and an omitted config defaults to
+the declared type's defaults, so a standalone task works out of the box. Overriding
+`from_trace(trace)` (not implemented by default) opts a task into being derived from a
+finished rollout's bare `Trace` — how a multi-agent step spawns a follow-up task. The task
+data rides the wire as `trace.task`; `trace.task_class` records which declared behavior to
+re-attach during replay.
+
+A task family uses a distinct config type and explicit field for each task type. `load()`
+may return only seed tasks; a taskset-specific factory can construct a later type when the
+orchestrator has the preceding trace:
+
+```python
+class ProposerConfig(vf.TaskConfig): ...
+class SolvedConfig(vf.TaskConfig): ...
+
+class WorkflowConfig(vf.TasksetConfig):
+    proposer: ProposerConfig = ProposerConfig()
+    solved: SolvedConfig = SolvedConfig()
+
+class WorkflowTaskset(
+    vf.Taskset[ProposerTask | SolvedTask, WorkflowConfig]
+):
+    def load(self) -> list[ProposerTask | SolvedTask]:
+        return [ProposerTask(row, self.config.proposer) for row in load_rows()]
+
+    def solved_task(self, trace: vf.Trace) -> SolvedTask:
+        return SolvedTask.from_trace(trace, config=self.config.solved)
+```
 
 ## Adding Tools
 
 Some environments require custom tools, which are bundled as a `vf.Toolset` (similar to how a `vf.Taskset` bundles `vf.Task`).
 Tools are exposed as MCP servers to the given harness and thus need a harness which exposes MCP support (via `SUPPORTS_MCP`).
 
-You can create them like this (remember the bootstrapping with `uv run init MY_ENV -T`):
+Where you register a toolset decides its **scope** — per rollout, or shared across the eval:
+
+- **On the Task** (`Task.tools`): one server per rollout, in the harness's runtime
+  (`colocated`) or its own (`vf.ToolsetConfig`). For tools that see per-task data.
+- **On the Taskset** (`Taskset.tools`): ONE server for the whole eval, shared by every
+  rollout (`vf.SharedToolsetConfig` — own runtime or a remote `url`, no `colocated`). For
+  an expensive, task-agnostic resource (a corpus, an index) built once. Per-rollout writes
+  stay isolated via `self.state`.
+
 ```python
 DATABASE = None
 
-class SearchToolset(vf.Toolset[vf.ToolsetConfig]):
+class SearchToolset(vf.Toolset[vf.ToolsetConfig]):          # task-scoped
     TOOL_PREFIX = "search"
 
     @vf.tool
@@ -94,15 +173,30 @@ class SearchToolset(vf.Toolset[vf.ToolsetConfig]):
         """Search the task corpus."""
         return DATABASE.search(text)
 
-# User-configurable knobs
-class SearchConfig(vf.TasksetConfig):
-    tools: vf.ToolsetConfig = vf.ToolsetConfig()
+class CorpusToolset(vf.Toolset[vf.SharedToolsetConfig]):    # taskset-scoped (shared)
+    TOOL_PREFIX = "corpus"
+    ...
 
-class SearchTaskset(vf.Taskset[vf.Task, SearchConfig]):
-    # Launch the tools during setup
-    def tools(self, task: vf.Task) -> list[vf.Toolset]:
-        return [SearchToolset(self.config.tools)]
+class SearchTaskConfig(vf.TaskConfig):
+    tools: vf.ToolsetConfig = vf.ToolsetConfig()             # --taskset.task.tools.*
+
+class SearchTask(vf.Task[vf.TaskData, vf.State, SearchTaskConfig]):
+    tools = (SearchToolset,)                                 # per rollout
+
+class SearchConfig(vf.TasksetConfig):
+    tools: vf.SharedToolsetConfig = vf.SharedToolsetConfig() # --taskset.tools.*
+    task: SearchTaskConfig = SearchTaskConfig()
+
+class SearchTaskset(vf.Taskset[SearchTask, SearchConfig]):
+    tools = (CorpusToolset,)                                 # once per eval
 ```
+
+The framework builds each declared server with the matching config off the declaring
+scope's config — the field whose type is the server's declared config type, falling back
+to a default-constructed one. Override `server_config` (on `Task` or `Taskset`) if you
+need explicit pairing (e.g. two servers sharing one config type). User simulators are
+task-scoped only — they drive one rollout's conversation: `user = MyUser` on the task, a
+`vf.UserConfig` field on the task config.
 
 ## Using Judges
 
@@ -110,10 +204,6 @@ If your reward is semantic, use an LLM judge.
 
 ```python
 import verifiers.v1 as vf
-from functools import cached_property
-
-class Task(vf.Task):
-    answer: str
 
 class CorrectnessJudge(vf.Judge[bool]):
     # The rubric for the judge
@@ -127,31 +217,44 @@ class CorrectnessJudge(vf.Judge[bool]):
         return "yes" in response.text
 
 
-class Config(vf.TasksetConfig):
+class Config(vf.TaskConfig):
     # The judge inherits base_url and api keys from the client config (env vars, with the Prime CLI config as a fallback)
     judge: vf.JudgeConfig = vf.JudgeConfig(model="openai/gpt-5-mini")
 
 
-class JudgeTraceTaskset(vf.Taskset[Task, Config]):
-    # Build the judge lazily from config — no Taskset.__init__ override needed.
-    @cached_property
-    def judge(self) -> CorrectnessJudge:
-        return CorrectnessJudge(self.config.judge)
-
-    def load_tasks(self) -> list[Task]:
-        return [Task(idx=0, prompt="What is 2+2?", answer="4")]
+class JudgedTask(vf.Task[vf.State, Config]):
+    answer: str
 
     @vf.reward()
-    async def correct(self, task, trace) -> float:
-        result = await self.judge.evaluate(
-            trace=trace, 
-            question=task.prompt, 
-            answer=task.answer, 
+    async def correct(self, trace: vf.Trace) -> float:
+        judge = CorrectnessJudge(self.config.judge)  # config knobs stay CLI-tunable
+        result = await judge.evaluate(
+            trace=trace,
+            question=self.prompt,
+            answer=self.answer,
             # give the last assistant message to the judge
-            response=trace.last_reply
+            response=trace.last_reply,
         )
         return 1.0 if result.parsed else 0.0
+
+
+class SetConfig(vf.TasksetConfig):
+    task: Config = Config()
+
+
+class JudgeTraceTaskset(vf.Taskset[JudgedTask, SetConfig]):
+    def load(self) -> list[JudgedTask]:
+        return [JudgedTask(idx=0, prompt="What is 2+2?", answer="4")]
 ```
 
-To override the judge model, set `taskset.judge.model` in your config (it is a string).
-Sampling knobs live under `taskset.judge.sampling` — e.g. `taskset.judge.sampling.max_tokens`.
+To override the judge model, set `taskset.task.judge.model` in your config (it is a string).
+Sampling knobs live under `taskset.task.judge.sampling` — e.g.
+`taskset.task.judge.sampling.max_tokens`.
+
+Judges can also be plugged **from config alone** — no judge-calling code: the base
+`TaskConfig.judges` list on the corresponding task-config field (for example,
+`--taskset.task.judges` or `--taskset.proposer.judges`) plugs judge plugins (built-ins like
+`reference` / `rubric`, or hub packages) into each task using that config, and `Task.score`
+resolves and runs them after the task's own `@reward`s. Judges are config, never row data — the run's
+`config.toml` records what judged it, and `replay`'s layered config re-runs (or re-tunes)
+exactly those judges.

--- a/environments/proposer_solver_v1/proposer_solver_v1/__init__.py
+++ b/environments/proposer_solver_v1/proposer_solver_v1/__init__.py
@@ -1,0 +1,17 @@
+from proposer_solver_v1.taskset import (
+    ProposerConfig,
+    ProposerSolverConfig,
+    ProposerSolverTaskset,
+    ProposerTask,
+    SolvedConfig,
+    SolvedTask,
+)
+
+__all__ = [
+    "ProposerConfig",
+    "ProposerSolverConfig",
+    "ProposerSolverTaskset",
+    "ProposerTask",
+    "SolvedConfig",
+    "SolvedTask",
+]

--- a/environments/proposer_solver_v1/proposer_solver_v1/servers/__init__.py
+++ b/environments/proposer_solver_v1/proposer_solver_v1/servers/__init__.py
@@ -1,0 +1,1 @@
+"""Task-scoped servers for proposer-solver-v1."""

--- a/environments/proposer_solver_v1/proposer_solver_v1/servers/submit.py
+++ b/environments/proposer_solver_v1/proposer_solver_v1/servers/submit.py
@@ -1,0 +1,40 @@
+"""The proposer's typed submission tool."""
+
+import verifiers.v1 as vf
+
+
+class SubmissionState(vf.State):
+    submitted: bool = False
+    code: str = ""
+    input: str = ""
+    question: str = ""
+
+
+class SubmitToolsetConfig(vf.ToolsetConfig):
+    pass
+
+
+class SubmitToolset(vf.Toolset[SubmitToolsetConfig, SubmissionState]):
+    TOOL_PREFIX = "propose"
+
+    @vf.tool
+    def submit_question(self, code: str, input: str, question: str) -> str:
+        """Commit one code-checkable reasoning problem.
+
+        Args:
+            code: Complete stdlib-only Python script. It reads the input from
+                ``sys.argv[1]`` and prints exactly one answer.
+            input: The single command-line argument passed to the script.
+            question: Self-contained natural-language problem shown to the solver.
+        """
+        if not code.strip() or not question.strip():
+            raise ValueError("code and question must be non-empty")
+        self.state.code = code
+        self.state.input = input
+        self.state.question = question
+        self.state.submitted = True
+        return "Submission recorded."
+
+
+if __name__ == "__main__":
+    SubmitToolset.run()

--- a/environments/proposer_solver_v1/proposer_solver_v1/taskset.py
+++ b/environments/proposer_solver_v1/proposer_solver_v1/taskset.py
@@ -1,0 +1,189 @@
+"""A plural taskset for a proposer -> solver workflow.
+
+`load()` creates only proposer seeds. After a proposer rollout finishes, the orchestrator
+calls `solved_task(trace)` to create the second concrete task type. The taskset owns both
+types and their explicit configs even though orchestration happens outside the taskset.
+Both types require a container runtime because their rewards execute proposed code.
+"""
+
+import asyncio
+import math
+import re
+from typing import Self, cast
+
+import verifiers.v1 as vf
+
+from proposer_solver_v1.servers.submit import (
+    SubmissionState,
+    SubmitToolset,
+    SubmitToolsetConfig,
+)
+
+PROPOSE_PROMPT = """You are inventing a compact reasoning puzzle.
+
+Submit exactly one self-contained problem with the `propose_submit_question` tool. The
+problem must be solvable both by careful reasoning and by a complete stdlib-only Python
+script that reads one argument from `sys.argv[1]` and prints exactly one answer. Use small
+integers or short strings; avoid randomness, external facts, placeholders, and ambiguity.
+Do not reveal the code or answer in the natural-language question."""
+
+SOLVE_PROMPT = """Solve this puzzle. Reason it out carefully.
+
+{question}
+
+Show your reasoning, then put the final answer alone on the last line as
+`{answer_prefix} <value>`."""
+
+UV_SCRIPT_HEADER = "# /// script\n# dependencies = []\n# ///\n"
+GROUND_TRUTH_TIMEOUT = 10
+UNTRUSTED_CODE_RESOURCES = vf.TaskResources(cpu=1, memory=1)
+
+
+def parse_number(text: str) -> str | None:
+    cleaned = text.strip().strip("`").lstrip("$").replace(",", "").rstrip(".")
+    try:
+        value = float(cleaned)
+    except ValueError:
+        return None
+    if not math.isfinite(value):
+        return None
+    return str(int(value)) if value == int(value) else str(value)
+
+
+def answer_tokens(text: str) -> list[str]:
+    parts = [part for part in re.split(r"[,\s]+", text.strip().strip("[]()")) if part]
+    return [parse_number(part) or part.lower() for part in parts]
+
+
+def answers_match(expected: str, got: str) -> bool:
+    expected_number, got_number = parse_number(expected), parse_number(got)
+    if expected_number is not None and got_number is not None:
+        return expected_number == got_number
+    return answer_tokens(expected) == answer_tokens(got)
+
+
+async def run_ground_truth(runtime: vf.Runtime, code: str, input: str) -> str | None:
+    try:
+        result = await asyncio.wait_for(
+            runtime.run_uv_script(UV_SCRIPT_HEADER + code, args=[input]),
+            GROUND_TRUTH_TIMEOUT,
+        )
+    except TimeoutError:
+        return None
+    if result.exit_code != 0 or not result.stdout.strip():
+        return None
+    return result.stdout.strip().splitlines()[-1].strip()
+
+
+class ProposerData(vf.TaskData):
+    pass
+
+
+class SolvedData(vf.TaskData):
+    question: str
+    code: str
+    input: str
+
+
+class ProposerConfig(vf.TaskConfig):
+    submit: SubmitToolsetConfig = SubmitToolsetConfig()
+
+
+class SolvedConfig(vf.TaskConfig):
+    answer_prefix: str = "ANSWER:"
+
+
+class ProposerTask(vf.Task[ProposerData, SubmissionState, ProposerConfig]):
+    NEEDS_CONTAINER = True
+    tools = (SubmitToolset,)
+
+    async def finalize(self, trace: vf.Trace, runtime: vf.Runtime) -> None:
+        state = cast(SubmissionState, trace.state)
+        if state.submitted:
+            trace.info["submission"] = {
+                "code": state.code,
+                "input": state.input,
+                "question": state.question,
+            }
+
+    @vf.stop
+    async def submitted(self, trace: vf.Trace) -> bool:
+        return cast(SubmissionState, trace.state).submitted
+
+    @vf.reward(weight=0.1)
+    async def well_formed(self, trace: vf.Trace, runtime: vf.Runtime) -> float:
+        submission = trace.info.get("submission")
+        if not submission or not submission.get("code"):
+            return 0.0
+        expected = await run_ground_truth(
+            runtime, submission["code"], submission.get("input", "")
+        )
+        return float(expected is not None)
+
+
+class SolvedTask(vf.Task[SolvedData, vf.State, SolvedConfig]):
+    NEEDS_CONTAINER = True
+
+    @classmethod
+    def from_trace(cls, trace: vf.Trace, *, config: SolvedConfig | None = None) -> Self:
+        submission = trace.info["submission"]
+        config = config or SolvedConfig()
+        return cls(
+            SolvedData(
+                idx=trace.task.idx,
+                prompt=SOLVE_PROMPT.format(
+                    question=submission["question"],
+                    answer_prefix=config.answer_prefix,
+                ),
+                resources=UNTRUSTED_CODE_RESOURCES,
+                question=submission["question"],
+                code=submission["code"],
+                input=submission["input"],
+            ),
+            config,
+        )
+
+    async def validate(self, runtime: vf.Runtime) -> bool:
+        return (
+            await run_ground_truth(runtime, self.data.code, self.data.input) is not None
+        )
+
+    @vf.reward
+    async def correct(self, trace: vf.Trace, runtime: vf.Runtime) -> float:
+        config = cast(SolvedConfig, self.config)
+        got = None
+        for line in reversed(trace.last_reply.splitlines()):
+            text = line.strip().strip("*`").strip()
+            if text.upper().startswith(config.answer_prefix.upper()):
+                got = text[len(config.answer_prefix) :].strip().strip("*`")
+                break
+        if got is None:
+            return 0.0
+        expected = await run_ground_truth(runtime, self.data.code, self.data.input)
+        return float(expected is not None and answers_match(expected, got))
+
+
+class ProposerSolverConfig(vf.TasksetConfig):
+    num_tasks: int = 1
+    proposer: ProposerConfig = ProposerConfig()
+    solved: SolvedConfig = SolvedConfig()
+
+
+class ProposerSolverTaskset(
+    vf.Taskset[ProposerTask | SolvedTask, ProposerSolverConfig]
+):
+    def load(self) -> list[ProposerTask | SolvedTask]:
+        return [
+            ProposerTask(
+                ProposerData(
+                    idx=idx,
+                    prompt=PROPOSE_PROMPT,
+                    resources=UNTRUSTED_CODE_RESOURCES,
+                ),
+                self.config.proposer,
+            )
+            for idx in range(self.config.num_tasks)
+        ]
+
+    def solved_task(self, trace: vf.Trace) -> SolvedTask:
+        return SolvedTask.from_trace(trace, config=self.config.solved)

--- a/environments/proposer_solver_v1/pyproject.toml
+++ b/environments/proposer_solver_v1/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "proposer-solver-v1"
+version = "0.1.0"
+description = "A plural taskset that turns proposer traces into code-verified solved tasks."
+requires-python = ">=3.11"
+dependencies = ["verifiers"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["proposer_solver_v1"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ examples = [
     "compact",
     "gsm8k-v1", "glossary-v1", "deepwiki-v1", "wiki-search-v1", "code-golf-v1",
     "reverse-text-v1", "color-codeword-v1",
-    "wordle-v1", "alphabet-sort-v1", "scratchpad-v1",
+    "wordle-v1", "alphabet-sort-v1", "scratchpad-v1", "proposer-solver-v1",
 ]
 
 [project.optional-dependencies]
@@ -148,6 +148,7 @@ wordle-v1 = { path = "environments/wordle_v1", editable = true }
 color-codeword-v1 = { path = "environments/color_codeword_v1", editable = true }
 alphabet-sort-v1 = { path = "environments/alphabet_sort_v1", editable = true }
 scratchpad-v1 = { path = "environments/scratchpad_v1", editable = true }
+proposer-solver-v1 = { path = "environments/proposer_solver_v1", editable = true }
 
 [tool.uv.exclude-newer-package]
 # PrimeIntellect-published on PyPI (trusted publisher)

--- a/tests/v1/test_envs.py
+++ b/tests/v1/test_envs.py
@@ -2,9 +2,9 @@
 
 The v0 counterpart (`tests/test_envs.py`) covers v0 envs (`vf.load_environment` + `vf-eval`);
 here we run each `_v1` taskset with its required harness for one short, capped rollout and
-require it to succeed — so a broken example taskset fails CI. `compact` is excluded (it's a
-harness, not a taskset); SWE/container tasksets need a docker/prime runtime and are covered by
-the dedicated v1 e2e tests instead.
+require it to succeed — so a broken example taskset fails CI. `compact` is excluded because
+it is a harness; container/corpus tasksets that cannot run in plain CI are listed in
+`SKIP_EVAL` below.
 """
 
 import os
@@ -20,9 +20,9 @@ EVAL_TIMEOUT = 600  # 10 minutes for a capped eval (-n 1 -r 2)
 ENVIRONMENTS = Path(__file__).parent.parent.parent / "environments"
 
 # v1 tasksets that can't run a plain-CI smoke eval — e.g. they need a docker/prime runtime or
-# clone a corpus CI can't read. Empty: the SWE/container and corpus tasksets live in
-# research-environments now.
-SKIP_EVAL: set[str] = set()
+# clone a corpus CI can't read. Proposer-solver executes model-authored ground-truth code and
+# therefore requires an explicitly selected docker/prime harness runtime.
+SKIP_EVAL = {"proposer_solver_v1"}
 
 
 def v1_tasksets() -> list[str]:

--- a/uv.lock
+++ b/uv.lock
@@ -4118,6 +4118,17 @@ wheels = [
 ]
 
 [[package]]
+name = "proposer-solver-v1"
+version = "0.1.0"
+source = { editable = "environments/proposer_solver_v1" }
+dependencies = [
+    { name = "verifiers" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "verifiers" }]
+
+[[package]]
 name = "protobuf"
 version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
@@ -6260,6 +6271,7 @@ examples = [
     { name = "deepwiki-v1" },
     { name = "glossary-v1" },
     { name = "gsm8k-v1" },
+    { name = "proposer-solver-v1" },
     { name = "reverse-text-v1" },
     { name = "scratchpad-v1" },
     { name = "wiki-search-v1" },
@@ -6345,6 +6357,7 @@ examples = [
     { name = "deepwiki-v1", editable = "environments/deepwiki_v1" },
     { name = "glossary-v1", editable = "environments/glossary_v1" },
     { name = "gsm8k-v1", editable = "environments/gsm8k_v1" },
+    { name = "proposer-solver-v1", editable = "environments/proposer_solver_v1" },
     { name = "reverse-text-v1", editable = "environments/reverse_text_v1" },
     { name = "scratchpad-v1", editable = "environments/scratchpad_v1" },
     { name = "wiki-search-v1", editable = "environments/wiki_search_v1" },

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -64,6 +64,7 @@ from verifiers.v1.loaders import (
     load_judge,
     load_taskset,
     task_type,
+    task_types,
     taskset_config_type,
 )
 from verifiers.v1.scoring import (
@@ -219,6 +220,7 @@ __all__ = [
     "load_harness",
     "load_judge",
     "task_type",
+    "task_types",
     "taskset_config_type",
     "harness_config_type",
     "judge_config_type",

--- a/verifiers/v1/cli/debug.py
+++ b/verifiers/v1/cli/debug.py
@@ -28,7 +28,7 @@ from verifiers.v1.decorators import invoke
 from verifiers.v1.env import resolve_runtime_config
 from verifiers.v1.runtimes import ProgramResult, Runtime, make_runtime
 from verifiers.v1.state import state_cls
-from verifiers.v1.task import Task
+from verifiers.v1.task import Task, task_class_path
 from verifiers.v1.trace import Error, Trace
 from verifiers.v1.utils.logging import setup_logging
 
@@ -204,7 +204,11 @@ async def run_action(runtime: Runtime, config: DebugConfig) -> dict[str, Any]:
 
 
 async def debug_task(task: Task, config: DebugConfig) -> tuple[Trace, bool]:
-    trace = Trace(task=task.data, state=state_cls(type(task))())
+    trace = Trace(
+        task=task.data,
+        task_class=task_class_path(type(task)),
+        state=state_cls(type(task))(),
+    )
     debug = {
         "task": task_info(task),
         "action": "command" if config.command is not None else "script",

--- a/verifiers/v1/cli/eval/resume.py
+++ b/verifiers/v1/cli/eval/resume.py
@@ -6,9 +6,8 @@ brings the good saved rollouts back into memory and re-runs only what's still ow
 *missing* rollouts (never written — the run was interrupted) and the *errored* ones (written
 with an error; dropped and redone). The loaded traces rejoin the run everywhere — counted,
 displayed, pushed, and printed alongside this session's — so a resumed run picks up exactly
-where the interrupted one stopped. A group-scored taskset is resumed a whole task at a time
-(its rollouts are scored together), so any task that isn't fully complete is redone from
-scratch.
+where the interrupted one stopped. A group-scored task is resumed whole (its rollouts are
+scored together), so any such task that isn't fully complete is redone from scratch.
 """
 
 import json
@@ -68,12 +67,15 @@ class Finished(Rollout):
 
 
 def load(
-    resume_dir: Path, selected_idxs: list[int], num_rollouts: int, group: bool
+    resume_dir: Path,
+    selected_idxs: list[int],
+    num_rollouts: int,
+    group_idxs: set[int],
 ) -> tuple[list[Trace], dict[int, int]]:
     """Load the good saved rollouts back into memory as finished traces and diff them against
     the run's target (`num_rollouts` per selected task): returns (the kept traces, rollouts
-    owed per task idx). An errored trace is dropped and re-run; a group-scored task is kept
-    only if fully complete, else its whole group is redone. Rewrites `traces.jsonl` to just
+    owed per task idx). An errored trace is dropped and re-run; each group-scored task is
+    kept only if fully complete, else its whole group is redone. Rewrites `traces.jsonl` to just
     the kept rows — verbatim, via a temp file + atomic rename, so an interrupted resume can't
     corrupt the prior good results — and the resumed rollouts then append. `WireTrace` reads
     any taskset's saved traces without importing it."""
@@ -100,7 +102,7 @@ def load(
     owed: dict[int, int] = {}
     for idx in selected_idxs:
         rows = good.get(idx, [])
-        if group and len(rows) < num_rollouts:
+        if idx in group_idxs and len(rows) < num_rollouts:
             owed[idx] = num_rollouts  # re-run the whole group; keep none of it
             continue
         keep.extend(rows)

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -46,11 +46,12 @@ async def run_eval(env: Environment, config: EvalConfig) -> list[Trace]:
     finished: list[Trace] = []
     if config.resume is not None:
         # A group-scored task's episode must be re-run whole (its `@group_reward`s
-        # compare all its rollouts); other tasks only re-run what's missing. One task
-        # type per taskset, so group scoring is a run-wide property.
-        group = bool(tasks) and bool(discover_decorated(tasks[0], "group_reward"))
+        # compare all its rollouts); other tasks only re-run what's missing.
+        group_idxs = {
+            task.data.idx for task in tasks if discover_decorated(task, "group_reward")
+        }
         finished, owed = resume.load(
-            out, [t.data.idx for t in tasks], config.num_rollouts, group
+            out, [t.data.idx for t in tasks], config.num_rollouts, group_idxs
         )
         if not owed:  # already complete - report it and exit successfully
             print(resume.nothing_to_resume_msg(out, len(tasks), config.num_rollouts))
@@ -177,20 +178,30 @@ async def run_eval_server(config: EvalConfig) -> list[Trace]:
         client = EnvClient(address=address)
         await client.wait_for_server_startup(timeout=600)
         info = await client.info()
-        group_scored = info.requires_group_scoring
+        group_idxs = set(info.group_idxs)
         idxs = list(range(info.num_tasks))
         if config.shuffle:
             random.Random(_SHUFFLE_SEED).shuffle(idxs)
         if config.num_tasks is not None:
             idxs = idxs[: config.num_tasks]
+        group_idxs.intersection_update(idxs)
         out = output_path(config)
         finished: list[Trace] = []
         if config.resume is not None:
-            finished, owed = resume.load(out, idxs, config.num_rollouts, group_scored)
+            data_idxs = [info.task_data_idxs[idx] for idx in idxs]
+            group_data_idxs = {info.task_data_idxs[idx] for idx in group_idxs}
+            finished, data_owed = resume.load(
+                out, data_idxs, config.num_rollouts, group_data_idxs
+            )
+            owed = {
+                idx: data_owed[info.task_data_idxs[idx]]
+                for idx in idxs
+                if info.task_data_idxs[idx] in data_owed
+            }
             if not owed:  # already complete - report it and exit successfully
                 print(resume.nothing_to_resume_msg(out, len(idxs), config.num_rollouts))
                 raise SystemExit(0)
-            idxs = [idx for idx in idxs if owed.get(idx)]
+            idxs = list(owed)
             logger.info(
                 "resuming %s: %d task(s), %d rollout(s) owed",
                 out,
@@ -208,18 +219,33 @@ async def run_eval_server(config: EvalConfig) -> list[Trace]:
                 config.model,
             )
         logger.info("results: %s", out)
-        request_concurrency = config.max_concurrent
-        if request_concurrency and group_scored:
-            # max_concurrent is a rollout resource bound, not a request-throughput target.
-            # A group is indivisible, so one oversized group must still be allowed to run.
-            request_concurrency = max(1, request_concurrency // config.num_rollouts)
-        semaphore = (
-            asyncio.Semaphore(request_concurrency) if request_concurrency else None
-        )
+        limit = config.max_concurrent
+        available = limit or 0
+        condition = asyncio.Condition()
+
+        @contextlib.asynccontextmanager
+        async def reserve_slots(count: int):
+            """Reserve rollout capacity; an oversized group may occupy the whole limit."""
+            nonlocal available
+            reserved = 0
+            try:
+                if limit:
+                    count = min(count, limit)
+                    async with condition:
+                        await condition.wait_for(lambda: available >= count)
+                        available -= count
+                        reserved = count
+                yield
+            finally:
+                if reserved:
+                    async with condition:
+                        available += reserved
+                        condition.notify_all()
+
         write_lock = asyncio.Lock()
 
         async def run_group_unit(idx: int) -> list[Trace]:
-            async with semaphore or contextlib.nullcontext():
+            async with reserve_slots(config.num_rollouts):
                 traces = await client.run_group(
                     task_idx=idx,
                     n=config.num_rollouts,
@@ -232,7 +258,7 @@ async def run_eval_server(config: EvalConfig) -> list[Trace]:
             return traces
 
         async def run_rollout_unit(idx: int) -> list[Trace]:
-            async with semaphore or contextlib.nullcontext():
+            async with reserve_slots(1):
                 trace = await client.run_rollout(
                     task_idx=idx,
                     client=config.client,
@@ -242,15 +268,14 @@ async def run_eval_server(config: EvalConfig) -> list[Trace]:
             await append_trace(out, trace, write_lock)
             return [trace]
 
-        # A group-scored task must run its rollouts together (cross-rollout scoring) →
-        # one `run_group` request per task (one worker); otherwise rollouts are
-        # independent → one `run_rollout` request each, which the broker round-robins
-        # (least-busy) across workers — mirrors the prime-rl dispatcher.
-        units = (
-            [run_group_unit(i) for i in idxs]
-            if group_scored
-            else [run_rollout_unit(i) for i in idxs for _ in range(owed[i])]
-        )
+        # Group-scored tasks run their rollouts together (one worker); the remaining
+        # rollouts are independent requests the broker can distribute across workers.
+        units = [run_group_unit(i) for i in idxs if i in group_idxs] + [
+            run_rollout_unit(i)
+            for i in idxs
+            if i not in group_idxs
+            for _ in range(owed[i])
+        ]
         results = await asyncio.gather(*units)
         await client.close()
         return finished + [trace for unit_traces in results for trace in unit_traces]

--- a/verifiers/v1/cli/replay.py
+++ b/verifiers/v1/cli/replay.py
@@ -34,8 +34,13 @@ from verifiers.v1.cli.output import (
     write_config,
 )
 from verifiers.v1.configs.replay import ReplayConfig
-from verifiers.v1.state import state_cls
-from verifiers.v1.task import Task, WireTaskData, task_data_cls
+from verifiers.v1.state import State, state_cls
+from verifiers.v1.task import (
+    Task,
+    WireTaskData,
+    resolve_task_class,
+    task_data_cls,
+)
 from verifiers.v1.trace import Trace
 from verifiers.v1.utils.logging import setup_logging
 
@@ -69,22 +74,32 @@ def output_dir(config: ReplayConfig) -> Path:
 
 async def run_replay(config: ReplayConfig, source: Path, out: Path) -> list[Trace]:
     logger.debug("replay config:\n%s", config.model_dump_json(indent=2))
-    task_cls = vf.task_type(config.taskset.id)
-    data_cls = task_data_cls(task_cls)
+    taskset = vf.load_taskset(config.taskset)
+    declared = taskset.task_types()
     # `WireTaskData` reads any taskset's saved task without a runtime or its Task type (see WireTaskData).
-    traces = read_traces(source, Trace[WireTaskData, state_cls(task_cls)])
+    traces = read_traces(source, Trace[WireTaskData, State])
     if config.num_traces is not None:
         traces = traces[: config.num_traces]
-    # `trace.task` is pure data; re-scoring with the taskset's behavior needs the declared
-    # `TaskData` type — which every saved row is (`Taskset.tasks` constructs one task type).
+    # `trace.task` is pure data; its recorded class selects both the behavior and data
+    # schema strictly from the taskset's declared union. Same-schema task classes remain
+    # distinguishable because replay never infers behavior from the row shape.
     # A row that can't be rebuilt from the wire (a load-time-only field excluded from
     # serialization, like harbor's `task_dir`) stays a `WireTaskData` and is scored by the
     # base `Task` (judges + base signals only; the subclass's own `@reward`s don't run —
     # runtime-dependent ones would be skipped offline anyway).
+    resolved = []
     for trace in traces:
+        task_cls = resolve_task_class(declared, trace.task_class)
+        data_cls = task_data_cls(task_cls)
+        task_config = taskset.task_config(task_cls)
+        state_type = state_cls(task_cls)
         try:
-            trace.task = data_cls.model_validate(trace.task.model_dump())
+            trace = Trace[data_cls, state_type].model_validate(trace.model_dump())
+            trace.state = state_type()
+            behavior_cls = task_cls
         except Exception:
+            trace.state = state_type()
+            behavior_cls = Task
             logger.warning(
                 "replay: can't rebuild %s from the saved task %s; re-scoring it as a "
                 "plain WireTaskData (judges + base-task signals only)",
@@ -92,12 +107,17 @@ async def run_replay(config: ReplayConfig, source: Path, out: Path) -> list[Trac
                 trace.task.idx,
                 exc_info=True,
             )
-    # Judges are config, not wire data: `Task.score` resolves them from the replay
-    # config's `taskset.task.judges` (the source run's config.toml layered under any CLI
-    # overrides) — so a re-tuned judge overrides the recorded run's and a newly-plugged
+        resolved.append((trace, behavior_cls, task_config))
+    # Judges are config, not wire data: `Task.score` resolves them from the matching
+    # explicit task config (the source run's config.toml layered under any
+    # CLI overrides) — so a re-tuned judge overrides the recorded run's and a newly-plugged
     # one joins, with no trace surgery.
     # `num_rescores` re-scores each trace that many times, each on its own copy.
-    work = [t.model_copy(deep=True) for t in traces for _ in range(config.num_rescores)]
+    work = [
+        (trace.model_copy(deep=True), behavior_cls, task_config)
+        for trace, behavior_cls, task_config in resolved
+        for _ in range(config.num_rescores)
+    ]
 
     save_config(config, out)
     logger.info(
@@ -110,10 +130,11 @@ async def run_replay(config: ReplayConfig, source: Path, out: Path) -> list[Trac
     start = time.time()
 
     sem = asyncio.Semaphore(config.max_concurrent) if config.max_concurrent else None
-    states = [ReplayProgress(idx=t.task.idx, name=t.task.name) for t in work]
+    states = [ReplayProgress(idx=t.task.idx, name=t.task.name) for t, *_ in work]
     lock = asyncio.Lock()
 
-    async def rescore(trace: Trace, st: ReplayProgress) -> None:
+    async def rescore(item, st: ReplayProgress) -> None:
+        trace, behavior_cls, task_config = item
         async with sem or contextlib.nullcontext():
             st.start = time.time()
             # A rollout that errored during generation was never scored by eval (its scoring phase
@@ -129,12 +150,10 @@ async def run_replay(config: ReplayConfig, source: Path, out: Path) -> list[Trac
                     trace.info.pop("judge", None)
                 prior_rewards, prior_metrics = trace.rewards, trace.metrics
                 trace.rewards, trace.metrics, trace.extra_usage = {}, {}, []
-                # The behavior wrapper around the saved row: the declared Task for a
+                # The behavior wrapper around the saved row: its recorded Task class for a
                 # rebuilt row, the base Task (judges + base signals) for a WireTaskData
-                # fallback; the replay config's task subtree supplies the knobs.
-                task = (task_cls if isinstance(trace.task, data_cls) else Task)(
-                    trace.task, config=config.taskset.task
-                )
+                # fallback; the matching explicit config field supplies the knobs.
+                task = behavior_cls(trace.task, config=task_config)
                 try:
                     # Pre-fill the runtime-only values the offline `score` can't recompute
                     # BEFORE scoring — so trace-only signals that read them (e.g. a
@@ -176,9 +195,11 @@ async def run_replay(config: ReplayConfig, source: Path, out: Path) -> list[Trac
         else contextlib.nullcontext()
     )
     async with display:
-        await asyncio.gather(*(rescore(t, s) for t, s in zip(work, states)))
+        await asyncio.gather(
+            *(rescore(item, state) for item, state in zip(work, states))
+        )
     logger.info("replay: done in %.1fs -> %s", time.time() - start, out)
-    return work
+    return [trace for trace, *_ in work]
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/verifiers/v1/cli/validate.py
+++ b/verifiers/v1/cli/validate.py
@@ -34,7 +34,7 @@ from verifiers.v1.decorators import invoke
 from verifiers.v1.env import resolve_runtime_config
 from verifiers.v1.runtimes import make_runtime
 from verifiers.v1.state import state_cls
-from verifiers.v1.task import Task
+from verifiers.v1.task import Task, task_class_path
 from verifiers.v1.trace import Trace
 from verifiers.v1.utils.logging import setup_logging
 
@@ -106,7 +106,11 @@ async def _run_gold(task: Task, config: ValidateConfig) -> ResultRow:
     )
     valid, exc = False, None
     try:
-        trace = Trace(task=task.data, state=state_cls(type(task))())
+        trace = Trace(
+            task=task.data,
+            task_class=task_class_path(type(task)),
+            state=state_cls(type(task))(),
+        )
         await runtime.start()
         await asyncio.wait_for(
             invoke(task.setup, {"trace": trace, "runtime": runtime}),
@@ -139,7 +143,11 @@ async def _run_setup(task: Task, config: ValidateConfig) -> ResultRow:
     )
     valid, exc = False, None
     try:
-        trace = Trace(task=task.data, state=state_cls(type(task))())
+        trace = Trace(
+            task=task.data,
+            task_class=task_class_path(type(task)),
+            state=state_cls(type(task))(),
+        )
         await runtime.start()
         await asyncio.wait_for(
             invoke(task.setup, {"trace": trace, "runtime": runtime}),

--- a/verifiers/v1/configs/replay.py
+++ b/verifiers/v1/configs/replay.py
@@ -27,8 +27,8 @@ class ReplayConfig(BaseConfig):
     """Auto-generated run id — the leaf of the output dir, so replays never overwrite."""
     taskset: SerializeAsAny[TasksetConfig] = TasksetConfig()
     """The taskset, selected by `--taskset.id` (narrowed to its config type). Its
-    `taskset.task.judges` replace the source run's judges entirely (and new ones
-    join); set them via `@ file.toml` / dotted flags."""
+    typed task-config fields replace the source run's judges entirely (and new ones
+    join); set their `judges` via `@ file.toml` / dotted flags."""
     num_traces: int | None = Field(
         None, validation_alias=AliasChoices("num_traces", "n")
     )
@@ -61,7 +61,8 @@ class ReplayConfig(BaseConfig):
     @classmethod
     def _resolve_taskset(cls, data):
         """Narrow the generic `taskset` to its specific config type by `id` (mirrors
-        `ValidateConfig`), so `taskset.task.judges` and other taskset fields validate typed."""
+        `ValidateConfig`), so judges on every task-config field and other taskset fields
+        validate typed."""
         from verifiers.v1.loaders import narrow_plugin_field, taskset_config_type
 
         narrow_plugin_field(data, "taskset", taskset_config_type)

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -9,7 +9,7 @@ Execution lives one level down: an `Episode` runs `n` `Rollout`s of a task and s
 runs one trajectory. The task's `@reward`/`@metric` get the rollout's runtime
 (read/exec inside it), so a task scores correctly under any harness; `@group_reward`s
 compare a task's rollouts. Harness capability checks (tools, user sim, container) read
-the class-level declarations (`Task.tools` / `Task.user`) — one task class per taskset.
+each task's concrete class-level declarations (`Task.tools` / `Task.user`).
 """
 
 import contextlib

--- a/verifiers/v1/judge.py
+++ b/verifiers/v1/judge.py
@@ -234,7 +234,7 @@ class Judge(Generic[ParsedT, ConfigT]):
     `prompt` template and use the defaults — then call `evaluate(**fields)`. Set `schema` to opt
     into structured outputs. Generic over the verdict and (optionally) the config type —
     `Judge[bool]` for a code-level judge, `Judge[float, MyJudgeConfig]` to also narrow
-    `self.config` (which is how a plugged judge declares its config for `--taskset.task.judges`
+    `self.config` (which is how a plugged judge declares its config for `TaskConfig.judges`
     narrowing; see `judge_config_cls`). A pluggable judge additionally implements `score`.
     """
 
@@ -288,7 +288,7 @@ class Judge(Generic[ParsedT, ConfigT]):
         via `TaskConfig.judges`; code-level judges just call `evaluate` from a `@reward`."""
         raise NotImplementedError(
             f"{type(self).__name__} implements no `score`, so it can't be plugged via "
-            "`taskset.task.judges`; implement `score` (see verifiers.v1.judges for examples) or "
+            "`TaskConfig.judges`; implement `score` (see verifiers.v1.judges for examples) or "
             "call it from a task `@reward` instead."
         )
 

--- a/verifiers/v1/legacy.py
+++ b/verifiers/v1/legacy.py
@@ -307,7 +307,10 @@ class LegacyEnvServer(EnvServer):
         except ValueError:
             self.dataset = self.env.get_eval_dataset()
         self.tasks = self.dataset  # `len(self.tasks)` drives the `info` response
-        self.requires_group_scoring = self.env.requires_group_rollouts
+        self.task_data_idxs = list(range(len(self.tasks)))
+        self.group_idxs = (
+            list(range(len(self.tasks))) if self.env.requires_group_rollouts else []
+        )
         self._clients: dict[tuple[str, str], Any] = {}
 
         self.ctx = zmq.asyncio.Context()

--- a/verifiers/v1/loaders.py
+++ b/verifiers/v1/loaders.py
@@ -12,8 +12,8 @@ with verifiers under `verifiers/v1/{harnesses,tasksets,judges}`; custom ones liv
 
 The taskset/harness class carries its types as generic args — `Taskset[TaskT, ConfigT]`,
 `Harness[ConfigT]` — which the CLI reads to narrow the plugin's config for `--taskset.*` /
-`--harness.*` flags (`taskset_config_type` / `harness_config_type`) and to type the wire trace
-(`task_type`).
+`--harness.*` flags (`taskset_config_type` / `harness_config_type`) and to resolve a wire
+trace's concrete behavior within the taskset's declared `task_types`.
 """
 
 import importlib
@@ -193,8 +193,10 @@ def judge_config_type(judge_id: str) -> type[JudgeConfig]:
 
 
 def task_type(taskset_id: str) -> type[Task]:
-    """The taskset's `Task` subclass (`Taskset.task_type`) — no data is loaded, so a caller
-    that imports the taskset can cheaply build a typed `Trace[TaskT]` for the otherwise
-    taskset-specific (loose dict) wire trace. Falls back to the base `Task` when no
-    subclass is given."""
+    """The taskset's sole task type; fail for a taskset that declares a union."""
     return taskset_class(taskset_id).task_type()
+
+
+def task_types(taskset_id: str) -> tuple[type[Task], ...]:
+    """Every concrete task type declared by a taskset, without loading its data."""
+    return taskset_class(taskset_id).task_types()

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -43,7 +43,7 @@ from verifiers.v1.runtimes import (
 )
 from verifiers.v1.mcp import SharedToolServer, serve_tools, serve_user
 from verifiers.v1.state import state_cls
-from verifiers.v1.task import Task
+from verifiers.v1.task import Task, task_class_path
 from verifiers.v1.trace import Trace
 
 logger = logging.getLogger(__name__)
@@ -139,7 +139,11 @@ class Rollout:
         eval-level shared tool servers / interception pool injected at construction (see
         `self.shared_tools` / `self.interception`)."""
         # The trace carries the DATA (the wire half); behavior stays on `self.task`.
-        trace: Trace = Trace(task=self.task.data, state=state_cls(type(self.task))())
+        trace: Trace = Trace(
+            task=self.task.data,
+            task_class=task_class_path(type(self.task)),
+            state=state_cls(type(self.task))(),
+        )
         self.trace = trace  # expose for the --rich dashboard
         self.phase = Phase.SETUP  # leaving the queue: provisioning starts now
         trace.timing.setup.start = time.time()

--- a/verifiers/v1/serve/client.py
+++ b/verifiers/v1/serve/client.py
@@ -136,7 +136,7 @@ class EnvClient:
         )
 
     async def info(self) -> InfoResponse:
-        """Return the taskset `num_tasks` + whether its tasks group-score."""
+        """Return task positions, stable data indexes, and which need group scoring."""
         return await self._request(InfoRequest(), InfoResponse)
 
     async def run_rollout(

--- a/verifiers/v1/serve/server.py
+++ b/verifiers/v1/serve/server.py
@@ -3,7 +3,7 @@
 A ZMQ ROUTER front end (msgpack frames) over a v1 `Environment`. The server
 owns the environment — taskset, harness, runtime — and is the only process that ever
 loads it. A caller (e.g. the orchestrator) stays env-agnostic: it asks `info` for
-the task count + whether group scoring is needed, then `run_rollout` / `run_group`
+the task count + which task positions need group scoring, then `run_rollout` / `run_group`
 by task index. Per request the server resolves a `Client` from the request's
 `client` config (cached, so a renderer's tokenizer is built once), wraps it in a
 `ModelContext`, and runs `env.episode(task, ctx, n).run()`, returning each
@@ -56,11 +56,12 @@ class EnvServer:
         self.env = Environment(config)
         # Load tasks once; the index range is fixed for the server's lifetime.
         self.tasks = self.env.taskset.load()
-        # One task type per taskset (`Taskset.tasks` enforces it), so group scoring is a
-        # run-wide property.
-        self.requires_group_scoring = bool(self.tasks) and bool(
-            discover_decorated(self.tasks[0], "group_reward")
-        )
+        self.task_data_idxs = [task.data.idx for task in self.tasks]
+        self.group_idxs = [
+            idx
+            for idx, task in enumerate(self.tasks)
+            if discover_decorated(task, "group_reward")
+        ]
         self._clients: dict[
             tuple[str, str], Client
         ] = {}  # (client_config, model) -> Client
@@ -145,7 +146,8 @@ class EnvServer:
             elif route == "info":
                 response = InfoResponse(
                     num_tasks=len(self.tasks),
-                    requires_group_scoring=self.requires_group_scoring,
+                    task_data_idxs=self.task_data_idxs,
+                    group_idxs=self.group_idxs,
                 )
             elif route == "run_rollout":
                 response = await self._run_rollout(
@@ -181,7 +183,7 @@ class EnvServer:
             self.taskset_id,
             self.address,
             len(self.tasks),
-            self.requires_group_scoring,
+            bool(self.group_idxs),
         )
         poller = zmq.asyncio.Poller()
         poller.register(self.frontend, zmq.POLLIN)

--- a/verifiers/v1/serve/types.py
+++ b/verifiers/v1/serve/types.py
@@ -2,7 +2,7 @@
 
 from typing import ClassVar
 
-from pydantic import BaseModel, field_serializer
+from pydantic import BaseModel, Field, field_serializer
 
 from verifiers.v1.clients.config import ClientConfig
 from verifiers.v1.task import WireTaskData
@@ -38,10 +38,12 @@ class InfoRequest(BaseRequest):
 class InfoResponse(BaseResponse):
     num_tasks: int = 0
     """Number of tasks in the taskset — the index range the caller samples from."""
-    requires_group_scoring: bool = False
-    """Whether the taskset's tasks define `@group_reward`s (one task type per taskset) —
-    the caller then runs each task via `run_group` (a whole episode per request) and
-    plans its resume whole-group; otherwise everything goes per-rollout."""
+    task_data_idxs: list[int] = Field(default_factory=list)
+    """`TaskData.idx` for each task position, used to map server requests to persisted
+    traces when the stable data index differs from the task's list position."""
+    group_idxs: list[int] = Field(default_factory=list)
+    """Task positions that define `@group_reward`s. The caller runs only these through
+    `run_group` and plans their resume whole-group; other tasks run per rollout."""
 
 
 class RunRolloutRequest(BaseRequest):
@@ -56,7 +58,7 @@ class RunRolloutResponse(BaseResponse):
     trace: Trace[WireTaskData] | None = None
     """A typed `Trace` with a non-strict `WireTaskData` (taskset-specific task fields ride in
     `model_extra`), so the server needn't assume the caller imports the taskset. A caller
-    that *does* import it upgrades via `Trace[task_type(taskset_id)].model_validate(...)`."""
+    that imports it resolves `trace.task_class` within `task_types(taskset_id)`."""
 
     @field_serializer("trace")
     def _ser_trace(self, trace: "Trace[WireTaskData] | None") -> dict | None:

--- a/verifiers/v1/task.py
+++ b/verifiers/v1/task.py
@@ -44,7 +44,7 @@ import asyncio
 import inspect
 import logging
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, ClassVar, Generic, Self, get_args
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, Self, get_args
 
 from pydantic import ConfigDict, model_validator
 from pydantic_config import BaseConfig
@@ -645,4 +645,4 @@ def resolve_task_class(
     )
 
 
-TaskT = TypeVar("TaskT", bound=Task)
+TaskT = TypeVar("TaskT", bound=Task[Any, Any, Any])

--- a/verifiers/v1/task.py
+++ b/verifiers/v1/task.py
@@ -17,9 +17,8 @@ a `TaskData` plus a `TaskConfig`, both plain constructor arguments:
 
 Subclass per dataset and parameterize `Task[MyData, MyState, MyConfig]` (all three
 default) — hooks and signals read the row off `self.data` and the knobs off
-`self.config`. Because behavior lives on the task class, verification never branches
-on a type field; a taskset yields one task type (its `load` constructs it), and
-instances differ per row through their data.
+`self.config`. A taskset declares every task type it can construct; each trace records
+the concrete behavior class so replay can re-attach the right one.
 
 The task is the single judgement authority, scored at two granularities (execution
 lives in the Rollout — per-rollout — and the Episode — group — which call these):
@@ -33,10 +32,10 @@ instance), so hooks and scoring methods must not stash per-rollout state on `sel
 that lives on the trace (`trace.state`, typed via the `Task[..., MyState, ...]`
 param).
 
-On the wire only the data travels: a saved `trace.task` reads back as `WireTaskData`
-(extra fields preserved) without importing the taskset; a consumer that re-scores
-(e.g. `replay`) rebuilds the declared `TaskData` type and wraps it in the declared
-`Task` — one task type per taskset.
+On the wire the row travels as data plus `Trace.task_class`: a saved `trace.task` reads
+back as `WireTaskData` (extra fields preserved) without importing the taskset; a consumer
+that re-scores (e.g. `replay`) resolves the recorded class within the taskset's declared
+task types, rebuilds its `TaskData`, and wraps it in that behavior.
 """
 
 from __future__ import annotations
@@ -123,7 +122,8 @@ class TaskConfig(BaseConfig):
     into any taskset/harness pair from the eval config alone, no taskset code. `Task.score`
     resolves and runs them after the task's `@reward`s; each entry records its verdict in
     `trace.rewards` under its `name` with its `weight` (see `JudgeConfig`). Set via
-    `--taskset.task.judges`."""
+    the matching task-config field (`--taskset.task.judges` by convention for a
+    single-type taskset)."""
 
     @model_validator(mode="before")
     @classmethod
@@ -154,7 +154,8 @@ class TaskData(StrictBaseModel):
     model_config = ConfigDict(frozen=True)
 
     idx: int
-    """Stable integer index of this example within its taskset."""
+    """Stable integer index of this example within its taskset. It must be unique among
+    the tasks returned by one `Taskset.load()` call."""
     name: str | None = None
     """Optional human-readable task name/label (for display/filtering)."""
     description: str | None = None
@@ -201,7 +202,7 @@ class WireTaskData(TaskData):
     `Trace` be typed on the wire — `Trace[WireTaskData]` — without importing the taskset,
     since the real `TaskData` subclass's extra fields land in `model_extra` instead of
     being rejected. A caller that re-scores rebuilds the real type via
-    `task_data_cls(task_type(taskset_id))` first."""
+    the trace's recorded class within `task_types(taskset_id)` first."""
 
     model_config = ConfigDict(extra="allow")
 
@@ -280,10 +281,10 @@ class Task(Generic[DataT, StateT, ConfigT]):
         MyTask(data, config=MyTaskConfig())  # or injected
         MyTask.from_trace(trace)             # opt-in: derived from a finished rollout
 
-    A taskset's `load()` constructs one per row with the eval's `TasksetConfig.task`.
-    Hooks and signals read the row off `self.data` and the knobs off `self.config`; one
-    instance is shared across a group's rollouts, so per-rollout state lives on
-    `trace.state`, never on `self`."""
+    A taskset constructs each task with its matching task-config field (`task` by convention
+    for a single-type taskset). Hooks and signals read the row off `self.data` and the knobs
+    off `self.config`; one instance is shared across a group's rollouts, so per-rollout
+    state lives on `trace.state`, never on `self`."""
 
     NEEDS_CONTAINER: ClassVar[bool] = False
     """Whether this task only runs in a container runtime (docker/prime). When True the
@@ -338,8 +339,8 @@ class Task(Generic[DataT, StateT, ConfigT]):
 
     def plugged_judges(self) -> list[Judge]:
         """The runtime `Judge` objects for this task's plugged judges — resolved from
-        `config.judges` alone (`--taskset.task.judges`; judges are config, never row
-        data). Built fresh per call — a judge is a cheap value (its HTTP client is
+        `config.judges` alone (the matching task-config field; judges are config, never
+        row data). Built fresh per call — a judge is a cheap value (its HTTP client is
         opened per call inside `Judge.complete` and closed when it returns), so nothing
         is shared or cached."""
         from verifiers.v1.loaders import load_judge
@@ -622,6 +623,26 @@ class Task(Generic[DataT, StateT, ConfigT]):
             for trace in traces:
                 if isinstance(trace.info, dict):
                     trace.info.setdefault("offline_keys", {})["group"] = group_keys
+
+
+def task_class_path(cls: type[Task]) -> str:
+    """Stable wire identity for a concrete task behavior class."""
+    return f"{cls.__module__}:{cls.__qualname__}"
+
+
+def resolve_task_class(
+    declared: tuple[type[Task], ...], path: str | None
+) -> type[Task]:
+    """Resolve a wire identity strictly within a taskset's declared task types."""
+    if path is not None:
+        for cls in declared:
+            if task_class_path(cls) == path:
+                return cls
+    if path is None and len(declared) == 1:
+        return declared[0]
+    raise ValueError(
+        f"task class {path!r} is not one of {[task_class_path(cls) for cls in declared]}"
+    )
 
 
 TaskT = TypeVar("TaskT", bound=Task)

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -2,22 +2,22 @@
 
 A `Taskset` is the data half of an environment: config in, tasks out. `load()` — the one
 subclass hook, and the one method consumers call — builds each row's `TaskData` and wraps
-it in the task type with the config's task-facing subtree:
+it in one of the taskset's declared task types with its task-facing config:
 
     def load(self) -> list[MyTask]:
         return [MyTask(MyData(idx=i, ...), self.config.task) for i in ...]
 
-Load-time knobs (dataset, split, seed) live on the taskset config; the task-facing knobs
-under its `task` subtree (`TasksetConfig.task`, a `TaskConfig`, everything under
-`--taskset.task.*`); an eval-wide shared tool server is declared on `tools` with its knobs
+Load-time knobs (dataset, split, seed) live on the taskset config. A single-type taskset
+usually narrows `TasksetConfig.task`; a multi-type taskset declares one explicit config
+field per task type. An eval-wide shared tool server is declared on `tools` with its knobs
 at the taskset level (`--taskset.tools.*`). All per-task behavior — runtime prep, tools,
 user simulation, `@reward`/`@metric` scoring — lives on the `Task` (see
 `verifiers.v1.task`).
 
 The class stays generic over its task and config types (`Taskset[TaskT, TasksetConfigT]`)
-so the loaders can read them: `taskset_config_type` narrows `--taskset.*` CLI/toml flags
-to the real config, and `task_type` types the wire trace — one task type per taskset, so
-replay can rebuild every saved row as the declared type's data and re-wrap it.
+so the loaders can read them: `TaskT` may be a union (`ProposerTask | SolvedTask`),
+`taskset_config_type` narrows `--taskset.*` CLI/toml flags to the real config, and
+`task_types` supplies the closed set replay may resolve from the wire.
 """
 
 from __future__ import annotations
@@ -28,7 +28,14 @@ from pydantic import SerializeAsAny
 from pydantic_config import BaseConfig
 from typing_extensions import TypeVar
 
-from verifiers.v1.task import Task, TaskConfig, TaskT, resolve_server_config
+from verifiers.v1.errors import TaskError
+from verifiers.v1.task import (
+    Task,
+    TaskConfig,
+    TaskT,
+    resolve_server_config,
+    task_config_cls,
+)
 from verifiers.v1.types import ID
 from verifiers.v1.utils.install import env_name
 
@@ -37,19 +44,17 @@ if TYPE_CHECKING:
 
 
 class TasksetConfig(BaseConfig):
-    """Base taskset config: load-time knobs (dataset, split, seed, ...) plus the task's own
-    config under `task`. Subclass to add task-generation knobs; narrow `task` to your
-    `TaskConfig` subclass when the task reads knobs (`task: MyTaskConfig = MyTaskConfig()`),
-    so `--taskset.task.*` flags validate against it. `load()` passes `config.task` to every
-    task it constructs."""
+    """Base taskset config: load-time knobs plus task-facing configs. A single-type
+    taskset normally narrows `task`; a multi-type taskset adds one explicitly typed field
+    per task type (for example `proposer` and `solved`)."""
 
     id: ID = ""
     """The taskset id, which selects this taskset: a local package, or an
     `org/name[@version]` package installed on demand from the Environments Hub (see
     `ID`). Set via `--taskset.id`."""
     task: SerializeAsAny[TaskConfig] = TaskConfig()
-    """The task-facing config, passed to every constructed task (`Task.config`): server
-    placement, judges, scoring knobs. Everything under `--taskset.task.*`."""
+    """The conventional task-facing config for a single-type taskset: server placement,
+    judges, scoring knobs. Multi-type tasksets use explicit sibling fields instead."""
 
     @property
     def name(self) -> str:
@@ -61,10 +66,10 @@ TasksetConfigT = TypeVar("TasksetConfigT", bound=TasksetConfig, default=TasksetC
 
 
 class Taskset(Generic[TaskT, TasksetConfigT]):
-    """Generic over its task and config types, so `self.config` and `load` are fully
-    typed (and the loaders can narrow CLI flags / type the wire trace off the generics).
-    Subclass: implement `load`, constructing each task from its row's data and the
-    config's task subtree (`MyTask(data, self.config.task)`)."""
+    """Generic over its task types and config, so `self.config` and `load` are fully
+    typed. `TaskT` may be a concrete task or a union of every task this factory owns.
+    Subclass: implement `load`; additional taskset-specific factory methods may construct
+    later task types from finished traces."""
 
     tools: ClassVar[tuple[type[Toolset], ...]] = ()
     """TASKSET-scoped (shared) tool server classes: each is launched ONCE per eval by the
@@ -81,6 +86,50 @@ class Taskset(Generic[TaskT, TasksetConfigT]):
     def load(self) -> list[TaskT]:
         raise NotImplementedError
 
+    @classmethod
+    def task_types(cls) -> tuple[type[Task], ...]:
+        """Concrete task types declared by `Taskset[TaskT, ConfigT]`, including unions."""
+        for klass in cls.__mro__:
+            for orig in getattr(klass, "__orig_bases__", ()):
+                if get_origin(orig) is Taskset:
+                    task_arg = get_args(orig)[0]
+                    declared = tuple(
+                        task
+                        for task in get_args(task_arg) or (task_arg,)
+                        if isinstance(task, type) and issubclass(task, Task)
+                    )
+                    if declared:
+                        return declared
+        return (Task,)
+
+    def task_config(self, task_cls: type[Task]) -> TaskConfig:
+        """Resolve a task type's config from an explicitly typed taskset-config field.
+
+        Exact type wins, then a unique isinstance match. Multi-type tasksets use a
+        distinct `TaskConfig` subclass and field for each task type.
+        """
+        if task_cls not in self.task_types():
+            raise TaskError(
+                f"{task_cls.__name__} is not declared by {type(self).__name__}"
+            )
+        config_cls = task_config_cls(task_cls)
+        values = {
+            name: getattr(self.config, name) for name in type(self.config).model_fields
+        }
+        matched = [name for name, value in values.items() if type(value) is config_cls]
+        if not matched:
+            matched = [
+                name for name, value in values.items() if isinstance(value, config_cls)
+            ]
+        if len(matched) == 1:
+            return values[matched[0]]
+        detail = f"matching fields {matched}" if matched else "no matching field"
+        raise TaskError(
+            f"{type(self).__name__}: {detail} for {task_cls.__name__}'s "
+            f"{config_cls.__name__}; declare exactly one explicit field of that type and "
+            "use a distinct TaskConfig subclass per task type"
+        )
+
     def server_config(self, server_cls: type) -> BaseConfig:
         """The config a `tools` entry is built with, resolved off `self.config` (the
         taskset config; see `resolve_server_config`). Override to pair explicitly."""
@@ -95,14 +144,11 @@ class Taskset(Generic[TaskT, TasksetConfigT]):
 
     @classmethod
     def task_type(cls) -> type[Task]:
-        """The declared `TaskT`, read off the `Taskset[TaskT, TasksetConfigT]` generic
-        across the MRO (most-derived specialization wins, so a thin wrapper re-binding only
-        the config inherits its parent's task type). Falls back to the base `Task` when no
-        subclass is given."""
-        for klass in cls.__mro__:
-            for orig in getattr(klass, "__orig_bases__", ()):
-                if get_origin(orig) is Taskset:
-                    for arg in get_args(orig):
-                        if isinstance(arg, type) and issubclass(arg, Task):
-                            return arg
-        return Task
+        """The sole declared task type; fail loudly for a multi-type taskset."""
+        declared = cls.task_types()
+        if len(declared) != 1:
+            raise TypeError(
+                f"{cls.__name__} declares multiple task types "
+                f"{[task.__name__ for task in declared]}; use task_types()"
+            )
+        return declared[0]

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -223,6 +223,9 @@ class Trace(StrictBaseModel, Generic[DataT, StateT]):
     """Unique id for this rollout, auto-generated per trace."""
     task: DataT
     """The (immutable) task being solved — fully typed, flows into scoring."""
+    task_class: str | None = None
+    """Concrete task behavior class (`module:qualname`). Rollouts stamp it so replay can
+    resolve each row within a multi-type taskset; None only for manually built/legacy traces."""
     runtime: RuntimeInfo | None = None
     """Where the rollout ran: the runtime's full config plus the provisioned resource's `id`
     (subprocess workdir / docker container id / prime or modal sandbox id). The rollout assigns


### PR DESCRIPTION
## Overview

Allow a V1 taskset to own a closed set of concrete task types, including task families such as `ProposerTask | SolvedTask`. This provides the taskset-level contract for one taskset to create differently configured tasks while preserving the existing single-task-type API.

The PR also adds `proposer_solver_v1` as a concrete example: proposer tasks collect a code-checkable problem, and the same taskset turns a completed proposer trace into a solved task for a later solver agent.

This change is stacked on #1948 and targets `feat/task-centric-tasks`.

## Details

- Add plural task-type introspection while keeping `task_type()` for tasksets with exactly one declared type.
- Resolve one explicit, distinctly typed task-config field per concrete task type.
- Record concrete task behavior identity on traces and reattach only classes declared by the originating taskset during replay.
- Rebuild replay traces with their concrete data, state, and config types.
- Route group-scored and ordinary tasks independently through local and server-backed eval paths.
- Document seed-only loading plus taskset-specific factories for follow-up task construction.
- Add `proposer_solver_v1` with:
  - a `ProposerTask` and typed submission tool for the proposed question, input, and ground-truth program;
  - a separately configured `SolvedTask` constructed from the proposer trace;
  - container-scoped, time-bounded execution of proposed verification code;
  - a `solved_task(trace)` handoff point that an agent topology can schedule on the solver.

The taskset owns task construction and configuration. Agent topology remains responsible for selecting the proposer and solver harnesses and scheduling the derived task on the next agent.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add multi-type taskset support with per-task behavior, config, and trace identity
> - Introduces `Taskset.task_types()` to enumerate all declared `Task` subclasses from generic parameters, and `Taskset.task_config()` to resolve the correct `TaskConfig` for a given task type in a multi-type taskset.
> - Adds `task_class_path()` and `resolve_task_class()` utilities; `Trace` now records `task_class` so replay can reconstruct the correct `Task` subclass per trace.
> - Reworks `cli/replay.py` to resolve behavior class and config per-trace using `trace.task_class` against the taskset's declared union, falling back to base `Task` if the trace cannot be rebuilt.
> - Replaces the run-wide `requires_group_scoring` boolean in the serve/eval layer with per-task `group_idxs` and stable `task_data_idxs`, affecting `InfoResponse`, `EnvServer`, `LegacyEnvServer`, and the resume/runner logic.
> - Adds a `proposer-solver-v1` reference environment implementing a two-phase `ProposerTask | SolvedTask` family, where a proposer submits code/input and a solver scores answers against ground-truth execution.
> - Risk: `Taskset.task_type()` now raises `TypeError` for multi-type tasksets (breaking callers that used it on union tasksets), and `InfoResponse` no longer includes `requires_group_scoring` (breaking older clients).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8462007.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->