### PR TITLE
Simplify task-centric v1 APIs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,8 @@ Use these rules when shaping public v1 APIs, configs, and environment files.
 - Prefer verifiers-native task, trace, server, harness, and runtime interfaces over repeated path/import/discovery plumbing in user packages.
 - Expose as few knobs in the configs as possible, but as many as needed.
 - Use strict Pydantic models for structured config, tasks, messages, and state.
-- A basic taskset should fit in a few dozen idiomatic lines: typed task/config classes, `load_tasks()`, and decorated scoring.
-- Do not override `Taskset.__init__`, `Harness.__init__`, or `User.__init__`. Use `setup()` instead.
+- A basic taskset should fit in a few dozen idiomatic lines: typed data/task/config classes, `load()`, and decorated scoring on the task.
+- Do not override `Taskset.__init__`; implement `load()`. Do not override `Harness.__init__` or `User.__init__`; use `setup()`.
 - Refer to the code as the source of truth.
 - Avoid mutable module globals. Process-level locks/rate limiters and immutable constants are the narrow exceptions.
 

--- a/assets/agents/common_best_practices.md
+++ b/assets/agents/common_best_practices.md
@@ -15,7 +15,7 @@ Use these rules when shaping public v1 APIs, configs, and environment files.
 - Prefer verifiers-native task, trace, server, harness, and runtime interfaces over repeated path/import/discovery plumbing in user packages.
 - Expose as few knobs in the configs as possible, but as many as needed.
 - Use strict Pydantic models for structured config, tasks, messages, and state.
-- A basic taskset should fit in a few dozen idiomatic lines: typed task/config classes, `load_tasks()`, and decorated scoring.
-- Do not override `Taskset.__init__`, `Harness.__init__`, or `User.__init__`. Use `setup()` instead.
+- A basic taskset should fit in a few dozen idiomatic lines: typed data/task/config classes, `load()`, and decorated scoring on the task.
+- Do not override `Taskset.__init__`; implement `load()`. Do not override `Harness.__init__` or `User.__init__`; use `setup()`.
 - Refer to the code as the source of truth.
 - Avoid mutable module globals. Process-level locks/rate limiters and immutable constants are the narrow exceptions.

--- a/assets/lab/AGENTS.md
+++ b/assets/lab/AGENTS.md
@@ -22,8 +22,8 @@ Use these rules when shaping public v1 APIs, configs, and environment files.
 - Prefer verifiers-native task, trace, server, harness, and runtime interfaces over repeated path/import/discovery plumbing in user packages.
 - Expose as few knobs in the configs as possible, but as many as needed.
 - Use strict Pydantic models for structured config, tasks, messages, and state.
-- A basic taskset should fit in a few dozen idiomatic lines: typed task/config classes, `load_tasks()`, and decorated scoring.
-- Do not override `Taskset.__init__`, `Harness.__init__`, or `User.__init__`. Use `setup()` instead.
+- A basic taskset should fit in a few dozen idiomatic lines: typed data/task/config classes, `load()`, and decorated scoring on the task.
+- Do not override `Taskset.__init__`; implement `load()`. Do not override `Harness.__init__` or `User.__init__`; use `setup()`.
 - Refer to the code as the source of truth.
 - Avoid mutable module globals. Process-level locks/rate limiters and immutable constants are the narrow exceptions.
 

--- a/assets/lab/environments/AGENTS.md
+++ b/assets/lab/environments/AGENTS.md
@@ -112,7 +112,7 @@ You can create them like this (remember the bootstrapping with `uv run init MY_E
 ```python
 DATABASE = None
 
-class SearchToolset(vf.Toolset[vf.ToolsetConfig]):
+class SearchToolset(vf.Toolset[vf.SharedToolsetConfig]):
     TOOL_PREFIX = "search"
 
     @vf.tool
@@ -122,15 +122,13 @@ class SearchToolset(vf.Toolset[vf.ToolsetConfig]):
 
 # User-configurable knobs
 class SearchConfig(vf.TasksetConfig):
-    tools: vf.ToolsetConfig = vf.ToolsetConfig()
+    tools: vf.SharedToolsetConfig = vf.SharedToolsetConfig()
 
 class SearchTaskset(vf.Taskset[vf.Task, SearchConfig]):
-    # Launch the tools during setup
-    def tools(self, task: vf.Task) -> list[vf.Toolset]:
-        return [SearchToolset(self.config.tools)]
+    tools = (SearchToolset,)
 ```
 
-Tools can also be set per task, not just per taskset.
+Taskset tools are shared by a worker's rollouts. Tools can also be set per task.
 
 ## Using Judges
 

--- a/assets/lab/environments/AGENTS.md
+++ b/assets/lab/environments/AGENTS.md
@@ -28,29 +28,34 @@ However, for most environments, building a taskset should be enough.
 ## A minimal environment
 
 ```python
-import verifiers.v1 as vf 
+import verifiers.v1 as vf
 
 
-# A task defines a single problem and is defined as a subclass of vf.Task
-class AdditionTask(vf.Task):
+# The data for a given task
+class AdditionData(vf.TaskData):
     answer: int
 
 
-# The taskset defines the dataset (collection of tasks) and needs a vf.TasksetConfig, which can be empty.
+# A task defines a single problem and is defined as a subclass of vf.Task
+class AdditionTask(vf.Task[AdditionData]):
+    # @vf.reward denotes the scoring function for the task.
+    # It needs the trace, which contains the whole message graph, including function calls, user messages etc.
+    # It returns the reward for the single task based on this function.
+    @vf.reward
+    async def exact_match(self, trace: vf.Trace) -> float:
+        return float(trace.last_reply == str(self.data.answer))
+
+
+# The taskset defines the tasks and needs a vf.TasksetConfig, which can be empty.
 class AdditionTaskset(vf.Taskset[AdditionTask, vf.TasksetConfig]):
-    def load_tasks(self) -> list[AdditionTask]:
-        # Load the dataset, in this case we built it on the initial load
+    def load(self) -> list[AdditionTask]:
         return [
-            AdditionTask(idx=i, prompt=f"What is {i} + {i}?", answer=2 * i)
+            AdditionTask(
+                AdditionData(idx=i, prompt=f"What is {i} + {i}?", answer=2 * i),
+                self.config.task,
+            )
             for i in range(100)
         ]
-
-    # @vf.reward denotes the scoring function for the environment.
-    # It needs the actual task (defined earlier) as well as the trace, which contains the whole message graph, including function calls, user messages etc.
-    # It returns the reward for the rollout based on this function.
-    @vf.reward
-    async def exact_match(self, task: AdditionTask, trace: vf.Trace) -> float:
-        return float(trace.last_reply == str(task.answer))
 
 
 # Export the Taskset for verifiers to find it when loading
@@ -69,14 +74,34 @@ class AdditionConfig(vf.TasksetConfig):
     num_tasks: int = 100
 
 class AdditionTaskset(vf.Taskset[AdditionTask, AdditionConfig]):
-    def load_tasks(self) -> list[AdditionTask]:
+    def load(self) -> list[AdditionTask]:
         return [
-            AdditionTask(idx=i, prompt=f"What is {i} + {i}?", answer=2 * i)
+            AdditionTask(
+                AdditionData(idx=i, prompt=f"What is {i} + {i}?", answer=2 * i),
+                self.config.task,
+            )
             for i in range(self.config.num_tasks) # <- re-use the value here
         ]
-
 ```
-Common usages for `vf.TasksetConfig` are settings like splits (e.g., train/test), difficulty settings, judge model names, etc.
+
+Common usages for `vf.TasksetConfig` are load-time settings, such as splits (e.g., train/test), dataset names, etc.
+
+You can also use `vf.TaskConfig` to configure task data, such as scoring parameters:
+
+```python
+class AdditionTaskConfig(vf.TaskConfig):
+    tolerance: float = 0.0
+
+class AdditionTask(vf.Task[AdditionData, vf.State, AdditionTaskConfig]):
+    @vf.reward
+    async def exact_match(self, trace: vf.Trace) -> float:
+        tolerance = self.config.tolerance  # A task-wide confgi
+        ...
+
+class AdditionConfig(vf.TasksetConfig):
+    num_tasks: int = 100                             # --taskset.num-tasks
+    task: AdditionTaskConfig = AdditionTaskConfig()  # --taskset.task.tolerance
+```
 
 ## Adding Tools
 
@@ -105,6 +130,8 @@ class SearchTaskset(vf.Taskset[vf.Task, SearchConfig]):
         return [SearchToolset(self.config.tools)]
 ```
 
+Tools can also be set per task, not just per taskset.
+
 ## Using Judges
 
 If your reward is semantic, use an LLM judge.
@@ -128,31 +155,41 @@ class CorrectnessJudge(vf.Judge[bool]):
         return "yes" in response.text
 
 
-class Config(vf.TasksetConfig):
-    # The judge inherits base_url and api keys from the client config (env vars, with the Prime CLI config as a fallback)
+class JudgedData(vf.TaskData):
+    answer: str
+
+
+class JudgedTaskConfig(vf.TaskConfig):
+    # The judge inherits base_url and api keys from the client config
     judge: vf.JudgeConfig = vf.JudgeConfig(model="openai/gpt-5-mini")
 
 
-class JudgeTraceTaskset(vf.Taskset[Task, Config]):
-    # Build the judge lazily from config — no Taskset.__init__ override needed.
-    @cached_property
-    def judge(self) -> CorrectnessJudge:
-        return CorrectnessJudge(self.config.judge)
-
-    def load_tasks(self) -> list[Task]:
-        return [Task(idx=0, prompt="What is 2+2?", answer="4")]
-
+class JudgedTask(vf.Task[JudgedData, vf.State, JudgedTaskConfig]):
     @vf.reward()
-    async def correct(self, task, trace) -> float:
-        result = await self.judge.evaluate(
-            trace=trace, 
-            question=task.prompt, 
-            answer=task.answer, 
-            # give the last assistant message to the judge
-            response=trace.last_reply
+    async def correct(self, trace: vf.Trace) -> float:
+        # Keeping judge configuration on TaskConfig makes it overridable from CLI/TOML.
+        judge = CorrectnessJudge(self.config.judge)
+        result = await judge.evaluate(
+            trace=trace,
+            question=self.data.prompt,
+            answer=self.data.answer,
+            response=trace.last_reply,  # Grade the final assistant answer.
         )
-        return 1.0 if result.parsed else 0.0
+        return float(result.parsed)
+
+
+class SetConfig(vf.TasksetConfig):
+    task: JudgedTaskConfig = JudgedTaskConfig()
+
+
+class JudgeTraceTaskset(vf.Taskset[JudgedTask, SetConfig]):
+    def load(self) -> list[JudgedTask]:
+        return [
+            JudgedTask(
+                JudgedData(idx=0, prompt="What is 2+2?", answer="4"),
+                self.config.task,
+            )
+        ]
 ```
 
-To override the judge model, set `taskset.judge.model` in your config (it is a string).
-Sampling knobs live under `taskset.judge.sampling` — e.g. `taskset.judge.sampling.max_tokens`.
+To override the judge model, set `taskset.task.judge.model` in your config (it is a string).

--- a/docs/v1/architecture.md
+++ b/docs/v1/architecture.md
@@ -2,16 +2,16 @@
 
 verifiers is built out of the following parts: 
 
-The overall evaluation or prime-rl **orchestrator**, which creates several worker processes. These **workers** load several other rollout-related objects, such as the harness or taskset object, as well as an **interception server**. The worker also creates the **rollout runtime**, where the actual rollout happens.
+A server-backed evaluation or prime-rl **orchestrator** creates worker processes and distributes rollout requests among them. Each worker loads its taskset and harness, owns an **interception pool**, and creates the runtime used by each rollout it handles.
 
 The orchestrator and workers are managed by verifiers and prime-rl themselves and thus offer few configurable knobs.
 
-The **rollout** is the actual environment, i.e., the combination of the taskset, the harness and, optionally, the registered tools. Each of the rollouts is independent from the others. verifiers has three different runtimes which you can use for most environments:
+The **rollout** is the executable combination of one loaded task, the harness, and any tools. Each rollout has an independent trace and runtime state. verifiers has three different runtimes which you can use for most environments:
 - The `subprocess` runtime runs the rollouts in Python subprocesses locally. Thus, it is meant for debugging purposes, as there might be side effects during runtime, such as one subprocess altering the config files of the harness, which then affects the other subprocesses.
 - The `docker` runtime runs the rollouts in docker containers on your local machine.
 - Sandbox runtimes, such as `prime` or `modal`, are meant for production, especially for training or higher concurrency evaluation. These runtimes run remotely.
 
-The harness is placed inside the runtime to interact with the taskset. However, the harness itself does _not_ call the model API (such as the OpenAI API or the vLLM endpoint) directly. Instead, they are connected to an **interception server** via a tunnel (either locally or by using [Prime Tunnels](https://docs.primeintellect.ai/sandboxes/tunnel)).
+The harness runs inside the rollout runtime to interact with the taskset. The harness does _not_ call the provider endpoint directly. Instead, model traffic goes through an **interception server** over a local connection or [Prime Tunnel](https://docs.primeintellect.ai/sandboxes/tunnel).
 
 The interception server receives all these requests and then sends them over to the actual API, e.g. the OpenAI responses endpoint. It uses the endpoint that the harness expects, so Codex will use OpenAI Responses, while Claude Code will use the Anthropic Messages API.
 

--- a/docs/v1/environments.md
+++ b/docs/v1/environments.md
@@ -105,7 +105,7 @@ You can create them like this (remember the bootstrapping with `uv run init MY_E
 ```python
 DATABASE = None
 
-class SearchToolset(vf.Toolset[vf.ToolsetConfig]):
+class SearchToolset(vf.Toolset[vf.SharedToolsetConfig]):
     TOOL_PREFIX = "search"
 
     @vf.tool
@@ -115,15 +115,13 @@ class SearchToolset(vf.Toolset[vf.ToolsetConfig]):
 
 # User-configurable knobs
 class SearchConfig(vf.TasksetConfig):
-    tools: vf.ToolsetConfig = vf.ToolsetConfig()
+    tools: vf.SharedToolsetConfig = vf.SharedToolsetConfig()
 
 class SearchTaskset(vf.Taskset[vf.Task, SearchConfig]):
-    # Launch the tools during setup
-    def tools(self, task: vf.Task) -> list[vf.Toolset]:
-        return [SearchToolset(self.config.tools)]
+    tools = (SearchToolset,)
 ```
 
-Tools can also be set per task, not just per taskset.
+Taskset tools are shared by a worker's rollouts. Tools can also be set per task.
 
 ## Using Judges
 

--- a/docs/v1/environments.md
+++ b/docs/v1/environments.md
@@ -20,35 +20,28 @@ However, for most environments, building a taskset should be enough.
 
 ## A minimal environment
 
-A task is split into data and behavior. `vf.TaskData` is one row's pure data — the wire
-shape saved on every trace; subclass it to add typed fields (the reference answer, ground
-truths). `vf.Task` is the behavior — `@vf.reward` / `@vf.metric` scoring methods, lifecycle
-hooks, and tool/user declarations — reading the row off `self.data`. The `vf.Taskset` is
-the loader: its `load()` builds each row's data and constructs the task around it (one
-task type per taskset).
-
 ```python
 import verifiers.v1 as vf
 
 
-# One row's data: the wire shape (what traces store).
+# The data for a given task
 class AdditionData(vf.TaskData):
     answer: int
 
 
-# The behavior: how a row is scored. @vf.reward receives whatever it declares by
-# parameter name (`trace`, `runtime`); the row is `self.data`. The trace contains
-# the whole message graph, including function calls and user messages.
+# A task defines a single problem and is defined as a subclass of vf.Task
 class AdditionTask(vf.Task[AdditionData]):
+    # @vf.reward denotes the scoring function for the task.
+    # It needs the trace, which contains the whole message graph, including function calls, user messages etc.
+    # It returns the reward for the single task based on this function.
     @vf.reward
     async def exact_match(self, trace: vf.Trace) -> float:
         return float(trace.last_reply == str(self.data.answer))
 
 
-# The taskset is the loader: it builds the tasks from their rows.
+# The taskset defines the tasks and needs a vf.TasksetConfig, which can be empty.
 class AdditionTaskset(vf.Taskset[AdditionTask, vf.TasksetConfig]):
     def load(self) -> list[AdditionTask]:
-        # Load the dataset, in this case we build it on the initial load
         return [
             AdditionTask(
                 AdditionData(idx=i, prompt=f"What is {i} + {i}?", answer=2 * i),
@@ -62,9 +55,7 @@ class AdditionTaskset(vf.Taskset[AdditionTask, vf.TasksetConfig]):
 __all__ = ["AdditionTaskset"]
 ```
 
-You can also use `@vf.metric` to record non-scored values, `@vf.group_reward` for group
-rewards (comparing a task's rollouts, useful for training), and `@vf.stop` for stop
-conditions. Lifecycle hooks (`setup`, `finalize`, `validate`) are methods on the task too.
+You can also use `@vf.metric` to record non-scored values and `@vf.group_reward` for group rewards, which might be useful for training.
 
 ## Making values configurable
 
@@ -86,12 +77,9 @@ class AdditionTaskset(vf.Taskset[AdditionTask, AdditionConfig]):
         ]
 ```
 
-Common usages for `vf.TasksetConfig` are **load-time** settings: splits (e.g., train/test),
-dataset names, sample counts, rng seeds.
+Common usages for `vf.TasksetConfig` are load-time settings, such as splits (e.g., train/test), dataset names, etc.
 
-Knobs the *task itself* reads — scoring parameters, judge endpoints, server placement — go
-on a `vf.TaskConfig`, nested on the taskset config under `task` and passed to every
-constructed task. The task reads them off `self.config`, typed by parameterizing the task:
+You can also use `vf.TaskConfig` to configure task data, such as scoring parameters:
 
 ```python
 class AdditionTaskConfig(vf.TaskConfig):
@@ -100,42 +88,24 @@ class AdditionTaskConfig(vf.TaskConfig):
 class AdditionTask(vf.Task[AdditionData, vf.State, AdditionTaskConfig]):
     @vf.reward
     async def exact_match(self, trace: vf.Trace) -> float:
-        tolerance = self.config.tolerance  # a config knob, not a per-row field
+        tolerance = self.config.tolerance  # A task-wide confgi
         ...
 
 class AdditionConfig(vf.TasksetConfig):
-    num_tasks: int = 100                              # load-time: --taskset.num-tasks
-    task: AdditionTaskConfig = AdditionTaskConfig()   # task-facing: --taskset.task.tolerance
+    num_tasks: int = 100                             # --taskset.num-tasks
+    task: AdditionTaskConfig = AdditionTaskConfig()  # --taskset.task.tolerance
 ```
-
-The boundary: per-row data (the question, the reference answer) lives on `TaskData` fields;
-values uniform across the taskset live on the config — load-time ones directly on the
-`TasksetConfig`, task-facing ones under `task`. A task can also be constructed directly —
-`AdditionTask(data, config=AdditionTaskConfig(...))` — and an omitted config defaults to
-the declared type's defaults, so a standalone task works out of the box. Overriding
-`from_trace(trace)` (not implemented by default) opts a task into being derived from a
-finished rollout's bare `Trace` — how a multi-agent step spawns a follow-up task. Only the data rides the wire:
-`trace.task` is the `TaskData`, and behavior re-attaches by constructing the task class
-around it.
 
 ## Adding Tools
 
 Some environments require custom tools, which are bundled as a `vf.Toolset` (similar to how a `vf.Taskset` bundles `vf.Task`).
 Tools are exposed as MCP servers to the given harness and thus need a harness which exposes MCP support (via `SUPPORTS_MCP`).
 
-Where you register a toolset decides its **scope** — per rollout, or shared across the eval:
-
-- **On the Task** (`Task.tools`): one server per rollout, in the harness's runtime
-  (`colocated`) or its own (`vf.ToolsetConfig`). For tools that see per-task data.
-- **On the Taskset** (`Taskset.tools`): ONE server for the whole eval, shared by every
-  rollout (`vf.SharedToolsetConfig` — own runtime or a remote `url`, no `colocated`). For
-  an expensive, task-agnostic resource (a corpus, an index) built once. Per-rollout writes
-  stay isolated via `self.state`.
-
+You can create them like this (remember the bootstrapping with `uv run init MY_ENV -T`):
 ```python
 DATABASE = None
 
-class SearchToolset(vf.Toolset[vf.ToolsetConfig]):          # task-scoped
+class SearchToolset(vf.Toolset[vf.ToolsetConfig]):
     TOOL_PREFIX = "search"
 
     @vf.tool
@@ -143,30 +113,17 @@ class SearchToolset(vf.Toolset[vf.ToolsetConfig]):          # task-scoped
         """Search the task corpus."""
         return DATABASE.search(text)
 
-class CorpusToolset(vf.Toolset[vf.SharedToolsetConfig]):    # taskset-scoped (shared)
-    TOOL_PREFIX = "corpus"
-    ...
-
-class SearchTaskConfig(vf.TaskConfig):
-    tools: vf.ToolsetConfig = vf.ToolsetConfig()             # --taskset.task.tools.*
-
-class SearchTask(vf.Task[vf.TaskData, vf.State, SearchTaskConfig]):
-    tools = (SearchToolset,)                                 # per rollout
-
+# User-configurable knobs
 class SearchConfig(vf.TasksetConfig):
-    tools: vf.SharedToolsetConfig = vf.SharedToolsetConfig() # --taskset.tools.*
-    task: SearchTaskConfig = SearchTaskConfig()
+    tools: vf.ToolsetConfig = vf.ToolsetConfig()
 
-class SearchTaskset(vf.Taskset[SearchTask, SearchConfig]):
-    tools = (CorpusToolset,)                                 # once per eval
+class SearchTaskset(vf.Taskset[vf.Task, SearchConfig]):
+    # Launch the tools during setup
+    def tools(self, task: vf.Task) -> list[vf.Toolset]:
+        return [SearchToolset(self.config.tools)]
 ```
 
-The framework builds each declared server with the matching config off the declaring
-scope's config — the field whose type is the server's declared config type, falling back
-to a default-constructed one. Override `server_config` (on `Task` or `Taskset`) if you
-need explicit pairing (e.g. two servers sharing one config type). User simulators are
-task-scoped only — they drive one rollout's conversation: `user = MyUser` on the task, a
-`vf.UserConfig` field on the task config.
+Tools can also be set per task, not just per taskset.
 
 ## Using Judges
 
@@ -174,6 +131,10 @@ If your reward is semantic, use an LLM judge.
 
 ```python
 import verifiers.v1 as vf
+from functools import cached_property
+
+class Task(vf.Task):
+    answer: str
 
 class CorrectnessJudge(vf.Judge[bool]):
     # The rubric for the judge
@@ -187,43 +148,41 @@ class CorrectnessJudge(vf.Judge[bool]):
         return "yes" in response.text
 
 
-class Config(vf.TaskConfig):
-    # The judge inherits base_url and api keys from the client config (env vars, with the Prime CLI config as a fallback)
+class JudgedData(vf.TaskData):
+    answer: str
+
+
+class JudgedTaskConfig(vf.TaskConfig):
+    # The judge inherits base_url and api keys from the client config
     judge: vf.JudgeConfig = vf.JudgeConfig(model="openai/gpt-5-mini")
 
 
-class JudgedTask(vf.Task[vf.State, Config]):
-    answer: str
-
+class JudgedTask(vf.Task[JudgedData, vf.State, JudgedTaskConfig]):
     @vf.reward()
     async def correct(self, trace: vf.Trace) -> float:
-        judge = CorrectnessJudge(self.config.judge)  # config knobs stay CLI-tunable
+        # Keeping judge configuration on TaskConfig makes it overridable from CLI/TOML.
+        judge = CorrectnessJudge(self.config.judge)
         result = await judge.evaluate(
             trace=trace,
-            question=self.prompt,
-            answer=self.answer,
-            # give the last assistant message to the judge
-            response=trace.last_reply,
+            question=self.data.prompt,
+            answer=self.data.answer,
+            response=trace.last_reply,  # Grade the final assistant answer.
         )
-        return 1.0 if result.parsed else 0.0
+        return float(result.parsed)
 
 
 class SetConfig(vf.TasksetConfig):
-    task: Config = Config()
+    task: JudgedTaskConfig = JudgedTaskConfig()
 
 
 class JudgeTraceTaskset(vf.Taskset[JudgedTask, SetConfig]):
     def load(self) -> list[JudgedTask]:
-        return [JudgedTask(idx=0, prompt="What is 2+2?", answer="4")]
+        return [
+            JudgedTask(
+                JudgedData(idx=0, prompt="What is 2+2?", answer="4"),
+                self.config.task,
+            )
+        ]
 ```
 
 To override the judge model, set `taskset.task.judge.model` in your config (it is a string).
-Sampling knobs live under `taskset.task.judge.sampling` — e.g.
-`taskset.task.judge.sampling.max_tokens`.
-
-Judges can also be plugged **from config alone** — no judge-calling code: the base
-`TaskConfig.judges` list (`--taskset.task.judges`) plugs judge plugins (built-ins like
-`reference` / `rubric`, or hub packages) into every task, and `Task.score` resolves and
-runs them after the task's own `@reward`s. Judges are config, never row data — the run's
-`config.toml` records what judged it, and `replay`'s layered config re-runs (or re-tunes)
-exactly those judges.

--- a/docs/v1/harbor.md
+++ b/docs/v1/harbor.md
@@ -5,7 +5,7 @@ verifiers offers built-in support for Harbor via the `HarborTaskset` class. Crea
 
 ```python
 import verifiers.v1 as vf
-from verifiers.v1.tasksets.harbor import HarborConfig, HarborData, HarborTask, HarborTaskset
+from verifiers.v1.tasksets.harbor import HarborConfig, HarborTask, HarborTaskset
 
 # Set the dataset to the same name as registered in the Harbor registry
 class TerminalBench2Config(HarborConfig):
@@ -15,7 +15,6 @@ class TerminalBench2Config(HarborConfig):
 # The data will get loaded automatically
 class TerminalBench2Taskset(HarborTaskset, vf.Taskset[HarborTask, TerminalBench2Config]):
     pass
-    # No need for a reward function, as it will get inherited from the Harbor dataset
 ```
 
 You can also write custom code for your environments. A common functionality is to set custom images for tasks that don’t come with an image in their `task.toml`:
@@ -25,20 +24,28 @@ from pathlib import Path
 from typing import Literal
 
 import verifiers.v1 as vf
-from verifiers.v1.tasksets.harbor import HarborConfig, HarborData, HarborTask, HarborTaskset
+from verifiers.v1.tasksets.harbor import HarborConfig, HarborTask, HarborTaskset
+
+IMAGE_TEMPLATE = "registry.example.com/openthoughts/{task}:latest"
+
 
 class OpenThoughtsTBLiteConfig(HarborConfig):
     dataset: Literal["openthoughts/openthoughts-tblite"] = "openthoughts/openthoughts-tblite"
-    # Tell verifiers to ignore the Dockerfile in the task
+    # Tell verifiers to use the pre-built image
     ignore_dockerfile: bool = True
 
 
 class OpenThoughtsTBLiteTaskset(HarborTaskset, vf.Taskset[HarborTask, OpenThoughtsTBLiteConfig]):
-    def load(self) -> list[HarborData]:
+    def load(self) -> list[HarborTask]:
         # Use the public image instead to avoid building the image at runtime
         return [
-            row.model_copy(update={"image": IMAGE_TEMPLATE.format(task=Path(row.task_dir).name)})
-            for row in super().load()
+            HarborTask(
+                task.data.model_copy(
+                    update={"image": IMAGE_TEMPLATE.format(task=Path(task.data.task_dir).name)}
+                ),
+                self.config.task,
+            )
+            for task in super().load()
         ]
 ```
 
@@ -55,7 +62,7 @@ timeout_multiplier = 2.0
 resource_multiplier = 2.0
 ```
 
-The `timeout_multiplier` multiplies both the reagent and the verifier timeout, while the `resource_multiplier` multiplies the task's CPU, memory and disk space. You might want to use these multipliers when the tasks set too tight limits and/or the agent is slow.
+The `timeout_multiplier` multiplies both the agent and verifier timeout, while the `resource_multiplier` multiplies the task's CPU, memory and disk space. You might want to use these multipliers when the tasks set too tight limits and/or the agent is slow.
 
 ## Shortcomings
 

--- a/docs/v1/harnesses.md
+++ b/docs/v1/harnesses.md
@@ -1,12 +1,12 @@
 # Harnesses
 
-verifiers supports a range of harnesses out of the box, such as Claude Code, Codex or a minimal, default harness without any built-in tools. However, you may want to build a custom one or extend the selection of third‑party harnesses.
+verifiers supports a range of harnesses out of the box, including Claude Code, Codex, the tool-enabled default harness, and the minimal tool-less `null` harness. However, you may want to build a custom one or extend the selection of third‑party harnesses.
 
 ## A minimal harness implementation
 
 
 ```python
-from verifiers.v1.clients import RolloutContext
+from verifiers.v1.clients import ModelContext
 from verifiers.v1.harness import Harness, HarnessConfig
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.trace import Trace
@@ -24,24 +24,19 @@ class MyHarness(Harness[MyHarnessConfig]):
     SUPPORTS_USER_SIM = True
 
     async def setup(self, runtime: Runtime) -> None:
-        # Add your install script(s) here
-        MY_INSTALL_COMMAND = "echo 'installing...'"
-        await runtime.run(["sh", MY_INSTALL_COMMAND], {})
+        # Install the harness in its rollout runtime
+        await runtime.run(["sh", "-c", "echo installing..."], {})
 
     async def launch(
         self,
-        ctx: RolloutContext,
+        ctx: ModelContext,
         trace: Trace,
         runtime: Runtime,
         endpoint: str,
         secret: str,
         mcp_urls: dict[str, str],
     ) -> ProgramResult:
-        # Run the harness in its respective runtime to completion
-        # The model (interception) endpoint is in endpoint
-        # mcp_urls are the URLs of the tools from the toolset (if registered)
-
-        # Resolve the task's prompt (and system prompt) for this harness
+        # Resolve the task prompt according to this harness's declared capabilities.
         _, prompt = self.resolve_prompt(trace.task)
 
         # Example: Use the harness, but overwrite the endpoint to use the interception server and the custom model name
@@ -51,7 +46,6 @@ class MyHarness(Harness[MyHarnessConfig]):
             "HARNESS_API_KEY": secret,
             "HARNESS_BASE_MODEL": ctx.model,
         }
-
-        # Run the harness using the values we defined earlier
-        return await runtime.run_program([HARNESS_BINARY, prompt], ENVIRONMENT_VARS)
+        # Run the harness to completion inside the selected runtime.
+        return await runtime.run_program(["<HARNESS_BINARY>", str(prompt or "")], env)
 ```

--- a/docs/v1/overview.md
+++ b/docs/v1/overview.md
@@ -6,7 +6,7 @@ The following concepts are important when creating or running environments, be i
 
 ## Environment Hub
 
-The [Environment Hub] is Prime Intellect's collection of (user-created) environments which are installable and ready to use with verifiers.
+The [Environment Hub](https://app.primeintellect.ai/dashboard/environments?ex_sort=most_stars) is Prime Intellect's collection of user-created environments which are installable and ready to use with verifiers.
 
 ## Environment
 
@@ -14,7 +14,7 @@ An environment combines a _taskset_ and a _harness_. Often, it is sufficient to 
 
 ## Taskset
 
-A taskset is a collection of tasks, i.e., the _what_. A task is a prompt, a set of files, etc. — and it carries its own scoring (rewards, metrics) and lifecycle hooks: each dataset's task class defines how it is graded. The taskset is the loader that yields them; every taskset yields exactly one task type.
+A taskset is the collection and loader for the tasks—the _what_ of an environment. Each task combines a serializable `TaskData` row (prompt, files, references, resource requirements) with its task class's behavior (lifecycle hooks, tools, metrics, and rewards). The taskset's `load()` method constructs those objects and declares their task/config types through `Taskset[TaskT, ConfigT]`.
 
 ## Harness
 

--- a/environments/AGENTS.md
+++ b/environments/AGENTS.md
@@ -27,29 +27,34 @@ However, for most environments, building a taskset should be enough.
 ## A minimal environment
 
 ```python
-import verifiers.v1 as vf 
+import verifiers.v1 as vf
 
 
-# A task defines a single problem and is defined as a subclass of vf.Task
-class AdditionTask(vf.Task):
+# The data for a given task
+class AdditionData(vf.TaskData):
     answer: int
 
 
-# The taskset defines the dataset (collection of tasks) and needs a vf.TasksetConfig, which can be empty.
+# A task defines a single problem and is defined as a subclass of vf.Task
+class AdditionTask(vf.Task[AdditionData]):
+    # @vf.reward denotes the scoring function for the task.
+    # It needs the trace, which contains the whole message graph, including function calls, user messages etc.
+    # It returns the reward for the single task based on this function.
+    @vf.reward
+    async def exact_match(self, trace: vf.Trace) -> float:
+        return float(trace.last_reply == str(self.data.answer))
+
+
+# The taskset defines the tasks and needs a vf.TasksetConfig, which can be empty.
 class AdditionTaskset(vf.Taskset[AdditionTask, vf.TasksetConfig]):
-    def load_tasks(self) -> list[AdditionTask]:
-        # Load the dataset, in this case we built it on the initial load
+    def load(self) -> list[AdditionTask]:
         return [
-            AdditionTask(idx=i, prompt=f"What is {i} + {i}?", answer=2 * i)
+            AdditionTask(
+                AdditionData(idx=i, prompt=f"What is {i} + {i}?", answer=2 * i),
+                self.config.task,
+            )
             for i in range(100)
         ]
-
-    # @vf.reward denotes the scoring function for the environment.
-    # It needs the actual task (defined earlier) as well as the trace, which contains the whole message graph, including function calls, user messages etc.
-    # It returns the reward for the rollout based on this function.
-    @vf.reward
-    async def exact_match(self, task: AdditionTask, trace: vf.Trace) -> float:
-        return float(trace.last_reply == str(task.answer))
 
 
 # Export the Taskset for verifiers to find it when loading
@@ -68,14 +73,34 @@ class AdditionConfig(vf.TasksetConfig):
     num_tasks: int = 100
 
 class AdditionTaskset(vf.Taskset[AdditionTask, AdditionConfig]):
-    def load_tasks(self) -> list[AdditionTask]:
+    def load(self) -> list[AdditionTask]:
         return [
-            AdditionTask(idx=i, prompt=f"What is {i} + {i}?", answer=2 * i)
+            AdditionTask(
+                AdditionData(idx=i, prompt=f"What is {i} + {i}?", answer=2 * i),
+                self.config.task,
+            )
             for i in range(self.config.num_tasks) # <- re-use the value here
         ]
-
 ```
-Common usages for `vf.TasksetConfig` are settings like splits (e.g., train/test), difficulty settings, judge model names, etc.
+
+Common usages for `vf.TasksetConfig` are load-time settings, such as splits (e.g., train/test), dataset names, etc.
+
+You can also use `vf.TaskConfig` to configure task data, such as scoring parameters:
+
+```python
+class AdditionTaskConfig(vf.TaskConfig):
+    tolerance: float = 0.0
+
+class AdditionTask(vf.Task[AdditionData, vf.State, AdditionTaskConfig]):
+    @vf.reward
+    async def exact_match(self, trace: vf.Trace) -> float:
+        tolerance = self.config.tolerance  # A task-wide confgi
+        ...
+
+class AdditionConfig(vf.TasksetConfig):
+    num_tasks: int = 100                             # --taskset.num-tasks
+    task: AdditionTaskConfig = AdditionTaskConfig()  # --taskset.task.tolerance
+```
 
 ## Adding Tools
 
@@ -104,6 +129,8 @@ class SearchTaskset(vf.Taskset[vf.Task, SearchConfig]):
         return [SearchToolset(self.config.tools)]
 ```
 
+Tools can also be set per task, not just per taskset.
+
 ## Using Judges
 
 If your reward is semantic, use an LLM judge.
@@ -127,31 +154,41 @@ class CorrectnessJudge(vf.Judge[bool]):
         return "yes" in response.text
 
 
-class Config(vf.TasksetConfig):
-    # The judge inherits base_url and api keys from the client config (env vars, with the Prime CLI config as a fallback)
+class JudgedData(vf.TaskData):
+    answer: str
+
+
+class JudgedTaskConfig(vf.TaskConfig):
+    # The judge inherits base_url and api keys from the client config
     judge: vf.JudgeConfig = vf.JudgeConfig(model="openai/gpt-5-mini")
 
 
-class JudgeTraceTaskset(vf.Taskset[Task, Config]):
-    # Build the judge lazily from config — no Taskset.__init__ override needed.
-    @cached_property
-    def judge(self) -> CorrectnessJudge:
-        return CorrectnessJudge(self.config.judge)
-
-    def load_tasks(self) -> list[Task]:
-        return [Task(idx=0, prompt="What is 2+2?", answer="4")]
-
+class JudgedTask(vf.Task[JudgedData, vf.State, JudgedTaskConfig]):
     @vf.reward()
-    async def correct(self, task, trace) -> float:
-        result = await self.judge.evaluate(
-            trace=trace, 
-            question=task.prompt, 
-            answer=task.answer, 
-            # give the last assistant message to the judge
-            response=trace.last_reply
+    async def correct(self, trace: vf.Trace) -> float:
+        # Keeping judge configuration on TaskConfig makes it overridable from CLI/TOML.
+        judge = CorrectnessJudge(self.config.judge)
+        result = await judge.evaluate(
+            trace=trace,
+            question=self.data.prompt,
+            answer=self.data.answer,
+            response=trace.last_reply,  # Grade the final assistant answer.
         )
-        return 1.0 if result.parsed else 0.0
+        return float(result.parsed)
+
+
+class SetConfig(vf.TasksetConfig):
+    task: JudgedTaskConfig = JudgedTaskConfig()
+
+
+class JudgeTraceTaskset(vf.Taskset[JudgedTask, SetConfig]):
+    def load(self) -> list[JudgedTask]:
+        return [
+            JudgedTask(
+                JudgedData(idx=0, prompt="What is 2+2?", answer="4"),
+                self.config.task,
+            )
+        ]
 ```
 
-To override the judge model, set `taskset.judge.model` in your config (it is a string).
-Sampling knobs live under `taskset.judge.sampling` — e.g. `taskset.judge.sampling.max_tokens`.
+To override the judge model, set `taskset.task.judge.model` in your config (it is a string).

--- a/environments/AGENTS.md
+++ b/environments/AGENTS.md
@@ -111,7 +111,7 @@ You can create them like this (remember the bootstrapping with `uv run init MY_E
 ```python
 DATABASE = None
 
-class SearchToolset(vf.Toolset[vf.ToolsetConfig]):
+class SearchToolset(vf.Toolset[vf.SharedToolsetConfig]):
     TOOL_PREFIX = "search"
 
     @vf.tool
@@ -121,15 +121,13 @@ class SearchToolset(vf.Toolset[vf.ToolsetConfig]):
 
 # User-configurable knobs
 class SearchConfig(vf.TasksetConfig):
-    tools: vf.ToolsetConfig = vf.ToolsetConfig()
+    tools: vf.SharedToolsetConfig = vf.SharedToolsetConfig()
 
 class SearchTaskset(vf.Taskset[vf.Task, SearchConfig]):
-    # Launch the tools during setup
-    def tools(self, task: vf.Task) -> list[vf.Toolset]:
-        return [SearchToolset(self.config.tools)]
+    tools = (SearchToolset,)
 ```
 
-Tools can also be set per task, not just per taskset.
+Taskset tools are shared by a worker's rollouts. Tools can also be set per task.
 
 ## Using Judges
 

--- a/environments/alphabet_sort_v1/alphabet_sort_v1/servers/user.py
+++ b/environments/alphabet_sort_v1/alphabet_sort_v1/servers/user.py
@@ -8,7 +8,7 @@ class AlphabetSortState(vf.State):
 class AlphabetSortUser(vf.User[vf.UserConfig, AlphabetSortState]):
     """Drives the whole conversation by replaying the episode's pre-generated user turns: each
     `respond` delivers the next queued turn as a user message, until the queue is exhausted (then it
-    flags `user_finished`, which the taskset's `@vf.stop` ends the trajectory on). The task carries no
+    flags `user_finished`, which the task's `@vf.stop` ends the trajectory on). The task carries no
     prompt, so the first turn (the opening `respond("")`) delivers the initial sort prompt; the rest
     are the follow-ups."""
 

--- a/environments/alphabet_sort_v1/alphabet_sort_v1/taskset.py
+++ b/environments/alphabet_sort_v1/alphabet_sort_v1/taskset.py
@@ -63,10 +63,6 @@ class AlphabetSortTask(
     vf.Task[AlphabetSortTaskData, AlphabetSortState, AlphabetSortTaskConfig]
 ):
     user = AlphabetSortUser
-    # Built with the task config's `user` field (placement stays CLI-tunable via
-    # --taskset.task.user.*), resolved by `Task.server_config`. The scoring knobs
-    # (`similarity_power`, `power_per_turn`) are read off `self.config`; the episode
-    # off `self.data`.
 
     @vf.stop
     async def user_finished(self, trace: vf.Trace) -> bool:

--- a/environments/color_codeword_v1/color_codeword_v1/servers/user.py
+++ b/environments/color_codeword_v1/color_codeword_v1/servers/user.py
@@ -25,7 +25,7 @@ class ColorCodewordState(vf.State):
 class ColorCodewordUser(vf.User[vf.UserConfig, ColorCodewordState]):
     """Reveals each turn's colored squares after the prior answer: one `respond` per assistant
     turn, injecting the next turn's squares (image_url parts) as a user message until every
-    `max_turns` turn is answered (then it flags `user_finished` for the taskset's `@vf.stop`)."""
+    `max_turns` turn is answered (then it flags `user_finished` for the task's `@vf.stop`)."""
 
     async def setup_task(self, task) -> None:
         self.colors_per_turn = task.info[

--- a/environments/color_codeword_v1/color_codeword_v1/taskset.py
+++ b/environments/color_codeword_v1/color_codeword_v1/taskset.py
@@ -105,8 +105,6 @@ class ColorCodewordTask(
     vf.Task[ColorCodewordTaskData, ColorCodewordState, ColorCodewordTaskConfig]
 ):
     user = ColorCodewordUser
-    # Built with the task config's `user` field (placement stays CLI-tunable via
-    # --taskset.task.user.*), resolved by `Task.server_config`.
 
     @vf.stop
     async def user_finished(self, trace: vf.Trace) -> bool:

--- a/environments/deepwiki_v1/deepwiki_v1/taskset.py
+++ b/environments/deepwiki_v1/deepwiki_v1/taskset.py
@@ -1,20 +1,16 @@
-"""deepwiki: an EXISTING (remote) tool server.
+"""Remote-tool example backed by the public DeepWiki MCP server.
 
-The other tool examples ship a server the harness runs (`glossary` host-side, `wikispeedia`
-its own runtime, `wiki_search` shared); this one points at a live, public streamable-HTTP MCP
-server — DeepWiki, which answers questions about GitHub repos. The `DeepWikiToolset` in
-`servers/deepwiki.py` has no `@tool` methods: setting `url` on its config makes the framework
-connect to the remote directly. Each task asks the model to use `deepwiki_ask_question` for a
-repo's primary language; the reward checks the answer.
-
-Runs in docker (the harness installs the mcp client there and needs outbound net).
+Unlike the locally authored `glossary` and worker-shared `wiki_search` examples,
+`DeepWikiToolset` declares no local `@tool` methods. Its config supplies an existing
+streamable-HTTP URL, so verifiers connects the harness directly to that remote server.
+The harness runtime therefore needs outbound network access.
 """
 
 import verifiers.v1 as vf
 
 from deepwiki_v1.servers.deepwiki import DEEPWIKI_URL, DeepWikiToolset
 
-# (repo, expected language) — unambiguous, well-indexed repos.
+# (repository, expected primary language) pairs chosen for unambiguous answers.
 TASKS = [
     ("modelcontextprotocol/python-sdk", "python"),
     ("tokio-rs/tokio", "rust"),
@@ -32,8 +28,6 @@ class DeepWikiTaskData(vf.TaskData):
 
 class DeepWikiTask(vf.Task[DeepWikiTaskData, vf.State, DeepWikiTaskConfig]):
     tools = (DeepWikiToolset,)
-    # Built with the task config's `tools` field (where the toolset points; stays
-    # CLI-tunable via --taskset.task.tools.*), resolved by `Task.server_config`.
 
     @vf.reward(weight=1.0)
     async def answered(self, trace: vf.Trace) -> float:

--- a/environments/glossary_v1/glossary_v1/taskset.py
+++ b/environments/glossary_v1/glossary_v1/taskset.py
@@ -1,10 +1,8 @@
-"""glossary: a custom tool server, authored as a vf-native class.
+"""The simplest locally authored, task-scoped tool example.
 
-Each task asks the model to look up an entity. The tool server is a `vf.Toolset` subclass in
-`servers/facts.py` (`@vf.tool` methods, no FastMCP boilerplate); the framework launches it in its
-own runtime and surfaces its `lookup` tool as `facts_lookup`. The reward checks the looked-up fact
-reached the answer. The simplest tool example — contrast `wikispeedia` (per-task state),
-`wiki_search` (shared), `deepwiki` (remote).
+`GlossaryToolset` is a vf-native class with an `@vf.tool` method. Verifiers launches
+one server per rollout and exposes it as `facts_lookup`; compare `deepwiki` for a remote
+server and `wiki_search` for an expensive worker-shared server.
 """
 
 import verifiers.v1 as vf
@@ -23,8 +21,6 @@ class GlossaryTaskData(vf.TaskData):
 
 class GlossaryTask(vf.Task[GlossaryTaskData, vf.State, GlossaryTaskConfig]):
     tools = (GlossaryToolset,)
-    # Built with the task config's `tools` field (placement stays CLI-tunable via
-    # --taskset.task.tools.*), resolved by `Task.server_config`.
 
     @vf.reward(weight=1.0)
     async def looked_up(self, trace: vf.Trace) -> float:

--- a/environments/scratchpad_v1/scratchpad_v1/servers/scratchpad.py
+++ b/environments/scratchpad_v1/scratchpad_v1/servers/scratchpad.py
@@ -1,6 +1,6 @@
 """A SHARED, writable tool server that exercises per-rollout state isolation.
 
-It is built once for the whole eval (taskset-scoped, `Taskset.tools`) but written to by every rollout: `roundtrip`
+It is built once per environment worker (taskset-scoped, `Taskset.tools`) but written to by every rollout: `roundtrip`
 stores a word and reads it back. Each rollout's write lands in its own `self.state` — the per-rollout
 shared-state channel the framework tags onto a shared server's URL — so concurrent rollouts never see
 each other's word even though they share one process. `roundtrip` sleeps between the write and the
@@ -19,7 +19,7 @@ class ScratchpadState(vf.State):
 
 class ScratchpadToolsetConfig(vf.SharedToolsetConfig):
     setup_seconds: float = 0.0
-    """Simulated expensive one-time `setup` cost (a shared server pays it once for the whole eval)."""
+    """Simulated expensive setup paid once per environment worker."""
 
 
 class ScratchpadToolset(vf.Toolset[ScratchpadToolsetConfig, ScratchpadState]):

--- a/environments/scratchpad_v1/scratchpad_v1/taskset.py
+++ b/environments/scratchpad_v1/scratchpad_v1/taskset.py
@@ -2,10 +2,10 @@
 
 Each rollout is assigned a unique word and asked to round-trip it through the shared scratchpad
 server, then report what came back. The reward is 1 iff the model reports its own word. The server
-is `shared` (one instance for the whole eval, simulating an expensive build) yet writable, so this
+is taskset-scoped (one instance per environment worker) yet writable, so this
 is a direct test of per-rollout isolation via `self.state`: `uv run eval scratchpad-v1 -n 8 -r 1`
 scores a mean reward of 1.0 because each rollout's write to `self.state` stays isolated even though
-every rollout shares the one server process.
+every rollout handled by that worker shares its server process.
 """
 
 import verifiers.v1 as vf
@@ -45,17 +45,11 @@ class ScratchpadTask(vf.Task[ScratchpadTaskData, ScratchpadState]):
 
 
 class ScratchpadConfig(vf.TasksetConfig):
-    # SHARED + writable: one instance for the whole eval (a stand-in for an expensive build),
-    # reused across rollouts. Each rollout's writes are isolated via `self.state` (the
-    # per-rollout shared-state channel) — the per-rollout isolation a writable shared server
-    # needs. Knobs at the taskset level: `--taskset.tools.runtime.type docker`.
     tools: ScratchpadToolsetConfig = ScratchpadToolsetConfig()
 
 
 class ScratchpadTaskset(vf.Taskset[ScratchpadTask, ScratchpadConfig]):
     tools = (ScratchpadToolset,)
-    # Declared on the TASKSET: shared scope is structural (one eval-level server), built
-    # with `ScratchpadConfig.tools` (exact-type match) via `Taskset.server_config`.
 
     def load(self) -> list[ScratchpadTask]:
         return [

--- a/environments/wiki_search_v1/wiki_search_v1/taskset.py
+++ b/environments/wiki_search_v1/wiki_search_v1/taskset.py
@@ -1,12 +1,9 @@
-"""wiki-search: answer trivia by searching a wiki corpus (read-only tools + judge).
+"""Answer trivia with a worker-shared wiki corpus and a reference judge.
 
-The opposite shape from wikispeedia: read-only tools and an LLM-judge reward. The taskset
-loads questions from a HuggingFace dataset and exposes semantic `search_pages` +
-`view_sections`/`read_section` over the full corpus (chroma index) via a `vf.Toolset`. The
-expensive corpus + index are built in the toolset's `setup` (runs in the server process), and
-the toolset is SHARED — one instance for the whole eval, not rebuilt per rollout. Grading is
-the plugged built-in `reference` judge (a default `judges` entry, overridable per eval) with a
-prompt that also requires coherence.
+The tool server builds an expensive corpus/index in its process-level `setup`, so
+`Taskset.tools` launches one instance per environment worker instead of rebuilding it
+per rollout. The tools are read-only; grading comes from the plugged `reference` judge,
+whose prompt also rejects incoherent answers.
 """
 
 import verifiers.v1 as vf
@@ -47,19 +44,16 @@ NUM_QUESTIONS = 20
 
 
 class WikiSearchTaskConfig(vf.TaskConfig):
-    # The built-in reference judge, plugged by default with this env's prompt (which also
-    # requires coherence). Fully eval-tunable: `--taskset.task.judges.0.model ...`, or
-    # replaced wholesale from the TOML's `[[taskset.task.judges]]`.
+    # Users can replace or reconfigure this judge through --taskset.task.judges.
     judges: vf.Judges = [
         vf.ReferenceJudgeConfig(prompt=JUDGE_PROMPT, question_field="question")
     ]
 
 
 class TriviaTaskData(vf.TaskData):
+    # These fields feed the reference judge's question and answer template values.
     question: str
     answer: str
-    # `question`/`answer` feed the plugged reference judge (it reads them off the row by
-    # field name: `question_field`/`answer_field`).
 
 
 class TriviaTask(vf.Task[TriviaTaskData, vf.State, WikiSearchTaskConfig]):
@@ -67,17 +61,12 @@ class TriviaTask(vf.Task[TriviaTaskData, vf.State, WikiSearchTaskConfig]):
 
 
 class WikiSearchConfig(vf.TasksetConfig):
-    # The chroma corpus is expensive, so the toolset is TASKSET-scoped: one shared server
-    # for the whole eval (its own runtime), reused across rollouts rather than rebuilt per
-    # rollout. Its knobs live at the taskset level: `--taskset.tools.runtime.type docker`.
     tools: vf.SharedToolsetConfig = vf.SharedToolsetConfig()
     task: WikiSearchTaskConfig = WikiSearchTaskConfig()
 
 
 class WikiSearchTaskset(vf.Taskset[TriviaTask, WikiSearchConfig]):
     tools = (WikiSearchToolset,)
-    # Declared on the TASKSET: shared scope is structural (one eval-level server),
-    # built with `WikiSearchConfig.tools` via `Taskset.server_config`.
 
     def load(self) -> list[TriviaTask]:
         from datasets import load_dataset

--- a/skills/browse-environments/SKILL.md
+++ b/skills/browse-environments/SKILL.md
@@ -38,11 +38,13 @@ prime env pull owner/name -t ./tmp-env
 
 When you find environments, look through the code to see if they import `verifiers.v1`. If they do, always prefer these.
 
-Inspect the taskset to learn about its task and config.
-- `load_tasks()` loads or creates the dataset
-- A `vf.TasksetConfig` denotes the user-configurable settings. As the creator of this environment has put them deliberately, pay attention to those.
-- Some environments come with custom harnesses, which require attention, while others only work with some harnesses.
-- Some environments only work in some runtimes.
+Inspect the taskset, task, data, and configs:
+
+- `Taskset.load()` constructs the tasks.
+- `TaskData` contains each serializable row.
+- `Task` contains hooks, scoring, task-scoped tools, and user simulation.
+- `TasksetConfig` contains load-time settings; task-facing settings live under its nested `task` config.
+- Check custom harness and runtime requirements explicitly.
 
 For each of the candidates, look into these categories to get a more complete picture.
 

--- a/skills/create-environments/SKILL.md
+++ b/skills/create-environments/SKILL.md
@@ -66,55 +66,69 @@ Never mix v0 `Environment`, `Rubric`, `Parser`, `SingleTurnEnv`, `MultiTurnEnv`,
 ## Minimal implementation
 
 ```python
-import verifiers.v1 as vf 
+import verifiers.v1 as vf
 
 
-# A task defines a single problem and is defined as a subclass of vf.Task
-class AdditionTask(vf.Task):
+# One row's serializable data. Add references or other task-specific fields here.
+class AdditionData(vf.TaskData):
     answer: int
 
 
-# The taskset defines the dataset (collection of tasks) and needs a vf.TasksetConfig, which can be empty.
+# The behavior for that row. Decorated methods may request only the values they need;
+# `trace` contains the full message graph and `self.data` is this task's row.
+class AdditionTask(vf.Task[AdditionData]):
+    @vf.reward
+    async def exact_match(self, trace: vf.Trace) -> float:
+        return float(trace.last_reply == str(self.data.answer))
+
+
+# The taskset is the loader. Its config can be the empty base config.
 class AdditionTaskset(vf.Taskset[AdditionTask, vf.TasksetConfig]):
-    def load_tasks(self) -> list[AdditionTask]:
-        # Load the dataset, in this case we built it on the initial load
+    def load(self) -> list[AdditionTask]:
+        # Construct one behavior object around each data row and the shared task config.
         return [
-            AdditionTask(idx=i, prompt=f"What is {i} + {i}?", answer=2 * i)
+            AdditionTask(
+                AdditionData(idx=i, prompt=f"What is {i} + {i}?", answer=2 * i),
+                self.config.task,
+            )
             for i in range(100)
         ]
 
-    # @vf.reward denotes the scoring function for the environment.
-    # It needs the actual task (defined earlier) as well as the trace, which contains the whole message graph, including function calls, user messages etc.
-    # It returns the reward for the rollout based on this function.
-    @vf.reward
-    async def exact_match(self, task: AdditionTask, trace: vf.Trace) -> float:
-        return float(trace.last_reply == str(task.answer))
 
-
-# Export the Taskset for verifiers to find it when loading
+# Export the taskset class so the v1 loader can discover it.
 __all__ = ["AdditionTaskset"]
 ```
 
-Do not override `Taskset.__init__`; use config, `load_tasks()`, lifecycle hooks, or an owning server.
+Do not override `Taskset.__init__`. Implement `load()` on the taskset and put hooks and scoring on the task.
 
 ## Ownership rules
 
-The taskset owns:
+`TaskData` owns the immutable, serializable values for one row:
 
-- task loading and prompt framing;
-- task-specific tools and user simulation;
-- typed transient state;
-- setup/finalize/validate hooks;
-- stop conditions, metrics, rewards, and group rewards.
+- prompts and optional system prompts;
+- reference answers or other ground truth;
+- container image, workdir, resources, and timeout requests;
+- any additional typed fields scoring or a user/tool server needs.
+
+Only `TaskData` is stored on the trace. Do not put live clients, runtime handles etc. here.
+
+`Task` owns the behavior applied to that row:
+
+- `setup`, `finalize`, and model-free `validate` hooks;
+- stop conditions, metrics, rewards, and group rewards;
+- task-scoped tool and user-simulator declarations;
+- task-facing configuration read from `self.config`.
+
+`Taskset` owns loading and selection-time concerns. Its `load()` constructs the tasks, its direct config fields hold dataset/split/seed/sample-count knobs, and `Taskset.tools` may declare task-agnostic servers shared by one environment worker's rollouts.
 
 The harness owns:
 
-- the reusable agent/chat program;
-- how the program is provisioned and launched;
-- wiring the program to the supplied interception endpoint;
+- the reusable agent or chat program;
+- how that program is provisioned and launched;
+- wiring model requests to the supplied interception endpoint and secret;
 - harness-generic execution metrics.
 
-The runtime config owns where code executes. The task should not interfere with the runtime nor manipulate it directly.
+Runtime config chooses where code executes. Task hooks should use the `vf.Runtime` interface they receive instead of assuming Docker-, Prime-, Modal-, or host-specific implementation details.
 
 ## Scoring rules
 
@@ -122,15 +136,15 @@ The runtime config owns where code executes. The task should not interfere with 
 - Use an LLM judge only when semantic judgment is unavoidable.
 - Metrics are for observability and do not contribute to reward, but are useful. Use them deliberately and appropriately!
 - Group rewards receive all traces for one task but no live runtime.
-- Raise ordinary Python exceptions for invalid verifier execution. The framework records a `TasksetError` in this case.
+- Raise ordinary Python exceptions from rollout hooks and scoring. The rollout records them as `TaskError`.
 
 ## Validation and lifecycle
 
-Implement `validate(task, runtime)` whenever ground truth can be checked without a model. Keep rollout work in the owning stage:
+Implement `Task.validate(self, runtime)` whenever ground truth can be checked without a model. Keep rollout work on the task:
 
-- `setup(task, runtime)` — prepare repo, files, or service.
+- `setup(self, trace, runtime)` — prepare files or services.
 - harness execution — let the agent act.
-- `finalize(task, trace, runtime)` — capture diffs/artifacts needed for scoring.
+- `finalize(self, trace, runtime)` — capture artifacts needed for scoring.
 - `@vf.reward` / `@vf.metric` — evaluate while the runtime is still live.
 
 Persist inspectable artifacts in JSON-serializable `trace.info`. Put counters and live coordination in a typed `vf.State` subclass.
@@ -139,41 +153,37 @@ Persist inspectable artifacts in JSON-serializable `trace.info`. Put counters an
 
 Some environments require custom tools. These should be the exception as they don’t work with every harness and are registered as MCP servers.
 
-You can create them like this (remember the bootstrapping with `prime env init MY_ENV -T`)
 ```python
 class SearchToolset(vf.Toolset[vf.ToolsetConfig]):
     TOOL_PREFIX = "search"
 
     @vf.tool
     async def query(self, text: str) -> list[str]:
+        # Tool docstrings are exposed to the model as the MCP tool description.
         """Search the task corpus."""
         return []
+
+
+class SearchTaskConfig(vf.TaskConfig):
+    tools: vf.ToolsetConfig = vf.ToolsetConfig()
+
+
+class SearchTask(vf.Task[vf.TaskData, vf.State, SearchTaskConfig]):
+    # Declaring the class on Task.tools gives it one-server-per-rollout scope.
+    tools = (SearchToolset,)
 
 
 if __name__ == "__main__":
     SearchToolset.run()
 ```
 
-Expose the tool to the config:
+Choose placement from the tool's lifetime and filesystem needs:
 
-```python
-class SearchConfig(vf.TasksetConfig):
-    tools: vf.ToolsetConfig = vf.ToolsetConfig(shared=True)
-```
+- **Task-scoped, own runtime:** declare the class on `Task.tools` with `vf.ToolsetConfig`. One server is launched per rollout. The default subprocess runtime is inexpensive and host-side.
+- **Task-scoped, colocated:** set `colocated = true` on its `ToolsetConfig` when the tool must see the harness's filesystem or processes. It still launches once per rollout.
+- **Taskset-scoped, shared:** parameterize the toolset with `vf.SharedToolsetConfig`, put the matching config field directly on `TasksetConfig`, and declare the class on `Taskset.tools`.
+- **Existing remote service:** set `url` on the matching toolset config. Verifiers connects to the streamable-HTTP MCP endpoint instead of launching the class locally.
 
-`Taskset.tools()` returns `[]` by default, so the toolset is never launched unless you wire it. Return it from the hook:
-
-```python
-class SearchTaskset(vf.Taskset[vf.Task, SearchConfig]):
-    def tools(self, task: vf.Task) -> list[vf.Toolset]:
-        return [SearchToolset(self.config.tools)]
-```
-
-Tools can be placed in various ways. Think about what the tool is and how expensive its setup is:
-- per-rollout for cheap setup MCPs;
-- colocated for shared harness filesystem;
-- shared for expensive read-only setup or writable state entirely in `self.state` (e.g. big databases);
-- remote URL for an existing MCP service.
 
 ## User simulation
 
@@ -209,14 +219,14 @@ Map concepts directly:
 
 | V0 | Native v1 |
 | --- | --- |
-| Dataset row | Typed `vf.Task` subclass |
+| Dataset row | Typed `vf.TaskData` subclass |
 | `load_environment(**kwargs)` | Exported `vf.Taskset` class + typed config |
-| `Rubric` reward function | Taskset `@vf.reward` method |
-| Parser object | Ordinary parsing inside scoring |
-| `ToolEnv` tools | `vf.Toolset` + `Taskset.tools()` |
-| `MultiTurnEnv.env_response` | `vf.User`, tools, or a reusable harness |
+| `Rubric` reward function | Task `@vf.reward` method |
+| Parser object | Ordinary parsing inside task scoring |
+| `ToolEnv` tools | `vf.Toolset` declared on `Task.tools` or `Taskset.tools` |
+| `MultiTurnEnv.env_response` | `vf.User` declared on the task |
 | Dict state | Typed `vf.State` |
-| Sandbox subclass | Harness runtime config + task hooks |
+| Sandbox subclass | Runtime config + task hooks |
 
 Preserve prompt, tool, and scoring equivalence before improving design. Compare representative v0 and v1 traces where feasible.
 

--- a/skills/evaluate-environments/SKILL.md
+++ b/skills/evaluate-environments/SKILL.md
@@ -25,7 +25,7 @@ prime eval run <MY_ENV>
 prime eval run <MY_ENV> --dry-run
 ```
 
-2. Run model-free gold validation when the taskset implements it:
+2. Run model-free gold validation when the taskset implements `validate`:
 
 ```bash
 prime eval validate <MY_ENV> --runtime.type subprocess
@@ -134,7 +134,7 @@ Whole-rollout retry is opt-in. That means if something fails in the rollout, the
 prime eval run my-task-v1 \
   --retries.rollout.max-retries 2 \
   --retries.rollout.include SandboxError ProviderError \
-  --retries.rollout.exclude TasksetError
+  --retries.rollout.exclude TaskError
 ```
 
 ## Output and resume
@@ -144,7 +144,7 @@ Default output:
 ```text
 outputs/<taskset>--<model>--<harness>/<uuid>/
 ├── config.toml
-├── results.jsonl
+├── traces.jsonl
 └── eval.log
 ```
 
@@ -173,7 +173,7 @@ Classify outcomes:
 1. Valid completion and correct reward.
 2. Valid completion with low reward (model/task outcome).
 3. Truncated completion (budget outcome).
-4. Captured rollout error (provider, harness, tool, user, runtime, taskset, or interception).
+4. Captured rollout error (provider, harness, tool, user, runtime, task, or interception).
 
 Do not average these categories together without reporting failure rate.
 

--- a/skills/evaluate-environments/references/REFERENCE.md
+++ b/skills/evaluate-environments/references/REFERENCE.md
@@ -8,6 +8,7 @@ The root config the eval CLI parses is [`EvalConfig`](#evalconfig--the-run). It 
 EvalConfig                       (the run + the env)
 ├─ model, sampling, client, num_tasks, num_rollouts, shuffle, max_concurrent, …
 ├─ taskset: TasksetConfig        (subclass resolved by --taskset.id)
+│  └─ task: TaskConfig           (judges, scoring knobs, task-scoped server config)
 ├─ harness: HarnessConfig        (subclass resolved by --harness.id)
 │  └─ runtime: RuntimeConfig     (subprocess | docker | prime | modal)
 ├─ timeout: TimeoutConfig
@@ -33,15 +34,16 @@ Sibling entrypoints reuse the same tree: [`ServeConfig`](#serveconfig--the-env-s
 | `client` | `ClientConfig` | `EvalClientConfig()` | — | The model client (discriminated union — see [Client config](#client-config)). |
 | `sampling` | `SamplingConfig` | `SamplingConfig()` | — | Per-request sampling knobs (see [Sampling config](#sampling-config)). |
 | `num_tasks` | `int \| None` | `None` | `batch_size`, `num_examples`, `num_tasks`, `n` | How many tasks to evaluate (None = all). |
-| `num_rollouts` | `int` | `1` | `group_size`, `rollouts_per_example`, `num_rollouts`, `r` | Rollouts per task. A taskset with `@group_reward`s requires ≥ 2. |
+| `num_rollouts` | `int` | `1` | `group_size`, `rollouts_per_example`, `num_rollouts`, `r` | Rollouts per task. A task with `@group_reward`s requires ≥ 2. |
 | `shuffle` | `bool` | `False` | `shuffle`, `s` | Shuffle tasks before taking the first `num_tasks`. |
 | `max_concurrent` | `int \| None` | `128` | `max_concurrent`, `c` | Max rollouts in flight at once. |
 | `verbose` | `bool` | `False` | `verbose`, `v` | Log at debug level instead of info. |
 | `dry_run` | `bool` | `False` | — | Resolve + validate the config and dump it, then exit. |
 | `rich` | `bool` | `True` | — | Live dashboard instead of per-rollout logs (in-process only). |
 | `server` | `bool` | `False` | — | Drive rollouts through the env-server worker pool (sized by `pool`) instead of in-process — the path prime-rl trains through. Incompatible with `--rich`. |
-| `output_dir` | `Path \| None` | `None` | `output_dir`, `o` | Where to write the run (`config.toml` + `results.jsonl`). None = a fresh per-run dir under `outputs/<env>--<model>--<harness>/<uuid>`. |
-| `resume` | `Path \| None` | `None` | — | Set by `--resume <dir>`: re-run only the rollouts a previous run left missing/errored. Excluded from the saved config; takes no other args. |
+| `push` | `bool` | `True` | — | Upload the finished run to the private Evaluations tab. Disable with `--no-push`. |
+| `output_dir` | `Path \| None` | `None` | `output_dir`, `o` | Where to write the run (`config.toml` + `traces.jsonl`). None = a fresh per-run dir under `outputs/<env>--<model>--<harness>/<uuid>`. |
+| `resume` | `Path \| None` | `None` | — | Set by `--resume <dir>`: re-run missing/errored rollouts; an incomplete group-scored task is re-run as a whole group. Excluded from the saved config; takes no other args. |
 
 Validator: `--rich` + `--server` together is rejected (the dashboard is in-process only).
 
@@ -91,7 +93,10 @@ A vLLM `/inference/v1/generate` endpoint with client-side tokenization (response
 
 ## EnvConfig — the environment
 
-`verifiers/v1/env.py` — `EnvConfig(BaseConfig)`. The two peers of a rollout: the taskset (data + scoring) and the harness (which program drives it, and where it runs — `harness.runtime`).
+`verifiers/v1/env.py` — `EnvConfig(BaseConfig)`. The taskset and harness are the two reusable
+parts of the environment: the taskset loads typed tasks, while the harness provisions and drives
+the agent program for each rollout in `harness.runtime`. Each loaded `Task` supplies the row's
+behavior, tools, user simulator, and scoring; only its `TaskData` is stored on the trace.
 
 | Field | Type | Default | Notes |
 |---|---|---|---|
@@ -107,12 +112,28 @@ A vLLM `/inference/v1/generate` endpoint with client-side tokenization (response
 
 The four `max_*` limits map onto [`RolloutLimits`](#rollout-limits) (interception server); each caps a trace computed property, checked between turns (soft by one turn).
 
+Although the annotations use the generic `TasksetConfig` and `HarnessConfig` bases, the raw config
+is narrowed **before validation**:
+
+1. `taskset.id` resolves the exported `Taskset` class and its concrete config type from the
+   `Taskset[TaskT, ConfigT]` generic.
+2. `harness.id` resolves the exported `Harness` class and its concrete config type. If no harness
+   id is supplied and the taskset package exports a bundled harness, that harness is selected;
+   otherwise the `default` harness is used.
+3. Validation then runs against those concrete config models, so plugin-specific fields remain
+   typed rather than being collected in an untyped `args` dictionary.
+
+Both fields use `SerializeAsAny`, which preserves their resolved subclass fields when configs are
+saved or sent to env-server workers. An explicit harness id always wins over a taskset's bundled
+default. `ServeConfig` inherits the same resolution, while `ValidateConfig` performs the
+taskset-only half because validation has no harness.
+
 ### Legacy (v0) backwards-compat fields
 Set `id` (leave `taskset` unset) to run a classic `verifiers.load_environment` env through the legacy bridge.
 
 | Field | Type | Default | Notes |
 |---|---|---|---|
-| `id` | `EnvId \| None` | `None` | Classic v0 env id (`name`, `org/name`, or `org/name@version`). |
+| `id` | `ID \| None` | `None` | Classic v0 env id (`name`, `org/name`, or `org/name@version`). |
 | `args` | `dict` | `{}` | Construction kwargs forwarded to `load_environment(id, **args)`. |
 | `extra_env_kwargs` | `dict` | `{}` | Post-load kwargs applied via `env.set_kwargs(**...)` (e.g. `max_total_completion_tokens`, `max_seq_len`, `timeout_seconds`). |
 
@@ -134,10 +155,10 @@ Set `id` (leave `taskset` unset) to run a classic `verifiers.load_environment` e
 
 | Field | Type | Default | Notes |
 |---|---|---|---|
-| `setup` | `float \| None` | `None` | Max wall-clock for the taskset's `setup` hook. |
+| `setup` | `float \| None` | `None` | Shared wall-clock budget for `Task.setup` and harness provisioning. |
 | `rollout` | `float \| None` | `None` | Max wall-clock for the rollout (the harness run). |
-| `finalize` | `float \| None` | `None` | Max wall-clock for the taskset's `finalize` hook. |
-| `scoring` | `float \| None` | `None` | Max wall-clock for scoring — verify + rewards/metrics. |
+| `finalize` | `float \| None` | `None` | Max wall-clock for the task's `finalize` hook. |
+| `scoring` | `float \| None` | `None` | Max wall-clock for task rewards/metrics/judges and harness metrics. |
 
 > Remote sandboxes cap any harness timeout at 24 hours (provider max lifetime).
 
@@ -186,18 +207,31 @@ Elastic pool: start at one worker and scale up on demand.
 
 ## Taskset config
 
-`verifiers/v1/taskset.py` — `TasksetConfig(BaseConfig)`. The base; **subclass per taskset to add task-generation knobs** (e.g. `split`, `difficulty`). The concrete subclass is resolved by `--taskset.id`, so a taskset's own fields become dotted flags (`--taskset.split test`).
+`verifiers/v1/taskset.py` — `TasksetConfig(BaseConfig)`. Subclass it for values used while
+`Taskset.load()` builds the task list: dataset id, split, seed, sample count, difficulty filters,
+and similar load-time choices. The concrete subclass is selected through `taskset.id`, so its
+fields become typed dotted flags such as `--taskset.split test`.
 
 | Field | Type | Default | Notes |
 |---|---|---|---|
-| `id` | `EnvId` | `""` | The taskset id, which selects it: a local package, or `org/name[@version]` from the Environments Hub. Set via `--taskset.id`. |
+| `id` | `ID` | `""` | Local package or Hub `org/name[@version]`; selects the taskset and its config type. Set via `--taskset.id`. |
+| `task` | `TaskConfig` | `TaskConfig()` | Task-facing config passed to every constructed task. `SerializeAsAny` preserves a narrowed subclass. Set through `--taskset.task.*`. |
 
 `.name` → the package name (id with org / version stripped).
 
-A taskset class also declares capabilities that affect config validation (not user-settable fields):
-- `NEEDS_CONTAINER: ClassVar[bool]` — refuse the subprocess runtime when True.
+A taskset implements `load()` and declares exactly one task type through its generic base. It may
+also declare task-agnostic tool classes on `Taskset.tools`; those servers are shared by the
+rollouts handled by one environment worker.
 
-See [`TaskResources`](#task-resources--timeouts) and [`TaskTimeout`](#task-resources--timeouts) for what a *task* (not the taskset) can carry.
+### Task config
+
+`TaskConfig` contains knobs read by task behavior. Subclass it for scoring parameters and
+task-scoped `ToolsetConfig` or `UserConfig` fields, then narrow the taskset config's `task` field to
+that subclass. These are run-wide knobs, not per-row data; the row itself belongs on `TaskData`.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `judges` | `Judges` | `[]` | Judge plugins run by `Task.score`; set through `--taskset.task.judges`. |
 
 ---
 
@@ -208,7 +242,7 @@ See [`TaskResources`](#task-resources--timeouts) and [`TaskTimeout`](#task-resou
 ### Base `HarnessConfig`
 | Field | Type | Default | Notes |
 |---|---|---|---|
-| `id` | `EnvId` | `"default"` | The harness id, which selects it. Set via `--harness.id`. |
+| `id` | `ID` | `"default"` | The harness id, which selects it. Set via `--harness.id`. |
 | `runtime` | `RuntimeConfig` | `SubprocessConfig()` | Where the harness runs. Discriminated union — see [Runtime configs](#runtime-configs). Set with `--harness.runtime.type docker\|prime\|modal`. |
 | `env` | `dict[str, str]` | `{}` | Additional env vars for the harness program. Harness-owned endpoint/auth/model vars take precedence. |
 | `forward_env` | `list[str]` | `[]` | Names of env vars to forward from `os.environ` into the harness program's runtime (for secrets not in checked-in config). Absent names are skipped; explicit `env` wins. |
@@ -232,7 +266,11 @@ A growing-message-list chat loop with a local `bash` tool, plus optional `edit`/
 | `search` | `bool` | `False` | Offer a `search` tool (Google web results via serper.dev). Requires `SERPER_API_KEY` in the eval environment. |
 
 #### `NullHarnessConfig` — `id: "null"`
-A pure chat-loop program with the taskset's MCP tools and **no tools of its own**. A uv script (deps: `openai`, `mcp`). No extra fields.
+A growing-message-list chat loop with the task- and taskset-scoped MCP tools, and **no built-in
+tools of its own**. It runs as a uv script whose dependencies are `openai` and `mcp`, so setup
+bootstraps everything it needs in the selected runtime. `NullHarnessConfig` adds no fields beyond
+the base `HarnessConfig` fields. Use it for pure chat or environments whose entire tool surface is
+provided through MCP; use an agentic harness for shell/edit capabilities.
 
 #### `CodexHarnessConfig` — `id: "codex"`
 Installs the Codex CLI into the runtime and runs `codex exec`.
@@ -279,9 +317,9 @@ Installs the Kimi Code CLI and runs it headlessly.
 `verifiers/v1/runtimes/`. Discriminated on `type`; selected with `--harness.runtime.type` (or `--runtime.type` for the validate CLI). The same union is reused as `ToolsetConfig.runtime` and `UserConfig.runtime`.
 
 ### `SubprocessConfig` — `type: "subprocess"` (default)
-Run on the host in a fresh `/tmp/<name>` workspace per rollout. **No extra fields.** Inherits the host env *except* any var whose name contains `API_KEY`.
-
-> Tool servers placed on subprocess can't receive host API keys (the strip applies to every program run here); give a key-needing tool its own runtime or have it fetch the key itself.
+Run on the host in a fresh `/tmp/<name>` workspace per rollout. **No extra fields.** Implicit
+host inheritance removes names containing `API_KEY`; explicit values passed in the runtime `env`
+mapping are merged afterward and inherited by child processes.
 
 ### `DockerConfig` — `type: "docker"`
 Local Docker container sharing the host network (`--network host`).
@@ -306,11 +344,12 @@ Remote Prime sandbox; reached via native port exposure.
 | `vm` | `bool` | `False` | Run as a micro-VM (kernel features / stronger isolation). |
 | `guaranteed` | `bool` | `False` | Request guaranteed (vs best-effort) capacity. |
 | `region` | `str \| None` | `None` | Region to provision in (None = provider-chosen). Note: port exposure is region-gated; `us` supports it. |
-| `labels` | `list[str]` | `[]` | Labels for the sandbox and its tunnels. The eval defaults them to the run's uuid when unset. |
+| `labels` | `list[str]` | `[]` | Labels attached to the sandbox. |
 | `cpu` | `float` | `1.0` | CPU cores. |
 | `memory` | `float` | `2.0` | Memory in GB. |
 | `gpu` | `str \| None` | `None` | GPU spec, e.g. `"A100"` or `"A100:2"` (bare count = provider-chosen type). |
 | `disk` | `float` | `5.0` | Disk in GB. |
+| `idle_timeout` | `float \| None` | `3600` | Seconds of inactivity before the sandbox is deleted; `None` disables it. |
 | `creates_per_min` | `int \| None` | `None` | Pace sandbox creation to this many per minute, host-wide across every env-server worker (None/≤0 disables). Tunnel creation is limited separately and globally. |
 
 ### `ModalConfig` — `type: "modal"`
@@ -328,67 +367,130 @@ Remote Modal sandbox; reached via Modal's own port forwarding (`encrypted_ports`
 | `disk` | `float` | `5.0` | Disk in GB. Modal sandboxes have no disk knob, so **accepted but not enforced**. |
 | `creates_per_sec` | `float \| None` | `40.0` | Pace sandbox creation to this many per second, host-wide across every env-server worker (None/≤0 disables). |
 
-All four `image`/`workdir`/`resource` fields are overridable per task via [`Task.image`](#task-resources--timeouts) / `Task.workdir` / [`TaskResources`](#task-resources--timeouts), with precedence cli/toml > task > runtime default.
+Before each rollout or validation check, `resolve_runtime_config` combines the selected runtime
+config with the row's `TaskData`:
+
+- `TaskData.image` is the row's required execution image and replaces the runtime's base image. A
+  row with an image cannot use the subprocess runtime.
+- `TaskData.workdir` fills the runtime workdir only while that field is still at the runtime
+  class's default. Any non-default runtime-config workdir wins.
+- Non-`None` `TaskData.resources` values similarly fill supported runtime fields only while those
+  fields remain at their defaults. Any non-default runtime-config resource value wins.
+- A resource field unsupported by the chosen runtime is ignored; evaluation warns once per
+  runtime/field combination. Docker and Modal accept `disk` so portable task data validates, but
+  neither enforces a disk limit.
+
+This resolution produces a copied runtime config; it does not mutate the frozen row or the shared
+base config.
 
 ---
 
 ## Task resources & timeouts
 
-`verifiers/v1/task.py`. A `Task` is an immutable, frozen pydantic model; environments subclass it to add typed task-specific fields (the reference answer, ground truths, …). These fields flow — fully typed — through the rollout into scoring. Not CLI flags (they come from `Taskset.load_tasks`), but they affect runtime resolution, so they're part of the reference.
+`verifiers/v1/task.py`. `TaskData` is the frozen, serializable row stored on `trace.task` and sent
+across worker/runtime boundaries. Environment packages subclass it for typed row-specific fields
+such as reference answers, repository metadata, or judge inputs. Those fields are not CLI flags;
+they are produced by `Taskset.load()`.
+
+`Task` is the behavior wrapper around that row. It owns hooks and scoring and reads uniform,
+run-configurable knobs from `TaskConfig`, but the `Task` object itself is not serialized onto the
+trace. Replay validates each recorded row as the taskset's declared `TaskData`, reattaches the
+declared task class, and propagates validation failures instead of changing task types.
 
 ### `TaskResources` (frozen)
-Runtime resources a task requests, in Modal's units. Applied where the runtime supports the field; an unsupported field is warned about and ignored. Precedence: cli/toml > task > runtime default (`None` here = use the runtime/provider default).
+Portable runtime resources requested by one row. CPU is measured in cores; memory and disk are in
+gigabytes. `None` means “do not override the chosen runtime/provider default.” Values are applied
+only to runtime fields that remain at their defaults; any non-default runtime-config value wins.
+Unsupported fields are ignored; evaluation warns once per runtime/field combination.
 
 | Field | Type | Default | Notes |
 |---|---|---|---|
-| `cpu` | `float \| None` | `None` | CPU cores. |
-| `memory` | `float \| None` | `None` | Memory in GB. |
-| `gpu` | `str \| None` | `None` | GPU spec, e.g. `"A100"` or `"A100:2"` (type[:count]). |
-| `disk` | `float \| None` | `None` | Disk in GB (enforced by prime; advisory on docker/modal). |
+| `cpu` | `float \| None` | `None` | CPU cores. Docker treats this as a hard `--cpus` limit; sandbox providers receive the same core count. |
+| `memory` | `float \| None` | `None` | Memory in GB. Docker enforces it as a hard limit; Modal receives the value converted to MB. |
+| `gpu` | `str \| None` | `None` | GPU spec such as `"A100"` or `"A100:2"` (`type[:count]`; a bare count lets supported providers choose the type). |
+| `disk` | `float \| None` | `None` | Disk in GB. Enforced by Prime; accepted but advisory/not enforced by Docker and Modal. |
 
 ### `TaskTimeout` (frozen)
-Per-task wall-clock timeout overrides (seconds), one per rollout stage. Each merges with the eval's `timeout` ([`TimeoutConfig`](#timeout-config)): cli/toml > this > default (no limit).
+Per-row wall-clock timeout requests, in seconds, one for each rollout stage. For eval, a non-`None`
+value in the run's `TimeoutConfig` wins; otherwise the corresponding row value is used. If both are
+`None`, that stage has no framework timeout. Remote harness execution is capped at the provider's
+24-hour sandbox lifetime.
 
 | Field | Type | Default | Notes |
 |---|---|---|---|
-| `setup` | `float \| None` | `None` | The taskset's `setup` hook. |
-| `harness` | `float \| None` | `None` | The harness run. |
-| `finalize` | `float \| None` | `None` | The taskset's `finalize` hook. |
-| `scoring` | `float \| None` | `None` | Verify + rewards/metrics. |
+| `setup` | `float \| None` | `None` | Task and harness setup stage. Overridden by eval's `timeout.setup`; validate uses it for `Task.setup` when `CheckTimeoutConfig.setup` is unset. |
+| `harness` | `float \| None` | `None` | Harness execution. Overridden by the run-level `timeout.rollout`. |
+| `finalize` | `float \| None` | `None` | Task `finalize` hook. Overridden by `timeout.finalize`. |
+| `scoring` | `float \| None` | `None` | Task rewards/metrics/judges and harness metrics. Overridden by `timeout.scoring`. |
 
-### `Task` (frozen)
+### `TaskData` (frozen)
 | Field | Type | Default | Notes |
 |---|---|---|---|
-| `idx` | `int` | — | Stable integer index within its taskset. |
-| `name` | `str \| None` | `None` | Optional human-readable label. |
+| `idx` | `int` | — | Stable integer index within the taskset. Used for selection, grouping, display, and reproducibility. |
+| `name` | `str \| None` | `None` | Optional human-readable label used in logs and dashboards. |
 | `description` | `str \| None` | `None` | Optional human-readable description. |
-| `prompt` | `str \| Messages \| None` | — | The user message. A `Messages` list seeds a full initial conversation (only accepted by harnesses with `SUPPORTS_MESSAGE_PROMPT`). `None` → the user simulator opens. |
-| `system_prompt` | `str \| None` | `None` | Optional system prompt. Harnesses with `APPENDS_SYSTEM_PROMPT` emit it as a real system message; others prepend to `prompt` (with a warning). |
-| `image` | `str \| None` | `None` | Container image this task needs. When set, the runtime must be a container (docker/prime); subprocess is refused. |
-| `workdir` | `str \| None` | `None` | Working directory for the harness and scoring. Injected where the runtime supports one. |
-| `timeout` | `TaskTimeout` | `TaskTimeout()` | Per-task timeout overrides. |
-| `resources` | `TaskResources` | `TaskResources()` | Runtime resources requested. |
+| `prompt` | `str \| Messages \| None` | — | Initial user input. A string is one user prompt; `Messages` seeds a full initial conversation and requires a harness with `SUPPORTS_MESSAGE_PROMPT`; `None` lets the user simulator open via `respond("")`. |
+| `system_prompt` | `str \| None` | `None` | Optional system prompt. Harnesses with `APPENDS_SYSTEM_PROMPT` emit a real system message; otherwise a string prompt is prefixed with a warning. A separate system prompt cannot be folded into `Messages` or `None`. |
+| `image` | `str \| None` | `None` | Required container/sandbox image for this row. It replaces the base runtime image; subprocess is refused when set. |
+| `workdir` | `str \| None` | `None` | Working directory for harness execution and task hooks. Applied when the runtime supports it and its config remains at the default. |
+| `timeout` | `TaskTimeout` | `TaskTimeout()` | Per-stage timeout requests described above. |
+| `resources` | `TaskResources` | `TaskResources()` | Portable runtime resource requests described above. |
+
+`TaskData.prompt_text` renders a string prompt directly or joins the textual content of a
+`Messages` prompt. Judges use it as the default question text when no dedicated question field is
+configured.
 
 ---
 
 ## Toolset config
 
-`verifiers/v1/mcp/toolset.py` — `ToolsetConfig(BaseConfig)`. Where one tool server runs (placement). A taskset declares `Toolset`s from `Taskset.tools`; each carries its `config`. **Subclass to add the server's own knobs** (the data its `@vf.tool` methods read).
+`verifiers/v1/mcp/toolset.py`. Tool scope is structural: a class declared on `Task.tools` is
+task-scoped, while a class declared on `Taskset.tools` is shared by one environment worker. The
+framework finds the matching config field by the toolset's generic config type. Subclass either
+config to add knobs consumed by the tool's `@vf.tool` methods.
+
+### `ToolsetConfig` — `Task.tools`
+
+A task-scoped server is launched per rollout. Its matching config field normally lives on
+`TaskConfig`, under `--taskset.task.*`.
+
+The default placement is the toolset's own subprocess runtime on the host, where verifiers and the
+environment package are already installed. The harness reaches that server over the host network
+when local or through a tunnel when remote. `colocated` instead runs the server inside the harness
+runtime; this is useful when both must see the same filesystem or processes, but a remote sandbox
+must then upload and install verifiers plus the environment package for every rollout.
 
 | Field | Type | Default | Notes |
 |---|---|---|---|
-| `colocated` | `bool` | `False` | Run inside the harness's OWN runtime (reached in-sandbox, no tunnel). In a sandbox this uploads + installs the env package + `verifiers` (a per-rollout cost). Mutually exclusive with `shared`. |
-| `shared` | `bool` | `False` | One instance for the whole eval, in its own `runtime` (pays an expensive `setup` once). Each rollout still reads/writes its OWN `self.state`. Mutually exclusive with `colocated`. |
-| `runtime` | `RuntimeConfig` | `SubprocessConfig()` | The server's own runtime, used unless `colocated`. Host/subprocess by default (always reachable from any harness). See [Runtime configs](#runtime-configs). |
-| `url` | `str \| None` | `None` | An already-running streamable-HTTP MCP endpoint to connect to instead of launching a server. When set, placement is ignored and the toolset needs no `@vf.tool` methods. |
+| `colocated` | `bool` | `False` | Run inside the harness's own runtime and reach the tool on an in-runtime local port. The separate `runtime` field is ignored. |
+| `runtime` | `RuntimeConfig` | `SubprocessConfig()` | The server's own runtime when not colocated. Select Docker/Prime/Modal to isolate it from the host. See [Runtime configs](#runtime-configs). |
+| `url` | `str \| None` | `None` | Existing streamable-HTTP MCP endpoint. When set, verifiers connects to it instead of launching the class, so placement fields do not take effect. |
 
-Validators: `colocated` + `shared` mutually exclusive.
+### `SharedToolsetConfig` — `Taskset.tools`
+
+A taskset-scoped tool uses one framework-launched server per environment worker, or reuses a
+configured external `url` without launching a server. Its matching config field lives directly on
+the taskset config, not under `task`.
+
+The framework-launched form is intended for expensive task-agnostic setup such as loading a corpus,
+index, or graph: `setup()` runs once per worker and `setup_task()` is not called because no single
+row owns the server. A vf-native shared tool may still use mutable `self.state`; the framework
+attaches each calling rollout's state channel to the shared URL so those values remain per rollout.
+There is no `colocated` option because a shared server has no single harness runtime.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `runtime` | `RuntimeConfig` | `SubprocessConfig()` | The framework-launched server's own runtime. Host subprocess is cheapest; a remote runtime pays setup once per worker. See [Runtime configs](#runtime-configs). |
+| `url` | `str \| None` | `None` | Existing streamable-HTTP MCP endpoint reused across workers and rollouts instead of launching a server. |
+
+There is no `shared` boolean on `ToolsetConfig`: declare the class on `Task.tools` or
+`Taskset.tools` and use the matching config type to choose its scope.
 
 ---
 
 ## User config
 
-`verifiers/v1/mcp/user.py` — `UserConfig(BaseConfig)`. Where the user simulator runs (placement). The framework always drives it from the host. **Subclass to add the user's own knobs.**
+`UserConfig` controls a simulator declared on `Task.user`; its matching config field belongs on `TaskConfig` under `--taskset.task.*`.
 
 | Field | Type | Default | Notes |
 |---|---|---|---|
@@ -399,22 +501,50 @@ Validators: `colocated` + `shared` mutually exclusive.
 
 ## Judge config
 
-`verifiers/v1/judge.py`. A reusable per-task LLM judge. A taskset holds a `JudgeConfig` (or subclass) and constructs a `vf.Judge` from it.
+`verifiers/v1/judge.py`. `TaskConfig.judges` holds plugged judge configs that `Task.score`
+constructs and runs after the task's own rewards. Each list entry needs an `id`; the loader resolves
+that plugin's concrete `JudgeConfig` subclass before validation, just like tasksets and harnesses.
+Duplicate reward keys are rejected unless entries receive distinct `name` values.
+
+A task may instead declare a custom `JudgeConfig` field on its own `TaskConfig`, construct the
+judge inside a reward, and call `evaluate()` directly. That direct-use config may leave `id` empty.
 
 ### `JudgeConfig(BaseClientConfig)`
-Inherits `base_url` / `api_key_var` / `headers` (with the Prime auto-config) from [`BaseClientConfig`](#client-config); adds the model + sampling. Subclass to add taskset-specific fields.
+
+Inherits `base_url`, `api_key_var`, and `headers` from
+[`BaseClientConfig`](#client-config). The default Prime endpoint, key, and team header use the same
+Prime CLI/environment fallback as the rollout client. Subclass `JudgeConfig` for additional knobs
+needed by a custom or plugin judge.
 
 | Field | Type | Default | Notes |
 |---|---|---|---|
-| `model` | `str` | `"openai/gpt-5-mini"` | Judge model id. |
-| `sampling` | `JudgeSamplingConfig` | `JudgeSamplingConfig()` | Per-call sampling knobs. |
+| `id` | `ID` | `""` | Judge plugin id: built-in (`reference`, `rubric`), local package, or Hub package. Required in `TaskConfig.judges`; empty is allowed for direct calls from task code. |
+| `name` | `str` | `""` | Reward-key override for a plugged judge. When empty, the plugin id supplies the key. |
+| `weight` | `float` | `1.0` | Weight applied when the plugged judge records its verdict into aggregate `trace.reward`. |
+| `model` | `str` | `"openai/gpt-5.4-nano"` | Judge model id. |
+| `sampling` | `JudgeSamplingConfig` | `JudgeSamplingConfig()` | Per-call sampling defaults; individual calls may override them. |
+| `prompt` | `str \| None` | `None` | Inline prompt-template override for this configured judge instance. |
+| `prompt_file` | `Path \| None` | `None` | Load the prompt template from a UTF-8 text file. Mutually exclusive with `prompt`. |
 
 ### `JudgeSamplingConfig(SamplingConfig)`
-Same shape as the rollout's [`SamplingConfig`](#sampling-config) — `temperature` / `top_p` / `reasoning_effort` / `max_tokens` (+ provider-specific keys via `extra='allow'`). Set e.g. `judge.sampling.max_tokens`.
 
-`Judge` itself is configured by **class attributes** (not config fields):
-- `prompt: str | None` — default template for `build_messages`, formatted with the `evaluate` kwargs.
-- `schema: type[BaseModel] | None` — pydantic schema for OpenAI structured outputs (when set, `JudgeResponse.parsed` is the validated object).
+The same extensible shape as the rollout's [`SamplingConfig`](#sampling-config): `temperature`,
+`top_p`, `reasoning_effort`, and `max_tokens`, plus provider-specific keys because
+`extra='allow'`. Values passed directly to `complete()` override these configured defaults.
+
+### Judge class behavior
+
+A judge class may define:
+
+- `prompt: str | None` — the default template formatted by `build_messages(**fields)`. A configured
+  `prompt` or `prompt_file` overrides it for that instance.
+- `schema: type[BaseModel] | None` — a Pydantic schema for structured output. `evaluate()` sends it
+  through the OpenAI-compatible parsed-completion path and places the validated object on
+  `JudgeResponse.parsed`; without a schema, `parse()` receives the text response.
+
+`evaluate()` renders the prompt, performs one judge completion, and calls `parse()`. When a trace
+is supplied, billed judge usage is recorded even if parsing later fails. Plugin judges implement
+`score(task, trace)` so `Task.score` can record the verdict under the configured key and weight.
 
 ---
 
@@ -447,27 +577,67 @@ Plus all inherited `EnvServerConfig` fields (`taskset`, `harness`, `timeout`, `r
 
 ## ValidateConfig — the validate CLI
 
-`verifiers/v1/configs/validate.py` — `ValidateConfig(BaseConfig)`. Per-task, **model-free** validation: runs the taskset's `validate` hook (apply a gold solution, run a verifier) in a runtime. No harness, model, or sampling; fire-and-forget (nothing written to disk).
+`verifiers/v1/configs/validate.py` — `ValidateConfig(BaseConfig)`. Model-free validation has no
+harness, model client, or sampling. For every selected task, the default mode runs two independent
+checks in separate fresh runtimes:
+
+1. **gold:** start the runtime, run `Task.setup`, call `Task.validate`, then tear down;
+2. **setup:** start another runtime, run `Task.setup`, mark it valid if setup returns, then tear down.
+
+The independent result separates basic provisioning/setup viability from the task's gold-check
+result. A task whose `validate()` returns `False` is `invalid`; a timeout is `timeout`; an exception
+is `error`. The base `Task.validate()` returns `True`, so tasks without a custom gold check still
+receive the setup checks.
+
+Use `only_gold` or `only_setup` to select one mode; setting both is rejected. The CLI writes no
+config or traces to disk. Its output is the live dashboard when `rich` is enabled, otherwise one
+log line per task.
 
 | Field | Type | Default | Aliases | Notes |
 |---|---|---|---|---|
-| `taskset` | `TasksetConfig` | `TasksetConfig()` | — | Resolved to its concrete subclass by `--taskset.id` (or a bare positional). `SerializeAsAny`. |
-| `runtime` | `RuntimeConfig` | `DockerConfig()` | — | Where each task's `validate` hook runs. Docker by default (a gold check often needs the task's container); use `--runtime.type subprocess` for a check that needs no container. |
-| `setup_timeout` | `float \| None` | `None` | — | Max wall-clock for the taskset's `setup` hook per task. |
-| `validate_timeout` | `float \| None` | `None` | — | Max wall-clock for the `validate` hook per task. |
-| `num_tasks` | `int \| None` | `None` | `num_tasks`, `n`, `num_examples`, `batch_size` | How many tasks to validate (None = all). |
-| `shuffle` | `bool` | `False` | `shuffle`, `s` | Shuffle before taking the first `num_tasks`. |
-| `max_concurrent` | `int \| None` | `128` | `max_concurrent`, `c` | Max tasks validated in flight at once (and, for a container runtime, live sandboxes). |
-| `verbose` | `bool` | `False` | `verbose`, `v` | Log at debug level. |
-| `rich` | `bool` | `True` | — | Live dashboard (one row per task) instead of per-task log lines. |
+| `taskset` | `TasksetConfig` | `TasksetConfig()` | — | Selected by `--taskset.id` or the bare positional id. Narrowed to the concrete taskset config before validation and serialized as that subclass. |
+| `runtime` | `RuntimeConfig` | `DockerConfig()` | — | Runtime used for setup and validation. Docker is the default because gold checks often need the row's image; use subprocess only when no selected task requires a container. Row image/workdir/resources are resolved as described above. |
+| `timeout` | `CheckTimeoutConfig` | `CheckTimeoutConfig()` | — | Nested setup and check budgets; see below. |
+| `only_setup` | `bool` | `False` | — | Run only the independent setup check. Mutually exclusive with `only_gold`. |
+| `only_gold` | `bool` | `False` | — | Run only setup followed by `Task.validate` in one runtime. Mutually exclusive with `only_setup`. |
+| `num_tasks` | `int \| None` | `None` | `num_tasks`, `n`, `num_examples`, `batch_size` | Number of tasks after optional shuffling; `None` means all. |
+| `shuffle` | `bool` | `False` | `shuffle`, `s` | Deterministically shuffle before taking the first `num_tasks`. |
+| `max_concurrent` | `int \| None` | `128` | `max_concurrent`, `c` | Maximum checks in flight, and therefore the maximum live containers/sandboxes. `None` disables the semaphore. |
+| `verbose` | `bool` | `False` | `verbose`, `v` | Log at debug rather than info level. |
+| `rich` | `bool` | `True` | — | Show one live dashboard row per task. Disable for per-task log lines. |
+
+### `CheckTimeoutConfig`
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `setup` | `float \| None` | `None` | Maximum seconds for `Task.setup`. When unset, validation falls back to the row's `TaskData.timeout.setup`; if that is also `None`, setup is unlimited. |
+| `total` | `float \| None` | `None` | Maximum seconds for the gold check's `Task.validate` call. `None` means no limit. The setup-only mode has no action after setup, so this field does not apply there. |
 
 ---
 
 ## Notes & conventions
 
-- **Plugin resolution.** `taskset` and `harness` are generic base fields; `EnvConfig._resolve_plugins` narrows each to its concrete config type by `id` *before* validation, so a taskset/harness's own fields validate against the real subclass (no untyped args dict). The same narrowing happens for `ValidateConfig` (taskset only) and `ServeConfig` (inherited).
-- **Dotted flags.** Every nested field is a CLI flag (`--harness.runtime.type docker`, `--taskset.split test`, `--pool.max_workers 8`, `--retries.rollout.max_retries 2`). Use `@ file.toml` for the same tree.
-- **Precedence.** Runtime resources/timeouts: cli/toml > task > runtime default. Timeouts: cli/toml > per-task `TaskTimeout` > `TimeoutConfig` default. A field left at its default may be overridden by a task; a field the CLI changed wins.
+- **Plugin resolution.** `taskset` and `harness` begin as generic base fields;
+  `EnvConfig._resolve_plugins` narrows each to the concrete config selected by `id` *before*
+  validation. `ValidateConfig` performs the taskset-only half and `ServeConfig` inherits both.
+  Entries in `TaskConfig.judges` are similarly narrowed by each judge `id`. This is why local and
+  Hub plugin fields remain typed and appear in CLI validation instead of living in an untyped
+  arguments dictionary.
+- **Dotted flags.** Every nested field is part of the same CLI tree
+  (`--harness.runtime.type docker`, `--taskset.split test`, `--pool.max_workers 8`,
+  `--retries.rollout.max_retries 2`). An `@ file.toml` describes the identical tree; explicit CLI
+  values layer over values loaded from the file.
+- **Runtime precedence.** An explicit, non-default CLI/TOML `workdir` or resource field wins over
+  `TaskData`; otherwise a non-`None` row value fills it, and otherwise the runtime/provider default
+  remains. `TaskData.image` is the required image for that row and replaces the runtime's base
+  image. Unsupported resource fields are ignored; evaluation warns once per runtime/field.
+- **Timeout precedence.** For eval stages, a non-`None` run-level `TimeoutConfig` value wins over
+  the corresponding `TaskData.timeout` value; if both are `None`, there is no framework timeout.
+  The setup value is one deadline shared by task setup and harness provisioning.
+  Validate uses `CheckTimeoutConfig.setup`, then falls back to `TaskData.timeout.setup`, while
+  `CheckTimeoutConfig.total` independently bounds `Task.validate`.
 - **Discriminated unions** are selected by their `type` field: `client.type` (eval|train), `pool.type` (static|elastic), `harness.runtime.type` / `runtime.type` (subprocess|docker|prime|modal).
-- **Frozen models.** `Task`, `TaskResources`, `TaskTimeout`, `RolloutLimits` are immutable — they're the wire input / framework limits, not mutated at runtime.
+- **Frozen models.** `TaskData`, `TaskResources`, and `TaskTimeout` are immutable wire input, not
+  mutable runtime state. Put per-rollout coordination on typed `trace.state`. `RolloutLimits` is an
+  immutable framework limit derived from `EnvConfig`.
 - **Legacy v0.** Set `EnvConfig.id` (leave `taskset` unset) to run a classic `load_environment` env through the bridge. `--resume` is not supported for legacy evals.

--- a/skills/train-with-environments/SKILL.md
+++ b/skills/train-with-environments/SKILL.md
@@ -112,8 +112,7 @@ can override it.
 - If groups are mostly all-one, increase difficulty or sample a harder task distribution.
 - Choose `batch_size` with whole groups, packing, sequence length, and GPU memory in mind.
 
-A taskset `@vf.group_reward` is scoring, not trainer advantage. The env server automatically keeps
-that task's rollouts together before returning traces.
+A task `@vf.group_reward` is scoring, not trainer advantage. The env server automatically keeps that task's rollouts together before returning traces.
 
 ## Difficulty filtering
 
@@ -194,7 +193,7 @@ Classify before changing hyperparameters:
 3. **HarnessError** — program installation, launch, or nonzero exit.
 4. **ToolsetError/UserError** — server startup, reachability, or call behavior.
 5. **SandboxError/TunnelError** — runtime capacity, lifecycle, filesystem, network, or rate limits.
-6. **TasksetError** — setup/finalize/scoring implementation.
+6. **TaskError** — task setup, finalize, or scoring implementation during a rollout.
 7. **Trainer instability** — valid branches arrive, then loss/KL/gradient/weight behavior fails.
 
 Retries may help transient provider/sandbox/tunnel failures. They do not fix deterministic taskset

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -82,11 +82,7 @@ def user_runtime(request) -> dict:
     return {"colocated": False, "runtime": {"type": request.param}}
 
 
-# The tool server's runtime: inside the harness's runtime (`colocated`) or its own runtime
-# per rollout; this fans the tool test across all of them, each carrying its placement/runtime
-# mark (colocated uses the host subprocess runtime). Eval-wide sharing is a different SCOPE
-# (a `Taskset.tools` declaration), not a placement flag — its e2e coverage is
-# `test_shared_tool_isolation`, which fans the shared server's own runtime off this fixture.
+# Task-scoped and shared tool tests both use these runtime placements.
 TOOL_RUNTIMES = [
     pytest.param("colocated", marks=pytest.mark.colocated, id="with-tool-colocated"),
     pytest.param(

--- a/tests/v1/fixtures/counter_tool_v1.py
+++ b/tests/v1/fixtures/counter_tool_v1.py
@@ -1,18 +1,8 @@
-"""counter (v1, shared state): a `@vf.tool` accumulates into `trace.state`, scored from it.
-
-The v1 state fixture for the e2e matrix. The taskset declares a typed `CounterState` and a
-`CounterToolset` whose `bump` tool increments `self.state.count` on each call — the shared
-per-rollout state, synced to the host's `trace.state` over the interception server. The `@reward`
-reads `trace.state.count` back, so a non-zero reward proves the whole round-trip: tool write ->
-host `trace.state` -> scoring. Placement is CLI-tunable like any toolset (colocated / own runtime);
-`shared` is excluded by the test (state is per-rollout, not wired to an eval-level server).
-"""
+"""Task-scoped counter tool with typed rollout state."""
 
 import verifiers.v1 as vf
 
-TARGET = (
-    3  # calls the prompt asks for; the reward accepts >= 2 (margin for an under-call)
-)
+TARGET = 3
 
 
 class CounterState(vf.State):
@@ -20,7 +10,7 @@ class CounterState(vf.State):
 
 
 class CounterToolset(vf.Toolset[vf.ToolsetConfig, CounterState]):
-    TOOL_PREFIX = "counter"  # the model sees `counter_bump`
+    TOOL_PREFIX = "counter"
 
     @vf.tool
     def bump(self) -> str:
@@ -35,13 +25,9 @@ class CounterTaskConfig(vf.TaskConfig):
 
 class CounterTask(vf.Task[vf.TaskData, CounterState, CounterTaskConfig]):
     tools = (CounterToolset,)
-    # Built with the task config's `tools` field (placement stays CLI-tunable via
-    # --taskset.task.tools.*), resolved by `Task.server_config`.
 
     @vf.reward(weight=1.0)
     async def counted(self, trace: vf.Trace) -> float:
-        # The tool incremented `self.state.count` per call and pushed it to `trace.state` over the
-        # interception channel; reading it back non-zero here proves the round-trip (>= 2 accumulated).
         return float(trace.state.count >= 2)
 
 

--- a/tests/v1/fixtures/echo_tool_v1.py
+++ b/tests/v1/fixtures/echo_tool_v1.py
@@ -1,11 +1,12 @@
 """echo (v1, MCP tool): retrieve a stamped echo from a `vf.Toolset`, then report it.
 
-The v1 tool fixture for the e2e matrix. The taskset declares an `EchoToolset` (`vf.Toolset`)
+The v1 tool fixture for the e2e matrix. The task declares an `EchoToolset` (`vf.Toolset`)
 with one `@vf.tool` method whose placement is CLI-tunable (`--taskset.task.tools.colocated`,
-`--taskset.task.tools.runtime.type`): it runs colocated in the harness's runtime or in its own
-runtime, and the harness must reach it wherever it lives. The tool stamps its output with a token the prompt never reveals, so the reward is
-1.0 only if the model actually called the tool — trivial when the infra works, impossible when
-it doesn't. The tool is task-agnostic, so it works in `shared` placement too.
+`--taskset.task.tools.runtime.type`): it runs colocated in the harness's runtime or in its
+own runtime, and the harness must reach it wherever it lives. The tool stamps its output
+with a token the prompt never reveals, so the reward is 1.0 only if the model actually
+called the tool — trivial when the infra works, impossible when it doesn't. The tool is
+task-agnostic, so it would also serve taskset-scoped (`Taskset.tools`).
 """
 
 import verifiers.v1 as vf
@@ -29,8 +30,6 @@ class EchoToolTaskConfig(vf.TaskConfig):
 
 class EchoToolTask(vf.Task[vf.TaskData, vf.State, EchoToolTaskConfig]):
     tools = (EchoToolset,)
-    # Built with the task config's `tools` field (placement stays CLI-tunable via
-    # --taskset.task.tools.*), resolved by `Task.server_config`.
 
     @vf.reward(weight=1.0)
     async def echoed(self, trace: vf.Trace) -> float:

--- a/tests/v1/fixtures/echo_user_sim_v1.py
+++ b/tests/v1/fixtures/echo_user_sim_v1.py
@@ -1,11 +1,4 @@
-"""echo (v1, user simulator): echo a phrase per turn, driven by a `vf.User` simulator.
-
-The v1 user-sim fixture for the e2e matrix. The user simulator is a `vf.User` class whose
-placement is CLI-tunable (`--taskset.task.user.colocated`, `--taskset.task.user.runtime.type`): it runs
-either inside the harness's runtime (`colocated`) or in its own runtime (the default), and
-either way the framework drives it and reaches it from wherever the harness runs. A user-sim is
-a task tool, so this needs a tool-supporting harness.
-"""
+"""Multi-turn echo task driven by a `vf.User` simulator."""
 
 import verifiers.v1 as vf
 
@@ -53,8 +46,6 @@ class EchoUserSimTask(
     vf.Task[EchoUserSimData, EchoUserSimState, EchoUserSimTaskConfig]
 ):
     user = EchoUserSimUser
-    # Built with the task config's `user` field (placement stays CLI-tunable via
-    # --taskset.task.user.*), resolved by `Task.server_config`.
 
     @vf.stop
     async def user_finished(self, trace: vf.Trace) -> bool:

--- a/tests/v1/fixtures/tool_response_image_v1.py
+++ b/tests/v1/fixtures/tool_response_image_v1.py
@@ -28,7 +28,6 @@ class VisionToolset(vf.Toolset[vf.ToolsetConfig]):
 
 class ToolResponseImageTask(vf.Task):
     tools = (VisionToolset,)
-    # No ToolsetConfig field on the taskset config -> `server_config` default-constructs one.
 
     @vf.reward(weight=1.0)
     async def preserved_image_tool_result(self, trace: vf.Trace) -> float:

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -1,17 +1,4 @@
-"""End-to-end eval runs on trivial tasksets — each scores reward 1.0, with no errors.
-
-Every task is one greedy rollout (`temperature=0`, set in `run_v1`) on a single task with
-turn/timeout caps. The matrix axes are the runtimes a rollout places things in: the **harness**
-runtime (`harness_runtime`), the **user** simulator's runtime (`user_runtime`), and the **tool**
-server's runtime (`tool_runtime`) — each spanning subprocess/docker/prime/modal. Every matrix value
-carries a pytest mark, so subsets select with `-m` (see `conftest.py`).
-
-`test_user` and `test_tool` fan a server's own runtime against the harness runtime (the full
-reachability matrix); `test_single_turn`/`test_agentic` fan the harness against the harness runtime.
-`test_shared_tool_isolation` runs two concurrent rollouts against one SHARED writable tool server
-across the full `harness_runtime` x (shared server's own) `tool_runtime` matrix — incl. mixed-locality
-combos — asserting each keeps its own `self.state`.
-"""
+"""End-to-end v1 eval smoke tests."""
 
 import pytest
 
@@ -64,16 +51,7 @@ async def test_user(run_v1, harness_runtime, user_runtime, tmp_path):
 
 @pytest.mark.e2e
 async def test_tool(run_v1, run_v1_server, harness_runtime, tool_runtime, tmp_path):
-    """A `vf.Toolset` (an echo tool) across the full matrix of its runtime (`tool_runtime`:
-    colocated in the harness's runtime, shared once per eval, or its own runtime) x the harness
-    `runtime`. The tool stamps its output with a token the prompt never reveals, so reward 1.0
-    proves the tool was reachable from wherever the harness runs and actually ran.
-
-    The `shared` case runs through the env-server worker pool (`run_v1_server`, prime-rl's path,
-    where serving the shared tool once is the server's job) — a regression guard for the env server
-    running rollouts without entering its serving context (a shared server would otherwise be rebuilt
-    per rollout or error with "shared server was launched with a task"). Other runtimes run
-    in-process."""
+    """A task-scoped echo tool across tool and harness runtime placements."""
     # Reaching a tool server in its own prime sandbox needs prime port exposure, whose URL isn't
     # reachable from the host here (region=us doesn't help). Skip until it is.
     if tool_runtime.get("runtime", {}).get("type") == "prime":
@@ -96,12 +74,7 @@ async def test_tool(run_v1, run_v1_server, harness_runtime, tool_runtime, tmp_pa
 
 @pytest.mark.e2e
 async def test_tool_state(run_v1, harness_runtime, tool_runtime, tmp_path):
-    """The shared-state round-trip: a `@vf.tool` increments the typed `trace.state` each call (synced
-    over the interception server) and the `@reward` reads it back — reward 1.0 proves tool writes
-    reach the host's `trace.state`. Fanned across the tool's placement (`tool_runtime`) x the harness
-    `runtime`, so the state channel is exercised colocated and own-runtime. `shared` is skipped: a
-    shared server is eval-level (one instance for the whole eval), so per-rollout state isn't wired
-    to it."""
+    """A task-scoped tool round-trips typed state across runtime placements."""
     if tool_runtime.get("shared"):
         pytest.skip(
             "shared tool servers are eval-level — per-rollout state isn't wired to them"
@@ -129,19 +102,7 @@ async def test_tool_state(run_v1, harness_runtime, tool_runtime, tmp_path):
 async def test_shared_tool_isolation(
     run_v1_server, harness_runtime, tool_runtime, tmp_path
 ):
-    """A SHARED, writable tool server keeps each rollout's `self.state` isolated across concurrent
-    rollouts, over the FULL `harness_runtime` x (shared server's own) `tool_runtime` matrix — including
-    the mixed-locality combos (e.g. a local harness with a remote shared tool), which is exactly where
-    the rollout's `/state` channel must be bridged to the tool's runtime. `scratchpad-v1` gives each
-    task a unique word and rewards 1.0 iff the rollout reads back its OWN word, so two concurrent
-    rollouts (two distinct words on the ONE shared instance) both scoring 1.0 proves the per-rollout
-    `self.state` channel keeps them isolated with no cross-rollout corruption.
-
-    Sharing is structural (`ScratchpadTaskset.tools`), so only the own-runtime cases of
-    `tool_runtime` apply (the colocated param has no meaning for a taskset-scoped server —
-    skipped). Runs through the env-server pool (`run_v1_server`, prime-rl's path), where
-    serving the one shared instance is the server's job."""
-    # colocated placement has no meaning for a taskset-scoped (shared) server
+    """A shared writable tool isolates state across concurrent rollouts and runtimes."""
     tool_rt = tool_runtime.get("runtime", {}).get("type")
     if tool_rt is None:
         pytest.skip("shared-isolation fans the tool's own runtime; this case has none")
@@ -156,18 +117,15 @@ async def test_shared_tool_isolation(
         harness="null",
         harness_overrides={"runtime": {"type": harness_runtime}},
         output_dir=tmp_path,
-        num_tasks=2,  # two distinct words, run concurrently against the one shared server
+        num_tasks=2,
         n=1,
         max_turns=4,
-        # the shared tool is taskset-scoped, so its runtime knob lives at the taskset
-        # level ({"runtime": {"type": ...}}), not under `task`
         taskset_overrides={"tools": tool_runtime},
     )
     assert len(traces) == 2
     for trace in traces:
         assert trace.errors == []
         assert trace.num_turns >= 2  # tool call + answer
-        # read back its OWN word — no cross-rollout corruption
         assert trace.reward == 1.0
 
 

--- a/tests/v1/test_envs.py
+++ b/tests/v1/test_envs.py
@@ -57,7 +57,7 @@ def test_eval(taskset: str):
         "uv", "run", "--no-sync", "eval",
         "--taskset.id", taskset,
         *model,
-        # -r 2: a taskset with @group_reward(s) needs >=2 rollouts to compare.
+        # -r 2: a task with @group_reward(s) needs >=2 rollouts to compare.
         "-n", "1", "-r", "2", "--max-turns", "4",
         "--sampling.max-tokens", "512", "--rich", "false",
     ]  # fmt: skip

--- a/tests/v1/test_judges.py
+++ b/tests/v1/test_judges.py
@@ -113,9 +113,6 @@ def test_judge_plugin_resolution():
 
 
 def test_taskset_config_narrows_judges(tmp_path):
-    # `judges` entries narrow to the config type their id resolves to (like taskset/harness
-    # narrowing in EnvConfig), so judge-specific fields validate against the real config —
-    # and survive model_dump (SerializeAsAny), which the env-server wire depends on.
     rubric = tmp_path / "rubric.toml"
     rubric.write_text(RUBRIC_TOML)
     cfg = vf.TaskConfig.model_validate(
@@ -133,7 +130,6 @@ def test_taskset_config_narrows_judges(tmp_path):
     )
     assert isinstance(rubric_cfg, vf.RubricJudgeConfig) and rubric_cfg.name == "quality"
     assert cfg.model_dump()["judges"][0]["answer_field"] == "gold"
-    # a round-trip through the dump re-narrows to the same types
     again = vf.TaskConfig.model_validate(cfg.model_dump())
     assert isinstance(again.judges[0], vf.ReferenceJudgeConfig)
 
@@ -227,7 +223,7 @@ async def test_reference_score(fake_judge_model):
 
 
 async def test_reference_score_messages_prompt(fake_judge_model):
-    # A Messages-form prompt still reaches the judge as text (via Task.prompt_text).
+    # A Messages-form prompt still reaches the judge as text (via TaskData.prompt_text).
     from verifiers.v1.types import TextContentPart, UserMessage as UM
 
     task = QAData(
@@ -592,9 +588,6 @@ async def test_rubric_reference_answer_optional(tmp_path, fake_judge_model):
     assert "ZEBRA-GOLD" in fake_judge_model[-1]
 
 
-# --- Task.score integration -------------------------------------------------------------
-
-
 class JudgedTask(vf.Task[QAData]):
     @vf.reward
     async def own(self, trace) -> float:
@@ -626,14 +619,10 @@ async def test_task_score_runs_plugged_judges(tmp_path, fake_judge_model):
     taskset = JudgedTaskset(cfg)
     trace = make_trace()
     await JudgedTask(trace.task, taskset.config.task).score(trace, runtime=None)
-    assert trace.rewards["own"] == 0.25  # decorated rewards still run
-    assert (
-        trace.rewards["reference"] == 0.5
-    )  # 1.0 * weight 0.5, under the id-derived name
-    assert trace.rewards["quality"] == 0.75  # the rubric's aggregate, under its `name`
-    assert (
-        len(trace.info["judge"]) == 2
-    )  # every judge call recorded (rubric = one call)
+    assert trace.rewards["own"] == 0.25
+    assert trace.rewards["reference"] == 0.5
+    assert trace.rewards["quality"] == 0.75
+    assert len(trace.info["judge"]) == 2
 
 
 async def test_task_without_judges_scores_as_before():

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -11,7 +11,7 @@ from verifiers.v1.types import AssistantMessage, UserMessage
 
 
 class MyTask(vf.TaskData):
-    answer: str = ""  # a taskset-specific field WireTaskData must absorb
+    answer: str = ""  # a task-specific field WireTaskData must absorb
 
 
 class MyState(vf.State):
@@ -29,7 +29,7 @@ def test_bare_trace_round_trip():
 
 
 def test_custom_task_state_round_trip():
-    # A custom Task + State, round-tripped into the same parameterization. Custom task fields are
+    # Custom data and state round-trip into the same parameterization. Data fields are
     # typed (not just `model_extra`); `state` is runtime-only and never crosses the wire.
     tr = vf.Trace[MyTask, MyState](
         task=MyTask(idx=0, prompt="q", answer="gold"),

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -1,8 +1,4 @@
-"""verifiers v1 — a clean-slate, heavily-typed reimplementation.
-
-Public surface is re-exported here so environments can `import verifiers.v1 as vf`
-and reach everything they need. Built up milestone by milestone.
-"""
+"""Public v1 API."""
 
 import logging as _logging
 
@@ -86,8 +82,15 @@ from verifiers.v1.runtimes import (
     SubprocessConfig,
 )
 from verifiers.v1.state import State, StateT
-from verifiers.v1.task import Task, TaskData, TaskResources, TaskTimeout, WireTaskData
-from verifiers.v1.taskset import TaskConfig, Taskset, TasksetConfig
+from verifiers.v1.task import (
+    Task,
+    TaskConfig,
+    TaskData,
+    TaskResources,
+    TaskTimeout,
+    WireTaskData,
+)
+from verifiers.v1.taskset import Taskset, TasksetConfig
 from verifiers.v1.mcp import (
     Toolset,
     SharedToolsetConfig,

--- a/verifiers/v1/cli/__init__.py
+++ b/verifiers/v1/cli/__init__.py
@@ -1,3 +1,1 @@
-"""CLI commands. Each exposes a `main()` registered in pyproject's `[project.scripts]` and
-runnable via `uv run <name> ...` — a single module (`validate`, `serve`, `init`), or a
-subpackage whose entry is `<name>.main` (`eval`)."""
+"""V1 CLI commands."""

--- a/verifiers/v1/cli/dashboard/__init__.py
+++ b/verifiers/v1/cli/dashboard/__init__.py
@@ -1,4 +1,4 @@
-"""Rich live dashboards for the eval and validate runs (one frame, refreshed on a tick)."""
+"""Rich live dashboards."""
 
 from verifiers.v1.cli.dashboard.eval import dashboard
 from verifiers.v1.cli.dashboard.validate import TaskProgress, validate_dashboard

--- a/verifiers/v1/cli/dashboard/base.py
+++ b/verifiers/v1/cli/dashboard/base.py
@@ -1,9 +1,4 @@
-"""The shared dashboard engine: a rich `Live` view on a fixed refresh tick.
-
-The eval and validate dashboards each build their own frame; `live_view` just drives whichever
-`render` it's given — refreshing on a timer and drawing a final frame on exit. When given an
-`on_key` handler it also reads left/right arrow presses from the terminal (see `_key_reader`).
-"""
+"""Shared live-dashboard rendering."""
 
 import asyncio
 import contextlib
@@ -36,11 +31,7 @@ _ARROWS = {
 def _key_reader(
     on_key: Callable[[str], None] | None, refresh: Callable[[], None]
 ) -> Iterator[None]:
-    """Dispatch left/right arrow presses to `on_key`, redrawing immediately after each so the
-    view feels instant rather than waiting for the next refresh tick. A no-op unless `on_key` is
-    given and stdin is a real terminal. Puts stdin in cbreak mode (char-at-a-time, no echo, Ctrl+C
-    still interrupts) and reads it via the event loop — no extra thread — restoring the terminal on
-    exit."""
+    """Read arrow keys and restore terminal state on exit."""
     if on_key is None or not _HAS_TTY or not sys.stdin.isatty():
         yield
         return

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -1,15 +1,4 @@
-"""The eval `--rich` dashboard: a config overview, a progress bar, and one line per rollout.
-
-Reads each `Rollout.trace`/`phase` every tick — no extra plumbing. Each row carries a bracketed
-phase marker that reads at a glance — `[pending]` (dim), `[setup]` (yellow), `[rollout]` (cyan),
-`[finalize]` (magenta), `[scoring]` (blue), `[success]` (green), `[error]` (red) — padded so the
-brackets line up in a column down the left edge. The reward shows only once a rollout is fully
-scored (phase DONE), so it never flips as scoring lands. A task's rollouts are grouped adjacently
-and joined by a left brace (╭│╰), so an episode (a task's n rollouts) reads as a unit. Every
-rollout is on screen from the start: one still queued behind the concurrency cap reads `[pending]`
-(its task is all that's known yet) until it begins, and finished ones keep their result. The
-overview + progress sit on top, above a rule.
-"""
+"""Live eval dashboard."""
 
 import contextlib
 import time
@@ -143,7 +132,7 @@ def overrides(
     field's declared default. Not `model_fields_set`: a `--resume` run reloads its config via
     `model_validate(config.toml)`, and that toml is dumped with `exclude_none` (every field), so
     `model_fields_set` would flag them all. `default` is the reference instance, threaded through
-    recursion so a pinned nested default (a taskset's `user=UserConfig(colocated=True)`) reads as
+    recursion so a pinned nested default (`taskset.task.user`) reads as
     unchanged. `skip` holds dotted paths (`harness.runtime.type`)."""
     segments: list[str] = []
     fields = type(config).model_fields
@@ -198,7 +187,7 @@ def Overview(config: EvalConfig) -> Table:
     # Non-default knobs the user set, one row each when non-empty. `escape` the cell: an override
     # value (or our `[...]`/`{...}` delimiters) can carry Rich markup that would otherwise be
     # parsed as styling and dropped. `id` is in the `env` row; harness `runtime.type` too (hidden
-    # here), but only for the harness — a taskset's `user.runtime.type` has no other display.
+    # here), but only for the harness — `taskset.task.user.runtime.type` has no other display.
     if taskset_over := overrides(config.taskset, skip=frozenset({"id"})):
         grid.add_row("taskset", escape("  ·  ".join(taskset_over)))
     if harness_over := overrides(
@@ -258,14 +247,6 @@ def Progress(
 
 
 def _breakdown(done: list[Trace]) -> Table | None:
-    """The per-component view under the headline (summed) reward: a `rewards` row of each named
-    `@reward` contribution and a `metrics` row of each `@metric`, then a `usage` row (tokens and
-    cost summed over completed rollouts) and a `time` row (each phase averaged over the rollouts
-    that have it timed), laid out like the Overview (dim label column). Reward/metric components
-    are error-corrected means, with the global mean (an errored trace's value counting as 0) in
-    parens when some errored (see `format_mean`); they're skipped when every rollout errored (no
-    clean mean to show), while usage/time still appear — those resources were spent regardless.
-    `None` when no rollout has completed."""
     grid = Table.grid(padding=(0, 2))
     grid.add_column(style="dim", min_width=_LABEL_WIDTH)
     grid.add_column()
@@ -408,8 +389,6 @@ def _groups(rollouts: list[Rollout]) -> list[list[Rollout]]:
 
 
 def _brace(i: int, size: int) -> str:
-    """The left brace piece joining a task's rollouts — ╭ top, │ middle, ╰ bottom; a space for
-    a lone rollout (n=1, nothing to group)."""
     if size == 1:
         return " "
     return "╭" if i == 0 else "╰" if i == size - 1 else "│"
@@ -520,19 +499,6 @@ def Rows(groups: list[list[Rollout]], now: float, runtime_type: str) -> Table:
 
 
 class Pager:
-    """Which page of overflowing rollout rows is on screen. Auto-advances on a timer until the
-    user takes over with the left/right arrows, after which it stays where they leave it. Paging
-    opens on the first page: the timer is anchored to `origin` (the clock at the first paged frame),
-    so `int((now - origin) / _PAGE_SECONDS)` is 0 when paging begins and rotates from there, rather
-    than off the raw wall clock (which would open on an arbitrary page). `_paginate` clears `origin`
-    whenever everything fits on one page, so paging re-anchors and re-opens on page 1 if rollouts
-    overflow again after a resize. `count` (the page count, set each render by `_paginate`) gates the
-    arrows: they're inert while a single page fits, so a stray press before rollouts overflow can't
-    switch off auto-advance or offset the starting page once paging begins. The arrows wrap around
-    (left on the first page lands on the last, right on the last lands on the first), so the pages
-    form a circle rather than dead-ending. The chosen page is still clamped to `count` between
-    presses (it can shrink on a resize; it otherwise only grows, as rollouts are never removed)."""
-
     def __init__(self) -> None:
         self.page = 0
         self.manual = False
@@ -594,7 +560,6 @@ def _render(
 ) -> Group:
     now = time.time()
     warning = _warning(config)
-    # `{warning}\n\n{overview}` — the caution sits at the very top, blank line, then the overview.
     header = Group(warning, Text(""), Overview(config)) if warning else Overview(config)
     # The --push status line appears under the rollouts once the upload starts (None during the run
     # / when off). Measure the fixed top (header + progress + rule) and the footer so the rollout
@@ -630,12 +595,6 @@ async def dashboard(
     start: float,
     push: "PushState | None" = None,
 ):
-    """Refresh the live eval view until the `with` block exits, then a final frame. Left/right
-    arrows page through rollout rows when they overflow the screen. On resume, `rollouts`
-    includes the previous session's kept rollouts (as finished ones), so the rows, counts, and
-    scores cover the whole run, not just this session's re-run rollouts. `push` is the shared
-    `--push` status the view renders as a line under the rollouts once the upload starts (dim ->
-    white URL / red error), updated by the caller as the inline upload runs and lands."""
     pager = Pager()
     async with live_view(
         lambda: _render(rollouts, config, start, pager, push),

--- a/verifiers/v1/cli/dashboard/replay.py
+++ b/verifiers/v1/cli/dashboard/replay.py
@@ -1,5 +1,4 @@
-"""Live dashboard for `replay` — one row per trace being re-scored (pending → running → its
-outcome), mirroring the validate view. Reuses `TaskProgress` and `live_view`."""
+"""Live replay dashboard."""
 
 import contextlib
 import time
@@ -19,9 +18,6 @@ from verifiers.v1.utils.format import format_time
 
 @dataclass
 class ReplayProgress(TaskProgress):
-    """`TaskProgress` plus the re-score `detail` shown per row: the final reward when scored, or
-    the exception type when it errored."""
-
     detail: str = ""
 
 

--- a/verifiers/v1/cli/dashboard/validate.py
+++ b/verifiers/v1/cli/dashboard/validate.py
@@ -1,11 +1,4 @@
-"""The validate `--rich` dashboard: a taskset overview, a progress bar, and one row per task.
-
-The model-free counterpart of the eval dashboard — no rollout phases, tokens, turns, or
-reward, just each task's validation outcome, shown as a bracketed marker that reads at a
-glance — `[pending]` / `[running]` / `[valid]` / `[invalid]` / `[error]` / `[timeout]`,
-padded so the brackets line up in a column. The runner advances a `TaskProgress` per task;
-this reads them each tick.
-"""
+"""Live task-validation dashboard."""
 
 import contextlib
 import time
@@ -40,9 +33,6 @@ _DONE = ("valid", "invalid", "error", "timeout")
 
 @dataclass
 class TaskProgress:
-    """Live state of one task's validation, read by the dashboard each tick and advanced by the
-    runner (pending → running → its outcome)."""
-
     idx: int
     name: str | None
     state: str = "pending"

--- a/verifiers/v1/cli/debug.py
+++ b/verifiers/v1/cli/debug.py
@@ -116,6 +116,7 @@ def error_info(
 
 
 def capture_trace_error(trace: Trace, error: BaseException) -> None:
+    # CancelledError is a BaseException; Trace.capture_error accepts Exception.
     if isinstance(error, Exception):
         trace.capture_error(error)
         return
@@ -323,6 +324,7 @@ def main(argv: list[str] | None = None) -> None:
     sys.argv = [sys.argv[0], *argv]
     config = cli(config_type)
     setup_logging("DEBUG" if config.verbose else "INFO")
+    # Translate SIGTERM so async finally blocks still tear down their resources.
     signal.signal(signal.SIGTERM, lambda *_: (_ for _ in ()).throw(KeyboardInterrupt()))
     asyncio.run(run_debug(config))
 

--- a/verifiers/v1/cli/eval/__init__.py
+++ b/verifiers/v1/cli/eval/__init__.py
@@ -1,1 +1,1 @@
-"""The eval command: `uv run eval` — the entry (`main`), the rollout `runner`, and `resume`."""
+"""Evaluation CLI."""

--- a/verifiers/v1/cli/eval/main.py
+++ b/verifiers/v1/cli/eval/main.py
@@ -1,14 +1,4 @@
-"""The eval entrypoint: `uv run eval --taskset.id <id> [options]`.
-
-Registered as the `eval` console script. Mirrors the `~/prime-rl` pattern (`config =
-cli(Config)`). The taskset and harness are selected by their `--taskset.id` / `--harness.id`
-(the discriminator fields); `cli/resolve.py` narrows each to its config type, so the single
-`prime-pydantic-config` parse keeps their fields typed and overridable via dotted flags
-(e.g. `--harness.runtime.type docker`, `--taskset.*`) / `@ eval.toml`.
-
-`-h`/`--help` (or no args) prints the local example tasksets/harnesses plus the full, typed
-pydantic-config help — narrowed to whatever `--taskset.id` / `--harness.id` are given.
-"""
+"""Eval CLI entrypoint."""
 
 import asyncio
 import logging

--- a/verifiers/v1/cli/eval/resume.py
+++ b/verifiers/v1/cli/eval/resume.py
@@ -55,11 +55,6 @@ def load_resume_config(resume_dir: Path) -> EvalConfig:
 
 
 class Finished(Rollout):
-    """A finished rollout reloaded from a previous session (see `load`): carries just the
-    surface the dashboard reads (`trace`/`task`/`phase`/`runtime`), so a resumed run's kept
-    rollouts render exactly like this session's. The saved row is pure data, so it's wrapped
-    in the base `Task` (display reads `task.data`; no behavior is needed)."""
-
     def __init__(self, trace: Trace) -> None:
         self.trace = trace
         self.task = Task(trace.task)

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -45,9 +45,7 @@ async def run_eval(env: Environment, config: EvalConfig) -> list[Trace]:
     # — so the resumed run is indistinguishable from one that was never interrupted.
     finished: list[Trace] = []
     if config.resume is not None:
-        # A group-scored task's episode must be re-run whole (its `@group_reward`s
-        # compare all its rollouts); other tasks only re-run what's missing. One task
-        # type per taskset, so group scoring is a run-wide property.
+        # Resume incomplete group-reward tasks whole so every rollout is present.
         group = bool(tasks) and bool(discover_decorated(tasks[0], "group_reward"))
         finished, owed = resume.load(
             out, [t.data.idx for t in tasks], config.num_rollouts, group
@@ -82,7 +80,7 @@ async def run_eval(env: Environment, config: EvalConfig) -> list[Trace]:
     # (non-shared ones start per rollout inside the episodes); the interception pool comes up
     # here too, so concurrent rollouts share its servers + tunnels rather than one each. Build
     # episodes inside `serving` so each rollout is wired to those resources at construction.
-    async with env.serving(tasks):
+    async with env.serving():
         episodes = [
             env.episode(
                 task, ctx, n=owed[task.data.idx] if owed else config.num_rollouts
@@ -92,10 +90,6 @@ async def run_eval(env: Environment, config: EvalConfig) -> list[Trace]:
         rollouts = [resume.Finished(trace) for trace in finished] + [
             rollout for episode in episodes for rollout in episode.rollouts
         ]
-        # --push in the live dashboard: share a status the dashboard renders as a line under the
-        # rollouts once the run finishes and the upload begins (dim -> green URL / red error), and
-        # do the upload inline below so it resolves on screen. Only the rich path has a dashboard;
-        # every other path uploads (+ logs the URL) from `main`.
         push_state = None
         if config.push and config.rich:
             from verifiers.v1.push import PushState
@@ -125,10 +119,7 @@ async def run_eval(env: Environment, config: EvalConfig) -> list[Trace]:
 
 
 async def run_eval_server(config: EvalConfig) -> list[Trace]:
-    """Eval through the env-server worker pool (`--num-workers > 0`). Spawns the pool
-    (works for v1 and the v0 bridge), then drives rollouts by task idx over an
-    `EnvClient` — the same path prime-rl trains through, so it exercises the
-    router + workers end-to-end. Output matches `run_eval` (config.toml + traces.jsonl)."""
+    """Run evaluation through the env-server worker pool."""
     import multiprocessing as mp
     from functools import partial
 

--- a/verifiers/v1/cli/init.py
+++ b/verifiers/v1/cli/init.py
@@ -1,13 +1,4 @@
-"""The init entrypoint: `uv run init <name> [--add-tool] [--add-user] [--add-harness]`.
-
-Registered as the `init` console script — the v1 sibling of v0's `vf-init`. It scaffolds a new
-environment package under `--path` (default `./environments`), following the layout of the
-shipped `environments/*_v1` examples: a `pyproject.toml`, a package whose `__init__.py` re-exports
-the plugin via `__all__`, and a `taskset.py` that runs out of the box (replace `load` and
-the `@reward`). The optional flags add more scaffolding — a `vf.Toolset` (`--add-tool`), a
-`vf.User` simulator (`--add-user`), and a custom `vf.Harness` (`--add-harness`). `--v0` scaffolds
-a legacy v0 `load_environment` package instead (via `verifiers.scripts.init`).
-"""
+"""Scaffold v1 environment packages."""
 
 import sys
 from pathlib import Path
@@ -24,9 +15,6 @@ USAGE = (
 
 
 def _names(name: str) -> tuple[str, str, str, str]:
-    """`(dash, pkg, stem, prefix)` derived from a raw name: the hyphenated id, the importable
-    package (underscores), the `_v1`-less stem (for tool prefixes), and the CamelCase class
-    prefix (e.g. `my-task-v1` -> `my-task-v1`, `my_task_v1`, `my_task`, `MyTask`)."""
     dash = name.strip().strip("/").replace("_", "-").lower()
     pkg = dash.replace("-", "_")
     stem = pkg[:-3] if pkg.endswith("_v1") else pkg
@@ -37,7 +25,6 @@ def _names(name: str) -> tuple[str, str, str, str]:
 
 
 def _write(path: Path, content: str, force: bool) -> bool:
-    """Write `content` to `path` unless it exists (and `force` is off). Returns whether it wrote."""
     if path.exists() and not force:
         print(f"  skip   {path} (exists)")
         return False
@@ -76,19 +63,11 @@ def _init_py(pkg: str, prefix: str, add_harness: bool) -> str:
 
 
 def _taskset_py(pkg: str, prefix: str, *, add_tool: bool, add_user: bool) -> str:
-    """The taskset module skeleton — the row's data on a `TaskData` subclass, the behavior
-    (`@reward`, tool/user declarations) on the `Task` subclass, and a thin `Taskset` whose
-    `load` constructs the tasks (`Task(Data(...), self.config.task)`). Each enabled piece (tool/user) adds its import, a
-    class-level declaration on the task, and a field on the task's config (`vf.TaskConfig`,
-    nested under `TasksetConfig.task` and read as `self.config` — the framework builds each
-    declared server with the matching config field; see `Task.server_config`)."""
     imports = "import verifiers.v1 as vf"
     local_imports: list[str] = []
     task_config_fields = ""
     task_decls = ""
     task_methods: list[str] = []
-    # a user simulator carries per-rollout state and a stop condition, so the task is typed with
-    # its `State` subclass (`vf.Task[MyState, ...]`); without one it stays on the default `State`.
     state = "vf.State"
     if add_tool:
         local_imports.append(f"from {pkg}.servers.tool import {prefix}Toolset")
@@ -109,62 +88,41 @@ def _taskset_py(pkg: str, prefix: str, *, add_tool: bool, add_user: bool) -> str
     if local_imports:
         imports += "\n\n" + "\n".join(local_imports)
     methods_block = "".join(f"\n{m}\n" for m in task_methods)
-    if not (add_tool or add_user):
-        return f'''\
-{imports}
-
-
-class {prefix}Data(vf.TaskData):
-    """One row's data. Add task-specific fields here (e.g. a reference answer)."""
-
-
-class {prefix}Task(vf.Task[{prefix}Data]):
-    """The task's behavior: rewards and hooks, reading the row off `self.data`."""
-
-    @vf.reward(weight=1.0)
-    async def reward(self, trace: vf.Trace) -> float:
-        raise NotImplementedError("Score the rollout and return a float (e.g. in [0, 1]).")
-
-
-class {prefix}Config(vf.TasksetConfig):
-    num_tasks: int = 5
-    """How many tasks to build."""
-
-
-class {prefix}Taskset(vf.Taskset[{prefix}Task, {prefix}Config]):
-    def load(self) -> list[{prefix}Task]:
-        raise NotImplementedError(
-            "Return this taskset's tasks, e.g. "
-            "[{prefix}Task({prefix}Data(idx=i, prompt=...), self.config.task) "
-            "for i in range(self.config.num_tasks)]."
-        )
-'''
+    has_task_config = add_tool or add_user
+    task_config = (
+        f"\n\nclass {prefix}TaskConfig(vf.TaskConfig):\n"
+        '    """Knobs the task reads from ``self.config``; configure them under '
+        f'``--taskset.task.*``."""{task_config_fields}\n'
+        if has_task_config
+        else ""
+    )
+    task_generic = (
+        f"{prefix}Data, {state}, {prefix}TaskConfig"
+        if has_task_config
+        else f"{prefix}Data"
+    )
+    config_body = '    num_tasks: int = 5\n    """How many tasks to build."""\n' + (
+        f"    task: {prefix}TaskConfig = {prefix}TaskConfig()\n"
+        if has_task_config
+        else ""
+    )
     return f'''\
 {imports}
 
 
 class {prefix}Data(vf.TaskData):
-    """One row's data. Add task-specific fields here (e.g. a reference answer)."""
+    """One row's data. Add task-specific fields here, such as a reference answer."""
+{task_config}
 
-
-class {prefix}TaskConfig(vf.TaskConfig):
-    """Knobs the task reads (`self.config`) — under `--taskset.task.*`."""{task_config_fields}
-
-
-class {prefix}Task(vf.Task[{prefix}Data, {state}, {prefix}TaskConfig]):
-    """The task's behavior: rewards, hooks, and server declarations, reading the row
-    off `self.data` and the knobs off `self.config`."""{task_decls}
-{methods_block}
+class {prefix}Task(vf.Task[{task_generic}]):
+    """Rewards, hooks, and servers, with row data available on ``self.data``."""{task_decls}{methods_block}
     @vf.reward(weight=1.0)
     async def reward(self, trace: vf.Trace) -> float:
         raise NotImplementedError("Score the rollout and return a float (e.g. in [0, 1]).")
 
 
 class {prefix}Config(vf.TasksetConfig):
-    num_tasks: int = 5
-    """How many tasks to build."""
-    task: {prefix}TaskConfig = {prefix}TaskConfig()
-
+{config_body}
 
 class {prefix}Taskset(vf.Taskset[{prefix}Task, {prefix}Config]):
     def load(self) -> list[{prefix}Task]:
@@ -284,12 +242,11 @@ uv run eval {dash} -n 3    # evaluate a few tasks with the default harness
 
 {layout_block}
 
-Tune knobs from the CLI: `--taskset.num-tasks 10`, `--model <id>`, `-n`/`-r`/`-t`/`-T`.
+Tune knobs from the CLI: `--taskset.num-tasks 10`, `--model <id>`, `-n`, and `-r`.
 """
 
 
 def scaffold(config: InitConfig) -> Path:
-    """Scaffold a v1 environment package from `config` and return its directory."""
     dash, pkg, stem, prefix = _names(config.name)
     env_dir = Path(config.path) / pkg
     pkg_dir = env_dir / pkg
@@ -334,7 +291,7 @@ def scaffold(config: InitConfig) -> Path:
 
 def main(argv: list[str] | None = None) -> None:
     argv = list(sys.argv[1:]) if argv is None else list(argv)
-    if argv and not argv[0].startswith(("-", "@")):  # leading bare token is the name
+    if argv and not argv[0].startswith(("-", "@")):
         argv = ["--name", argv[0], *argv[1:]]
 
     if not argv or any(arg in ("-h", "--help") for arg in argv):
@@ -343,7 +300,7 @@ def main(argv: list[str] | None = None) -> None:
         cli(InitConfig)
         return
 
-    sys.argv = [sys.argv[0], *argv]  # let prime-pydantic-config render help/errors
+    sys.argv = [sys.argv[0], *argv]
     config = cli(InitConfig)
     if not config.name:
         raise SystemExit(USAGE)

--- a/verifiers/v1/cli/output.py
+++ b/verifiers/v1/cli/output.py
@@ -58,6 +58,7 @@ def save_config(config: BaseModel, results_dir: Path) -> None:
 
 def write_trace(results_dir: Path, trace: Trace) -> None:
     """Serialize and append one trace in the worker thread."""
+    # Preserve fields declared by typed Trace subclasses.
     data = TypeAdapter(type(trace)).dump_json(trace, exclude_none=True)
     with (results_dir / TRACES_FILE).open("ab") as f:
         f.write(data + b"\n")
@@ -66,8 +67,7 @@ def write_trace(results_dir: Path, trace: Trace) -> None:
 def read_traces(results_dir: Path, trace_type: type) -> list[Trace]:
     """Load a run's saved traces from `traces.jsonl`, typed as `trace_type` — the inverse of
     `write_trace`. Used by `replay` to re-score finished rollouts (pass the task's typed
-    `Trace[...]`, or `Trace[WireTaskData, ...]` to read any taskset's traces without importing it).
-    Streams line-by-line so a large (multi-GB) traces file isn't loaded into memory at once."""
+    `Trace[...]`, or `Trace[WireTaskData, ...]` to read any taskset's traces without importing it)."""
     adapter = TypeAdapter(trace_type)
     traces: list[Trace] = []
     with (results_dir / TRACES_FILE).open(encoding="utf-8") as f:

--- a/verifiers/v1/cli/replay.py
+++ b/verifiers/v1/cli/replay.py
@@ -1,16 +1,7 @@
-"""The replay entrypoint: `uv run replay <output-dir> [options] [@ file.toml]`.
+"""Offline scoring for saved traces.
 
-Offline sibling of `eval`: loads a finished run's saved traces and re-runs **scoring only**, no
-runtime. The run's own `config.toml` is the base; CLI flags / `@ file.toml` layer on top (e.g. a
-different judge model). Signals needing a `runtime` (in-sandbox verifiers like a SWE `solved`
-reward) are skipped and left as the source recorded them — group rewards likewise (no group
-context offline); the config's judges and trace-only `@reward`/`@metric`s re-run (judges are
-config, so the layered replay config decides exactly what judges). Metrics the
-re-score doesn't re-record (harness metrics, a skipped signal's direct writes) keep their source
-values. Rollouts that errored during generation (`stop_condition == "error"`)
-were never scored by eval, so they're copied through unchanged rather than re-scored on a broken
-transcript. `--num-rescores`/`-r` re-scores each trace N times to sample judge variance. Results go
-to a fresh output dir, so the source run is never overwritten.
+Replay runs trace-only handlers and judges, preserving runtime and group scores recorded
+by the source run. Its saved config is the base for replay-specific overrides.
 """
 
 import asyncio
@@ -35,7 +26,7 @@ from verifiers.v1.cli.output import (
 )
 from verifiers.v1.configs.replay import ReplayConfig
 from verifiers.v1.state import state_cls
-from verifiers.v1.task import Task, WireTaskData, task_data_cls
+from verifiers.v1.task import WireTaskData, task_data_cls
 from verifiers.v1.trace import Trace
 from verifiers.v1.utils.logging import setup_logging
 
@@ -48,8 +39,7 @@ USAGE = (
 
 
 def _narrow(config_path: Path) -> type[ReplayConfig]:
-    """`ReplayConfig` with `taskset` narrowed to the saved run's taskset type, so the `cli()`
-    parse stays typed and CLI overrides of taskset fields validate (mirrors eval/validate)."""
+    """Narrow replay config to the saved taskset's config type."""
     data = tomllib.loads(config_path.read_text())
     taskset_id = (data.get("taskset") or {}).get("id")
     if not taskset_id:
@@ -63,7 +53,7 @@ def _narrow(config_path: Path) -> type[ReplayConfig]:
 
 
 def output_dir(config: ReplayConfig) -> Path:
-    """Where a replay writes: `--output-dir`, else a fresh `outputs/<taskset>--replay/<uuid>`."""
+    """Resolve a replay's output directory."""
     return config.output_dir or Path("outputs") / f"{config.name}--replay" / config.uuid
 
 
@@ -71,32 +61,12 @@ async def run_replay(config: ReplayConfig, source: Path, out: Path) -> list[Trac
     logger.debug("replay config:\n%s", config.model_dump_json(indent=2))
     task_cls = vf.task_type(config.taskset.id)
     data_cls = task_data_cls(task_cls)
-    # `WireTaskData` reads any taskset's saved task without a runtime or its Task type (see WireTaskData).
+    # Rebuild wire data as concrete TaskData so subclass scoring sees typed fields.
     traces = read_traces(source, Trace[WireTaskData, state_cls(task_cls)])
     if config.num_traces is not None:
         traces = traces[: config.num_traces]
-    # `trace.task` is pure data; re-scoring with the taskset's behavior needs the declared
-    # `TaskData` type — which every saved row is (`Taskset.tasks` constructs one task type).
-    # A row that can't be rebuilt from the wire (a load-time-only field excluded from
-    # serialization, like harbor's `task_dir`) stays a `WireTaskData` and is scored by the
-    # base `Task` (judges + base signals only; the subclass's own `@reward`s don't run —
-    # runtime-dependent ones would be skipped offline anyway).
     for trace in traces:
-        try:
-            trace.task = data_cls.model_validate(trace.task.model_dump())
-        except Exception:
-            logger.warning(
-                "replay: can't rebuild %s from the saved task %s; re-scoring it as a "
-                "plain WireTaskData (judges + base-task signals only)",
-                data_cls.__name__,
-                trace.task.idx,
-                exc_info=True,
-            )
-    # Judges are config, not wire data: `Task.score` resolves them from the replay
-    # config's `taskset.task.judges` (the source run's config.toml layered under any CLI
-    # overrides) — so a re-tuned judge overrides the recorded run's and a newly-plugged
-    # one joins, with no trace surgery.
-    # `num_rescores` re-scores each trace that many times, each on its own copy.
+        trace.task = data_cls.model_validate(trace.task.model_dump())
     work = [t.model_copy(deep=True) for t in traces for _ in range(config.num_rescores)]
 
     save_config(config, out)
@@ -116,50 +86,31 @@ async def run_replay(config: ReplayConfig, source: Path, out: Path) -> list[Trac
     async def rescore(trace: Trace, st: ReplayProgress) -> None:
         async with sem or contextlib.nullcontext():
             st.start = time.time()
-            # A rollout that errored during generation was never scored by eval (its scoring phase
-            # never ran), so re-scoring would grade a broken/partial transcript. Copy it through
-            # unchanged, mirroring eval. A *scoring* error leaves `stop_condition` as the
-            # generation outcome, so those still re-score (the offline-recovery case).
+            # Generation failures have no complete transcript to score.
             if trace.stop_condition == "error":
                 st.state, st.detail, st.end = "skipped", "rollout errored", time.time()
             else:
                 st.state = "running"
-                # Clear prior scores so a changed/removed judge leaves no stale (double-summed) entry.
-                if isinstance(trace.info, dict):
-                    trace.info.pop("judge", None)
+                # Recompute trace-only scores after restoring runtime-only values below.
+                trace.info.pop("judge", None)
                 prior_rewards, prior_metrics = trace.rewards, trace.metrics
                 trace.rewards, trace.metrics, trace.extra_usage = {}, {}, []
-                # The behavior wrapper around the saved row: the declared Task for a
-                # rebuilt row, the base Task (judges + base signals) for a WireTaskData
-                # fallback; the replay config's task subtree supplies the knobs.
-                task = (task_cls if isinstance(trace.task, data_cls) else Task)(
-                    trace.task, config=config.taskset.task
-                )
+                task = task_cls(trace.task, config=config.taskset.task)
                 try:
-                    # Pre-fill the runtime-only values the offline `score` can't recompute
-                    # BEFORE scoring — so trace-only signals that read them (e.g. a
-                    # `@reward` reading a runtime `@metric`'s entry) see them, and a failed
-                    # re-score still persists them.
+                    # Trace-only handlers may depend on restored runtime metrics.
                     task.restore_offline(trace, prior_rewards, prior_metrics)
                     await task.score(trace)
                     st.state, st.detail = "scored", f"reward {trace.reward:.3f}"
                 except Exception as exc:
                     st.state, st.detail = "error", type(exc).__name__
-                    trace.capture_error(
-                        exc
-                    )  # record the re-scoring failure on the trace
+                    trace.capture_error(exc)
                     if not config.rich:
                         logger.warning(
                             "replay: scoring failed for task %s",
                             trace.task.idx,
                             exc_info=True,
                         )
-                # Source metrics the re-score didn't re-record survive wholesale — harness
-                # metrics and direct `record_metric` writes by skipped runtime signals are
-                # unattributable to a producer (`Task.restore_offline` covers only returned
-                # keys). Fill-if-missing: everything re-recorded above keeps its fresh
-                # value. Rewards get no such sweep — they stay attributed, so a removed
-                # judge's entry is not resurrected into the reward sum.
+                # Harness and direct-write metrics have no attributable producer.
                 for name, value in prior_metrics.items():
                     trace.metrics.setdefault(name, value)
                 st.end = time.time()
@@ -167,7 +118,7 @@ async def run_replay(config: ReplayConfig, source: Path, out: Path) -> list[Trac
             logger.info(
                 "idx=%s %s (%.1fs)", trace.task.idx, st.state, st.end - st.start
             )
-        # Persist as each trace finishes (like eval), so an interrupted replay keeps its progress.
+        # Persist each result as it lands so an interrupted replay keeps its progress.
         await append_trace(out, trace, lock)
 
     display = (
@@ -188,44 +139,39 @@ def main(argv: list[str] | None = None) -> None:
         sys.argv = [sys.argv[0], "--help"]
         cli(ReplayConfig)  # full, typed pydantic-config option help
         return
-    source = Path(argv.pop(0))  # the finished run dir to replay
+    source = Path(argv.pop(0))
     config_path = source / CONFIG_FILE
     if not config_path.exists():
         raise SystemExit(f"{USAGE}\nno config.toml in {source}")
 
-    # The saved run's config is the base; user flags / @ file.toml layer on top.
     layered = ["@", str(config_path), *argv]
     config_type = _narrow(config_path)
     sys.argv = [sys.argv[0], *layered]
     config = cli(config_type)
-    # Honor a user-set output_dir (via -o or an @ file); drop the *source* run's own output_dir
-    # so a replay always writes to a fresh dir and never back over the run it re-scores.
-    source_out = (tomllib.loads(config_path.read_text())).get("output_dir")
+    source_out = tomllib.loads(config_path.read_text()).get("output_dir")
+    # Clear the source run's output_dir unless the user overrode it.
     if config.output_dir is None or str(config.output_dir) == str(source_out):
         config = config.model_copy(update={"output_dir": None})
 
     out = output_dir(config)
-    if (
-        out.resolve() == source.resolve()
-    ):  # never write back over the run being replayed
+    if out.resolve() == source.resolve():
         raise SystemExit(
             f"replay: --output-dir must differ from the source run ({source}); "
             "refusing to overwrite it"
         )
     level = "DEBUG" if config.verbose else "INFO"
-    if config.dry_run:  # resolve + validate, write the config, and exit (no re-scoring)
+    if config.dry_run:
         setup_logging(level)
         logger.info("wrote config to %s", write_config(config, out))
         return
 
-    log_file = str(
-        out / "replay.log"
-    )  # tee the run's logs to its output dir, like eval
-    if config.rich:  # the dashboard owns the screen, so keep logs off the console
+    log_file = str(out / "replay.log")
+    if config.rich:
         setup_logging(level, log_file=log_file, console=False)
         logging.lastResort = None
     else:
         setup_logging(level, log_file=log_file, console=True)
+    # Translate SIGTERM so async finally blocks still tear down their resources.
     signal.signal(signal.SIGTERM, lambda *_: (_ for _ in ()).throw(KeyboardInterrupt()))
     asyncio.run(run_replay(config, source, out))
 

--- a/verifiers/v1/cli/serve.py
+++ b/verifiers/v1/cli/serve.py
@@ -1,10 +1,4 @@
-"""`serve --taskset.id <id> [options]` — serve a taskset's environment over ZMQ.
-
-Mirrors the eval entrypoint (`cli/eval.py`): the taskset and harness are selected by their
-`--taskset.id` / `--harness.id` and narrowed to their config types (via `cli/resolve.py`), so
-the taskset/harness flags stay typed (`--taskset.*`, `--harness.*`). The server then runs
-rollouts on request by task idx.
-"""
+"""Environment-server CLI entrypoint."""
 
 import sys
 from functools import partial

--- a/verifiers/v1/cli/validate.py
+++ b/verifiers/v1/cli/validate.py
@@ -1,14 +1,4 @@
-"""The validate entrypoint: `uv run validate <taskset-id> [--runtime.type subprocess] [options]`.
-
-Registered as the `validate` console script — the model-free sibling of `eval`. Where `eval`
-runs a model rollout per task, `validate` runs each task's gold check (`setup` + the
-`validate` hook) and a setup-only check in independent runtimes — or just one of them via
-`--only-gold` / `--only-setup`. Each task is provisioned, set up, checked, and torn down
-independently with bounded concurrency.
-
-Fire-and-forget: progress is shown live (the `--rich` dashboard, or per-task log lines) and
-nothing is written to disk.
-"""
+"""Model-free task-validation CLI."""
 
 import asyncio
 import contextlib
@@ -66,8 +56,6 @@ ResultRow = dict[str, Any]
 
 
 def _classify(valid: bool, exc: BaseException | None) -> str:
-    """The outcome reason: `valid` (passed), `invalid` (returned False), `timeout` (a stage
-    timed out), or `error` (raised) — the error's message carries the detail."""
     if valid:
         return "valid"
     if isinstance(exc, asyncio.TimeoutError):
@@ -93,7 +81,6 @@ def _row(
 
 
 async def _run_gold(task: Task, config: ValidateConfig) -> ResultRow:
-    """The gold check: provision one runtime, run setup + validate, tear it down."""
     start = time.time()
     runtime = make_runtime(
         resolve_runtime_config(config.runtime, task),
@@ -126,7 +113,6 @@ async def _run_gold(task: Task, config: ValidateConfig) -> ResultRow:
 
 
 async def _run_setup(task: Task, config: ValidateConfig) -> ResultRow:
-    """The setup-only check: provision one runtime, run setup, tear it down."""
     start = time.time()
     runtime = make_runtime(
         resolve_runtime_config(config.runtime, task),
@@ -177,7 +163,6 @@ def _all_error(rows: list[ResultRow]) -> tuple[str | None, str | None]:
 
 
 async def _run_all(task: Task, config: ValidateConfig) -> ResultRow:
-    """Run every check (gold, setup-only) as independent high-level validations."""
     start = time.time()
     gold = await _run_gold(task, config)
     setup = await _run_setup(task, config)
@@ -206,8 +191,6 @@ async def _validate_task(task: Task, config: ValidateConfig) -> ResultRow:
 
 
 async def run_validate(config: ValidateConfig) -> list[dict]:
-    """Run each task's `validate` hook with bounded concurrency, showing progress live. Returns
-    the result rows in memory — nothing is persisted."""
     taskset = vf.load_taskset(config.taskset)
     tasks = taskset.load()
     if config.shuffle:

--- a/verifiers/v1/clients/client.py
+++ b/verifiers/v1/clients/client.py
@@ -1,8 +1,4 @@
-"""The client abstraction: turn a prompt into a `Response`.
-
-Collapsed from v1's 4-typevar generic ABC with five conversion hooks to a single
-abstract method. Each concrete client owns its own wire translation internally.
-"""
+"""Client interfaces for model inference and relay."""
 
 import logging
 from abc import ABC, abstractmethod
@@ -75,17 +71,16 @@ class Client(ABC):
         headers: Mapping[str, str] | None = None,
     ) -> dict:
         """Relay a non-model-turn side request (an `aux_route`, e.g. Anthropic's `count_tokens`)
-        verbatim to the provider and return its JSON. Only the relay (eval) client supports it."""
+        as native JSON and return the provider JSON. Only the relay (eval) client supports it."""
         raise NotImplementedError(f"{type(self).__name__} does not relay aux routes")
 
     async def close(self) -> None:
-        """Release any underlying resources. Default no-op."""
+        pass
 
 
 @dataclass(frozen=True)
 class ModelContext:
-    """The model-side collaborators a harness talks to (client + model + sampling),
-    bundled so harnesses hold no rollout state. Built by the Environment."""
+    """Client, model, and sampling settings for one rollout."""
 
     model: str
     client: Client

--- a/verifiers/v1/clients/eval.py
+++ b/verifiers/v1/clients/eval.py
@@ -108,7 +108,8 @@ class EvalClient(Client):
                 f"malformed upstream response: {type(e).__name__}: {e}",
                 status_code=502,
             ) from e
-        response.raw = raw  # the program gets the provider's bytes back 1:1
+        # The interception server returns this full native provider object to the program.
+        response.raw = raw
         return response
 
     def _headers(

--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -35,7 +35,6 @@ from verifiers.v1.types import (
 
 
 def tool_to_wire(tool: Tool) -> dict:
-    """A vf tool -> the OpenAI chat wire dict (the renderer's generate request)."""
     function: dict = {
         "name": tool.name,
         "description": tool.description,

--- a/verifiers/v1/configs/debug.py
+++ b/verifiers/v1/configs/debug.py
@@ -12,10 +12,6 @@ from verifiers.v1.taskset import TasksetConfig
 
 
 class DebugConfig(BaseConfig):
-    """A taskset plus one setup-only debug action. The taskset is selected by a positional
-    id or `--taskset.id`; after setup, each task runs either an inline shell command or a
-    host script uploaded into the runtime. Results are persisted as traces."""
-
     uuid: str = Field(default_factory=lambda: str(uuid4()), exclude=True)
     """Auto-generated run id, used as the default output directory leaf."""
     taskset: SerializeAsAny[TasksetConfig] = TasksetConfig()
@@ -55,7 +51,6 @@ class DebugConfig(BaseConfig):
     @model_validator(mode="before")
     @classmethod
     def resolve_taskset(cls, data):
-        """Narrow the generic `taskset` to its concrete config type by id."""
         from verifiers.v1.loaders import narrow_plugin_field, taskset_config_type
 
         narrow_plugin_field(data, "taskset", taskset_config_type)

--- a/verifiers/v1/configs/eval.py
+++ b/verifiers/v1/configs/eval.py
@@ -11,13 +11,6 @@ from verifiers.v1.types import SamplingConfig
 
 
 class EvalConfig(EnvServerConfig):
-    """The eval run plus its environment: inherits the env's fields (`taskset`, `harness`,
-    `max_turns`, token limits, timeouts) and the worker `pool` so they're top-level flags
-    (`--taskset.id`, `--harness.id`, `--harness.runtime.*`, `--pool.*`, …) with no `--env.`
-    prefix, and adds the run knobs (model, sampling, counts, …). Rollouts run in-process by
-    default; `--server` drives them through the env-server worker pool (sized by `pool`) — the
-    path prime-rl trains through. `--rich` adds a live dashboard (in-process only)."""
-
     uuid: str = Field(default_factory=lambda: str(uuid4()), exclude=True)
     """Auto-generated run id — the leaf of the output dir, so runs never overwrite.
     Excluded from the saved config so re-running `@ config.toml` lands in a fresh dir."""
@@ -39,7 +32,7 @@ class EvalConfig(EnvServerConfig):
             "group_size", "rollouts_per_example", "num_rollouts", "r"
         ),
     )
-    """Rollouts per task. A taskset with `@group_reward`s requires >=2)."""
+    """Rollouts per task. A task with `@group_reward`s requires at least two."""
     shuffle: bool = Field(False, validation_alias=AliasChoices("shuffle", "s"))
     """Shuffle tasks before taking the first `num_tasks`."""
     max_concurrent: int | None = Field(
@@ -65,9 +58,10 @@ class EvalConfig(EnvServerConfig):
     """Where to write the run (config.toml + traces.jsonl). None = a fresh per-run dir
     under `outputs/<env>--<model>--<harness>/<uuid>` (so runs never overwrite each other)."""
     resume: Path | None = Field(None, exclude=True)
-    """Set by `--resume <dir>`: re-run only the rollouts a previous run left missing or
-    errored, appending to that run's own results. The run's saved config is loaded verbatim,
-    so `--resume` takes no other arguments. Excluded from the saved config."""
+    """Set by `--resume <dir>`: re-run missing or errored rollouts, or an incomplete
+    group-scored task as a whole group, appending to that run's own results. The run's saved
+    config is loaded verbatim, so `--resume` takes no other arguments. Excluded from the
+    saved config."""
 
     @model_validator(mode="after")
     def reject_rich_with_server(self):

--- a/verifiers/v1/configs/init.py
+++ b/verifiers/v1/configs/init.py
@@ -1,27 +1,18 @@
-"""The `InitConfig`: the config the `init` CLI parses.
-
-`init` scaffolds a new environment package (see `verifiers.v1.cli.init`); this config is just
-the "what to scaffold" knobs — the new env name, where to create it, and which optional pieces
-(tool server, user simulator, custom harness) to include.
-"""
+"""Environment-scaffold CLI configuration."""
 
 from pydantic import AliasChoices, Field
 from pydantic_config import BaseConfig
 
 
 class InitConfig(BaseConfig):
-    """What to scaffold. The `name` is the new environment id (a leading bare token, e.g.
-    `init my-task-v1`); the package dir, ids, and class names are derived from it. The
-    `--add-*` flags add optional pieces (tool server, user simulator, custom harness)."""
-
     name: str = ""
     """The new environment id, e.g. `my-task-v1` (positional: `init my-task-v1`)."""
     path: str = Field("./environments", validation_alias=AliasChoices("path", "p"))
     """Parent directory the package is created in (default `./environments`)."""
     add_tool: bool = Field(False, validation_alias=AliasChoices("add_tool", "T"))
-    """Also scaffold a `vf.Toolset` tool server (`servers/tool.py`), wired into the taskset (`-T`)."""
+    """Also scaffold a `vf.Toolset` declared on the task (`-T`)."""
     add_user: bool = Field(False, validation_alias=AliasChoices("add_user", "U"))
-    """Also scaffold a `vf.User` simulator (`servers/user.py`), wired into the taskset (`-U`)."""
+    """Also scaffold a `vf.User` declared on the task (`-U`)."""
     add_harness: bool = Field(False, validation_alias=AliasChoices("add_harness", "H"))
     """Also scaffold a custom `vf.Harness` (`harness.py`), selectable via `--harness.id <name>` (`-H`)."""
     v0: bool = False

--- a/verifiers/v1/configs/replay.py
+++ b/verifiers/v1/configs/replay.py
@@ -1,11 +1,4 @@
-"""The `ReplayConfig`: the config the `replay` CLI parses.
-
-Replay re-scores a finished run's saved traces with no runtime, so it needs only a subset of
-`EvalConfig` — the taskset (with its plugged judges) and a few run knobs. It carries no harness,
-runtime, model, sampling, or pool. Its base is the replayed run's own `config.toml` (a full
-`EvalConfig`), so `model_config` ignores the eval-only fields rather than rejecting them; CLI
-flags / `@ file.toml` then layer overrides (e.g. re-judge with different judge settings).
-"""
+"""Offline re-scoring config; source eval-only fields are ignored."""
 
 from pathlib import Path
 from uuid import uuid4
@@ -17,10 +10,6 @@ from verifiers.v1.taskset import TasksetConfig
 
 
 class ReplayConfig(BaseConfig):
-    """A taskset (with its config-plugged judges) plus replay run knobs. The saved run's
-    `config.toml` is the base; its eval-only fields (harness, runtime, model, sampling, pool, …)
-    are ignored here — replay only re-runs scoring from the trace."""
-
     model_config = ConfigDict(extra="ignore")
 
     uuid: str = Field(default_factory=lambda: str(uuid4()), exclude=True)
@@ -60,8 +49,6 @@ class ReplayConfig(BaseConfig):
     @model_validator(mode="before")
     @classmethod
     def _resolve_taskset(cls, data):
-        """Narrow the generic `taskset` to its specific config type by `id` (mirrors
-        `ValidateConfig`), so `taskset.task.judges` and other taskset fields validate typed."""
         from verifiers.v1.loaders import narrow_plugin_field, taskset_config_type
 
         narrow_plugin_field(data, "taskset", taskset_config_type)

--- a/verifiers/v1/configs/serve.py
+++ b/verifiers/v1/configs/serve.py
@@ -1,10 +1,4 @@
-"""The `ServeConfig`: the config the env-server CLI parses.
-
-Inherits `EnvServerConfig` (taskset + harness + timeouts + turn/token limits + the worker
-`pool`), so the swappable harness/runtime knobs are the same flags as the eval CLI
-(`--taskset.id`, `--harness.id`, `--harness.runtime.type`, `--taskset.*`, `--pool.*`), and
-adds only the CLI-specific serving knobs (bind address, verbose, dry-run).
-"""
+"""Environment-server CLI configuration."""
 
 from pydantic import AliasChoices, Field
 

--- a/verifiers/v1/configs/validate.py
+++ b/verifiers/v1/configs/validate.py
@@ -1,12 +1,4 @@
-"""The `ValidateConfig`: the single config object the validate CLI parses.
-
-Validation is per-task and model-free — it runs the taskset's `validate` hook (apply a gold
-solution, run a verifier) in a runtime, not a harness rollout. So the config carries just the
-taskset, the `runtime` its hook runs in (docker by default — a gold check often needs the
-task's declared container), the stage timeouts, and the run knobs. No harness, model, or
-sampling — and it's fire-and-forget: nothing is written to disk, so there's no output dir /
-resume / dry-run.
-"""
+"""Configuration for model-free task validation."""
 
 from pydantic import AliasChoices, Field, SerializeAsAny, model_validator
 from pydantic_config import BaseConfig
@@ -16,37 +8,22 @@ from verifiers.v1.taskset import TasksetConfig
 
 
 class CheckTimeoutConfig(BaseConfig):
-    """Per-task wall-clock timeouts for the model-free check CLIs (validate/debug), in
-    seconds (None = no limit). The nested shape mirrors eval's `--timeout.*` flags."""
-
     setup: float | None = None
-    """Max wall-clock for the taskset's `setup` hook per task."""
+    """Max wall-clock for the task's `setup` hook."""
     total: float | None = None
     """Max wall-clock for the check itself per task — the `validate` hook, or the debug
     command/script."""
 
 
 class ValidateConfig(BaseConfig):
-    """A taskset plus how to validate it. The taskset is selected by `--taskset.id` (with a
-    bare positional shorthand, `validate gsm8k-v1`); its fields stay typed and overridable
-    via dotted flags (`--taskset.split test`). The `validate` hook runs in `--runtime.*`
-    (docker by default; SWE rows carry their own per-task image)."""
-
     taskset: SerializeAsAny[TasksetConfig] = TasksetConfig()
     runtime: RuntimeConfig = DockerConfig()
-    """Where each task's `validate` hook runs. Docker by default — unlike the eval harness
-    (subprocess), a gold check often needs the task's declared container; a SWE task overrides
-    the image per task. Use `--runtime.type subprocess` for a check that needs no container —
-    one that only reads task data or runs a uv-script verifier (e.g. gsm8k)."""
+    """Where each task's validation hooks run."""
     timeout: CheckTimeoutConfig = CheckTimeoutConfig()
-    """Per-task stage timeouts: `--timeout.setup` for the `setup` hook, `--timeout.total`
-    for the `validate` hook."""
     only_setup: bool = False
-    """Run only the setup check per task (the `setup` hook, no gold check). By default
-    every check — setup-only and gold — runs in independent runtimes per task, reported
-    as one aggregate row."""
+    """Run only `Task.setup`."""
     only_gold: bool = False
-    """Run only the gold check per task (`setup` + the `validate` hook)."""
+    """Run only `Task.setup` and `Task.validate`."""
     num_tasks: int | None = Field(
         None,
         validation_alias=AliasChoices("num_tasks", "n", "num_examples", "batch_size"),
@@ -76,8 +53,6 @@ class ValidateConfig(BaseConfig):
     @model_validator(mode="before")
     @classmethod
     def _resolve_taskset(cls, data):
-        """Narrow the generic `taskset` to its specific config type by `id` — the taskset-only
-        half of `EnvConfig._resolve_plugins` (validate has no harness)."""
         from verifiers.v1.loaders import narrow_plugin_field, taskset_config_type
 
         narrow_plugin_field(data, "taskset", taskset_config_type)

--- a/verifiers/v1/decorators.py
+++ b/verifiers/v1/decorators.py
@@ -1,31 +1,6 @@
-"""Decorators that program rollout control flow + scoring.
+"""Scoring and rollout-control decorators."""
 
-Each decorator just tags a method with attributes; `discover_decorated` collects
-the tagged bound methods, sorted by descending priority then name.
-
-Scoring methods declare the inputs they need *by parameter name* and the framework
-injects them (`invoke`) — so a pure-trace reward needn't take the runtime, and an
-in-runtime verifier needn't take the trace. They live on the `Task` subclass, so
-`self` IS the task; the available names are:
-
-    @reward / @metric  (per rollout):  trace, runtime
-    @group_reward      (per group):    traces
-
-All handlers must be `async`. Examples (on a Task subclass):
-
-    @vf.reward(weight=1.0)
-    async def correct(self, trace, runtime) -> float: ...         # both
-
-    @vf.metric
-    async def turns(self, trace) -> float: ...                    # trace only
-
-    @vf.group_reward
-    async def most_concise(self, traces) -> list[float]: ...      # compares this task's rollouts
-
-A `@group_reward` compares trace metadata across a task's rollouts; anything from the
-runtime is recorded per rollout as a `@metric` first.
-"""
-
+import asyncio
 import inspect
 from typing import Any, Callable, TypeVar, overload
 
@@ -33,19 +8,14 @@ F = TypeVar("F", bound=Callable[..., Any])
 
 
 def discover_decorated(obj: object, attr: str) -> list[Callable[..., Any]]:
-    """Bound methods on `obj` tagged with `attr`, sorted by priority then name. Scans the
-    class MRO for tagged functions (not `inspect.getmembers(obj)`, which evaluates every
-    descriptor — e.g. a property like `Task.config` that raises until attached) and binds
-    each through `getattr`, so the most-derived override wins."""
+    """Find tagged methods without evaluating unrelated descriptors."""
     names = {
         name
         for klass in type(obj).__mro__
         for name, fn in vars(klass).items()
         if callable(fn) and hasattr(fn, attr)
     }
-    # Re-check the mark on the resolved attribute: an undecorated subclass override of a
-    # decorated base method must NOT run as a signal (the base's mark found the name, but
-    # the override is what getattr binds).
+    # An undecorated override suppresses a decorated base method.
     methods = [method for name in names if hasattr(method := getattr(obj, name), attr)]
     priority_attr = f"{attr}_priority"
     methods.sort(key=lambda m: (-getattr(m, priority_attr, 0), m.__name__))
@@ -53,11 +23,15 @@ def discover_decorated(obj: object, attr: str) -> list[Callable[..., Any]]:
 
 
 def invoke(fn: Callable[..., Any], available: dict[str, Any]) -> Any:
-    """Call `fn`, passing only the items of `available` whose name it declares as a
-    parameter. `fn` is a bound method (so `self` is already excluded); the result is
-    a coroutine because handlers are async."""
     params = inspect.signature(fn).parameters
     return fn(**{name: value for name, value in available.items() if name in params})
+
+
+async def invoke_all(
+    fns: list[Callable[..., Any]], available: dict[str, Any]
+) -> list[Any]:
+    """Invoke scoring handlers concurrently, including empty and singleton lists."""
+    return await asyncio.gather(*(invoke(fn, available) for fn in fns))
 
 
 def mark(attr: str, **extra: Any) -> Callable[[F], F]:
@@ -110,10 +84,7 @@ def reward(
 def reward(
     func: F | None = None, weight: float = 1.0, priority: int = 0
 ) -> F | Callable[[F], F]:
-    """Mark a per-rollout reward (weighted, summed into trace.reward). Declare any of
-    `trace`/`runtime`; they're injected by name (`self` is the task). Return a `float`
-    (recorded under the method name) or a `dict[str, float]` (each entry under its own
-    key); every contribution is scaled by `weight` before it's summed into `trace.reward`."""
+    """Mark a weighted per-rollout reward returning a float or keyed scores."""
     decorator = mark("reward", reward_priority=priority, _vf_weight=weight)
     return decorator if func is None else decorator(func)
 
@@ -127,9 +98,6 @@ def group_reward(
 def group_reward(
     func: F | None = None, weight: float = 1.0, priority: int = 0
 ) -> F | Callable[[F], F]:
-    """Mark a group reward `(self, traces) -> list[float]`: one score per trace,
-    computed by comparing all rollouts of this task (e.g. pairwise preference) — a function
-    of trace metadata. Each score is weighted and summed into that trace's reward,
-    alongside the per-rollout rewards."""
+    """Mark a weighted group reward returning one score per trace."""
     decorator = mark("group_reward", group_reward_priority=priority, _vf_weight=weight)
     return decorator if func is None else decorator(func)

--- a/verifiers/v1/dialects/__init__.py
+++ b/verifiers/v1/dialects/__init__.py
@@ -1,9 +1,4 @@
-"""Wire dialects: per-native-format translators (wire -> vf) for the interception trace.
-
-`Dialect` is the abstraction; one module per native format (`chat`, `responses`, `anthropic`).
-The interception server serves each registered dialect's `routes`, so the wire format is
-resolved from the endpoint the program's SDK posts to — no per-harness declaration.
-"""
+"""Registered wire dialects for interception."""
 
 from verifiers.v1.dialects.anthropic import AnthropicDialect
 from verifiers.v1.dialects.base import Dialect, StreamParser, iter_sse

--- a/verifiers/v1/dialects/anthropic.py
+++ b/verifiers/v1/dialects/anthropic.py
@@ -1,9 +1,9 @@
 """The Anthropic Messages dialect (claude-code and friends).
 
 Request parsing maps Anthropic content blocks onto the typed messages; response parsing reads
-the content blocks of a `Message`. Relay-only: the eval client forwards the program's bytes to a
+the content blocks of a `Message`. Relay-only: the eval client forwards the program's native JSON to a
 `/v1/messages` endpoint (auth is `x-api-key`, not Bearer) and this dialect parses a copy for the
-trace. `count_tokens` is relayed verbatim (an `aux_route`), never recorded.
+trace. `count_tokens` is relayed as native JSON (an `aux_route`), never recorded.
 """
 
 import json
@@ -243,8 +243,6 @@ class AnthropicStreamParser(StreamParser):
 
 
 class AnthropicDialect(Dialect[dict, AnthropicMessage]):
-    """The Anthropic Messages wire format."""
-
     routes = ("/v1/messages",)
     aux_routes = ("/v1/messages/count_tokens",)
     upstream_path = "/v1/messages"
@@ -290,7 +288,7 @@ class AnthropicDialect(Dialect[dict, AnthropicMessage]):
         return AnthropicStreamParser(self.validate_response)
 
     def apply_overrides(self, body: dict, model: str, sampling: SamplingConfig) -> dict:
-        # Forward verbatim except the eval's model + sampling. `temperature`/`top_p` are
+        # Preserve native fields except the eval's model + sampling. `temperature`/`top_p` are
         # authoritative (always dropped, the eval's applied if set); `max_tokens` is required by
         # the API, so the program's is kept unless the eval sets one.
         s = sampling.model_dump(exclude_none=True)

--- a/verifiers/v1/dialects/base.py
+++ b/verifiers/v1/dialects/base.py
@@ -5,8 +5,8 @@ trace from the program's native request + the provider's native response. The se
 every registered dialect's `routes` (see `dialects.DIALECTS`), so a request's format is resolved
 from the endpoint the program's SDK posts to — the harness declares nothing.
 
-The eval client relays a request's bytes verbatim to a matching endpoint, while a dialect-owned
-`StreamParser` incrementally assembles a response copy for the trace; the renderer is chat-only.
+The eval client preserves a request's native JSON fields except for eval-owned overrides, while a
+dialect-owned `StreamParser` incrementally assembles a response copy for the trace; the renderer is chat-only.
 A dialect is therefore mostly wire -> vf (`parse_request`/`parse_response`/`stream_parser`); the
 exceptions are `apply_overrides` (impose the eval's model + sampling in this format's shape) and
 `extend` (chat-only user-sim injection).
@@ -128,7 +128,7 @@ class Dialect(ABC, Generic[ReqT, RespT]):
 
     aux_routes: ClassVar[tuple[str, ...]] = ()
     """Side endpoints the SDK may call that aren't model turns (e.g. Anthropic's
-    `count_tokens`): relayed verbatim by the eval client, never recorded on the trace."""
+    `count_tokens`): relayed as native JSON by the eval client, never recorded on the trace."""
 
     upstream_path: ClassVar[str]
     """The provider endpoint the proxy forwards to for this format (e.g. `/chat/completions`)."""
@@ -182,7 +182,7 @@ class Dialect(ABC, Generic[ReqT, RespT]):
     @abstractmethod
     def apply_overrides(self, body: ReqT, model: str, sampling: SamplingConfig) -> ReqT:
         """Return `body` with the eval's `model` + `sampling` imposed in this protocol's shape —
-        the only mutation the proxy makes to an otherwise byte-exact forward. Model overlays;
+        the only field mutation the proxy makes to the native JSON object. Model overlays;
         sampling is authoritative (the program's sampling keys are dropped, the eval's applied)."""
 
     def extend(

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -58,7 +58,6 @@ def reasoning_text(data: Mapping[str, Any]) -> str | None:
 
 
 def _content_text(content) -> str:
-    """Flatten content to text for roles that never carry images."""
     if isinstance(content, list):
         return "".join(p.get("text", "") for p in content if isinstance(p, dict))
     return content or ""
@@ -113,8 +112,8 @@ def parse_tools(raw: list[dict] | None) -> list[Tool] | None:
 
 # --- vf -> chat wire ----------------------------------------------------------
 # `message_to_wire` (chat-only): used by `extend` (user-sim turn injection), the default harness
-# (a Messages prompt), and the train client (its generate request). The proxy never
-# serializes — it relays the provider's raw bytes.
+# (a Messages prompt), and the train client (its generate request). The proxy preserves its parsed
+# native JSON independently and does not use this serializer.
 
 
 def _content_to_wire(content):
@@ -126,7 +125,6 @@ def _content_to_wire(content):
 
 
 def message_to_wire(message: Message) -> dict:
-    """A vf message -> the OpenAI chat wire dict."""
     if message.role == "assistant":
         wire: dict = {"role": "assistant", "content": message.content}
         if message.provider_state:
@@ -281,8 +279,6 @@ class ChatStreamParser(StreamParser):
 
 
 class ChatDialect(Dialect[dict, ChatCompletion]):
-    """The OpenAI chat-completions wire format."""
-
     routes = ("/v1/chat/completions",)
     upstream_path = "/chat/completions"
     response_type = ChatCompletion
@@ -309,7 +305,7 @@ class ChatDialect(Dialect[dict, ChatCompletion]):
         return ChatStreamParser()
 
     def apply_overrides(self, body: dict, model: str, sampling: SamplingConfig) -> dict:
-        # Forward the program's body verbatim, overlaying only what the eval owns: the model and
+        # Preserve the program's native fields, overlaying only what the eval owns: the model and
         # the sampling knobs it set (later keys win, so the eval's override the program's).
         return {**body, "model": model, **sampling.model_dump(exclude_none=True)}
 

--- a/verifiers/v1/dialects/responses.py
+++ b/verifiers/v1/dialects/responses.py
@@ -217,6 +217,7 @@ def response_from_wire(response: OpenAIResponse) -> Response:
         input_details = provider_usage.input_tokens_details
         output_details = provider_usage.output_tokens_details
         cached = input_details.cached_tokens if input_details else None
+        # Responses input_tokens includes cache hits; vf keeps the buckets disjoint.
         usage = Usage(
             prompt_tokens=provider_usage.input_tokens - (cached or 0),
             completion_tokens=provider_usage.output_tokens,
@@ -264,8 +265,6 @@ class ResponsesStreamParser(StreamParser):
 
 
 class ResponsesDialect(Dialect[dict, OpenAIResponse]):
-    """The OpenAI Responses wire format."""
-
     routes = ("/v1/responses",)
     upstream_path = "/responses"
     response_type = OpenAIResponse
@@ -334,7 +333,7 @@ class ResponsesDialect(Dialect[dict, OpenAIResponse]):
         return ResponsesStreamParser()
 
     def apply_overrides(self, body: dict, model: str, sampling: SamplingConfig) -> dict:
-        # Forward verbatim except the eval's model + sampling, mapped to the Responses shape
+        # Preserve native fields except the eval's model + sampling, mapped to the Responses shape
         # (`max_tokens` -> `max_output_tokens`); sampling is authoritative.
         s = sampling.model_dump(exclude_none=True)
         name = model.rsplit("/", 1)[-1]
@@ -345,6 +344,7 @@ class ResponsesDialect(Dialect[dict, OpenAIResponse]):
         )
         overrides: dict = {"model": model}
         if reasoning_model:
+            # Preserve opaque reasoning state so it can be replayed on the next turn.
             include = list(body.get("include") or [])
             if "reasoning.encrypted_content" not in include:
                 include.append("reasoning.encrypted_content")
@@ -357,6 +357,7 @@ class ResponsesDialect(Dialect[dict, OpenAIResponse]):
             overrides["max_output_tokens"] = s["max_tokens"]
         reasoning = dict(body.get("reasoning") or {})
         if reasoning_model:
+            # Summaries provide the trace's readable reasoning text.
             reasoning = {"summary": "auto", **reasoning}
         if "reasoning_effort" in s:
             reasoning["effort"] = s["reasoning_effort"]
@@ -372,7 +373,6 @@ class ResponsesDialect(Dialect[dict, OpenAIResponse]):
     def extend(
         self, body: dict, completion: dict | None, user_messages: Messages
     ) -> dict:
-        """Append raw model output and the user simulator's reply for the next turn."""
         raw = body.get("input")
         items: ResponseInputParam = (
             [EasyInputMessageParam(role="user", content=raw)]

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -1,16 +1,4 @@
-"""The environment: a taskset composed with an harness and a runtime.
-
-The Environment is the eval-level composition and *resolver* — it does not itself run
-rollouts. It holds the taskset (the loader), harness, runtime config, and timeouts; lists
-the tasks; and turns one task into a runnable `Episode` of `n` `Rollout`s, resolving per
-task the runtime (image + resources, with cli/task/default precedence) and the timeouts.
-Execution lives one level down: an `Episode` runs `n` `Rollout`s of a task and scores them
-(per-rollout `@reward`/`@metric`, then cross-rollout `@group_reward`); each `Rollout`
-runs one trajectory. The task's `@reward`/`@metric` get the rollout's runtime
-(read/exec inside it), so a task scores correctly under any harness; `@group_reward`s
-compare a task's rollouts. Harness capability checks (tools, user sim, container) read
-the class-level declarations (`Task.tools` / `Task.user`) — one task class per taskset.
-"""
+"""Compose a taskset and harness into runnable episodes."""
 
 import contextlib
 import logging
@@ -39,17 +27,17 @@ from verifiers.v1.mcp import SharedToolServer, serve_shared
 
 class TimeoutConfig(BaseConfig):
     """Framework-enforced wall-clock timeouts per rollout stage, in seconds (None = no
-    limit). Each bounds one stage of `Rollout.run`: the task's `setup` hook, the harness
+    limit). Each bounds one stage of `Rollout.run`: task and harness setup, the harness
     run, the task's `finalize` hook, then scoring."""
 
     setup: float | None = None
-    """Max wall-clock for the task's `setup` hook (per-task runtime prep)."""
+    """Shared wall-clock budget for task setup and harness provisioning."""
     rollout: float | None = None
     """Max wall-clock for the rollout (the harness run)."""
     finalize: float | None = None
     """Max wall-clock for the task's `finalize` hook (post-run work, before scoring)."""
     scoring: float | None = None
-    """Max wall-clock for scoring — verify + rewards/metrics."""
+    """Max wall-clock for task and harness scoring."""
 
 
 class StaticPoolConfig(BaseConfig):
@@ -89,11 +77,7 @@ def pool_serve_kwargs(pool: StaticPoolConfig | ElasticPoolConfig) -> dict:
 
 
 class EnvConfig(BaseConfig):
-    """The rollout's two peers: the taskset (data + scoring) and the harness (which
-    program drives it, and where it runs — `harness.runtime`). Both are chosen at eval
-    time, not by the env — only `taskset` is narrowed per env (to its config type,
-    inferred from `load_taskset`). Tool servers are declared on `Task.tools` (per rollout)
-    or `Taskset.tools` (shared, once per eval)."""
+    """The taskset that loads tasks and the harness that runs them."""
 
     # SerializeAsAny: these hold resolved subclasses (e.g. MathConfig, DefaultHarnessConfig);
     # without it model_dump() narrows to the base type and drops the subclass fields, so the
@@ -120,10 +104,6 @@ class EnvConfig(BaseConfig):
     tunnel). N concurrent rollouts use ~N/multiplex servers + tunnels instead of one each —
     key past the per-token tunnel cap. 1 = a server (+ tunnel) per rollout."""
     # --- legacy (v0) backwards-compat -----------------------------------------
-    # Run a classic `verifiers.load_environment(id, **args)` env, bridged to v1 Traces (see
-    # `verifiers.v1.legacy`), instead of a v1 taskset/harness. Set `id` (leave `taskset`
-    # unset) to opt in; native v1 envs leave these untouched. Mirrors prime-rl's EnvConfig
-    # so it inherits these (a v0 env is driven the same way in eval and the env server).
     id: ID | None = None
     """Classic (v0) env id (`name`, `org/name`, or `org/name@version` — installed from the
     hub on demand), loaded via `verifiers.load_environment` and run through the legacy
@@ -264,9 +244,6 @@ class Environment:
         self._warned_resources: set[tuple[str, str]] = set()
         self._shared_tools: dict[str, SharedToolServer] = {}
         self._interception: InterceptionPool | None = None
-        """Eval-level serving resources, live only inside `serving()`: shared tool servers
-        ({name: url}) and the interception pool. `episode()` injects them into every rollout
-        so neither runner has to thread them through `Episode.run`/`Rollout.run`."""
 
     def runtime_for(self, task: Task) -> RuntimeConfig:
         """Resolve the runtime config for a task off the harness's runtime (see
@@ -276,18 +253,7 @@ class Environment:
         )
 
     def episode(self, task: Task, ctx: ModelContext, n: int = 1) -> Episode:
-        """Resolve `task` into a runnable episode of `n` rollouts: check the harness
-        supports what this task needs (tools / user sim / a container — per task, by
-        value, since instances differ per row), pick its runtime (image + resources) and its
-        timeouts (cli/toml > task > default, None = no limit), build one `Rollout` per
-        sample sharing them, and wrap them in an `Episode` (which runs them and applies
-        the task's `@group_reward`s across their traces).
-
-        A task with `@group_reward`s compares its rollouts, so it needs >=2 of
-        them — refuse `n < 2` there (rather than silently scoring a group of one)."""
-        # Capability checks read the class-level declarations (`Task.tools` / `Task.user`)
-        # — declarative, so nothing is constructed; the real per-rollout instances are
-        # built in `Rollout.run`.
+        """Resolve a task into an episode of `n` rollouts."""
         if not self.harness.SUPPORTS_MCP and (
             type(task).tools or type(self.taskset).tools
         ):
@@ -369,12 +335,8 @@ class Environment:
         return Episode(rollouts, retry=retries.rollout)
 
     @contextlib.asynccontextmanager
-    async def serving(self, tasks: list[Task] | None = None):
-        """Hold the env-level serving resources for the duration of an eval: the shared tool
-        servers (built once, see `shared_tools`) and the interception pool. Stash them so
-        every `episode()` built inside this context injects them into its rollouts — that's
-        what keeps both eval runners (in-process and env-server) on one serving path. Build
-        episodes inside this context; the resources are torn down on exit."""
+    async def serving(self):
+        """Hold one worker's servers; build episodes inside so they inherit these resources."""
         async with (
             self.shared_tools() as shared,
             self.interception_pool() as interception,
@@ -388,22 +350,10 @@ class Environment:
                 self._interception = None
 
     def interception_pool(self) -> InterceptionPool:
-        """The shared interception pool for this env's rollouts — one server (+ tunnel
-        behind a remote runtime) per `multiplex` rollouts, grown on demand. Built here,
-        where the harness runtime and `multiplex` live; the caller (eval runner / env
-        server) enters it for the run and tears it down. Pass it to `Episode.run`."""
         return InterceptionPool(self.harness.config.runtime, self.config.multiplex)
 
     @contextlib.asynccontextmanager
     async def shared_tools(self):
-        """Start the taskset-scoped (shared) tool servers ONCE for the eval — the classes
-        declared on `Taskset.tools`, each in its own `runtime` — and yield
-        `{name: SharedToolServer}` to inject into every rollout, so an expensive corpus is
-        built once, not per rollout. No-op ({}) when the taskset declares none. Sharing is
-        structural: the taskset carries no per-row data, so a shared server is
-        task-agnostic by construction (its `setup` gets no task). A shared server on a host
-        runtime is bridged to the host once (a tunnel) when the harness runs remotely, so
-        an in-sandbox harness can still reach it (see `serve_shared`)."""
         servers = self.taskset.tool_servers()
         if not servers:
             yield {}

--- a/verifiers/v1/episode.py
+++ b/verifiers/v1/episode.py
@@ -1,19 +1,4 @@
-"""An episode: evaluate one task — its rollout(s) and all scoring across them.
-
-An Episode is the largest unit the *evaluator* knows about: it runs `n` Rollouts of one
-task (each a single trajectory) under a shared concurrency limit, then scores across
-them. Per-rollout `@reward`/`@metric` already ran inside each Rollout; the Episode adds
-the cross-rollout `@group_reward` stage — pairwise/preference rewards that compare a
-task's rollouts. n=1 is just an episode with a single rollout.
-
-These are env-level *rewards*. Training-time transforms of rewards — advantages (GRPO,
-RLOO), on-policy distillation — are deliberately NOT modeled here; they sit a level
-above, in a trainer that consumes episodes. That's why this is an "Episode" and not a
-"group": nothing here computes an advantage.
-
-Each Rollout tears its own runtime down (see rollout.py), so the Episode owns no
-runtimes — only the rollouts and the scoring across them.
-"""
+"""Run and group-score all rollouts for one task."""
 
 from __future__ import annotations
 
@@ -38,8 +23,6 @@ class Episode:
             raise ValueError("an episode needs at least one rollout (n >= 1)")
         self.rollouts = rollouts
         self.task = rollouts[0].task
-        """The shared task — every rollout in an episode samples the same one; its
-        `@group_reward`s (if any) run across their traces."""
         self.retry = retry
 
     async def run(
@@ -47,15 +30,7 @@ class Episode:
         semaphore: asyncio.Semaphore | None = None,
         on_complete: Callable[[Trace], Awaitable[None]] | None = None,
     ) -> list[Trace]:
-        """Run all rollouts (each under `semaphore`), then group-score across their
-        traces. Without `@group_reward`s a rollout's reward is final the moment its own
-        scoring ends, so it's marked DONE then (no waiting for slower siblings); with
-        them, the whole group is marked DONE together after `score_group` — the reward
-        isn't final until every rollout is in. Each rollout already carries the eval-level
-        shared tool servers / interception pool (injected by `Environment.episode`).
-        `on_complete` (the runner's persist hook) is called with each trace the instant
-        it's finalized (DONE) — per rollout without group rewards, or once per trace after
-        group scoring with them."""
+        """Run rollouts; delay completion callbacks only when group scoring needs all of them."""
         group_scored = bool(discover_decorated(self.task, "group_reward"))
 
         async def run_one(rollout: Rollout) -> Trace:

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -181,6 +181,7 @@ class MessageNode(StrictBaseModel):
 
 
 def _canonical_tool_arguments(arguments: str) -> str:
+    # Ignore JSON key order and whitespace when hashing equivalent tool calls.
     try:
         return json.dumps(json.loads(arguments), sort_keys=True, separators=(",", ":"))
     except (json.JSONDecodeError, ValueError):
@@ -434,15 +435,6 @@ def _attribute_routed_experts(
 
 
 def _commit_turn(turn: PendingTurn, response: Response) -> None:
-    """Insert one prepared model turn into the graph.
-
-    Token attribution anchors new tokens to the cumulative *stored* length of the reused
-    prefix (`path_len`), not message spans — the previous assistant's closing scaffold lives
-    in its later input-form span but not its stored generation form, so anchoring on spans
-    would drop it. The new tokens (`prompt_ids[path_len:]`) are split among the new input
-    messages by span (leading template scaffold folds into the following message), and the
-    trailing generation prompt goes on the assistant node before its sampled completion. By
-    construction `concat(node.token_ids along the path) == prompt_ids + completion_ids`."""
     trace = turn.trace
     prompt = turn.prompt
     tokens = response.tokens

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -1,12 +1,3 @@
-"""The harness: a program that runs in a runtime and drives the conversation.
-
-A `Harness` provisions itself into the already-started runtime, then runs there;
-its model calls hit the interception server, which records the turns. Provisioning
-runs during rollout setup; only execution counts against the harness timeout. The
-runtime and the interception server are owned by the Rollout.
-"""
-
-import asyncio
 import logging
 import os
 from abc import ABC, abstractmethod
@@ -17,7 +8,7 @@ from pydantic import Field
 from pydantic_config import BaseConfig
 
 from verifiers.v1.clients import ModelContext
-from verifiers.v1.decorators import discover_decorated, invoke
+from verifiers.v1.decorators import discover_decorated, invoke_all
 from verifiers.v1.errors import HarnessError, boundary
 from verifiers.v1.utils.install import env_name
 from verifiers.v1.runtimes import (
@@ -34,41 +25,22 @@ logger = logging.getLogger(__name__)
 
 
 class HarnessConfig(BaseConfig):
-    """A harness's config — subclass per harness to add run knobs. Mirrors `TasksetConfig`: the
-    base type names the field, the concrete subclass is resolved by id (no closed union) — the
-    id is supplied by the caller (`--harness.id` / toml / a taskset's bundled harness), never
-    pinned on the subclass."""
-
     id: ID = "default"
-    """The harness id, which selects this harness: a local package, or an
-    `org/name[@version]` package installed on demand from the Environments Hub (see
-    `ID`). Set via `--harness.id`."""
+    """Local package or Hub `org/name[@version]`, set through `--harness.id`."""
     runtime: RuntimeConfig = SubprocessConfig()
-    """Where the harness runs (subprocess / docker / prime). Subprocess by default — a local
-    process on the host; a taskset that needs a container (its own image, or NEEDS_CONTAINER)
-    selects `--harness.runtime.type docker` (or prime/modal). Lives on the harness — it's the
-    harness's box; tool servers have their own placement (see `TasksetConfig.tools`)."""
+    """Runtime for the harness program; tool servers choose their placement separately."""
     env: dict[str, str] = Field(default_factory=dict)
-    """Additional environment variables for the harness program. Harness-owned endpoint,
-    authentication, and model variables take precedence."""
+    """Extra program variables; harness-owned variables take precedence."""
     forward_env: list[str] = Field(default_factory=list)
-    """Names of environment variables to forward into the harness program's runtime, for
-    secrets that must not be written into a checked-in config. Resolved from `os.environ` at
-    launch — names absent from the environment are skipped, and an explicit `env` value takes
-    precedence over a forwarded one."""
+    """Host variables to forward without writing secrets into config; explicit `env` wins."""
     disabled_tools: list[str] | None = None
-    """Harness-specific tool names to disable."""
 
     @property
     def name(self) -> str:
-        """The harness's package name (the id with any org / version stripped)."""
         return env_name(self.id)
 
     @property
     def resolved_env(self) -> dict[str, str]:
-        """`env` merged with the `forward_env` variables present in the current process
-        environment (explicit `env` wins). This is the environment the harness program runs
-        with; harnesses pass it to the runtime instead of `env` directly."""
         forwarded = {k: os.environ[k] for k in self.forward_env if k in os.environ}
         return {**forwarded, **self.env}
 
@@ -77,17 +49,11 @@ ConfigT = TypeVar("ConfigT", bound=HarnessConfig)
 
 
 class Harness(ABC, Generic[ConfigT]):
-    """Generic over its config type, so `self.config` is fully typed in subclasses
-    (e.g. `RLMHarness(Harness[RLMHarnessConfig])`)."""
-
     APPENDS_SYSTEM_PROMPT: ClassVar[bool] = False
-    """Emit task.system_prompt as a system message (else fold into the user message)."""
+    """Emit `TaskData.system_prompt` separately instead of folding it into the user prompt."""
     SUPPORTS_MCP: ClassVar[bool] = False
-    """Expose a task's MCP tool servers to the model; opt in (set True) for harnesses with an MCP client."""
     SUPPORTS_USER_SIM: ClassVar[bool] = False
-    """Drive a task's user simulator (multi-turn user injection); opt in per harness."""
     SUPPORTS_MESSAGE_PROMPT: ClassVar[bool] = False
-    """Accept a Messages-list task.prompt (e.g. an image-bearing prompt); opt in per harness."""
 
     def __init__(self, config: ConfigT) -> None:
         self.config = config
@@ -95,13 +61,6 @@ class Harness(ABC, Generic[ConfigT]):
     def resolve_prompt(
         self, task: TaskData
     ) -> tuple[str | None, str | Messages | None]:
-        """Resolve `(system_prompt, prompt)` for this harness. If the harness
-        appends the system prompt natively, returns it separately; otherwise folds it into
-        the user prompt (warning that it isn't sent as a system message). A `Messages`
-        prompt (e.g. an image-bearing prompt) is only allowed for harnesses that set
-        `SUPPORTS_MESSAGE_PROMPT`. A `None` prompt means the task has no prompt —
-        the user simulator opens the conversation (see `Task.user`); the harness emits no
-        opening user message."""
         prompt = task.prompt
         if (
             prompt is not None
@@ -140,9 +99,6 @@ class Harness(ABC, Generic[ConfigT]):
         secret: str,
         mcp_urls: dict[str, str],
     ) -> None:
-        """Run the harness in `runtime` (via `launch`) and handle its exit; its model calls
-        reach the interception server at `endpoint`, and `mcp_urls` are the task's tool
-        servers (name -> URL) to expose to the model."""
         async with boundary(HarnessError, f"harness {self.config.id!r}"):
             result = await self.launch(ctx, trace, runtime, endpoint, secret, mcp_urls)
         if trace.stop_condition is not None:
@@ -156,19 +112,10 @@ class Harness(ABC, Generic[ConfigT]):
         trace.stop("agent_completed")
 
     async def score(self, trace: Trace, runtime: Runtime) -> None:
-        """Run this harness's `@metric` methods over the finished trace, concurrently,
-        recording each into `trace.metrics`. Mirrors `Task.score` (which the
-        Rollout runs in parallel with this); metrics declare what they need (`task`,
-        `trace`, `runtime`) and can read what the harness left behind in the runtime.
-        No-op for an harness with no `@metric`s."""
         available = {"task": trace.task, "trace": trace, "runtime": runtime}
         fns = discover_decorated(self, "metric")
         async with boundary(HarnessError, f"harness {self.config.id!r} metric"):
-            results = (
-                [await invoke(fn, available) for fn in fns]
-                if len(fns) < 2
-                else await asyncio.gather(*(invoke(fn, available) for fn in fns))
-            )
+            results = await invoke_all(fns, available)
         for fn, result in zip(fns, results):
             if isinstance(result, Mapping):
                 trace.record_metrics(result)
@@ -185,10 +132,4 @@ class Harness(ABC, Generic[ConfigT]):
         secret: str,
         mcp_urls: dict[str, str],
     ) -> ProgramResult:
-        """Run the harness program in `runtime` to completion and return its result. The
-        task is `trace.task`; model calls should reach the interception server at
-        `endpoint` (bearer token `secret`); `mcp_urls` are the task's tool servers
-        (name -> URL) to wire in. Each harness owns the env its program needs — read
-        `ctx.model` for the model id (the default/compact harnesses set OPENAI_*; rlm sets
-        RLM_* too). UV-script harnesses prepare dependencies in `setup`, then launch the
-        returned argv through `runtime.run_program(...)` here."""
+        """Run the harness program to completion."""

--- a/verifiers/v1/harnesses/__init__.py
+++ b/verifiers/v1/harnesses/__init__.py
@@ -1,7 +1,3 @@
-"""Built-in harnesses, resolved by id (`--harness.id <id>`) as `verifiers.v1.harnesses.<id>`.
-
-Re-exports each harness's class + config off the package."""
-
 from verifiers.v1.harnesses.codex import CodexHarness, CodexHarnessConfig
 from verifiers.v1.harnesses.default import DefaultHarness, DefaultHarnessConfig
 from verifiers.v1.harnesses.kimi_code import KimiCodeHarness, KimiCodeHarnessConfig

--- a/verifiers/v1/harnesses/codex/harness.py
+++ b/verifiers/v1/harnesses/codex/harness.py
@@ -1,10 +1,6 @@
-"""The codex harness: installs the Codex CLI into the runtime and runs `codex exec`.
+"""Codex reaches interception as a Responses API provider using the session secret.
 
-Codex only speaks the streaming OpenAI Responses API, so it reaches the interception server as a
-custom model provider (`wire_api = responses`) pointed at the rollout endpoint — served by the
-Responses dialect + SSE relay (see `verifiers.v1.dialects.responses`). The binary is the static
-musl release, so it drops into any linux container with no runtime deps; its bearer token (the
-session secret) is read from an env var.
+The static musl binary runs in Linux containers without additional runtime dependencies.
 """
 
 import logging
@@ -37,8 +33,6 @@ chmod +x {bin}
 
 
 class CodexHarnessConfig(HarnessConfig):
-    """The Codex CLI harness — which codex release to install in the runtime."""
-
     version: str = "0.137.0"
     """Codex release to install (the `rust-v<version>` GitHub release); pinned for reproducibility."""
 

--- a/verifiers/v1/harnesses/default/__init__.py
+++ b/verifiers/v1/harnesses/default/__init__.py
@@ -1,8 +1,3 @@
-"""default — v1's built-in agentic harness (the fallback when no `--harness.id` is given): a chat
-loop with a local `bash` tool and an optional `edit` tool (single-occurrence string replacement,
-on by default). Its `harness.py` (class + config) and the `program.py` script staged into the
-runtime. Resolved by id via `load_harness`."""
-
 from verifiers.v1.harnesses.default.harness import (
     DefaultHarness,
     DefaultHarnessConfig,

--- a/verifiers/v1/harnesses/default/harness.py
+++ b/verifiers/v1/harnesses/default/harness.py
@@ -1,14 +1,3 @@
-"""The built-in default harness: a chat loop with a local `bash` tool, plus optional `edit`/`search`.
-
-A growing-message-list chat loop with a local `bash` tool that runs shell commands in the runtime,
-the task's MCP tools, and two optional local tools: `edit` (single-occurrence string replacement
-in a file, ported from the rlm `edit` skill; on by default — a model handles it more reliably than
-hand-built `sed`/heredoc shell) and `search` (Google results via serper.dev; off by default, needs
-`SERPER_API_KEY`). This is the fallback harness when no `--harness.id` is given. Its uv script
-(deps: openai, mcp) is prepared during setup, then launched as the harness program. For a pure chat
-loop with no local tools, use the `null` harness.
-"""
-
 import json
 import os
 from pathlib import Path
@@ -37,9 +26,6 @@ SEARCH_PROMPT = (
 
 
 class DefaultHarnessConfig(HarnessConfig):
-    """The built-in default harness. A uv script (deps: openai, mcp), so it runs in any runtime
-    that has `uv` (the harness bootstraps it) with no other setup."""
-
     edit: bool = True
     """Offer the local `edit` tool (single-occurrence string replacement in a file) alongside
     `bash`. On by default; set `--harness.edit false` for a bash-only agent."""

--- a/verifiers/v1/harnesses/default/program.py
+++ b/verifiers/v1/harnesses/default/program.py
@@ -2,19 +2,7 @@
 # requires-python = ">=3.10"
 # dependencies = ["openai", "mcp", "httpx"]
 # ///
-"""The default harness's program: a chat loop with a local `bash` tool (+ optional `edit`, `search`, MCP).
-
-A growing-message-list chat loop. It always offers a local `bash` tool that runs shell commands in
-the runtime; with `--edit` it also offers a local `edit` tool that replaces a unique string in a
-file, and with `--search` a `search` tool (Serper Google search). When the harness sets
-MCP_CONFIG (a standard `mcpServers` URL map) it also connects to those servers over streamable
-HTTP, exposes their tools to the model as `<server>_<tool>`, and routes those calls to the server.
-The loop runs until the model answers without a tool call.
-
-It runs as a uv script (deps: openai, mcp, httpx), so the chat + tool plumbing is just the SDKs —
-the harness bootstraps `uv` in the runtime. The interception endpoint, per-rollout secret, model,
-and serper key arrive as argv (not env), so the local tools' subprocesses never inherit them.
-"""
+"""Secrets arrive through argv so local tool subprocesses do not inherit them."""
 
 import argparse
 import asyncio

--- a/verifiers/v1/harnesses/kimi_code/harness.py
+++ b/verifiers/v1/harnesses/kimi_code/harness.py
@@ -1,9 +1,4 @@
-"""The Kimi Code harness: installs the CLI into the runtime and runs it headlessly.
-
-Kimi Code speaks the OpenAI Chat Completions API through an environment-defined model, so
-the rollout interception endpoint and session secret are passed through `KIMI_MODEL_*`.
-Task-owned MCP servers live in an isolated Kimi home.
-"""
+"""Kimi receives interception through `KIMI_MODEL_*`; task MCP config uses an isolated home."""
 
 import json
 import logging
@@ -37,8 +32,6 @@ env \
 
 
 class KimiCodeHarnessConfig(HarnessConfig):
-    """The Kimi Code CLI harness."""
-
     version: str = "0.14.3"
     """Kimi Code release to install, pinned for reproducibility."""
 

--- a/verifiers/v1/harnesses/mini_swe_agent/harness.py
+++ b/verifiers/v1/harnesses/mini_swe_agent/harness.py
@@ -1,5 +1,3 @@
-"""The mini-swe-agent harness: runs the native bash-tool agent through LiteLLM."""
-
 from pathlib import Path
 
 from verifiers.v1.clients import ModelContext
@@ -11,8 +9,6 @@ PROGRAM_SOURCE = (Path(__file__).resolve().parent / "program.py").read_text()
 
 
 class MiniSWEAgentHarnessConfig(HarnessConfig):
-    """The mini-swe-agent CLI harness."""
-
     version: str = "2.2.8"
     """mini-swe-agent release to install, pinned for reproducibility."""
 

--- a/verifiers/v1/harnesses/null/__init__.py
+++ b/verifiers/v1/harnesses/null/__init__.py
@@ -1,7 +1,3 @@
-"""null — v1's built-in tool-less harness: its `harness.py` (class + config) and the
-`program.py` script it stages into the runtime. A plain chat loop with the task's MCP tools
-and no tools of its own. Resolved by id via `load_harness`."""
-
 from verifiers.v1.harnesses.null.harness import NullHarness, NullHarnessConfig
 
 __all__ = ["NullHarness", "NullHarnessConfig"]

--- a/verifiers/v1/harnesses/null/harness.py
+++ b/verifiers/v1/harnesses/null/harness.py
@@ -1,12 +1,3 @@
-"""The built-in null harness: runs a small chat-loop program as a uv script, no tools of its own.
-
-A growing-message-list chat loop with the task's MCP tools (host-side, resolved to URLs by
-the Environment) — and no tools of its own (it's "null" precisely because it adds no
-harness-side tooling). Its uv script (deps: openai, mcp) is prepared during setup, then launched
-as the harness program. For a shell-driving agent, use a dedicated agentic harness (e.g.
-`mini-swe-agent`).
-"""
-
 import json
 from pathlib import Path
 
@@ -20,8 +11,7 @@ PROGRAM_SOURCE = (Path(__file__).resolve().parent / "program.py").read_text()
 
 
 class NullHarnessConfig(HarnessConfig):
-    """The built-in null harness. A uv script (deps: openai, mcp), so it runs in any runtime that
-    has `uv` (the harness bootstraps it) with no other setup."""
+    pass
 
 
 class NullHarness(Harness[NullHarnessConfig]):

--- a/verifiers/v1/harnesses/null/program.py
+++ b/verifiers/v1/harnesses/null/program.py
@@ -2,17 +2,7 @@
 # requires-python = ">=3.10"
 # dependencies = ["openai", "mcp"]
 # ///
-"""The null harness's program: a chat loop with the task's MCP tools (and none of its own).
-
-A growing-message-list chat loop. When the harness sets MCP_CONFIG (a standard `mcpServers` URL
-map) it connects to those servers over streamable HTTP, exposes their tools to the model as
-`<server>_<tool>`, and routes those calls to the server. The loop runs until the model answers
-without a tool call (immediately, when no tools are offered).
-
-It runs as a uv script (deps: openai, mcp), so the chat + tool plumbing is just the
-SDKs — the harness bootstraps `uv` in the runtime. The interception endpoint, per-rollout
-secret, and model arrive as argv (not env), so nothing the program spawns inherits them.
-"""
+"""The interception endpoint and secret arrive through argv rather than the environment."""
 
 import argparse
 import asyncio

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -1,13 +1,4 @@
-"""The rlm harness: installs the rlm CLI into the runtime and runs the binary.
-
-`RLMHarnessConfig` carries both how to install rlm (repo/branch/token/path) and its
-runtime knobs (`max_depth`, `skills`, `summarize_at_tokens`), which rlm reads from `RLM_*`
-env vars. The base `HarnessConfig.env` still passes any other `RLM_*` var through verbatim.
-
-A task's MCP tool servers are passed to rlm via `RLM_MCP_CONFIG` (a standard `mcpServers`
-URL map); rlm exposes each tool as a pre-imported IPython skill the agent calls
-programmatically (`await tools_<name>(...)`), rather than via a native MCP client.
-"""
+"""RLM exposes `RLM_MCP_CONFIG` tools as pre-imported IPython skills."""
 
 import json
 import logging
@@ -36,8 +27,6 @@ RLM_BIN = f"{RLM_DIR}/bin/rlm"
 
 
 class RLMHarnessConfig(HarnessConfig):
-    """The rlm CLI harness — how to install rlm and how it should run."""
-
     version: str = "main"
     """Git ref (branch, tag, or commit) of rlm to install."""
     max_depth: int = 0

--- a/verifiers/v1/harnesses/terminus_2/harness.py
+++ b/verifiers/v1/harnesses/terminus_2/harness.py
@@ -1,5 +1,3 @@
-"""The Terminus 2 harness: runs Harbor's tmux agent through LiteLLM."""
-
 import logging
 from pathlib import Path
 
@@ -13,8 +11,6 @@ logger = logging.getLogger(__name__)
 
 
 class Terminus2HarnessConfig(HarnessConfig):
-    """The Harbor Terminus 2 harness."""
-
     version: str = "0.14.0"
     """Harbor release to install, pinned for reproducibility."""
 

--- a/verifiers/v1/interception/__init__.py
+++ b/verifiers/v1/interception/__init__.py
@@ -1,9 +1,4 @@
-"""The interception layer.
-
-`server` catches an harness's chat-completions and proxies them to the model, multiplexing
-many rollouts on one server keyed by their secret; `pool` shares those servers (one tunnel
-each, behind a remote runtime) across all of an eval's or env-server's rollouts.
-"""
+"""Model-request interception and server pooling."""
 
 from verifiers.v1.interception.pool import InterceptionPool, PooledServer
 from verifiers.v1.interception.server import (

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -14,7 +14,7 @@ one tunnel) per pool member rather than one each — see `interception.pool`.
 When a rollout sets a user simulator (see `verifiers.v1.mcp.user`), the session also drives it:
 after each model turn it injects the simulator's reply as a user turn and re-prompts the
 model, so a multi-turn exchange plays out within one program request, transparently to the
-harness. When the task carries no prompt (`task.prompt is None`), the simulator also
+harness. When the row carries no prompt (`TaskData.prompt is None`), the simulator also
 opens the conversation: its first turn is seeded before the model is ever called. Tools are
 handled out-of-band (run by the harness).
 """
@@ -123,12 +123,6 @@ class RolloutLimits:
 
 @dataclass
 class RolloutSession:
-    """One rollout's interception state, served by a (possibly shared) `InterceptionServer`
-    and keyed there by its secret. Holds everything a single rollout's chat-completions need:
-    the client/model context, the trace to record turns onto, the framework limits + `@stop`s
-    checked before each turn, and (optionally) a user simulator the rollout sets before the
-    harness runs."""
-
     ctx: ModelContext
     trace: Trace
     stops: list[Callable[[Trace], Awaitable[bool]]] = field(default_factory=list)
@@ -152,7 +146,7 @@ class RolloutSession:
     async def refused(self) -> str | None:
         """The framework's limits (turns / token budget) and `@stop` checks, run before each
         model call. Sets the stop condition and returns its name, else None. A refused first
-        call halts the harness (its model call errors out); Harness.run treats it as clean. A taskset
+        call halts the harness (its model call errors out); Harness.run treats it as clean. A task
         that ends a trajectory from `trace.state` does it with its own `@stop` (run here generically),
         so the interception server holds no opinion about the state's contents."""
         if (limit := self.limits.reached(self.trace)) is not None:
@@ -168,13 +162,6 @@ class RolloutSession:
 
 
 class InterceptionServer:
-    """A localhost server that proxies model calls for one or more rollouts. It serves every
-    registered dialect's routes (see `dialects.DIALECTS`), so a request's wire format is resolved
-    from the endpoint it arrived on — not declared by the harness. Each rollout `register`s a
-    `RolloutSession` and gets back a secret; each request is routed to the session whose secret
-    matches its bearer token. A single server can multiplex many rollouts (the basis for
-    `interception.pool`); used 1:1 it's just a server with one session."""
-
     def __init__(self) -> None:
         self.sessions: dict[str, RolloutSession] = {}
         self.port = 0
@@ -268,20 +255,12 @@ class InterceptionServer:
             session.trace.id,
             dialect.streaming(body),
         )
-        # `body` is forwarded to the model 1:1 (the proxy mutates only model + sampling), so no
-        # provider field is lost. `prompt` is the dialect's typed parse, kept only to build the
-        # trace (the renderer re-derives its own from the body it's handed). A user simulator
-        # extends both each turn (`dialect.extend` for the wire, `prompt` for the trace).
+        # The proxy preserves native JSON fields except model + sampling. `prompt` is only the
+        # dialect's typed view for building the trace; the renderer re-derives its own from `body`.
+        # A user simulator extends both each turn (`dialect.extend` for wire, `prompt` for trace).
         prompt: Messages
         prompt, _ = dialect.parse_request(body)
-        # A task with no prompt has its conversation opened by the user simulator: before the
-        # first model call, seed the simulator's opening user turn(s) into both the wire request
-        # and the trace prompt, so the model answers the user rather than an empty prompt. Guarded
-        # to the opening (`num_turns == 0`), so a later program request (e.g. after a tool call)
-        # never re-seeds. The opening `respond("")` is cached on the session and reused, so a
-        # retried opening request (e.g. the harness SDK retrying a transient model 502, before any
-        # turn is recorded) doesn't advance the simulator's queue and skip the opening turn. The
-        # post-turn loop below then drives the remaining turns as usual.
+        # Cache the opening so retries do not advance the simulator twice.
         if (
             session.user is not None
             and session.trace.task.prompt is None
@@ -291,7 +270,7 @@ class InterceptionServer:
                 session.opening = await session.user("")
             body = dialect.extend(body, None, session.opening)
             prompt = [*prompt, *session.opening]
-            # If the simulator ended at the open (its taskset's `@stop` now fires), the loop's
+            # If the simulator ended at the open (its task's `@stop` now fires), the loop's
             # `refused()` below halts the harness before any model call — no special-casing here.
         if dialect.streaming(body):
             return await self._stream(request, session, dialect, body, prompt)
@@ -367,8 +346,8 @@ class InterceptionServer:
                     e,
                 )
                 return web.json_response(dialect.error_body(str(e)), status=502)
-            # `Response.raw` is the wire response handed to the program 1:1 — the provider's
-            # verbatim bytes (proxy) or the client's serialized completion (renderer).
+            # `Response.raw` is the full native provider object, or the renderer's synthesized
+            # completion object, that the server serializes for the program.
             completion = response.raw
             logger.debug(
                 "intercept turn: id=%s tools=%d",
@@ -394,7 +373,7 @@ class InterceptionServer:
             # Inject the model turn + the simulator's user turn(s): into the wire request for the
             # next model call (`dialect.extend`, which keeps the model turn verbatim so reasoning
             # survives) and into the typed prompt for the trace. The simulator ends the trajectory
-            # through its taskset's `@stop` (e.g. a `user_finished` flag it set on `self.state`),
+            # through its task's `@stop` (e.g. a `user_finished` flag it set on `self.state`),
             # caught by `refused()` at the top of the next iteration — the interception server holds
             # no opinion about the state's contents.
             body = dialect.extend(body, completion, user_messages)
@@ -536,7 +515,7 @@ class InterceptionServer:
         self, request: web.Request, dialect: Dialect, route: str
     ) -> web.Response:
         """A non-model-turn side request (an `aux_route`, e.g. Anthropic's `count_tokens`):
-        relayed verbatim to the provider, never recorded on the trace."""
+        relayed as native JSON, never recorded on the trace."""
         session = self.sessions.get(dialect.secret(request.headers))
         if session is None:
             return web.json_response(dialect.error_body("unauthorized"), status=401)
@@ -601,7 +580,7 @@ class InterceptionServer:
 
     async def handle_state_put(self, request: web.Request) -> web.Response:
         """Replace a rollout's shared `trace.state` with a server's pushed copy (validated into the
-        trace's `State` type). Last write wins per call. A taskset ends the trajectory from state via
+        trace's `State` type). Last write wins per call. A task ends the trajectory from state via
         its own `@stop` (run in `RolloutSession.refused` before each model call)."""
         session = self._session_for(request)
         if session is None:

--- a/verifiers/v1/judge.py
+++ b/verifiers/v1/judge.py
@@ -1,56 +1,9 @@
-"""A reusable per-task LLM judge for v1 tasksets.
-
-Most tasksets that can't grade deterministically reach for the same shape: an OpenAI-compatible
-endpoint, a prompt built from `(question, answer, response)`, one chat call, and a verdict parsed
-out of the reply. `Judge` centralizes that — the client construction (incl. the Prime key/team
-fallback), the call, and usage/cost capture — and leaves the two things that actually differ as
-hooks: `build_messages` (prompt setup) and `parse`
-(verdict parsing). Set `schema` to use OpenAI structured outputs (where the provider supports it),
-in which case `JudgeResponse.parsed` is the validated pydantic object.
-
-    class CorrectnessJudge(vf.Judge[bool]):
-        prompt = "Question: {question}\\nAnswer: {answer}\\nResponse: {response}\\nCorrect? yes/no"
-
-        def parse(self, response: vf.JudgeResponse[bool]) -> bool:
-            return response.text.strip().lower().startswith("yes")
-
-    class MyData(vf.TaskData):
-        answer: str
-
-    class MyTask(vf.Task[MyData, vf.State, MyConfig]):
-        @vf.reward
-        async def correct(self, trace) -> float:
-            judge = CorrectnessJudge(self.config.judge)  # config.judge: vf.JudgeConfig
-            result = await judge.evaluate(
-                trace=trace,
-                question=self.data.prompt_text,
-                answer=self.data.answer,
-                response=...,
-            )
-            return float(result.parsed)
-
-A judge is cheap to construct (the HTTP client is opened per call, inside `complete`, and
-closed when the call returns), so build it where you use it.
-
-Passing `trace=` records the call onto it — a typed record appended to `trace.info["judge"]` and
-the call's tokens + cost added to `trace.extra_usage` (kept separate from the agent's `trace.usage`),
-so judge behaviour and spend are no longer invisible. The record lands even if the judge refuses, an
-empty structured output comes back, or `parse` raises (the request was already billed). Omit `trace`
-for a pure call (e.g. in tests).
-
-A judge can also be *plugged* rather than called from task code: a judge with an `id` and a
-`score` implementation is a plugin (like a taskset or harness — see `verifiers.v1.judges` for the
-built-ins and `verifiers.v1.loaders` for resolution). Its config lives on the task (`Task.judges`
-— per row, per task class, or appended to every row from the base `TaskConfig.judges` at
-load), and `Task.score` builds and runs it after the task's own `@reward`s.
-"""
-
 from __future__ import annotations
 
 import re
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Generic, Literal, cast, get_args
+from typing import TYPE_CHECKING, Any, Callable, Generic, Literal, cast
 
 from pydantic import BaseModel, SerializeAsAny, model_validator
 from typing_extensions import TypeVar
@@ -59,6 +12,7 @@ from verifiers.v1.clients.config import BaseClientConfig, build_async_openai
 from verifiers.v1.dialects.chat import message_to_wire
 from verifiers.v1.scoring import parse_judge_choice
 from verifiers.v1.utils.install import env_name
+from verifiers.v1.utils.generic import generic_type
 from verifiers.v1.types import ID, Messages, SamplingConfig, StrictBaseModel, Usage
 
 if TYPE_CHECKING:
@@ -69,36 +23,20 @@ ParsedT = TypeVar("ParsedT")
 
 
 class JudgeSamplingConfig(SamplingConfig):
-    """Sampling knobs for a judge call (`temperature` / `top_p` / `reasoning_effort` /
-    `max_tokens`, plus provider-specific keys via `extra='allow'`). Same shape as the rollout's
-    `SamplingConfig` — set e.g. `judge.sampling.max_tokens`."""
+    pass
 
 
 class JudgeConfig(BaseClientConfig):
-    """An LLM-judge endpoint. Inherits `base_url` / `api_key_var` / `headers` (with the Prime
-    auto-config) from `BaseClientConfig`; adds the model and sampling. Subclass to add
-    judge-specific fields (see `verifiers.v1.judges.rubric.RubricJudgeConfig`)."""
-
     id: ID = ""
-    """The judge id, which selects a judge plugin for a config-plugged judge (see
-    `TaskConfig.judges`): a built-in (`reference`, `rubric`), a local package, or an
-    `org/name[@version]` package installed on demand from the Environments Hub (see `ID`).
-    Empty for a judge the task builds and calls itself."""
+    """Plugin id; empty for a judge called directly by task code."""
     name: str = ""
-    """The reward key this judge's verdict records under when plugged (see `Judge.reward_name`);
-    defaults to the id's package name. Set it to disambiguate two plugged judges sharing an id."""
+    """Reward key override for a plugged judge."""
     weight: float = 1.0
-    """How a plugged judge's verdict weighs into `trace.reward` (like `@vf.reward(weight=...)`)."""
     model: str = "openai/gpt-5.4-nano"
     sampling: JudgeSamplingConfig = JudgeSamplingConfig()
     prompt: str | None = None
-    """Prompt-template override for `build_messages` (None = the judge class's own `prompt`),
-    so a plugged judge's prompt is tunable from config alone."""
     prompt_file: Path | None = None
-    """Load the `prompt` template from a text file instead of inlining it (mutually exclusive
-    with `prompt`; the same `{field}` placeholders work). Read once at judge construction, so
-    a bad path fails the eval up front. A relative path resolves against the process working
-    directory (like `RubricJudgeConfig.path`)."""
+    """Prompt file override, mutually exclusive with `prompt`."""
 
     @model_validator(mode="after")
     def check_prompt_source(self) -> "JudgeConfig":
@@ -108,23 +46,14 @@ class JudgeConfig(BaseClientConfig):
 
 
 Judges = list[SerializeAsAny[JudgeConfig]]
-"""The type of `TaskConfig.judges` — a list of plugged-judge configs, each resolved by its
-`id`. `SerializeAsAny` keeps the resolved subclasses' fields through `model_dump` (the
-env-server wire). Use it to give a taskset config a default judge:
-`judges: vf.Judges = [vf.ReferenceJudgeConfig()]` (the built-ins pin their own `id`)."""
+"""Config-plugged judges, resolved by id and serialized as their concrete types."""
 
 
 def judge_key(config: JudgeConfig) -> str:
-    """The reward key a plugged judge records under: the config `name`, else the id's
-    package name (`Judge.reward_name` adds a class-name fallback for code-level judges,
-    which have neither)."""
     return config.name or env_name(config.id)
 
 
 def resolve_judges(entries: Sequence[Any]) -> list[JudgeConfig]:
-    """Narrow raw judge entries to the config type their `id` resolves to (mirrors
-    `EnvConfig._resolve_plugins`), so judge-specific fields (e.g. rubric's `path`)
-    validate against the real config instead of being rejected by the base type."""
     from verifiers.v1.loaders import judge_config_type
 
     resolved = []
@@ -140,9 +69,6 @@ def resolve_judges(entries: Sequence[Any]) -> list[JudgeConfig]:
 
 
 def check_judges(entries: Sequence[JudgeConfig]) -> None:
-    """Hold judge entries to the plugged rules: an `id` on every entry (class-level
-    defaults never pass through `resolve_judges`) and no two entries sharing a reward
-    key (the second would clobber the first's verdict)."""
     for entry in entries:
         if not entry.id:
             raise ValueError(
@@ -158,26 +84,15 @@ def check_judges(entries: Sequence[JudgeConfig]) -> None:
 
 
 class JudgeResponse(StrictBaseModel, Generic[ParsedT]):
-    """One judge call's result — returned to the caller and (JSON-serialized) appended to
-    `trace.info["judge"]` for debugging, including the provider-reported `usage` (tokens + cost)."""
-
     text: str
-    """The judge's raw reply."""
     parsed: ParsedT | None = None
-    """The verdict the task acts on (`parse`'s output, or the structured object for `schema`)."""
     usage: Usage | None = None
 
 
 JudgeView = Literal["last_reply", "full_trace"]
-"""How much of a rollout a judge grades: the final reply's text, or the whole transcript
-(`Trace.transcript` — every recorded turn incl. system/tool messages, reasoning excluded).
-The type of the built-ins' `view` field; resolve it with `judge_response`."""
 
 
 def judge_question(task: "TaskData", question_field: str) -> str:
-    """The text a judge prompt's `{question}` gets: the task field named by `question_field`
-    (raising on a missing field, like `answer_field`), or — when unset — the whole task
-    prompt rendered as text (`Task.prompt_text`)."""
     if not question_field:
         return task.prompt_text
     question = getattr(task, question_field, None)
@@ -191,20 +106,11 @@ def judge_question(task: "TaskData", question_field: str) -> str:
 
 
 def judge_response(trace: "Trace", view: JudgeView) -> str:
-    """The text a judge prompt's `{response}` gets, by `view`: the final reply
-    (`last_reply`), or the whole transcript minus reasoning (`full_trace`,
-    `Trace.transcript`)."""
     return trace.transcript if view == "full_trace" else trace.last_reply
 
 
 def judge_verdict(text: str, choices: Sequence[str]) -> str:
-    """The verdict label in `text` (via `parse_judge_choice`), raising when none is found.
-
-    This is the error-attribution contract for judge rewards: a *model* failure (empty,
-    wrong, or non-committal reply) scores 0, but a *judge* failure — and an unparseable
-    verdict is one — must not be scored against the model. Raising errors the rollout
-    (recorded on the trace, excluded/retried in training) instead of hiding a broken judge
-    behind silent 0s."""
+    """Parse a verdict, raising so judge failures are not scored against the model."""
     verdict = parse_judge_choice(text, choices)
     if verdict is None:
         raise ValueError(f"judge returned no {'/'.join(choices)} verdict: {text!r}")
@@ -215,60 +121,28 @@ ConfigT = TypeVar("ConfigT", bound=JudgeConfig, default=JudgeConfig)
 
 
 def judge_config_cls(cls: type) -> type[JudgeConfig]:
-    """The `JudgeConfig` subclass a judge parameterizes — `Judge[ParsedT, MyJudgeConfig]` — read
-    off its generic bases, walking the MRO so a further subclass inherits it. Falls back to the
-    base `JudgeConfig` when none is given (the common case: a code-level judge written without
-    the extra generic param). Mirrors `state_cls` / `taskset_config_type`."""
-    for klass in getattr(cls, "__mro__", [cls]):
-        for base in getattr(klass, "__orig_bases__", ()):
-            for arg in get_args(base):
-                if isinstance(arg, type) and issubclass(arg, JudgeConfig):
-                    return arg
-    return JudgeConfig
+    """Resolve a judge's config specialization through its MRO, else `JudgeConfig`."""
+    return generic_type(cls, JudgeConfig) or JudgeConfig
 
 
 class Judge(Generic[ParsedT, ConfigT]):
-    """A per-task LLM judge over an OpenAI-compatible endpoint.
-
-    Override `build_messages` (prompt setup) and `parse` (verdict parsing) — or just set the
-    `prompt` template and use the defaults — then call `evaluate(**fields)`. Set `schema` to opt
-    into structured outputs. Generic over the verdict and (optionally) the config type —
-    `Judge[bool]` for a code-level judge, `Judge[float, MyJudgeConfig]` to also narrow
-    `self.config` (which is how a plugged judge declares its config for `--taskset.task.judges`
-    narrowing; see `judge_config_cls`). A pluggable judge additionally implements `score`.
-    """
-
     prompt: str | None = None
-    """Default template for `build_messages`, formatted with the `evaluate` kwargs and sent as a
-    single user message. Override `build_messages` for system+user or non-template prompts;
-    `config.prompt` (inline) or `config.prompt_file` (a text file) overrides it from config."""
+    """Default prompt template, overridden by config."""
     schema: type[BaseModel] | None = None
-    """Pydantic schema for OpenAI structured outputs. When set, the call uses
-    `response_format=schema` and `JudgeResponse.parsed` is the validated object (provider must
-    support structured outputs)."""
 
     def __init__(self, config: ConfigT | None = None) -> None:
         self.config = cast(ConfigT, config or judge_config_cls(type(self))())
         if self.config.prompt_file is not None:
-            # Read eagerly so a bad path fails at construction, not mid-eval; shadows the
-            # class `prompt` for this instance (`config.prompt` is None — they're exclusive).
             self.prompt = self.config.prompt_file.read_text(encoding="utf-8")
 
     @property
     def reward_name(self) -> str:
-        """The reward key this judge records under (and the built-in rubric judge's metric
-        prefix): the config `name`, else the id's package name, else the snake-cased class
-        name (a code-level judge with neither)."""
         fallback = re.sub(
             r"(?<!^)(?=[A-Z])", "_", type(self).__name__.removesuffix("Judge")
         ).lower()
         return judge_key(self.config) or fallback or "judge"
 
     def build_messages(self, **fields: Any) -> str | Messages:
-        """Prompt-setup hook: turn the `evaluate` fields into the messages to send (a single user
-        message as a plain `str`, or a `vf.Messages` list). The default formats the `prompt`
-        template (the config's, else the class's) with the fields; override it for a
-        system+user / non-template prompt."""
         template = self.config.prompt or self.prompt
         if template is None:
             raise ValueError(
@@ -279,13 +153,6 @@ class Judge(Generic[ParsedT, ConfigT]):
     async def score(
         self, task: "TaskData", trace: "Trace"
     ) -> float | Mapping[str, float]:
-        """The plugged-judge contract: grade one finished rollout, returning a verdict that
-        `Task.score` records into `trace.rewards` under `config.reward_name` with
-        `config.weight` (a mapping records each entry under its own key, like a `@reward`).
-        Like the scoring hooks, an override declares the inputs it needs *by parameter name*
-        and the framework injects them: any subset of `task`, `trace`, `runtime`. Not
-        implemented on the base class — only a judge that implements `score` can be plugged
-        via `TaskConfig.judges`; code-level judges just call `evaluate` from a `@reward`."""
         raise NotImplementedError(
             f"{type(self).__name__} implements no `score`, so it can't be plugged via "
             "`taskset.task.judges`; implement `score` (see verifiers.v1.judges for examples) or "
@@ -293,8 +160,6 @@ class Judge(Generic[ParsedT, ConfigT]):
         )
 
     def parse(self, response: JudgeResponse[ParsedT]) -> ParsedT:
-        """Parsing hook: turn a `JudgeResponse` into the verdict. The default returns the
-        structured object when `schema` is set, otherwise the raw reply text."""
         if self.schema is not None:
             return cast(ParsedT, response.parsed)
         return cast(ParsedT, response.text)
@@ -308,10 +173,7 @@ class Judge(Generic[ParsedT, ConfigT]):
         parse: Callable[[JudgeResponse[Any]], Any] | None = None,
         **sampling: Any,
     ) -> JudgeResponse[Any]:
-        """Call the judge once: send `messages`, build the `JudgeResponse`, and — when a `trace` is
-        given — record it (`Trace.record_judge`) in a `finally`, so the call's tokens + cost are
-        captured even when a refusal / empty structured output / `parse` hook raises after the
-        billed request. `schema` opts into structured outputs; `parse` sets `JudgeResponse.parsed`."""
+        """Call the judge and record billed usage even when parsing fails."""
         wire = (
             [{"role": "user", "content": messages}]
             if isinstance(messages, str)
@@ -323,9 +185,6 @@ class Judge(Generic[ParsedT, ConfigT]):
 
         response: JudgeResponse[Any] | None = None
         try:
-            # A fresh client per call, closed deterministically — no leaked sockets, no
-            # process-level sharing. Construction is milliseconds and the extra TLS
-            # handshake is noise next to the judge's LLM call.
             async with build_async_openai(self.config) as client:
                 if schema is not None:
                     completion = await client.beta.chat.completions.parse(
@@ -342,8 +201,6 @@ class Judge(Generic[ParsedT, ConfigT]):
                             f"judge refused structured output: {choice.message.refusal}"
                         )
                     if response.parsed is None:
-                        # No refusal but no object either — e.g. a truncated/malformed reply. Surface it
-                        # rather than returning a None verdict callers read as a (falsy) failure.
                         raise RuntimeError(
                             f"judge returned no parseable structured output "
                             f"(finish_reason={choice.finish_reason})"
@@ -364,9 +221,6 @@ class Judge(Generic[ParsedT, ConfigT]):
     async def evaluate(
         self, *, trace: "Trace | None" = None, **fields: Any
     ) -> JudgeResponse[ParsedT]:
-        """Render the prompt (`build_messages(**fields)`), call the judge, and parse the verdict
-        (`parse`). When a `trace` is given the call is recorded onto it (`trace.info["judge"]` +
-        usage on `trace.extra_usage`), even if a refusal / empty output / parse raises."""
         messages = self.build_messages(**fields)
         return await self.complete(
             messages, trace=trace, schema=self.schema, parse=self.parse

--- a/verifiers/v1/judges/__init__.py
+++ b/verifiers/v1/judges/__init__.py
@@ -1,10 +1,4 @@
-"""Built-in judges, resolved by id (a `taskset.task.judges` entry's `id`) as
-`verifiers.v1.judges.<id>`.
-
-A judge plugin is a module exporting its `Judge` subclass via `__all__` (exactly like a taskset
-or harness plugin — see `verifiers.v1.loaders`): the built-ins ship here, any other id names a
-local package or an `org/name[@version]` package installed on demand from the Environments Hub.
-Re-exports each judge's class + config off the package."""
+"""Built-in V1 judges."""
 
 from verifiers.v1.judges.reference import ReferenceJudge, ReferenceJudgeConfig
 from verifiers.v1.judges.rubric import Criterion, RubricJudge, RubricJudgeConfig

--- a/verifiers/v1/judges/reference.py
+++ b/verifiers/v1/judges/reference.py
@@ -1,21 +1,7 @@
-"""reference — an off-the-shelf reference-answer judge, plugged from config alone.
+"""Built-in reference-answer judge.
 
-Asks the judge model whether the rollout's reply matches the task's reference answer and
-scores 1/0. The reference answer is read off the task by field name (`answer_field`, default
-`"answer"`; a list-valued field is judged as multiple acceptable answers), so it plugs into
-any taskset that carries one — no taskset code:
-
-    [[env.taskset.task.judges]]
-    id = "reference"
-    answer_field = "answer"
-
-Grading inputs are config-selectable: `question_field` (what fills `{question}`), `view`
-(final reply vs the whole transcript), and `choices` (the verdict labels, e.g. `["A", "B"]`).
-
-Error attribution: a *model* failure scores 0 — an empty response short-circuits to 0.0
-without a judge call, a wrong/non-committal reply gets the negative verdict. A *judge*
-failure — an API error or an unparseable verdict — raises instead, erroring the rollout so
-the sample is excluded/retried rather than scored against the model.
+Empty model output scores zero. Judge API or parsing failures raise so the sample can
+be retried instead of being scored against the model.
 """
 
 from pathlib import Path
@@ -36,7 +22,6 @@ from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
 from verifiers.v1.types import ID
 
-# A sibling text file so it doubles as a starting point for a config `prompt_file`.
 REFERENCE_PROMPT = (Path(__file__).resolve().parent / "reference.txt").read_text(
     encoding="utf-8"
 )
@@ -53,7 +38,7 @@ class ReferenceJudgeConfig(JudgeConfig):
     question_field: str = ""
     """Task field to fill the prompt's `{question}` (e.g. a dedicated `question` column
     without the prompt's instruction framing); empty = the task's prompt rendered as text
-    (`Task.prompt_text`)."""
+    (`TaskData.prompt_text`)."""
     view: JudgeView = "last_reply"
     """How much of the rollout fills `{response}` (see `JudgeView`). Defaults to the final
     reply — a reference-answer check grades the answer, not the path to it."""
@@ -76,8 +61,6 @@ class ReferenceJudgeConfig(JudgeConfig):
 
 
 class ReferenceJudge(Judge[float, ReferenceJudgeConfig]):
-    """Scores the reply 1/0 against the task's reference answer."""
-
     prompt = REFERENCE_PROMPT
 
     def parse(self, response: JudgeResponse[float]) -> float:

--- a/verifiers/v1/judges/rubric.py
+++ b/verifiers/v1/judges/rubric.py
@@ -1,30 +1,4 @@
-"""rubric — an off-the-shelf rubric judge, plugged from config alone.
-
-Reads a rubric — a list of criteria — from a JSON or TOML file and asks the judge model to grade
-each by picking one of its ordered `choices` (default `["no", "yes"]`, a binary check), scored to
-[0, 1] by rank — worst → best, so the first choice is 0.0 and the last 1.0 (all in one call by
-default, or batched `max_criteria`-at-a-time). Grading uses plain-text JSON by default, or
-structured output when `structured_output=true` (see `RubricJudgeConfig`). The reward is the
-weighted mean of the per-criterion scores (`sum(w*v) / sum(w)`, so it stays in [0, 1]); each score
-is also recorded as a `<name>/<criterion>` metric. Criterion weights come from the rubric file and
-are overridable from config (`weights`); the aggregate weighs into `trace.reward` via the judge's
-`weight`:
-
-    [[env.taskset.task.judges]]
-    id = "rubric"
-    path = "rubrics/quality.toml"
-    weight = 0.5
-    weights = { cites_sources = 2.0 }   # override the file's per-criterion weight
-
-with `rubrics/quality.toml` listing the criteria (JSON takes `{"criteria": [...]}` or a bare list):
-
-    [[criteria]]
-    name = "cites_sources"
-    text = "The response cites at least one specific source."
-    weight = 1.0
-    # choices default to ["no", "yes"]; give an ordered worst→best list for a graded criterion:
-    # choices = ["none", "partial", "thorough"]   # -> 0.0, 0.5, 1.0
-"""
+"""Built-in weighted rubric judge."""
 
 import asyncio
 import json
@@ -48,7 +22,6 @@ from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
 from verifiers.v1.types import ID, StrictBaseModel
 
-# A sibling text file so it doubles as a starting point for a config `prompt_file`.
 RUBRIC_PROMPT = (Path(__file__).resolve().parent / "rubric.txt").read_text(
     encoding="utf-8"
 )
@@ -67,8 +40,6 @@ JSON_SUFFIX = (
 
 
 def normalize_choice(choice: str, choices: list[str]) -> float:
-    """Score a chosen option to [0, 1] by rank. `choices` are ordered worst → best, so the first
-    scores 0.0, the last 1.0, and the rest evenly spaced (`choices` always has >= 2 entries)."""
     return choices.index(choice) / (len(choices) - 1)
 
 
@@ -91,13 +62,9 @@ def first_verdicts_object(text: str) -> dict | None:
 
 
 class Criterion(StrictBaseModel):
-    """One rubric entry the judge grades by picking one of `choices`, scored to [0, 1] by rank.
-    Defaults to a binary yes/no check (1/0)."""
-
     name: str
     """Key for the criterion's metric (`<judge name>/<name>`) and its `weights` override."""
     text: str
-    """The check itself, phrased so the first (best) choice means satisfied."""
     weight: float = 1.0
     """The criterion's share of the reward (overridable per name via `weights` in config)."""
     choices: list[str] = ["no", "yes"]
@@ -118,13 +85,13 @@ class RubricJudgeConfig(JudgeConfig):
     id: ID = "rubric"
     """Pinned to the built-in, so a code-level default entry needs no explicit id."""
     path: Path
-    """The rubric file (`.toml` or `.json`) listing the criteria — see the module docstring
-    for the shape. A relative path resolves against the eval's working directory."""
+    """A `.toml` or `.json` file containing a `criteria` list. Relative paths resolve
+    against the evaluation's working directory."""
     weights: dict[str, float] = {}
     """Per-criterion weight overrides by criterion name (config wins over the file)."""
     question_field: str = ""
     """Task field to fill the prompt's `{question}`; empty = the task's prompt rendered as
-    text (`Task.prompt_text`)."""
+    text (`TaskData.prompt_text`)."""
     answer_field: str = ""
     """Optional task field holding a reference answer (e.g. a gold patch) to show the judge, like
     the reference judge. Empty (default) shows none — `{reference}` renders blank. A list-valued
@@ -148,34 +115,21 @@ class RubricJudgeConfig(JudgeConfig):
 
 
 class CriterionVerdict(StrictBaseModel):
-    """One criterion's reply, matched back to the rubric by `name`: a short `reason`
-    (chain-of-thought, always recorded for auditability in `trace.info["judge"]`) written *before*
-    the `verdict`, so the verdict follows from it. `verdict` is one of the criterion's `choices`
-    (validated per criterion in `grade_batch`, since choices vary by criterion)."""
-
     name: str
     reason: str
     verdict: str
 
 
 class RubricVerdicts(StrictBaseModel):
-    """The judge's reply: one reasoned verdict per rubric criterion."""
-
     verdicts: list[CriterionVerdict]
 
 
 class RubricJudge(Judge[RubricVerdicts, RubricJudgeConfig]):
-    """Scores every rubric criterion 1/0 (in one judge call, or batched `max_criteria` at a
-    time) and rewards their weighted mean."""
-
     prompt = RUBRIC_PROMPT
     schema = RubricVerdicts
 
     @cached_property
     def criteria(self) -> list[Criterion]:
-        """The rubric, parsed once from `config.path` (TOML by suffix, else JSON) with the
-        config's `weights` overrides applied. Fails loudly on a missing/empty file, duplicate
-        criterion names, or an override naming no criterion."""
         path = self.config.path
         text = path.read_text(encoding="utf-8")
         data = (
@@ -213,17 +167,10 @@ class RubricJudge(Judge[RubricVerdicts, RubricJudgeConfig]):
     async def grade_batch(
         self, task: TaskData, trace: Trace, batch: list[Criterion]
     ) -> dict[str, float]:
-        """Grade one batch of criteria in a single judge call — structured output, or plain-text
-        JSON when `structured_output` is off (which avoids flaky structured decoding). Returns
-        `{name: score}`, each the chosen option normalized to [0, 1] by rank (best → worst),
-        matched back to the batch by name. `score` fans this out per batch."""
-
-        def render(
-            c: Criterion,
-        ) -> str:  # every criterion states its own allowed answers inline
+        def render(c: Criterion) -> str:
             return f"- {c.name}: {c.text} (answer one of, worst to best: {', '.join(c.choices)})"
 
-        reference = ""  # optional gold answer shown to the judge; blank unless `answer_field` set
+        reference = ""
         if self.config.answer_field:
             answer = getattr(task, self.config.answer_field, None)
             if answer is None:
@@ -256,9 +203,7 @@ class RubricJudge(Judge[RubricVerdicts, RubricJudgeConfig]):
             verdicts = cast(RubricVerdicts, result.parsed).verdicts
         else:
             messages = cast(str, self.build_messages(**fields)) + JSON_SUFFIX
-            result = await self.complete(
-                messages, trace=trace
-            )  # no schema -> plain text
+            result = await self.complete(messages, trace=trace)
             obj = first_verdicts_object(result.text)
             if obj is None:
                 raise ValueError(
@@ -276,9 +221,8 @@ class RubricJudge(Judge[RubricVerdicts, RubricJudgeConfig]):
         scores: dict[str, float] = {}
         for v in verdicts:
             choices = by_criterion[v.name].choices
-            if (
-                v.verdict not in choices
-            ):  # an off-menu answer is a judge failure, not a 0
+            # An off-menu answer is a judge failure, not a zero score.
+            if v.verdict not in choices:
                 raise ValueError(
                     f"judge answered {v.verdict!r} for '{v.name}', expected one of {choices}"
                 )
@@ -287,8 +231,6 @@ class RubricJudge(Judge[RubricVerdicts, RubricJudgeConfig]):
 
     async def score(self, task: TaskData, trace: Trace) -> float:
         criteria = self.criteria
-        # Split into batches of `max_criteria` (None = one batch of all), then grade the batches
-        # concurrently (one judge call each) and merge.
         k = self.config.max_criteria
         if k is not None and k < 1:
             raise ValueError(f"`max_criteria` must be >= 1 or None, got {k}")

--- a/verifiers/v1/legacy.py
+++ b/verifiers/v1/legacy.py
@@ -252,7 +252,7 @@ def rollout_output_to_trace(out: dict, task_idx: int) -> Trace:
 def _to_wire_task(task_idx: int, prompt: Any, answer: Any) -> WireTaskData:
     """Carry the v0 prompt's meta onto the v1 task: the system message becomes
     ``system_prompt``, the user message(s) become ``prompt``, and the reference
-    ``answer`` rides along as a taskset-extra field (``WireTaskData`` allows extras)."""
+    ``answer`` rides along as a task-specific extra field (``WireTaskData`` allows extras)."""
     system_prompt: str | None = None
     user_texts: list[str] = []
     for m in prompt or []:
@@ -398,7 +398,7 @@ class LegacyEnvServer(EnvServer):
         return RunGroupResponse(traces=traces)
 
 
-# --- in-process v0 eval (the `eval` CLI's `--legacy.id` path) ------------------
+# --- in-process v0 eval (the `eval` CLI's `--id` path) -------------------------
 
 
 def _eval_client(client_config: ClientConfig, model: str):
@@ -430,15 +430,7 @@ def _legacy_output_dir(config) -> Path:
 
 
 async def run_legacy_eval(config) -> list[Trace]:
-    """In-process v0 eval used by the `eval` CLI when `config.is_legacy` (a legacy `id` is
-    set, no v1 `taskset`).
-
-    Loads the v0 env, runs `num_rollouts` per task with bounded concurrency, maps each v0
-    `RolloutOutput` to a v1 `Trace` (`rollout_output_to_trace`), persists results as they
-    land (the same `traces.jsonl` / `config.toml` a native run writes), and returns the
-    traces. The v0 env is run directly (`env.run_rollout`, no env server), so this needs no
-    runtime / interception server. All v0 specifics live here; the CLI only branches on
-    `config.is_legacy`."""
+    """Run a legacy environment in process and return v1 traces."""
     import asyncio
     import random
 

--- a/verifiers/v1/loaders.py
+++ b/verifiers/v1/loaders.py
@@ -1,31 +1,16 @@
-"""Loaders: resolve a plugin id to its taskset, harness, or judge.
-
-A plugin (taskset, harness, or judge) is a module that exports its `Taskset` / `Harness` /
-`Judge` subclass via `__all__` — vf walks the exported names and finds the single subclass of
-the base. An id (an `ID`) resolves to that module: a built-in id (`default`, `rlm`,
-`harbor`, `reference`, ...) resolves to its namespaced module under the group package
-(`verifiers.v1.harnesses.rlm`, `verifiers.v1.tasksets.harbor`, `verifiers.v1.judges.reference`,
-...); any other id names a flat module — a local package (hyphens → underscores), or an
-`org/name[@version]` package installed on demand from the Environments Hub. Built-ins ship
-with verifiers under `verifiers/v1/{harnesses,tasksets,judges}`; custom ones live under
-`environments/`, on `sys.path`, or on the hub.
-
-The taskset/harness class carries its types as generic args — `Taskset[TaskT, ConfigT]`,
-`Harness[ConfigT]` — which the CLI reads to narrow the plugin's config for `--taskset.*` /
-`--harness.*` flags (`taskset_config_type` / `harness_config_type`) and to type the wire trace
-(`task_type`).
-"""
+"""Resolve taskset, harness, and judge plugins."""
 
 import importlib
 import importlib.util
 from types import ModuleType
-from typing import Callable, get_args, get_origin
+from typing import Callable
 
 from pydantic_config import BaseConfig
 
 from verifiers.v1.harness import Harness, HarnessConfig
 from verifiers.v1.judge import Judge, JudgeConfig, judge_config_cls
 from verifiers.v1.utils.install import ensure_installed
+from verifiers.v1.utils.generic import generic_type
 from verifiers.v1.task import Task
 from verifiers.v1.taskset import Taskset, TasksetConfig
 
@@ -36,11 +21,6 @@ def narrow_plugin_field(
     resolve: Callable[[str], type],
     default_id: str | None = None,
 ) -> None:
-    """Narrow `data[field]` (a plugin config, as a dict or BaseConfig) in place to the specific
-    config type its `id` resolves to via `resolve` (`taskset_config_type` / `harness_config_type`),
-    so plugin-specific fields validate against the real config instead of an untyped dict.
-    `default_id` supplies the id when the field omits one (the harness default); a no-op when
-    neither is set. Shared by `EnvConfig._resolve_plugins` and `ValidateConfig`."""
     raw = data.get(field)
     if isinstance(raw, BaseConfig):
         raw = raw.model_dump()
@@ -51,10 +31,6 @@ def narrow_plugin_field(
 
 
 def _import_plugin(plugin_id: str, kind: str, group: str) -> ModuleType:
-    """Import a plugin by id. A built-in id resolves to its namespaced module under the
-    `group` package (`verifiers.v1.harnesses` / `verifiers.v1.tasksets`); a hub
-    `org/name[@version]` id is installed on demand; any other is a local package
-    (hyphens → underscores)."""
     module = ensure_installed(plugin_id)
     namespaced = f"{group}.{module}"
     target = namespaced if importlib.util.find_spec(namespaced) else module
@@ -70,9 +46,6 @@ def _import_plugin(plugin_id: str, kind: str, group: str) -> ModuleType:
 
 
 def _plugin_class(module: ModuleType, base: type, kind: str) -> type:
-    """The single class exported via `module.__all__` that subclasses `base`. A taskset/harness
-    module exports exactly one such class — the walk filters its public names down to subclasses
-    of the base, and rejects anything other than exactly one with an informative error."""
     names = getattr(module, "__all__", None)
     if names is None:
         raise AttributeError(
@@ -99,18 +72,6 @@ def _plugin_class(module: ModuleType, base: type, kind: str) -> type:
     return matches[0]
 
 
-def _generic_args(cls: type, base: type) -> list:
-    """Type args of every `base[...]` specialization across `cls`'s MRO, most-derived first —
-    so a subclass that re-binds a type param (e.g. a thin wrapper narrowing the config) wins
-    over the base it inherits from."""
-    args: list = []
-    for klass in cls.__mro__:
-        for orig in getattr(klass, "__orig_bases__", ()):
-            if get_origin(orig) is base:
-                args.extend(get_args(orig))
-    return args
-
-
 def import_taskset(taskset_id: str) -> ModuleType:
     return _import_plugin(taskset_id, "taskset", "verifiers.v1.tasksets")
 
@@ -124,26 +85,18 @@ def import_judge(judge_id: str) -> ModuleType:
 
 
 def taskset_class(taskset_id: str) -> type[Taskset]:
-    """The taskset's `Taskset` subclass, exported via its module's `__all__`."""
     return _plugin_class(import_taskset(taskset_id), Taskset, "taskset")
 
 
 def harness_class(harness_id: str) -> type[Harness]:
-    """The harness's `Harness` subclass, exported via its module's `__all__`."""
     return _plugin_class(import_harness(harness_id), Harness, "harness")
 
 
 def judge_class(judge_id: str) -> type[Judge]:
-    """The judge's `Judge` subclass, exported via its module's `__all__`."""
     return _plugin_class(import_judge(judge_id), Judge, "judge")
 
 
 def default_harness_id(taskset_id: str) -> str:
-    """The harness id to use when none is given. A taskset that bundles its own harness — its
-    module also exports a `Harness` subclass via `__all__`, so the taskset id doubles as the
-    harness id — runs with that harness by default; otherwise the shared `default` harness (a
-    bash + edit agent). An explicit `--harness.id` / toml id always takes precedence (this only
-    supplies the fallback); for a tool-less chat loop, pass `--harness.id null`."""
     if not taskset_id:
         return "default"
     try:
@@ -155,46 +108,40 @@ def default_harness_id(taskset_id: str) -> str:
 
 
 def load_taskset(config: TasksetConfig) -> Taskset:
-    """Build the taskset for a config by dispatching on its `id` (the taskset id)."""
     return taskset_class(config.id)(config)
 
 
 def load_harness(config: HarnessConfig) -> Harness:
-    """Build the harness for a config by dispatching on its `id` (the harness id)."""
     return harness_class(config.id)(config)
 
 
 def load_judge(config: JudgeConfig) -> Judge:
-    """Build a plugged judge for a config by dispatching on its `id` (the judge id).
-    Judges are cheap, throwaway values — the HTTP client is opened per call inside
-    `Judge.complete` and closed when it returns — so there's nothing to share or cache."""
     return judge_class(config.id)(config)
 
 
 def taskset_config_type(taskset_id: str) -> type[TasksetConfig]:
-    """The taskset's `TasksetConfig` subclass, from its `Taskset[TaskT, ConfigT]` generic."""
-    for arg in _generic_args(taskset_class(taskset_id), Taskset):
-        if isinstance(arg, type) and issubclass(arg, TasksetConfig):
-            return arg
-    return TasksetConfig
+    """Resolve the taskset's config specialization through its MRO."""
+    return (
+        generic_type(taskset_class(taskset_id), TasksetConfig, origin=Taskset)
+        or TasksetConfig
+    )
 
 
 def harness_config_type(harness_id: str) -> type[HarnessConfig]:
-    """The harness's config subclass, from its `Harness[ConfigT]` generic."""
-    for arg in _generic_args(harness_class(harness_id), Harness):
-        if isinstance(arg, type) and issubclass(arg, HarnessConfig):
-            return arg
-    return HarnessConfig
+    """Resolve the harness's config specialization through its MRO."""
+    return (
+        generic_type(harness_class(harness_id), HarnessConfig, origin=Harness)
+        or HarnessConfig
+    )
 
 
 def judge_config_type(judge_id: str) -> type[JudgeConfig]:
-    """The judge's config subclass, from its `Judge[ParsedT, ConfigT]` generic."""
+    """Resolve the judge's config specialization through its MRO."""
     return judge_config_cls(judge_class(judge_id))
 
 
 def task_type(taskset_id: str) -> type[Task]:
-    """The taskset's `Task` subclass (`Taskset.task_type`) — no data is loaded, so a caller
-    that imports the taskset can cheaply build a typed `Trace[TaskT]` for the otherwise
-    taskset-specific (loose dict) wire trace. Falls back to the base `Task` when no
-    subclass is given."""
-    return taskset_class(taskset_id).task_type()
+    """The taskset's `Task` subclass from its `Taskset[TaskT, ConfigT]` generic — no
+    data is loaded, so replay can cheaply recover the task data type. Falls back to
+    the base `Task` when no subclass is given."""
+    return generic_type(taskset_class(taskset_id), Task, origin=Taskset) or Task

--- a/verifiers/v1/mcp/__init__.py
+++ b/verifiers/v1/mcp/__init__.py
@@ -1,11 +1,4 @@
-"""vf-native MCP servers: tool servers (`Toolset`) and user simulators (`User`).
-
-A server is a class authored from a config (`server.ServerBase`), self-launched via its env module's
-`__main__` (`ServerBase.run`). The host side (`launch`) brings servers up in a runtime and reaches
-them: `serve` (one server, any placement), `serve_tools` / `serve_shared` / `serve_user` (a
-rollout's tools / the eval's shared tools / the user sim), and `connect_user` (the MCP client the
-framework drives the user sim through).
-"""
+"""MCP tool servers and user simulators."""
 
 from verifiers.v1.mcp.launch import (
     Respond,

--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -1,12 +1,3 @@
-"""Host-side launching: bring a vf-native server up in a runtime and reach it.
-
-`serve` is the single launcher (any server, any placement); `serve_tools` / `serve_shared` /
-`serve_user` are thin wrappers for a rollout's tools, the eval's shared tools, and the user sim.
-`serve_in_runtime` runs the server's module (`python -m <module>`) in a runtime — host (ambient) or
-sandbox (after `_install_in_sandbox` uploads + installs the working-tree `verifiers` source + the env
-package). `connect_user` is the MCP client the framework drives the user sim through.
-"""
-
 from __future__ import annotations
 
 import asyncio
@@ -43,25 +34,18 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# The verifiers source tree's wheel-build inputs — uploaded into a sandbox so it installs the
-# developer's working-tree verifiers (deps resolve from PyPI off the uploaded pyproject), with no
-# publish or git pin to keep in sync.
+# Sandboxed servers install the working tree, so only wheel inputs need to cross the boundary.
 VF_BUILD_INPUTS = ("pyproject.toml", "README.md", "LICENSE", "verifiers")
 
-# The model's last assistant text in; the next user messages out. The user sim ends the trajectory
-# by setting a flag on the shared `self.state` that the task's `@vf.stop` checks, not via a return
-# flag — so this hands back only messages.
+# A user ends the trajectory through shared state and `@stop`, not through this return value.
 Respond = Callable[[str], Awaitable[Messages]]
 
-# The colocated user server is up once its in-runtime probe passes, but under high concurrency
-# it can still momentarily refuse a host connection. Retry the connect before giving up so a
-# transient refusal doesn't fail the rollout.
+# A server can pass its in-runtime probe before its host-facing connection settles.
 _USER_CONNECT_ATTEMPTS = 12
 _USER_CONNECT_BACKOFF = 0.2  # seconds, exponential up to the cap
 _USER_CONNECT_MAX_BACKOFF = 2.0
 
-# Poll a URL from inside a runtime until it serves (any HTTP response — incl. MCP's 406
-# to a bare GET — means up), or the deadline passes. python3 is present in every runtime.
+# Any HTTP response, including MCP's 406 to a bare GET, proves the server is listening.
 _PROBE = """
 import sys, time, urllib.error, urllib.request
 for _ in range(180):
@@ -76,9 +60,6 @@ sys.exit(1)
 
 
 def _source_dir(cls: type) -> str | None:
-    """The local directory of `cls`'s env package — the nearest ancestor of its module file that
-    holds a `pyproject.toml` (what gets uploaded + installed in a sandbox). `None` when the module
-    has no on-disk package (a hub install in site-packages, or a built-in)."""
     module = sys.modules.get(cls.__module__)
     path = getattr(module, "__file__", None)
     if not path:
@@ -89,6 +70,7 @@ def _source_dir(cls: type) -> str | None:
     return None
 
 
+# These can be gigabytes and are not package source, so uploading them can stall startup.
 _TAR_EXCLUDE = {
     "__pycache__",
     ".venv",
@@ -98,21 +80,10 @@ _TAR_EXCLUDE = {
     ".ruff_cache",
     "node_modules",
 }
-"""Directory names never uploaded to a sandbox — build/VCS/cache trees that aren't package source
-and can be gigabytes (a `.venv` alone is many GB), which would otherwise stall the upload."""
 
 
 @cache
 def _tar_source(src: Path, members: tuple[str, ...] = ()) -> bytes:
-    """Gzipped tarball of a local package dir, rooted at `src.name/`, skipping `_TAR_EXCLUDE` dirs.
-    `members` limits it to those top-level entries (the verifiers tree only needs its package +
-    project files); otherwise the whole dir (a small env package).
-
-    An eval worker's imported code is already a startup snapshot, so its source archives are too.
-    If development-time source mutation becomes supported, replace this process cache with an
-    explicit cache scoped to that lifecycle rather than serving stale global data.
-    """
-
     def keep(info: tarfile.TarInfo) -> tarfile.TarInfo | None:
         return None if _TAR_EXCLUDE & set(info.name.split("/")) else info
 
@@ -126,7 +97,6 @@ def _tar_source(src: Path, members: tuple[str, ...] = ()) -> bytes:
 
 
 def _verifiers_root() -> Path:
-    """The verifiers source checkout — the dir holding its `pyproject.toml`, above the package."""
     import verifiers
 
     root = Path(verifiers.__file__).resolve().parent.parent
@@ -139,11 +109,6 @@ def _verifiers_root() -> Path:
 
 
 async def _install_in_sandbox(server: ServerBase, runtime: Runtime) -> str:
-    """Make `server`'s env module importable in a sandbox: upload the working-tree `verifiers`
-    source and the env package (tarballs over `write`), create a venv, and `uv pip install` both —
-    verifiers first (deps resolve from PyPI off its pyproject), then the env package (its `verifiers`
-    dep already satisfied). Returns the venv's python. Uses the developer's current code — no publish
-    or pin to keep in sync."""
     source_dir = _source_dir(type(server))
     if source_dir is None:
         raise ToolsetError(
@@ -172,8 +137,6 @@ async def _install_in_sandbox(server: ServerBase, runtime: Runtime) -> str:
 
 
 async def log_tail(runtime: Runtime, log: str, limit: int = 2000) -> str:
-    """The last `limit` bytes of a program's `log` in `runtime`, empty if it can't be read — for
-    enriching an error with what the program (e.g. a tool server) wrote before it died."""
     if limit <= 0:
         return ""
     with contextlib.suppress(Exception):
@@ -185,12 +148,7 @@ async def log_tail(runtime: Runtime, log: str, limit: int = 2000) -> str:
 
 
 async def _read_back_port(runtime: Runtime, path: str) -> int:
-    """The port the server bound and wrote to `path` in its runtime. The server writes it the moment
-    it binds (before setup/serving), so this resolves quickly; poll because it's a separate process.
-
-    Read through the un-retrying inner runtime: a missing file just means the server hasn't bound
-    yet, so a per-call retry wrapper would spam `retrying runtime.read` 3x on every poll — this loop
-    is itself the retry."""
+    """Poll the server's port file without stacking the runtime's own read retries."""
     reader = getattr(runtime, "inner", runtime)
     for _ in range(180):
         with contextlib.suppress(Exception):
@@ -209,35 +167,28 @@ async def serve_in_runtime(
     state_url: str | None = None,
     state_secret: str = "",
 ) -> int:
-    """Start `server` inside `runtime` (background, by running its env module — `python -m <module>`,
-    whose `__main__` calls `ServerBase.run()`), wait until it serves, and return the port it bound.
-    An `exposed` server (reached from outside its runtime) binds the runtime's fixed `published_port`
-    (modal/prime forward only that); otherwise the server binds an OS-assigned free port in its own
-    environment and reports it back (`MCP_PORT_FILE`) — so the launcher never probes for a free port.
-    Only the `config` crosses as env JSON; the rollout's task is fetched by the server from the
-    interception `/task` channel (`state_url`), so it isn't passed here. On a host (`subprocess`)
-    runtime it runs with the eval's own interpreter; in a sandbox the working-tree `verifiers` source
-    + the env package are uploaded and installed first (`_install_in_sandbox`)."""
+    """Start a server and return its bound port.
+
+    Exposed remote servers must use the runtime's forwarded port. Local or colocated servers let
+    the OS choose and report the result through a file. With a state channel, the server fetches
+    the current rollout task from the adjacent `/task` endpoint rather than a launch argument.
+    """
     env = {"VF_CONFIG": server.config.model_dump_json()}
-    if (
-        state_url
-    ):  # the shared-state + /task back-channel to this rollout's interception server
+    if state_url:
         env["VF_STATE_URL"] = state_url
         env["VF_STATE_SECRET"] = state_secret
-    if (
-        runtime.published_port is not None
-    ):  # a self-publishing runtime (modal/prime) forwards to
-        env["MCP_HOST"] = "0.0.0.0"  # all interfaces, not just loopback
+    if runtime.published_port is not None:
+        env["MCP_HOST"] = "0.0.0.0"
     fixed = runtime.published_port if exposed else None
     port_file = None
     if fixed is not None:
         env["MCP_PORT"] = str(fixed)
-    else:  # bind an OS-assigned free port in the server's own environment, reported back here
+    else:
         port_file = f"/tmp/vf-port-{uuid.uuid4().hex}"
         env["MCP_PORT_FILE"] = port_file
-    if runtime.type == "subprocess":  # host: verifiers + env module already installed
+    if runtime.type == "subprocess":
         python = sys.executable
-    else:  # sandbox: upload + install the verifiers source + the env package
+    else:
         python = await _install_in_sandbox(server, runtime)
     log = f"vf_tool_{server.server_name}.log"
     await runtime.run_background([python, "-m", type(server).__module__], env, log)
@@ -261,7 +212,6 @@ async def serve_in_runtime(
 @contextlib.asynccontextmanager
 async def serve(
     server: ServerBase,
-    task,
     harness_runtime: Runtime | None = None,
     for_host: bool = False,
     harness_is_local: bool = True,
@@ -270,16 +220,6 @@ async def serve(
     state_secret: str = "",
     state_base: str | None = None,
 ):
-    """The single internal launcher for a vf-native server — a `Toolset` OR a `User`. Brings it
-    up in its configured placement and yields one reachable URL, tearing down any runtime it
-    owns. Placement comes from `server.config`:
-      - `colocated` (with an `harness_runtime`): runs in the harness's own runtime, reusing it;
-      - otherwise: its OWN `runtime` (host by default), started and stopped here.
-    (A remote `url` toolset is short-circuited by the caller — it isn't launched.) Reachability
-    depends on who consumes it: `for_host` (a user sim the framework drives) yields a
-    host-reachable URL; otherwise (a tool the model calls) a harness-reachable one — localhost
-    in-sandbox when colocated, else the tool runtime's `expose` (its published URL) or, for a
-    host-side tool reached by an in-sandbox harness, a `host_endpoint` tunnel to the host port."""
     cfg = server.config
     async with contextlib.AsyncExitStack() as stack:
         if getattr(cfg, "colocated", False) and harness_runtime is not None:
@@ -288,22 +228,13 @@ async def serve(
             runtime = make_runtime(cfg.runtime)
             await runtime.start()
             stack.push_async_callback(runtime.stop)
-        # `exposed` = the port is reached from OUTSIDE the server's runtime — a `for_host` server (the
-        # host reaches it) or a tool in its own runtime (the harness, elsewhere, reaches it) — so it
-        # binds the runtime's fixed published_port. A colocated tool is reached in-sandbox at localhost
-        # and binds an OS-assigned free port instead (two colocated servers can't then clash on the
-        # published SERVICE_PORT). `serve_in_runtime` returns the actual bound port.
+        # Only consumers outside the server runtime need its fixed published port. Colocated tools
+        # use independent OS-assigned ports, avoiding clashes on the runtime's service port.
         exposed = for_host or runtime is not harness_runtime
-        # The shared-state channel: the interception server is a HOST service the server reaches from
-        # its own runtime — localhost when local, a tunnel when remote. Shared/eval-level servers get
-        # no channel (state is per-rollout; `state_port` is None for them).
         state_url = None
         if state_port is not None:
-            # A colocated server shares the harness's runtime, so the interception URL the harness
-            # already reaches (`state_base` — the pool's tunnel behind a remote runtime) is reachable
-            # from it too; reuse it instead of opening a second host tunnel to the same port (at high
-            # concurrency one per rollout swamps the tunnel service). A server in its own runtime
-            # can't assume that reach, so it bridges to the host port itself.
+            # Colocated servers reuse the harness's interception URL. A server in another runtime
+            # needs its own bridge to the host state port.
             if state_base is not None and runtime is harness_runtime:
                 base = state_base
             else:
@@ -318,9 +249,7 @@ async def serve(
             state_url=state_url,
             state_secret=state_secret,
         )
-        # Who consumes the server decides reachability (see `reachable_url`): a user sim is reached
-        # by the host (`for_host`); a tool by the harness — its `harness_runtime` per rollout, or, for
-        # a shared eval-level tool with no single harness, just the harness locality (`harness_is_local`).
+        # User simulators are host-driven; tool servers are harness-facing.
         consumer = HOST if for_host else harness_runtime
         base = await stack.enter_async_context(
             reachable_url(
@@ -332,43 +261,23 @@ async def serve(
 
 @dataclass(frozen=True)
 class SharedToolServer:
-    """One live taskset-scoped (shared) server, as the rollouts see it: its eval-level
-    `url` plus whether its runtime is `local` (host-reachable) — which decides whether a
-    rollout must bridge its state channel to reach a REMOTE shared server (see
-    `serve_tools`)."""
-
     url: str
     local: bool
 
 
 @contextlib.asynccontextmanager
 async def serve_shared(toolsets: list[Toolset], harness_is_local: bool = True):
-    """Start the taskset-scoped (shared) tool servers ONCE for a whole eval, each in its OWN
-    `runtime`, and yield `{name: SharedToolServer}` reachable by every rollout's harness.
-    Reachability mirrors a per-rollout tool, but there's no single harness runtime to read
-    locality off — the caller (`Environment.shared_tools`) passes the harness runtime's
-    `harness_is_local`, so a host tool gets one host bridge (tunnel) when the harness runs
-    remotely, and a remote tool runtime publishes its own URL. Torn down when the eval ends.
-    A shared server is task-agnostic — the taskset carries no per-row data — so its `setup`
-    gets no task (`serve(toolset, None)`) and `setup_task` is never called."""
+    """Serve one taskset-scoped tool instance for an environment worker."""
     servers: dict[str, SharedToolServer] = {}
     async with contextlib.AsyncExitStack() as stack:
         for toolset in toolsets:
             cfg = toolset.config
             name = toolset.server_name
-            if type(toolset).setup_task is not ServerBase.setup_task:
-                logger.warning(
-                    "shared server %r overrides `setup_task`, but `setup_task` is NEVER "
-                    "called for a taskset-scoped server (it's built once, task-agnostic) — "
-                    "its per-task logic will not run. Move task-agnostic work into `setup`, "
-                    "or declare it on `Task.tools` to run it per-rollout.",
-                    name,
-                )
-            if cfg.url:  # already running remotely; nothing launched, nothing to bridge
-                servers[name] = SharedToolServer(url=cfg.url, local=True)
+            if cfg.url:
+                servers[name] = SharedToolServer(url=cfg.url, local=False)
             else:
                 url = await stack.enter_async_context(
-                    serve(toolset, None, harness_is_local=harness_is_local)
+                    serve(toolset, harness_is_local=harness_is_local)
                 )
                 servers[name] = SharedToolServer(
                     url=url, local=runtime_is_local(cfg.runtime)
@@ -378,12 +287,7 @@ async def serve_shared(toolsets: list[Toolset], harness_is_local: bool = True):
 
 
 def _shared_url_for_rollout(url: str, state_base: str | None, state_secret: str) -> str:
-    """Tag a `shared` server's eval-level URL with this rollout's state-channel coordinates, so the
-    one shared process serves each rollout its OWN `self.state`. `state_base` is the interception
-    server's reachable base for THIS rollout, chosen by the caller to be reachable from the shared
-    server's runtime (localhost, or a host tunnel for a remote runtime). The secret is the bearer the
-    harness already holds, so it's no new exposure — but it must not be logged (callers log the
-    untagged base)."""
+    """Attach one rollout's state bridge to a shared server URL."""
     if not state_base:
         return url
     parts = urlsplit(url)
@@ -397,28 +301,18 @@ def _shared_url_for_rollout(url: str, state_base: str | None, state_secret: str)
 async def serve_tools(
     toolsets: list[Toolset],
     harness_runtime: Runtime,
-    task,
     shared: dict[str, SharedToolServer] | None = None,
     *,
     state_port: int | None = None,
     state_secret: str = "",
     state_base: str | None = None,
 ):
-    """Bring up a rollout's tool servers and yield `{name: url}` the harness reaches: the
-    task-scoped `toolsets` are launched by `serve` (placement off each one's `config`, the
-    rollout's `task` for its `setup`), and the taskset-scoped `shared` servers — already
-    running eval-level (see `serve_shared`) — join under their per-rollout state tag.
-    `state_port`/`state_secret` wire each per-rollout server to the interception server's
-    shared-state channel; `state_base` (its reachable URL for this rollout) wires a shared
-    server, which can't take a per-process channel, via its per-request URL tag."""
+    """Serve rollout tools; task and state reach servers through the state channel."""
     urls: dict[str, str] = {}
     async with contextlib.AsyncExitStack() as stack:
         for name, server in (shared or {}).items():
             tool_state_base = state_base
-            # `state_base` is the HARNESS-facing interception URL — host loopback when the harness
-            # is local, which a REMOTE shared tool can't reach. Bridge the interception's state
-            # port to a host tunnel the remote tool CAN reach (per-rollout, torn down with this
-            # scope). A remote harness already made `state_base` a public tunnel, so reuse it.
+            # A remote shared server cannot reach a local harness's loopback state URL.
             if state_base and harness_runtime.is_local and not server.local:
                 tool_state_base = await stack.enter_async_context(
                     reachable_url(HOST, state_port, consumer_is_local=False)
@@ -426,20 +320,18 @@ async def serve_tools(
             urls[name] = _shared_url_for_rollout(
                 server.url, tool_state_base, state_secret
             )
-            # log the untagged base, NOT urls[name] — the per-rollout tag carries the rollout's
-            # bearer secret (`vf_state_secret`), which must not reach a log sink
+            # The tagged URL contains the bearer secret; log only the untagged base URL.
             logger.info("tool server '%s' (shared): %s", name, server.url)
         for toolset in toolsets:
             name = toolset.server_name
             cfg = toolset.config
-            if cfg.url:  # already running remotely
+            if cfg.url:
                 urls[name] = cfg.url
                 logger.info("tool server '%s' (remote): %s", name, cfg.url)
             else:
                 urls[name] = await stack.enter_async_context(
                     serve(
                         toolset,
-                        task,
                         harness_runtime,
                         state_port=state_port,
                         state_secret=state_secret,
@@ -452,17 +344,11 @@ async def serve_tools(
 
 @contextlib.asynccontextmanager
 async def connect_user(url: str) -> AsyncIterator[Respond]:
-    """Open an MCP client session to a user server at `url` and yield an async
-    `respond(message)` that calls its `respond` tool, parsing the JSON it returns
-    (`{"messages": [...]}`) into typed `Messages`. End-of-trajectory is signalled out-of-band: the
-    server sets a flag on the shared state (a task `@vf.stop` checks it), not in this reply.
+    """Connect to a user server, retrying only initial connection failures.
 
-    Retries the connect — under high concurrency the colocated user server can be slow to
-    accept (or briefly refuse) a connection. A server that stays unreachable raises
-    `UserError` (a captured, retryable rollout error), so a transport failure never escapes
-    as a raw `ExceptionGroup`/`ConnectError` that would bypass rollout error handling and crash
-    the batch. The connect is entered and exited in this one frame so anyio's cancel scopes stay
-    correctly nested."""
+    Body errors propagate unchanged; transport failures after connecting become `UserError`. The
+    session stays in this frame so AnyIO cancellation scopes remain correctly nested.
+    """
     from mcp import ClientSession
     from mcp.client.streamable_http import streamable_http_client
 
@@ -489,22 +375,20 @@ async def connect_user(url: str) -> AsyncIterator[Respond]:
                     data = json.loads("\n".join(texts))
                     return [parse_message(m) for m in data["messages"]]
 
-                in_body = True  # while the harness drives; an error here is the body's, not ours
+                # Errors thrown into the yield belong to the harness body, not the connection.
+                in_body = True
                 yield respond
                 in_body = False
             return
         except RolloutError:
-            raise  # a real rollout error surfaced after connecting: propagate as-is
+            raise
         except Exception as e:
             if in_body:
-                raise  # the harness body raised (thrown back at the yield): propagate untouched,
-                # don't mislabel it as a connection loss
+                raise
             if connected:
-                # the user-sim connection broke mid-rollout/teardown (e.g. the colocated server
-                # was killed under memory pressure): capture it as a retryable rollout error
-                # instead of letting the raw transport ExceptionGroup escape and crash the batch
+                # Raw transport groups bypass rollout handling, so attribute the loss here.
                 raise UserError(f"user server at {url} connection lost: {e!r}") from e
-            last_exc = e  # the connect itself failed: back off and retry
+            last_exc = e
             await asyncio.sleep(
                 min(_USER_CONNECT_BACKOFF * 2**attempt, _USER_CONNECT_MAX_BACKOFF)
             )
@@ -516,26 +400,18 @@ async def connect_user(url: str) -> AsyncIterator[Respond]:
 @contextlib.asynccontextmanager
 async def serve_user(
     user: User | None,
-    task,
     harness_runtime: Runtime | None = None,
     *,
     state_port: int | None = None,
     state_secret: str = "",
     state_base: str | None = None,
 ) -> AsyncIterator[Respond | None]:
-    """Bring a rollout's user server up (via the shared `serve` launcher, `for_host=True` since
-    the framework drives the user from the HOST) and yield the async `respond` the interception
-    server drives — or `None` when the task has no user server. Placement is the user's
-    `config` (colocated in the harness's runtime, or its own); the rollout's `task` is shipped to
-    the server for its `setup`. `state_port`/`state_secret` wire it to the shared-state channel — how
-    the user sim's `respond` reads/writes `self.state` (and ends the trajectory via a flag a task
-    `@vf.stop` checks)."""
+    """Serve a rollout user; task and state reach it through the state channel."""
     if user is None:
         yield None
         return
     async with serve(
         user,
-        task,
         harness_runtime,
         for_host=True,
         state_port=state_port,

--- a/verifiers/v1/mcp/server.py
+++ b/verifiers/v1/mcp/server.py
@@ -1,11 +1,3 @@
-"""`ServerBase`: the vf-native server base — a class authored from a config, shared by `Toolset`
-and `User`.
-
-A server's env module is self-runnable: its `__main__` calls `ServerBase.run()`, which rebuilds the
-server from the environment the framework set and serves it over MCP (`_serve`). The host side that
-starts these in a runtime lives in `launch`.
-"""
-
 from __future__ import annotations
 
 import contextlib
@@ -14,12 +6,13 @@ import functools
 import inspect
 import logging
 import os
-from typing import TYPE_CHECKING, Callable, ClassVar, Generic, TypeVar, get_args
+from typing import TYPE_CHECKING, Callable, ClassVar, Generic, TypeVar
 
 from pydantic import TypeAdapter, ValidationError
 from pydantic_config import BaseConfig
 
 from verifiers.v1.state import State, StateT, state_cls
+from verifiers.v1.utils.generic import generic_type
 
 if TYPE_CHECKING:
     from httpx import AsyncClient, Response
@@ -28,12 +21,9 @@ if TYPE_CHECKING:
 ConfigT = TypeVar("ConfigT", bound=BaseConfig)
 logger = logging.getLogger(__name__)
 
-STATE_TIMEOUT = 30.0
-"""Seconds for a state-channel GET/PUT (localhost, or a tunnel to the host)."""
+# State calls may cross a tunnel, so allow transient startup failures without hanging forever.
+STATE_TIMEOUT = 30.0  # seconds per request
 STATE_RETRIES = 4
-"""Retries for a state/task channel request. Behind a remote runtime the channel is reached over a
-host tunnel that can return a transient 5xx or reset the connection while it settles (e.g. just
-after the sandbox/tunnel comes up), so a single blip must not fail the tool call."""
 
 
 async def _channel_request(
@@ -44,10 +34,7 @@ async def _channel_request(
     content: bytes | None = None,
     client: AsyncClient | None = None,
 ) -> Response:
-    """One bearer-authed call to the interception `/state` or `/task` channel, retried with
-    exponential backoff + jitter on transient failures (connection resets / 5xx from the host
-    tunnel). A 4xx is a real error (e.g. an invalid state PUT) and is not retried. Returns the
-    response so typed callers can validate its JSON bytes directly."""
+    """Retry tunnel transport errors and 5xx responses, but not invalid 4xx requests."""
     import httpx
     from tenacity import (
         AsyncRetrying,
@@ -85,27 +72,18 @@ async def _channel_request(
     )(request)
 
 
-# A `shared` server is one process for the whole eval, so it can't take a per-rollout state channel
-# from its environment like a per-rollout server does. Instead the framework tags each rollout's URL
-# to a shared server with that rollout's channel coordinates as these query params (`serve_tools`);
-# `_state_channel` reads them back per call from the MCP request, so `self.state` is the CALLING
-# rollout's state. The secret is the bearer token the harness already holds — no new exposure.
+# Shared servers receive the calling rollout's state channel in URL parameters because one
+# process cannot carry a single rollout's channel in its environment.
 STATE_URL_PARAM = "vf_state_url"
 STATE_SECRET_PARAM = "vf_state_secret"
 
-# The in-flight call's pulled `self.state`, set per call by `_with_state`. Per-call (not an instance
-# attribute) so concurrent calls — including different rollouts on one `shared` server — each see
-# their own state and never clobber each other.
+# A context variable isolates the state seen by concurrent calls on one shared server.
 _call_state: contextvars.ContextVar[State | None] = contextvars.ContextVar(
     "vf_call_state", default=None
 )
 
 
 def _request_query(name: str) -> str | None:
-    """A query param of the in-flight tool/respond call's HTTP request, read from MCP's per-call
-    request context (streamable HTTP threads the originating request through to the handler) — or
-    None outside an HTTP call. How a `shared` server reads the per-rollout state coordinates the
-    framework tagged on its URL."""
     from mcp.server.lowlevel.server import request_ctx
 
     try:
@@ -116,9 +94,7 @@ def _request_query(name: str) -> str | None:
 
 
 def _die_with_parent() -> None:
-    """Ask the kernel to SIGKILL this process when its parent (the launcher) dies, so a server is
-    never orphaned if its launcher is torn down without stopping it (a backstop to the runtime's
-    own cleanup). Linux-only; a no-op elsewhere."""
+    """On Linux, prevent a server from outliving its launcher."""
     import ctypes
     import signal
 
@@ -127,7 +103,6 @@ def _die_with_parent() -> None:
 
 
 def _import_ref(ref: str) -> object:
-    """Resolve a `module:qualname` reference (e.g. `glossary_v1:GlossaryTask`) to the object."""
     import importlib
 
     module_name, _, qualname = ref.partition(":")
@@ -138,53 +113,23 @@ def _import_ref(ref: str) -> object:
 
 
 class ServerBase(Generic[ConfigT, StateT]):
-    """A vf-native server authored as a class, initialized from its config — the same shape as
-    `Taskset`/`TasksetConfig`: the config (a `ToolsetConfig`/`UserConfig` subclass) is the
-    serializable data (placement + the server's own knobs); the class is the behaviour. The
-    framework launches it by running its env module (`python -m <module>`), whose `__main__` calls
-    `cls.run()` to rebuild `cls(config)` from the environment and serve over MCP — no FastMCP
-    boilerplate. Subclassed by `Toolset` (`@tool` methods) and `User` (a `respond` hook). Build
-    expensive/non-serializable state in `setup` — set it as plain instance attributes (it runs in
-    the server process). The server's deps come from its env package's `pyproject` (the install in
-    a sandbox), so the class may freely `import verifiers`, import siblings, and use module
-    globals.
-
-    `self.state` is the rollout's shared `State` (see `verifiers.v1.state`): a `@vf.tool` / `respond`
-    reads+writes it, and each call is bracketed (`_with_state`) to pull the latest from the
-    interception server and push back any change — so tools and the user sim share state, and a
-    task can end the trajectory from it via a `@vf.stop` over a flag a server sets. Parameterize a
-    stateful server with its `State` subclass (`Toolset[Config, MyState]`); defaults to base `State`."""
-
+    # The empty value falls back to the snake-cased class name.
     TOOL_PREFIX: ClassVar[str] = ""
-    """Prefix the model sees on this server's tools (`<TOOL_PREFIX>_<tool>`), set on the class,
-    not the config. Empty falls back to the class name snake-cased — set it explicitly for a
-    toolset the model calls (e.g. `wiki` -> `wiki_search`)."""
 
     def __init__(self, config: ConfigT) -> None:
         self.config = config
         self._state_cls = state_cls(type(self))
-        # Reuse Pydantic's public byte serializer/validator across state-channel calls.
         self._state_adapter = TypeAdapter(self._state_cls)
         self._inert_state: StateT = self._state_cls()  # type: ignore[assignment]
-        """A fresh state used outside a tool/respond call (setup, or a manual debug run) — there's
-        no channel to sync, so writes to it don't escape the process (matches the no-channel case)."""
         self._state_client: AsyncClient | None = None
 
     @property
     def state(self) -> StateT:
-        """The rollout's shared runtime state for the in-flight tool/respond call, refreshed from the
-        interception server's channel before the call and pushed back after (see `_with_state`).
-        Backed by a per-call contextvar, so concurrent calls — including different rollouts on one
-        `shared` server — each see their own state and never clobber each other. Outside a call it's
-        a fresh, inert `State`."""
         current = _call_state.get()
         return current if current is not None else self._inert_state  # type: ignore[return-value]
 
     def _state_channel(self) -> tuple[str | None, str]:
-        """The interception server's state channel `(url, secret)` for the in-flight call: the
-        per-rollout coordinates the framework tagged on a `shared` server's URL (read per call from
-        the MCP request), else the per-process channel it set in the environment (a per-rollout
-        server), else `(None, "")` (no channel — a manual debug run)."""
+        """Prefer per-call coordinates for shared servers, then the process environment."""
         url = _request_query(STATE_URL_PARAM) or os.environ.get("VF_STATE_URL")
         secret = _request_query(STATE_SECRET_PARAM) or os.environ.get(
             "VF_STATE_SECRET", ""
@@ -192,8 +137,6 @@ class ServerBase(Generic[ConfigT, StateT]):
         return url, secret
 
     async def _pull_state(self) -> State:
-        """Fetch the in-flight call's shared state from the channel (so it reflects other servers'
-        writes); a fresh inert state when there's no channel."""
         url, secret = self._state_channel()
         if not url:
             return self._state_cls()
@@ -201,15 +144,12 @@ class ServerBase(Generic[ConfigT, StateT]):
         try:
             return self._state_adapter.validate_json(response.content)
         except ValidationError as e:
-            # Excessively nested or otherwise invalid state is a broken channel contract.
             logger.warning(
                 "state pull rejected for %s: %s", self._state_cls.__name__, e
             )
             raise
 
     async def _push_state(self, before: bytes) -> None:
-        """Push the in-flight call's `self.state` back to the shared channel if it changed. No-op
-        without a channel or when nothing changed."""
         url, secret = self._state_channel()
         if not url:
             return
@@ -223,9 +163,7 @@ class ServerBase(Generic[ConfigT, StateT]):
         )
 
     async def _fetch_task(self, state_url: str | None, secret: str):
-        """Fetch this rollout's task from the interception server's `/task` channel (the sibling of
-        `/state`, keyed by the same bearer secret) and rebuild it — how EVERY launched server gets its
-        task to run `setup_task`. `None` when there's no channel (a shared, task-agnostic server)."""
+        """Fetch the rollout task; shared task-agnostic servers have no task channel."""
         if not state_url:
             return None
         task_url = (
@@ -239,24 +177,16 @@ class ServerBase(Generic[ConfigT, StateT]):
     async def _setup_task_from_channel(
         self, state_url: str | None, secret: str
     ) -> None:
-        """Fetch this rollout's task over the state channel and run `setup_task` for it — a no-op
-        without a channel or task (a shared, task-agnostic server). Called by `_serve` with the
-        per-rollout env channel a launched server carries."""
         task = await self._fetch_task(state_url, secret)
         if task is not None:
             await self.setup_task(task)
 
     def _with_state(self, fn: Callable) -> Callable:
-        """Wrap a tool/respond callable so each invocation pulls the latest shared state into
-        `self.state` before running and pushes back any change after — the read/write channel a
-        `@vf.tool` and `respond` use via `self.state`. The pulled state lives in a per-call
-        contextvar, so concurrent calls (and concurrent rollouts on a `shared` server) don't share
-        it. Preserves `fn`'s signature so FastMCP advertises the tool unchanged. A no-op (fresh inert
-        state) when the server runs outside a rollout (no channel).
+        """Sync state around one call, isolated by a context variable.
 
-        This is a whole-object read-modify-write, so it is **last-write-wins**: calls a harness runs
-        concurrently (several `tool_calls` in one turn) race and can lose each other's writes; calls
-        run sequentially compose correctly. Keep shared-state mutations on the sequential path."""
+        Updates replace the whole state, so concurrent writes are last-write-wins. Mutations that
+        must compose need to run sequentially.
+        """
 
         @functools.wraps(fn)
         async def wrapper(*args, **kwargs):
@@ -265,7 +195,6 @@ class ServerBase(Generic[ConfigT, StateT]):
             state = await self._pull_state() if sync_state else State()
             token = _call_state.set(state)
             try:
-                # Reuse the second serialization as the PUT body when the callback mutates state.
                 before = self._state_adapter.dump_json(state) if sync_state else None
                 result = fn(*args, **kwargs)
                 if inspect.isawaitable(result):
@@ -276,36 +205,26 @@ class ServerBase(Generic[ConfigT, StateT]):
             finally:
                 _call_state.reset(token)
 
+        # FastMCP must advertise the wrapped tool's parameters, not `*args, **kwargs`.
         wrapper.__signature__ = inspect.signature(fn)  # type: ignore[attr-defined]
         return wrapper
 
     @property
     def server_name(self) -> str:
-        """The server's identity (MCP name, log + namespace key): `TOOL_PREFIX`, else the class
-        name snake-cased."""
         return self.TOOL_PREFIX or "".join(
             ("_" + c.lower() if c.isupper() else c) for c in type(self).__name__
         ).lstrip("_")
 
     async def setup(self) -> None:
-        """Task-agnostic setup, in the server process: global state (a corpus / index / graph loaded
-        from disk or a dataset) as plain instance attributes (`self.x = ...`). Runs for every server
-        — shared or per-rollout. Config knobs stay on `self.config`."""
+        """Initialize task-agnostic server state."""
 
     async def setup_task(self, task) -> None:
-        """Per-rollout setup, in the server process: per-task input read off `task` (this rollout's
-        task) and initial per-rollout mutable state (counters, paths). Runs only when the server has
-        a task — SKIPPED for a `shared` server (one instance for the whole eval), so don't override
-        it on a shared server (the framework warns loudly if you do)."""
+        """Initialize per-task state; taskset-scoped servers skip this hook."""
 
     def _register(self, mcp: FastMCP) -> None:
         raise NotImplementedError
 
     def _serve(self) -> None:
-        """Run this server's MCP server: bind its port, `setup` (always) + `setup_task` for the
-        rollout's task (fetched from the interception `/task` channel — skipped for a shared server,
-        which has no channel), build a FastMCP from the registered tools, and serve it over streamable
-        HTTP on `MCP_HOST`. Called by `run()`."""
         import asyncio
         import socket
         from pathlib import Path
@@ -313,13 +232,10 @@ class ServerBase(Generic[ConfigT, StateT]):
         import uvicorn
         from mcp.server.fastmcp import FastMCP
 
-        _die_with_parent()  # never outlive the launcher that started us, even if it skips cleanup
+        _die_with_parent()
         host = os.environ.get("MCP_HOST", "127.0.0.1")
-        # Bind our own socket up front: `MCP_PORT` when the framework fixed one (a self-publishing
-        # runtime's forwarded port), else 0 = an OS-assigned free port — guaranteed free in whatever
-        # environment we run in (host or sandbox), so the launcher never probes for a free port.
-        # Report the bound port back via `MCP_PORT_FILE` before setup, so the launcher learns it
-        # without waiting on a slow `setup` (its readiness probe absorbs that).
+        # Remote runtimes require their forwarded port; local servers let the OS choose. Report it
+        # before setup so an expensive setup does not block port discovery.
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         sock.bind((host, int(os.environ.get("MCP_PORT", 0))))
@@ -329,19 +245,14 @@ class ServerBase(Generic[ConfigT, StateT]):
 
         async def _setup() -> None:
             await self.setup()
-            # Per-rollout servers carry the rollout's state channel in their env; fetch this rollout's
-            # task over it and run `setup_task`. A shared server has no env channel, so this is a
-            # no-op for it (it's task-agnostic — one instance for the whole eval).
+            # Shared taskset-scoped servers have no task channel and skip this hook.
             await self._setup_task_from_channel(*self._state_channel())
 
         asyncio.run(_setup())
-        # Relax FastMCP's DNS-rebinding guard: it 421s a non-localhost Host, but our servers are
-        # reached only by our own harness over localhost or a tunnel (never a browser).
+        # These servers are reached by the harness through localhost or a tunnel, never a browser.
         from mcp.server.transport_security import TransportSecuritySettings
 
         security = TransportSecuritySettings(enable_dns_rebinding_protection=False)
-        # Short vf-native rollouts do tiny tool calls; stateless JSON avoids FastMCP's
-        # session/SSE overhead while keeping the same MCP initialize/list/call flow.
         mcp = FastMCP(
             self.server_name,
             json_response=True,
@@ -372,25 +283,15 @@ class ServerBase(Generic[ConfigT, StateT]):
 
     @classmethod
     def _config_cls(cls) -> type[BaseConfig]:
-        """The config type from the `Toolset[Config]` / `User[Config]` generic parameter. Walks the
-        MRO, so a further subclass that doesn't re-parameterize (`class B(MyToolset)`) inherits the
-        config from where it was set."""
-        for klass in cls.__mro__:
-            for base in getattr(klass, "__orig_bases__", ()):
-                for arg in get_args(base):
-                    if isinstance(arg, type) and issubclass(arg, BaseConfig):
-                        return arg
+        """Resolve the server's config specialization through its MRO."""
+        if config_cls := generic_type(cls, BaseConfig):
+            return config_cls
         raise TypeError(
             f"{cls.__name__} must parameterize its config, e.g. Toolset[MyConfig]"
         )
 
     @classmethod
     def run(cls) -> None:
-        """Entry point a server module calls from `if __name__ == "__main__"`: rebuild this server
-        from the config the framework set (`VF_CONFIG` JSON) and serve it over MCP. The rollout's task
-        is NOT passed in the environment — the server fetches it from the interception `/task` channel
-        at startup (see `_serve` / `_fetch_task`). With no `VF_CONFIG` the config is parsed from the CLI
-        instead (`cli(config)`), so the module is runnable by hand for debugging (no channel, no task)."""
         config_cls = cls._config_cls()
         if "VF_CONFIG" in os.environ:
             config = config_cls.model_validate_json(os.environ["VF_CONFIG"])

--- a/verifiers/v1/mcp/toolset.py
+++ b/verifiers/v1/mcp/toolset.py
@@ -1,9 +1,3 @@
-"""`Toolset` + `ToolsetConfig`: a tool server authored as a vf-native class with `@vf.tool` methods.
-
-A task gives the harness tools by declaring `Toolset`s from `Task.tools`. The config carries
-placement (where the server runs); the class carries the `@vf.tool` methods the model calls.
-"""
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -20,74 +14,17 @@ if TYPE_CHECKING:
 
 
 class ToolsetConfig(BaseConfig):
-    """Where one TASK-scoped tool server runs (placement) — a server declared on
-    `Task.tools`, launched per rollout. The default — its own host (`subprocess`)
-    runtime — is the cheap one: the server runs in the eval process's environment, where
-    `verifiers` and the env module are already installed (nothing to fetch), and the harness
-    reaches it over the host network (docker `--network host`) or a tunnel (prime).
-    `colocated` trades that off:
-      - default: its own `runtime`, per rollout (host by default).
-      - colocated: in the harness's OWN runtime, per rollout (no tunnel). In a sandbox this means
-        the `verifiers` source + the env module are uploaded and `uv pip install`ed there, so it
-        costs a per-rollout install.
-    An eval-wide server is a different scope, not a flag: declare it on `Taskset.tools` with a
-    `SharedToolsetConfig`. Subclass to add the server's own knobs (the data its `@tool` methods
-    read). The server name is the class's `TOOL_PREFIX` ClassVar, not a field here — it's an
-    identity (the model sees `<prefix>_<tool>`, baked into the taskset's prompt), not a
-    tunable knob."""
-
     colocated: bool = False
-    """Run the server inside the harness's runtime (reached in-sandbox, no tunnel). Off by
-    default — on the host it's free, but in a sandbox the harness runtime must install the env
-    package + `verifiers` (a per-rollout cost), so prefer the default own-runtime placement
-    unless co-locating genuinely helps."""
     runtime: RuntimeConfig = SubprocessConfig()
-    """The server's own runtime, used unless `colocated` (host/subprocess by default — always
-    reachable from any harness runtime; set docker/prime to isolate it in its own sandbox)."""
     url: str | None = None
-    """An already-running streamable-HTTP MCP endpoint to connect to instead of launching a
-    server (e.g. a public remote like DeepWiki). When set, placement is ignored — the toolset
-    needs no `@tool` methods, the model just sees the remote's tools as `<name>_<tool>`."""
 
 
 class SharedToolsetConfig(BaseConfig):
-    """Where one TASKSET-scoped (shared) tool server runs — a server declared on
-    `Taskset.tools`, launched ONCE per eval and reached by every rollout. Pays an expensive
-    `setup` (a corpus/index) once. Task-agnostic by construction: the taskset carries no
-    per-row data, so a shared server never receives a task (`setup_task` is not called).
-    It may still be writable: each rollout reads and writes its OWN `self.state` (the
-    framework tags the per-rollout state channel onto the shared server's URL), so
-    concurrent rollouts don't corrupt each other — provided the server runs on a local
-    runtime (the default), which can reach the host's interception server. There is no
-    `colocated` here — a shared server has no single harness runtime to co-locate with.
-    A shared toolset declares this config type (`Toolset[MySharedConfig]`); subclass to
-    add the server's own knobs."""
-
     runtime: RuntimeConfig = SubprocessConfig()
-    """The server's own runtime (host/subprocess by default — always reachable from any
-    harness runtime; set docker/prime to isolate it in its own sandbox)."""
     url: str | None = None
-    """An already-running streamable-HTTP MCP endpoint to connect to instead of launching a
-    server. When set, nothing is launched — every rollout connects to the remote."""
 
 
 class Toolset(ServerBase[ConfigT, StateT]):
-    """A tool server authored as a class: write `@vf.tool` methods (the model calls them as
-    `<prefix>_<method>`; the docstring is the tool description), reading config off `self.config` and
-    optionally the rollout's shared `self.state`. Example:
-
-        class GlossaryToolsetConfig(vf.ToolsetConfig):
-            facts: dict[str, str] = {}
-
-        class GlossaryToolset(vf.Toolset[GlossaryToolsetConfig]):
-            @vf.tool
-            def lookup(self, name: str) -> str:
-                return self.config.facts.get(name.lower(), "unknown")
-
-    Parameterize a stateful toolset with its `State` subclass too — `Toolset[Config, MyState]` — so
-    `self.state` is typed; it defaults to the base `State`.
-    """
-
     def _register(self, mcp: FastMCP) -> None:
         for fn in discover_decorated(self, "tool"):
             mcp.add_tool(

--- a/verifiers/v1/mcp/user.py
+++ b/verifiers/v1/mcp/user.py
@@ -1,14 +1,7 @@
-"""`User` + `UserConfig`: the user simulator authored as a vf-native class with a `respond` hook.
+"""Framework-driven user simulation.
 
-A task registers a `User` via `Task.user` — a vf-native class (like `Toolset`, served as an
-MCP server with a runtime) exposing a single `respond` tool. Unlike a tool server it is never handed
-to the model: the framework drives it. After each model turn the interception server calls `respond`
-with the model's last message, appends the simulated user message(s), and re-prompts — so a
-multi-turn game plays out as alternating assistant/user turns in the trace, the harness none the
-wiser. When the task carries no prompt (`task.prompt is None`), the simulator also opens the
-conversation: the interception server calls `respond("")` once before the first model turn and seeds
-its reply as the initial user message. The host side that drives it lives in `launch` (`serve_user` /
-`connect_user`).
+When `TaskData.prompt` is `None`, `respond("")` supplies the opening message. A simulator ends
+the interaction by setting shared state that the task checks with `@stop`.
 """
 
 from __future__ import annotations
@@ -28,54 +21,22 @@ if TYPE_CHECKING:
 
 
 class UserConfig(BaseConfig):
-    """Where the user simulator runs (placement). The framework always drives it from the host.
-    Default — its own host (`subprocess`) runtime — runs it where `verifiers` + the env module
-    already live, reachable from any harness runtime (nothing to fetch). Set `colocated` to run it
-    inside the harness's runtime instead (in a sandbox that uploads + installs the env package, a
-    per-rollout cost). Subclass to add the user's own knobs (the data its `respond` reads)."""
+    """Placement for a host-driven simulator.
+
+    By default it runs in `runtime`; `colocated` reuses the harness runtime while remaining
+    reachable from the host.
+    """
 
     colocated: bool = False
-    """Run the user simulator inside the harness's runtime, reusing it (its port is published
-    back to the host so the framework can still drive it). Off by default — see `ToolsetConfig`."""
     runtime: RuntimeConfig = SubprocessConfig()
-    """The user simulator's own runtime, used unless `colocated` (host/subprocess by default)."""
 
 
 ConfigT = TypeVar("ConfigT", bound=UserConfig)
 
 
 class User(ServerBase[ConfigT, StateT]):
-    """A user simulator authored as a vf-native class, initialized from its config: implement
-    `respond` (the model's last message in → the next user message(s) out). Consumed by the framework
-    (the interception server drives it), never shown to the model. To end the trajectory, set a flag
-    on the shared `self.state` and have the task declare a `@vf.stop` over it (the framework holds
-    no built-in end signal — see `verifiers.v1.state`). Example:
-
-        class HagglerState(vf.State):
-            deal_closed: bool = False
-
-        class HagglerUser(vf.User[vf.UserConfig, HagglerState]):
-            async def respond(self, message: str) -> vf.Messages:
-                ...
-                if deal_done:
-                    self.state.deal_closed = True   # the task's @vf.stop ends it on this
-                return [{"role": "user", "content": reply}]
-
-        class HagglerTask(vf.Task[vf.TaskData, HagglerState]):
-            user = HagglerUser   # built with the task config's UserConfig field
-
-            @vf.stop
-            async def deal_closed(self, trace) -> bool:
-                return trace.state.deal_closed
-
-    Parameterize the user with the same `State` subclass — `User[Config, MyState]` — so `self.state`
-    is typed; it defaults to the base `State`.
-    """
-
     async def respond(self, message: str) -> Messages:
-        """The model's last assistant text in → the next user message(s) out. Called once with an
-        empty `message` to open the conversation when the task has no prompt (`task.prompt is
-        None`); end the trajectory by setting a `self.state` flag a task `@vf.stop` checks."""
+        """Return the next user messages; an empty message opens a task without a prompt."""
         raise NotImplementedError
 
     def _register(self, mcp: FastMCP) -> None:

--- a/verifiers/v1/push.py
+++ b/verifiers/v1/push.py
@@ -27,11 +27,7 @@ DEFAULT_FRONTEND_URL = "https://app.primeintellect.ai"
 
 @dataclass
 class PushState:
-    """Live status of the push, shared with the v1 `--rich` dashboard so it can show a status line
-    under the rollouts once the run finishes and the upload begins: dim while uploading, then the
-    viewer URL (green) or the error (red). `started` flips true when the upload begins (the caller
-    sets it), `done` when it returns; `url` is set on success and `error` on a skip/failure. No line
-    is shown until `started`. Populated by `push_traces` (pass the state in)."""
+    """Mutable upload status shared with the dashboard."""
 
     started: bool = False
     done: bool = False

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -1,17 +1,3 @@
-"""A rollout: one trajectory — drive an harness in a runtime and score its trace.
-
-A Rollout owns a single trajectory end-to-end, including its runtime's lifecycle. It
-makes and starts the runtime, gets an interception endpoint (a slot on the shared pool if
-one is given, else a per-rollout server exposed via its own runtime), then drives the
-staged lifecycle while the runtime is live — task + harness setup, the harness run,
-the task's `finalize`, and per-rollout `@reward`/`@metric` scoring — each under its own stage
-timeout (`setup_timeout`/`harness_timeout`/`finalize_timeout`/`scoring_timeout`),
-then tears the runtime down in a `finally`. Cross-rollout `@group_reward`s run afterwards (in the Episode) over the traces
-alone — they never need a live runtime — so a runtime is never kept up past its own
-rollout. The runtime ref is set the instant it's created, so it's always tearable-down
-even if `run()` crashes.
-"""
-
 import asyncio
 import logging
 import time
@@ -50,10 +36,6 @@ logger = logging.getLogger(__name__)
 
 
 class Phase(StrEnum):
-    """A rollout's lifecycle phase (for display): queued behind the concurrency cap,
-    provisioning, the harness driving, post-run finalize, per-rollout + group scoring,
-    then fully scored."""
-
     PENDING = "pending"
     SETUP = "setup"
     RUNNING = "running"
@@ -87,23 +69,10 @@ class Rollout:
         self.scoring_timeout = scoring_timeout
         self.limits = limits or RolloutLimits()
         self.shared_tools = shared_tools or {}
-        """Eval-level shared tool servers ({name: url}) to reuse instead of starting per rollout;
-        the eval-level interception pool. Both injected by `Environment.episode` from the active
-        `Environment.serving` context — so a rollout always has them and no runner has to thread
-        them in."""
         self.interception = interception
         self.phase = Phase.PENDING
-        """Lifecycle phase for display (see `Phase`); starts PENDING (queued behind the
-        concurrency cap) so the --rich dashboard can list it before it begins, advances to
-        SETUP the moment `run()` starts, and is set to DONE by the Episode once group
-        scoring has run."""
         self.runtime: Runtime | None = None
-        """The runtime, set the moment `run()` creates it (so it's always tearable-down
-        even if setup crashes) and torn down in `run()`'s `finally`; the --rich dashboard
-        reads it for the runtime descriptor."""
         self.trace: Trace | None = None
-        """The live trace, set the moment `run()` creates it; a --rich dashboard reads
-        it to show in-flight progress (None until the rollout starts)."""
 
     @asynccontextmanager
     async def _serve_interception(
@@ -112,11 +81,6 @@ class Rollout:
         runtime: Runtime,
         session: RolloutSession,
     ):
-        """Yield `(endpoint, secret, state_port, state_base)` for the harness — a slot on the shared
-        `pool` if one is given, else a per-rollout server exposed via this rollout's own runtime.
-        `endpoint` is the model route; `state_port` the interception server's host port (a per-rollout
-        tool server tunnels to it itself); `state_base` its reachable URL (localhost, or the pool's
-        tunnel) — how a SHARED tool server reaches this rollout's `/state` + `/task` channel."""
         if pool is not None:
             async with pool.acquire(session) as (
                 endpoint,
@@ -128,27 +92,17 @@ class Rollout:
         else:
             async with InterceptionServer() as server:
                 secret = server.register(session)
-                # a HOST service the harness (in `runtime`) reaches: localhost or a tunnel
+                # The runtime reaches this host service through localhost or a tunnel.
                 async with reachable_url(HOST, server.port, consumer=runtime) as url:
                     yield f"{url}/v1", secret, server.port, url
 
     async def run(self) -> Trace:
-        """Run the rollout and return its trace. Captures expected `RolloutError`s onto
-        the trace (a bad rollout is data, not a crash), runs per-rollout scoring while
-        the runtime is live, then tears the runtime down in a `finally`. Reuses the
-        eval-level shared tool servers / interception pool injected at construction (see
-        `self.shared_tools` / `self.interception`)."""
-        # The trace carries the DATA (the wire half); behavior stays on `self.task`.
         trace: Trace = Trace(task=self.task.data, state=state_cls(type(self.task))())
-        self.trace = trace  # expose for the --rich dashboard
-        self.phase = Phase.SETUP  # leaving the queue: provisioning starts now
+        self.trace = trace
+        self.phase = Phase.SETUP
         trace.timing.setup.start = time.time()
-        self.runtime = make_runtime(
-            self.runtime_config, name=trace.id
-        )  # ref set first → always tearable-down; named after the rollout for traceability
+        self.runtime = make_runtime(self.runtime_config, name=trace.id)
         runtime = self.runtime
-        # The live info object, shared by reference: the trace carries the full runtime config
-        # from the start, and the resource `id` lands on it the moment start() provisions.
         trace.runtime = runtime.info
         ctx = self.ctx
         stops = discover_decorated(self.task, "stop")
@@ -162,6 +116,7 @@ class Rollout:
         try:
             session = RolloutSession(ctx, trace, stops, self.limits)
             await runtime.start()
+            # Task setup and harness provisioning share one setup-stage deadline.
             setup_deadline = (
                 None
                 if self.setup_timeout is None
@@ -191,7 +146,6 @@ class Rollout:
                     serve_tools(
                         tool_servers,
                         runtime,
-                        self.task,
                         shared=self.shared_tools,
                         state_port=state_port,
                         state_secret=secret,
@@ -199,7 +153,6 @@ class Rollout:
                     ) as urls,
                     serve_user(
                         self.task.user_server(),
-                        self.task,
                         harness_runtime=runtime,
                         state_port=state_port,
                         state_secret=secret,
@@ -212,16 +165,12 @@ class Rollout:
                             "conversation; set task.prompt or declare a simulator "
                             "class on Task.user"
                         )
-                    # setup done — the harness is now driving
                     now = time.time()
                     trace.timing.setup.end = now
                     trace.timing.generation.start = now
                     self.phase = Phase.RUNNING
-                    # A model/tool/user call that failed behind the harness (surfaced to the program
-                    # as an HTTP error it may have swallowed or exited on) is the real cause — prefer
-                    # it over the harness's own exit (see `RolloutSession.error`). But a harness
-                    # *timeout* is a budget limit, not a crash: score whatever the harness produced
-                    # (like max_turns), even if its last call had failed.
+                    # Prefer an intercepted model/tool/user error to the harness exit it caused.
+                    # A timeout still scores the partial trajectory.
                     try:
                         await asyncio.wait_for(
                             self.harness.run(
@@ -241,7 +190,7 @@ class Rollout:
             now = time.time()
             trace.timing.generation.end = now
             trace.timing.finalize.start = now
-            self.phase = Phase.FINALIZE  # post-run task work, before scoring
+            self.phase = Phase.FINALIZE
             async with boundary(TaskError, "task finalize"):
                 await asyncio.wait_for(
                     invoke(self.task.finalize, {"trace": trace, "runtime": runtime}),
@@ -249,14 +198,10 @@ class Rollout:
                 )
             now = time.time()
             trace.timing.finalize.end = now
-            self.phase = (
-                Phase.SCORING
-            )  # per-rollout scoring; the Episode marks DONE after group scoring
+            self.phase = Phase.SCORING
             trace.timing.scoring.start = now
             async with boundary(TaskError, "scoring"):
-                # Per-rollout scoring: task + harness, concurrently, both with the live
-                # runtime. (Cross-rollout `@group_reward`s run later, in the Episode.) Each
-                # method types its own failures; only a timeout is attributed here.
+                # Group rewards run later, after the runtime is gone.
                 await asyncio.wait_for(
                     asyncio.gather(
                         self.task.score(trace, runtime),
@@ -268,23 +213,18 @@ class Rollout:
         except RolloutError as e:
             trace.capture_error(e)
         except Exception as e:
-            # An unexpected (non-RolloutError) failure is still this rollout's alone: record it
-            # (with traceback) on the trace rather than letting it propagate and cancel sibling
-            # rollouts / the eval. `BaseException` (CancelledError, KeyboardInterrupt) still
-            # propagates, so shutdown/cancellation is unaffected.
             logger.exception("unexpected error in rollout %s", trace.id)
             trace.capture_error(e)
         finally:
             trace.is_completed = True
             now = time.time()
-            if not trace.timing.setup.end:  # error during setup: close the setup span
-                trace.timing.setup.end = now
-            if trace.timing.generation.start and not trace.timing.generation.end:
-                trace.timing.generation.end = now  # error mid-run: close generation
-            if trace.timing.finalize.start and not trace.timing.finalize.end:
-                trace.timing.finalize.end = now  # error mid-finalize: close finalize
-            # Tear down here — group rewards (later) need only the trace, not a live
-            # runtime. `runtime` is always set: make_runtime() ran before the `try`.
+            for span in (
+                trace.timing.setup,
+                trace.timing.generation,
+                trace.timing.finalize,
+            ):
+                if span.start and not span.end:
+                    span.end = now
             try:
                 await runtime.stop()
             except Exception:

--- a/verifiers/v1/runtimes/__init__.py
+++ b/verifiers/v1/runtimes/__init__.py
@@ -1,11 +1,4 @@
-"""Execution runtimes for harnesses.
-
-Each runtime decides WHERE the program runs and HOW it reaches the host
-interception server: subprocess (local), docker (local container), or prime /
-modal (remote sandbox). They share the `Runtime` contract, so the Environment is
-runtime-agnostic. `RuntimeConfig` is the discriminated config union and
-`make_runtime` builds the runtime matching a config.
-"""
+"""Execution runtimes for harnesses."""
 
 from typing import Annotated
 
@@ -38,9 +31,6 @@ RuntimeInfo = Annotated[
     SubprocessRuntimeInfo | DockerRuntimeInfo | PrimeRuntimeInfo | ModalRuntimeInfo,
     Field(discriminator="type"),
 ]
-"""What a rollout's runtime looked like, as trace data: each runtime's info type is its full
-config plus the provisioned resource's `id` (see `BaseRuntimeInfo`). The discriminated union
-is `Trace.runtime`'s type, so a dumped trace round-trips to the exact info class."""
 
 
 def _runtime_cls(config: RuntimeConfig) -> type[Runtime]:

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -1,9 +1,4 @@
-"""The runtime contract: provision execution, run the program, tear down.
-
-A runtime decides WHERE the program runs and HOW it reaches the host interception
-server. Concrete runtimes live alongside this base; harnesses and the Environment
-depend only on this contract, so they stay runtime-agnostic.
-"""
+"""Execution runtime contract."""
 
 import asyncio
 import atexit
@@ -109,16 +104,7 @@ def cleanup_at_exit() -> None:
 
 
 class BaseRuntimeInfo(BaseConfig):
-    """Runtime metadata persisted with the rollout (`Trace.runtime`): each runtime's info class
-    inherits its full config — every knob the runtime ran with — and adds the provisioned
-    resource's `id`. Built with the runtime and shared by reference with the trace, so fields
-    land there the moment they're known: the config at creation, `id` once `start()` has
-    provisioned the resource. `RuntimeInfo` (the discriminated union over the concrete info
-    types) is what a dumped trace round-trips through."""
-
     id: str | None = None
-    """The provisioned resource's identifier (None until the runtime is up): the subprocess
-    workdir, the docker container id, the prime/modal sandbox id."""
 
 
 class Runtime(ABC):
@@ -129,38 +115,23 @@ class Runtime(ABC):
     need a tunnel each way: `host_endpoint` inward, `expose` outward)."""
 
     info: BaseRuntimeInfo
-    """This runtime's trace-facing metadata (see `BaseRuntimeInfo`): the full config plus the
-    resolved resource `id`. Each runtime constructs its own info type in `__init__` and fills
-    `id` in `start()`."""
 
     def __init__(self, name: str | None = None) -> None:
         self.name = name or f"vf-{uuid.uuid4().hex[:12]}"
-        """Resource name — the subprocess workdir, docker `--name`, prime sandbox name.
-        The rollout passes its trace id, so the provisioned resource is greppable back to
-        the rollout it serves; falls back to a unique `vf-` name (standalone / tool
-        runtimes, where there's no single owning rollout)."""
         self._uv_interpreters: dict[str, str] = {}
         self._uv_script_locks: dict[str, asyncio.Lock] = {}
 
-    # --- identity / display ---
-
     @property
     def type(self) -> str:
-        """The runtime's config discriminator ("subprocess" / "docker" / "prime" / "modal")."""
         return self.config.type
 
     @property
     def descriptor(self) -> str | None:
-        """A short resolved id for display (None until provisioned): the runtime's `info.id` —
-        subprocess workdir, docker container id, prime/modal sandbox id."""
         return self.info.id
-
-    # --- lifecycle ---
 
     @abstractmethod
     async def start(self) -> None:
-        """Provision execution (workspace / container / sandbox). Use `expose` to turn a
-        host port into a URL the program can reach."""
+        pass
 
     async def stop(self) -> None:
         """Free the provisioned resource on the normal path (the owner's `finally`),
@@ -183,11 +154,9 @@ class Runtime(ABC):
         source of truth for teardown: usable from the atexit backstop where async machinery
         is dead, and run off the event loop by `stop` on the normal path. Default no-op."""
 
-    # --- execution ---
-
     @abstractmethod
     async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
-        """Run `argv` (with the interception env vars `env`) to completion."""
+        pass
 
     async def run_program(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
         """Run the harness's MAIN program — the rollout itself (a possibly long-lived, stateful,
@@ -212,7 +181,6 @@ class Runtime(ABC):
         script: str | bytes,
         env: dict[str, str] | None = None,
     ) -> list[str]:
-        """Stage a PEP 723 script and resolve its dependencies, returning its executable argv."""
         data = script.encode() if isinstance(script, str) else script
         digest = hashlib.sha256(data).hexdigest()
         path = f"/tmp/vf-scripts/{digest}.py"
@@ -261,38 +229,22 @@ class Runtime(ABC):
         args: list[str] | None = None,
         env: dict[str, str] | None = None,
     ) -> ProgramResult:
-        """Run a self-contained uv script (PEP 723 inline deps) in this runtime, with
-        `args` as its positional arguments (the script's `sys.argv[1:]`).
-
-        `prepare_uv_script` stages the script and resolves its dependencies once; this method
-        then runs it directly with the prepared interpreter. Built on `write`/`run`, so it
-        works the same on every runtime. `args` are passed as separate argv entries, so
-        spaces, quotes, and newlines in them are safe; pass structured data as a JSON string
-        if you need to.
-
-        The script is written to a stable, content-addressed path (NOT the per-rollout
-        workspace): uv keys its per-script environment by the script's full path, so a
+        """The script is written to a stable, content-addressed path rather than the per-rollout
+        workspace: uv keys its per-script environment by the script's full path, so a
         unique path per call would mint a fresh env every rollout. A path derived from the
         content means identical scripts share one path → uv reuses one env, bounded by the
         number of distinct scripts. Published via a unique temp + atomic `mv`, so
-        concurrent rollouts writing the same content never race a half-written read. This is
-        the general-purpose script path; stateful harness programs use the prepared argv with
-        `run_program` instead."""
+        concurrent rollouts writing the same content never race a half-written read."""
         argv = await self.prepare_uv_script(script, env)
         return await self.run([*argv, *(args or [])], env or {})
 
-    # --- filesystem ---
-
     @abstractmethod
     async def read(self, path: str) -> bytes:
-        """Read a file from the runtime's workspace. The caller need not know
-        whether that's the host fs or across a container/sandbox boundary."""
+        pass
 
     @abstractmethod
     async def write(self, path: str, data: bytes) -> None:
-        """Write a file into the runtime's workspace, creating parent dirs."""
-
-    # --- networking ---
+        pass
 
     @property
     def published_port(self) -> int | None:
@@ -366,15 +318,10 @@ async def host_endpoint(port: int, is_local: bool, labels: list[str] | None = No
 
 
 class _Host:
-    """The host network as a `reachable_url` location: shares the host network (so it's `is_local`)
-    and publishes nothing itself (it's reached *into* via `host_endpoint`, not via `expose`)."""
-
     is_local = True
 
 
 HOST = _Host()
-"""The host network, as a service location (e.g. the interception server) or a consumer (the
-framework driving a user sim) — see `reachable_url`."""
 
 
 @contextlib.asynccontextmanager
@@ -387,8 +334,8 @@ async def reachable_url(
 
     `service` is the `Runtime` the service runs in, or `HOST` (a host-network service). `consumer` is
     the consuming `Runtime` (used for the colocated check and its locality); leave it `None` for a
-    host consumer or an eval-level consumer with no single instance (a shared tool reused by every
-    rollout's harness) and pass its locality as `consumer_is_local`:
+    host consumer or a worker-shared tool with no single harness instance, and pass its locality as
+    `consumer_is_local`:
 
     - same location (a colocated tool in the consumer's own runtime, or host -> host): localhost;
     - the service runs in a sandbox (a remote runtime): its own published URL (`expose`), reachable

--- a/verifiers/v1/runtimes/docker.py
+++ b/verifiers/v1/runtimes/docker.py
@@ -1,8 +1,4 @@
-"""Local Docker runtime: run the program in a container sharing the host network.
-
-On Linux the container shares the host network (`--network host`), so it reaches
-the interception server on localhost directly — no tunnel needed.
-"""
+"""Local Docker runtime using host networking."""
 
 import asyncio
 import contextlib
@@ -29,7 +25,7 @@ class DockerConfig(BaseConfig):
     type: Literal["docker"] = "docker"
     image: str = "python:3.11-slim"
     workdir: str = "/app"
-    # TaskResources in Modal's units (also settable per-task via Task.resources).
+    # TaskData.resources uses these units; non-default runtime config values take precedence.
     cpu: float | None = None
     """Pin the container to this many CPU cores (docker `--cpus`). None = unlimited."""
     memory: float | None = None
@@ -43,11 +39,10 @@ class DockerConfig(BaseConfig):
 
 
 class DockerRuntimeInfo(DockerConfig, BaseRuntimeInfo):
-    """`DockerConfig` + the resolved `id` — docker's short container id."""
+    pass
 
 
 async def docker(*args: str) -> ProgramResult:
-    """Run a `docker` CLI command, capturing its result."""
     proc = await asyncio.create_subprocess_exec(
         "docker",
         *args,
@@ -63,8 +58,6 @@ async def docker(*args: str) -> ProgramResult:
 
 
 class DockerRuntime(Runtime):
-    """Runs the program in a local Docker container reachable over the host network."""
-
     def __init__(self, config: DockerConfig, name: str | None = None) -> None:
         super().__init__(name)
         self.config = config

--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -1,4 +1,4 @@
-"""Remote Modal sandbox runtime: run the program in a Modal sandbox, reached via a tunnel.
+"""Remote Modal sandbox runtime.
 
 `expose` (sandbox port -> public internet) uses Modal's own forwarding — a port named via
 `encrypted_ports` at `Sandbox.create`, read back from `sandbox.tunnels()` — so a host-side
@@ -39,8 +39,7 @@ class ModalConfig(BaseConfig):
     network_access: bool = True
     region: str | None = None
     """Region to provision in (None = provider-chosen)."""
-    # TaskResources, in Modal's native units (also settable per-task via Task.resources, with
-    # precedence cli/toml > task > this default).
+    # TaskData.resources uses these units; non-default runtime config values take precedence.
     cpu: float = 1.0
     """CPU cores."""
     memory: float = 2.0
@@ -56,12 +55,10 @@ class ModalConfig(BaseConfig):
 
 
 class ModalRuntimeInfo(ModalConfig, BaseRuntimeInfo):
-    """`ModalConfig` + the resolved `id` — the modal sandbox object id."""
+    pass
 
 
 class ModalRuntime(Runtime):
-    """Runs the program in a Modal sandbox; the server is reached via a tunnel."""
-
     is_local: ClassVar[bool] = False
 
     def __init__(self, config: ModalConfig, name: str | None = None) -> None:

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -1,4 +1,4 @@
-"""Remote Prime sandbox runtime: run the program in a sandbox, reached via native port exposure.
+"""Remote Prime sandbox runtime.
 
 `expose` (sandbox port -> public URL) uses the SDK's native exposure (`client.expose`), so a
 host-side harness/framework can reach a tool/user server hosted in the sandbox. The reverse
@@ -46,10 +46,8 @@ class PrimeConfig(BaseConfig):
     region: str | None = None
     """Region to provision in (None = provider-chosen)."""
     labels: list[str] = []
-    """Labels attached to the sandbox and its tunnels — e.g. to group every resource a run
-    creates. When unset, the eval defaults them to the run's uuid (see `run_eval`)."""
-    # TaskResources, in Modal's units (also settable per-task via Task.resources, with
-    # precedence cli/toml > task > this default). Mapped to prime's API in `start`.
+    """Labels attached to the sandbox."""
+    # TaskData.resources uses these units; non-default runtime config values take precedence.
     cpu: float = 1.0
     """CPU cores."""
     memory: float = 2.0
@@ -76,12 +74,10 @@ class PrimeConfig(BaseConfig):
 
 
 class PrimeRuntimeInfo(PrimeConfig, BaseRuntimeInfo):
-    """`PrimeConfig` + the resolved `id` — the prime sandbox id."""
+    pass
 
 
 class PrimeRuntime(Runtime):
-    """Runs the program in a Prime sandbox; the server is reached via a tunnel."""
-
     is_local: ClassVar[bool] = False
 
     def __init__(self, config: PrimeConfig, name: str | None = None) -> None:

--- a/verifiers/v1/runtimes/subprocess.py
+++ b/verifiers/v1/runtimes/subprocess.py
@@ -1,9 +1,4 @@
-"""Local subprocess runtime: run the program on the host; server on localhost.
-
-Each rollout gets a fresh `/tmp/<name>` workspace (created on `start`, removed on
-`stop`/`cleanup`) used as the program's cwd, so concurrent local rollouts are isolated
-and trivially cleaned up. Relative `read`/`write` paths resolve against it.
-"""
+"""Local subprocess runtime."""
 
 import asyncio
 import contextlib
@@ -17,16 +12,10 @@ from pydantic_config import BaseConfig
 
 from verifiers.v1.runtimes.base import BaseRuntimeInfo, ProgramResult, Runtime
 
-# A local subprocess inherits the host environment EXCEPT any var whose name
-# contains "API_KEY" — so it can never reach a real provider with the host's API
-# key, while still inheriting harmless config (PATH, HOME, UV_CACHE_DIR, HF_HOME,
-# ...). Harnesses hand their interception endpoint + per-rollout secret to their own
-# client via argv/CLI (not OPENAI_*), so nothing they spawn inherits the endpoint.
-# A container/sandbox is isolated and inherits nothing, so this
-# allow-by-default model is subprocess-only. NOTE: this strip applies to EVERY
-# program run here, including a task's tool/user server — so a tool server that
-# genuinely needs an API key won't get one on subprocess placement; give it its
-# own runtime (docker/prime) or have it fetch the key itself.
+# Implicit host inheritance removes every name containing "API_KEY" while keeping
+# harmless settings such as PATH, HOME, and cache locations. The explicit `env`
+# argument is merged afterward, so callers can deliberately pass credentials and
+# child processes inherit them. Containers and sandboxes inherit no host environment.
 
 
 class SubprocessConfig(BaseConfig):
@@ -34,12 +23,10 @@ class SubprocessConfig(BaseConfig):
 
 
 class SubprocessRuntimeInfo(SubprocessConfig, BaseRuntimeInfo):
-    """`SubprocessConfig` + the resolved `id` — the `/tmp/<name>` workspace path."""
+    pass
 
 
 class SubprocessRuntime(Runtime):
-    """Runs the program as a local subprocess in a unique /tmp workspace."""
-
     # Share prepared script environments across the worker's per-rollout runtimes.
     _interpreters: dict[str, str] = {}
     _locks: dict[str, asyncio.Lock] = {}

--- a/verifiers/v1/serve/__init__.py
+++ b/verifiers/v1/serve/__init__.py
@@ -1,9 +1,4 @@
-"""Serve a v1 environment over ZMQ.
-
-`EnvServer` loads an environment once and runs rollouts on request by task index;
-`EnvClient` is the matching ZMQ client. The orchestrator talks to the server and
-never loads the environment itself — the env runtime is independent of it.
-"""
+"""Serve V1 environments over ZMQ."""
 
 from verifiers.v1.serve.client import EnvClient
 from verifiers.v1.serve.pool import EnvServerPool, env_config_data, serve_env

--- a/verifiers/v1/serve/server.py
+++ b/verifiers/v1/serve/server.py
@@ -1,21 +1,3 @@
-"""The env server: load a taskset once, run rollouts on request by task index.
-
-A ZMQ ROUTER front end (msgpack frames) over a v1 `Environment`. The server
-owns the environment — taskset, harness, runtime — and is the only process that ever
-loads it. A caller (e.g. the orchestrator) stays env-agnostic: it asks `info` for
-the task count + whether group scoring is needed, then `run_rollout` / `run_group`
-by task index. Per request the server resolves a `Client` from the request's
-`client` config (cached, so a renderer's tokenizer is built once), wraps it in a
-`ModelContext`, and runs `env.episode(task, ctx, n).run()`, returning each
-`Trace` as a JSON dict (with its computed `branches`).
-
-Minimal port of `verifiers.serve` (ROUTER + msgpack), single async process: each
-request is its own `asyncio.Task`, so many rollouts run concurrently. No worker
-pool / heartbeats yet — the rollout's own runtime already isolates execution, and
-the structure leaves room to add a pool later. Health is just another request type
-(no separate socket), which is enough at this scale.
-"""
-
 import asyncio
 import contextlib
 import logging
@@ -46,18 +28,13 @@ logger = logging.getLogger(__name__)
 
 
 class EnvServer:
-    """Serve one v1 environment over ZMQ. The only process that loads the env."""
-
     def __init__(
         self, config: EnvConfig, address: str = "tcp://127.0.0.1:5000"
     ) -> None:
         self.address = address
         self.taskset_id = config.taskset.id
         self.env = Environment(config)
-        # Load tasks once; the index range is fixed for the server's lifetime.
         self.tasks = self.env.taskset.load()
-        # One task type per taskset (`Taskset.tasks` enforces it), so group scoring is a
-        # run-wide property.
         self.requires_group_scoring = bool(self.tasks) and bool(
             discover_decorated(self.tasks[0], "group_reward")
         )
@@ -78,10 +55,7 @@ class EnvServer:
 
     @classmethod
     def run_server(cls, address_queue=None, **kwargs) -> None:
-        """Build and run a server (entry point for a spawned process). If
-        `address_queue` is given, report the concrete bound address on it (so a
-        spawner that passed a `:0` address learns the OS-assigned port) before
-        serving."""
+        """Run a spawned server and report its concrete address when requested."""
         # This worker loads the taskset (and any HF datasets it pulls in) and is killed at
         # teardown; pin tqdm to a threading lock first so it never leaks a multiprocessing
         # semaphore (resource_tracker warning at shutdown).
@@ -98,9 +72,7 @@ class EnvServer:
             pass
 
     def _client(self, client_config: ClientConfig, model: str) -> Client:
-        """Resolve (and cache) a `Client` for this config+model. Cached because a
-        renderer client builds the model's tokenizer pool on first use — doing that
-        per request would be ruinous."""
+        """Cache clients because renderer initialization builds a tokenizer pool."""
         key = (client_config.model_dump_json(), model)
         if key not in self._clients:
             self._clients[key] = resolve_client(client_config)
@@ -114,11 +86,7 @@ class EnvServer:
         )
 
     def serving(self):
-        """Context for the server's eval-level serving resources (shared tool servers +
-        interception pool), entered for the server's lifetime so they're reused across
-        requests; episodes built inside it inherit them (see `Environment.serving`). The
-        legacy v0 bridge overrides this (it runs its own rollouts, with no v1 serving)."""
-        return self.env.serving(self.tasks)
+        return self.env.serving()
 
     async def _run_rollout(self, req: RunRolloutRequest) -> RunRolloutResponse:
         ctx = self._context(req.client, req.model, req.sampling)
@@ -186,9 +154,7 @@ class EnvServer:
         poller = zmq.asyncio.Poller()
         poller.register(self.frontend, zmq.POLLIN)
         tasks: set[asyncio.Task] = set()
-        # Enter the serving resources (shared tool servers + interception pool) for the
-        # server's lifetime so they're reused across requests; episodes built per request
-        # inherit them (the legacy bridge overrides this to a no-op).
+        # Shared servers and the interception pool live across requests in this worker.
         async with self.serving():
             try:
                 while True:

--- a/verifiers/v1/serve/types.py
+++ b/verifiers/v1/serve/types.py
@@ -1,5 +1,3 @@
-"""Wire types for the env-server RPC (msgpack over ZMQ)."""
-
 from typing import ClassVar
 
 from pydantic import BaseModel, field_serializer
@@ -11,9 +9,7 @@ from verifiers.v1.types import SamplingConfig
 
 
 class BaseRequest(BaseModel):
-    """Marker base for requests. ``method`` is the RPC route — a class var sent as its
-    own ZMQ frame, not a model field — so the request type never rides as payload data
-    and the request models stay pure data."""
+    """`method` is sent as its own route frame, not as payload data."""
 
     method: ClassVar[str]
 
@@ -37,11 +33,8 @@ class InfoRequest(BaseRequest):
 
 class InfoResponse(BaseResponse):
     num_tasks: int = 0
-    """Number of tasks in the taskset — the index range the caller samples from."""
     requires_group_scoring: bool = False
-    """Whether the taskset's tasks define `@group_reward`s (one task type per taskset) —
-    the caller then runs each task via `run_group` (a whole episode per request) and
-    plans its resume whole-group; otherwise everything goes per-rollout."""
+    """Whether tasks must be run and resumed as whole groups."""
 
 
 class RunRolloutRequest(BaseRequest):
@@ -54,9 +47,7 @@ class RunRolloutRequest(BaseRequest):
 
 class RunRolloutResponse(BaseResponse):
     trace: Trace[WireTaskData] | None = None
-    """A typed `Trace` with a non-strict `WireTaskData` (taskset-specific task fields ride in
-    `model_extra`), so the server needn't assume the caller imports the taskset. A caller
-    that *does* import it upgrades via `Trace[task_type(taskset_id)].model_validate(...)`."""
+    """A trace whose task-specific data is preserved in `model_extra`."""
 
     @field_serializer("trace")
     def _ser_trace(self, trace: "Trace[WireTaskData] | None") -> dict | None:
@@ -74,7 +65,6 @@ class RunGroupRequest(BaseRequest):
 
 class RunGroupResponse(BaseResponse):
     traces: list[Trace[WireTaskData]] | None = None
-    """Typed `Trace`s with non-strict `WireTaskData`, like `RunRolloutResponse.trace`."""
 
     @field_serializer("traces")
     def _ser_traces(

--- a/verifiers/v1/state.py
+++ b/verifiers/v1/state.py
@@ -1,32 +1,17 @@
-"""Per-rollout shared runtime state.
+"""Mutable state shared within one rollout.
 
-`Trace.state` is a typed, mutable `State` that a rollout's tool servers (`@vf.tool`) and user
-simulator (`respond`) read+write as `self.state` (synced over the interception server per call), and
-that `@reward`/`@metric`/`finalize` read+write directly off the trace. Unlike `Trace.info` — the
-free-form artifact bag persisted to `traces.jsonl` — `state` is transient runtime scratch (counters,
-game progress, an end-of-trajectory flag): never written to disk or sent over the wire.
-
-The base `State` is empty — the framework holds no opinion about its contents. Subclass it to declare
-typed fields, then parameterize the task (`Task[MyData, MyState]`) and any stateful server
-(`Toolset[Config, MyState]` / `User[Config, MyState]`) to type it. To end a trajectory from state,
-add your own flag and a `@vf.stop` that checks it (e.g. `user_finished`) — see the user-sim examples.
+Tool and user servers synchronize it through the interception state channel. It is excluded
+from serialized traces; persist artifacts in `Trace.info` instead.
 """
-
-from typing import get_args
 
 from pydantic import ConfigDict
 from typing_extensions import TypeVar
 
 from verifiers.v1.types import StrictBaseModel
+from verifiers.v1.utils.generic import generic_type
 
 
 class State(StrictBaseModel):
-    """Per-rollout mutable runtime state shared across a rollout's tool/user servers and its scoring.
-    Empty by default — subclass to declare typed fields, e.g. `class MyState(State): count: int = 0`
-    (fields need defaults so the framework can build the initial state). Strict (unknown fields are
-    rejected) and transient: never persisted to disk or sent over the wire (use the free-form
-    `Trace.info` for artifacts that must persist)."""
-
     model_config = ConfigDict(ser_json_inf_nan="constants")
 
 
@@ -34,13 +19,5 @@ StateT = TypeVar("StateT", bound=State, default=State)
 
 
 def state_cls(cls: type) -> type[State]:
-    """The `State` subclass a class parameterizes — `Task[MyData, MyState]`,
-    `Toolset[Config, MyState]`, `User[Config, MyState]` — read off its generic bases, walking the MRO
-    so a further subclass inherits it. Falls back to the base `State` when none is given (the common
-    case: an env that doesn't customize state, written without the generic param)."""
-    for klass in getattr(cls, "__mro__", [cls]):
-        for base in getattr(klass, "__orig_bases__", ()):
-            for arg in get_args(base):
-                if isinstance(arg, type) and issubclass(arg, State):
-                    return arg
-    return State
+    """Resolve a class's `State` specialization through its MRO, else `State`."""
+    return generic_type(cls, State) or State

--- a/verifiers/v1/task.py
+++ b/verifiers/v1/task.py
@@ -1,61 +1,26 @@
-"""The task, split into data and behavior.
+"""Task data, configuration, behavior, and scoring.
 
-`TaskData` is the wire half: a frozen pydantic model carrying everything a rollout's
-row IS — the base fields (prompt, image, timeouts, judges) plus your typed,
-task-specific fields (the reference answer, ground truths, ...). It is what rides on
-`trace.task`, what `traces.jsonl` stores, and what tool/user servers receive over the
-`/task` channel. Subclass it per dataset.
-
-`Task` is the behavior half: a plain class owning runtime prep (`setup`/`finalize`),
-server declarations (`tools`/`user`), well-formedness (`validate`), and judgement
-(`@reward`/`@metric`/`@group_reward` methods, run by `score`/`score_group`). It wraps
-a `TaskData` plus a `TaskConfig`, both plain constructor arguments:
-
-    task = MyTask(data)                        # config defaults to the declared type's
-    task = MyTask(data, config=MyTaskConfig()) # or is injected, like Taskset/Harness/Judge
-    task = MyTask.from_trace(trace)            # opt-in: derived from a finished rollout
-
-Subclass per dataset and parameterize `Task[MyData, MyState, MyConfig]` (all three
-default) — hooks and signals read the row off `self.data` and the knobs off
-`self.config`. Because behavior lives on the task class, verification never branches
-on a type field; a taskset yields one task type (its `load` constructs it), and
-instances differ per row through their data.
-
-The task is the single judgement authority, scored at two granularities (execution
-lives in the Rollout — per-rollout — and the Episode — group — which call these):
-  - `score` runs `@metric`/`@reward` — plus the plugged judges resolved from
-    `config.judges` (see `verifiers.v1.judge`) — over one trace (in its live runtime).
-  - `score_group` runs `@group_reward` over all the rollouts of this task at once —
-    pairwise/preference rewards that compare samples.
-
-A Task instance is shared across its rollouts (a group's `n` samples hold the same
-instance), so hooks and scoring methods must not stash per-rollout state on `self` —
-that lives on the trace (`trace.state`, typed via the `Task[..., MyState, ...]`
-param).
-
-On the wire only the data travels: a saved `trace.task` reads back as `WireTaskData`
-(extra fields preserved) without importing the taskset; a consumer that re-scores
-(e.g. `replay`) rebuilds the declared `TaskData` type and wraps it in the declared
-`Task` — one task type per taskset.
+Only `TaskData` travels on traces. `Task` wraps that data with runtime behavior and a
+config; parameterize it as `Task[MyData, MyState, MyConfig]`.
 """
 
 from __future__ import annotations
 
-import asyncio
 import inspect
 import logging
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, ClassVar, Generic, Self, get_args
+from typing import TYPE_CHECKING, ClassVar, Generic
 
 from pydantic import ConfigDict, model_validator
 from pydantic_config import BaseConfig
 from typing_extensions import TypeVar
 
-from verifiers.v1.decorators import discover_decorated, invoke
+from verifiers.v1.decorators import discover_decorated, invoke_all
 from verifiers.v1.errors import TaskError, boundary
 from verifiers.v1.judge import Judges, check_judges, resolve_judges
 from verifiers.v1.state import StateT
 from verifiers.v1.types import Messages, StrictBaseModel, content_text
+from verifiers.v1.utils.generic import generic_type
 
 if TYPE_CHECKING:
     from verifiers.v1.judge import Judge
@@ -67,19 +32,35 @@ logger = logging.getLogger(__name__)
 
 
 def _requires_runtime(fn) -> bool:
-    """A signal with a default-less `runtime` parameter can't run without a live runtime.
-    A `runtime` parameter with a default (e.g. `runtime=None`) is optional — `invoke`
-    just omits it — so those still run offline."""
     param = inspect.signature(fn).parameters.get("runtime")
+    # A defaulted runtime parameter can still be called offline with None.
     return param is not None and param.default is inspect.Parameter.empty
 
 
-class TaskResources(StrictBaseModel):
-    """Runtime resources a task requests (all optional), in Modal's units. Applied to the
-    runtime config where the field exists; a field the runtime doesn't support is warned
-    about and ignored. Precedence: cli/toml > task > the runtime default (`None` here =
-    use the runtime/provider default)."""
+def _record_result(
+    trace: Trace,
+    fn,
+    name: str,
+    result,
+    section: str,
+    weight: float | None = None,
+) -> None:
+    """Record a scalar or keyed scoring result and its runtime-only replay keys."""
+    values = list(result.items()) if isinstance(result, Mapping) else [(name, result)]
+    for key, value in values:
+        if weight is None:
+            trace.record_metric(key, value)
+        else:
+            trace.record_reward(key, value, weight)
+    # Record runtime-only keys so offline replay can preserve them.
+    if _requires_runtime(fn):
+        offline = trace.info.setdefault("offline_keys", {})
+        offline.setdefault(section, {}).setdefault(name, []).extend(
+            key for key, _ in values
+        )
 
+
+class TaskResources(StrictBaseModel):
     model_config = ConfigDict(frozen=True)
 
     cpu: float | None = None
@@ -93,103 +74,56 @@ class TaskResources(StrictBaseModel):
 
 
 class TaskTimeout(StrictBaseModel):
-    """Per-task wall-clock timeout overrides (seconds, all optional), one per rollout stage. Each
-    merges with the eval's `timeout` (`TimeoutConfig`): cli/toml > this > default (no limit).
-    Frozen, like `TaskResources`."""
+    """Optional per-task timeout overrides, in seconds."""
 
     model_config = ConfigDict(frozen=True)
 
     setup: float | None = None
-    """The task's `setup` hook."""
     harness: float | None = None
-    """The harness run."""
     finalize: float | None = None
-    """The task's `finalize` hook."""
     scoring: float | None = None
-    """Verify + rewards/metrics."""
 
 
 class TaskConfig(BaseConfig):
-    """Rollout/scoring-time knobs the task reads off `self.config` — server placement
-    (`ToolsetConfig`/`UserConfig` fields), judge endpoints, scoring parameters. Subclass to
-    add your task's knobs; every field needs a default (a task constructed without one —
-    e.g. via `Task.from_trace` — falls back to a default-constructed config). Load-time
-    knobs (dataset, split, seed) belong on `TasksetConfig` instead — the task never needs
-    them."""
+    """Run-time knobs read by `Task` behavior.
+
+    Subclass for server placement, judge, or scoring settings. Every field needs a
+    default because constructing a task without a config builds the declared config type.
+    Load-time dataset settings belong on `TasksetConfig` instead.
+    """
 
     judges: Judges = []
-    """Config-plugged judges, each resolved by `id` — a built-in (`reference`, `rubric`), a local
-    package, or a hub `org/name[@version]` package exporting a `Judge` subclass: grading plugged
-    into any taskset/harness pair from the eval config alone, no taskset code. `Task.score`
-    resolves and runs them after the task's `@reward`s; each entry records its verdict in
-    `trace.rewards` under its `name` with its `weight` (see `JudgeConfig`). Set via
-    `--taskset.task.judges`."""
+    """Judge plugins run after task rewards, set through `--taskset.task.judges`."""
 
     @model_validator(mode="before")
     @classmethod
     def _resolve_judges(cls, data):
-        """Narrow each `judges` entry to the config type its `id` resolves to (see
-        `judge.resolve_judges`), so judge-specific fields (e.g. rubric's `path`)
-        validate against the real config instead of being rejected by the base type."""
         if isinstance(data, dict) and data.get("judges"):
             data["judges"] = resolve_judges(data["judges"])
         return data
 
     @model_validator(mode="after")
     def _check_judges(self) -> TaskConfig:
-        """Validate the resolved `judges` — after the before-hook so class-level *defaults*
-        (which never pass through it, e.g. a taskset config pre-plugging a judge) are held
-        to the same rules (see `judge.check_judges`)."""
         check_judges(self.judges)
         return self
 
 
 class TaskData(StrictBaseModel):
-    """The task's wire half: one row's pure data, a frozen pydantic model. Subclass per
-    dataset to add typed, task-specific fields (the reference answer, ground truths,
-    per-row metadata) next to the base fields below. This is what `trace.task` holds,
-    what `traces.jsonl` stores, and what tool/user servers receive over the `/task`
-    channel — behavior lives on `Task`, which wraps this (`self.data`)."""
-
     model_config = ConfigDict(frozen=True)
 
     idx: int
-    """Stable integer index of this example within its taskset."""
     name: str | None = None
-    """Optional human-readable task name/label (for display/filtering)."""
     description: str | None = None
-    """Optional human-readable task description."""
     prompt: str | Messages | None
-    """The user message shown to the model (the task's question/framing). Usually a `str`; a
-    `Messages` list seeds a full initial conversation (e.g. a user message carrying images) and
-    is only accepted by harnesses that set `SUPPORTS_MESSAGE_PROMPT`. Required — set it
-    explicitly to `None` to mean the task carries no prompt: the task's user simulator
-    (`Task.user`) then opens the conversation, its first `respond` supplying the initial user
-    turn before the model is ever called."""
+    """Initial user prompt; `None` lets the user simulator open the conversation."""
     system_prompt: str | None = None
-    """Optional system prompt. Harnesses that set `APPENDS_SYSTEM_PROMPT` emit it as a real
-    system message (or their own mechanism); others prepend it to `prompt` (with a
-    warning). See `Harness.resolve_prompt`."""
     image: str | None = None
-    """Container image this task needs (e.g. its harbor environment). When set, the
-    runtime must be a container (docker/prime): the Environment injects it into the
-    runtime config and refuses the subprocess runtime, which has no container."""
     workdir: str | None = None
-    """Working directory the harness and scoring run in — the Environment injects it into
-    the runtime config's `workdir` (where the runtime supports one). For a containerized
-    task whose image puts the working tree at a non-default path (e.g. a SWE row's
-    `/workspace/<repo>`)."""
     timeout: TaskTimeout = TaskTimeout()
-    """Optional per-task timeout overrides, one per rollout stage (merge with the eval's `timeout`)."""
     resources: TaskResources = TaskResources()
-    """Optional runtime resources this task requests (applied where supported)."""
 
     @property
     def prompt_text(self) -> str:
-        """The prompt as plain text — `prompt` itself when it's a `str`, the joined text
-        content of a `Messages` prompt (images are dropped), `""` when the task carries no
-        prompt. For consumers that need the task's framing as text regardless of the prompt
-        form, e.g. the built-in judges' prompt templates."""
         if isinstance(self.prompt, str):
             return self.prompt
         texts = [content_text(message.content) for message in self.prompt or []]
@@ -197,11 +131,7 @@ class TaskData(StrictBaseModel):
 
 
 class WireTaskData(TaskData):
-    """A `TaskData` that accepts (and preserves) taskset-specific extra fields. Lets a
-    `Trace` be typed on the wire — `Trace[WireTaskData]` — without importing the taskset,
-    since the real `TaskData` subclass's extra fields land in `model_extra` instead of
-    being rejected. A caller that re-scores rebuilds the real type via
-    `task_data_cls(task_type(taskset_id))` first."""
+    """Wire form that preserves task-specific fields without importing the task class."""
 
     model_config = ConfigDict(extra="allow")
 
@@ -213,45 +143,25 @@ DataT = TypeVar("DataT", bound=TaskData)
 ConfigT = TypeVar("ConfigT", bound=TaskConfig, default=TaskConfig)
 
 
-def _generic_arg(cls: type, base: type, default: type) -> type:
-    """The `base` subclass a task class parameterizes — `Task[MyData, MyState, MyConfig]` —
-    read off its generic bases, walking the MRO so a further subclass inherits it. Falls
-    back to `default` when none is given. Mirrors `state_cls` (which reads the same
-    generic for the `State` param)."""
-    for klass in getattr(cls, "__mro__", [cls]):
-        for orig in getattr(klass, "__orig_bases__", ()):
-            for arg in get_args(orig):
-                if isinstance(arg, type) and issubclass(arg, base):
-                    return arg
-    return default
-
-
 def task_data_cls(cls: type) -> type[TaskData]:
-    """The `TaskData` subclass a task class declares (`Task[MyData, ...]`); the base
-    `TaskData` when none is given."""
-    return _generic_arg(cls, TaskData, TaskData)
+    """Resolve a task's `TaskData` specialization through its MRO, else `TaskData`."""
+    return generic_type(cls, TaskData) or TaskData
 
 
 def task_config_cls(cls: type) -> type[TaskConfig]:
-    """The `TaskConfig` subclass a task class declares (`Task[..., MyConfig]`); the base
-    `TaskConfig` when none is given."""
-    return _generic_arg(cls, TaskConfig, TaskConfig)
+    """Resolve a task's `TaskConfig` specialization through its MRO, else `TaskConfig`."""
+    return generic_type(cls, TaskConfig) or TaskConfig
 
 
 def resolve_server_config(
     owner: str, config: BaseConfig, server_cls: type
 ) -> BaseConfig:
-    """The config a declared server class is built with, resolved off `config`'s fields:
-    the field whose value is exactly the server's declared config type
-    (`Toolset[MyConfig]` / `User[MyConfig]`), else the unique field whose value
-    isinstance-matches it, else a default-constructed one. Two matching fields raise —
-    the `server_config` methods (`Task` / `Taskset`) are the override points for explicit
-    pairing. `owner` names the declaring class in errors."""
     cfg_cls = server_cls._config_cls()
     values = {name: getattr(config, name) for name in type(config).model_fields}
-    matched = [name for name, v in values.items() if type(v) is cfg_cls]
+    # Prefer an exact field over a broader base-config match.
+    matched = [name for name, value in values.items() if type(value) is cfg_cls]
     if not matched:
-        matched = [name for name, v in values.items() if isinstance(v, cfg_cls)]
+        matched = [name for name, value in values.items() if isinstance(value, cfg_cls)]
     if len(matched) > 1:
         raise TaskError(
             f"{owner}: ambiguous config for {server_cls.__name__} — config fields "
@@ -260,281 +170,108 @@ def resolve_server_config(
         )
     if matched:
         return values[matched[0]]
-    try:
-        return cfg_cls()
-    except Exception as exc:
-        raise TaskError(
-            f"{owner}: no {cfg_cls.__name__} to build {server_cls.__name__} with — add a "
-            f"{cfg_cls.__name__} field to the config, or pass `config=...` at construction"
-        ) from exc
+    return cfg_cls()
 
 
 class Task(Generic[DataT, StateT, ConfigT]):
-    """The task's behavior half: hooks, server declarations, and `@reward`/`@metric`
-    scoring over one row's `TaskData`. A plain class — subclass per dataset and
-    parameterize `Task[MyData, MyState, MyConfig]` (all three default) so `self.data`,
-    `trace.state`, and `self.config` are typed. Constructed from its two inputs like
-    every other plugin (`Taskset(config)` / `Harness(config)` / `Judge(config)`):
+    """Behavior, lifecycle, servers, and scoring for one `TaskData` row.
 
-        MyTask(data)                         # config = the declared type's defaults
-        MyTask(data, config=MyTaskConfig())  # or injected
-        MyTask.from_trace(trace)             # opt-in: derived from a finished rollout
-
-    A taskset's `load()` constructs one per row with the eval's `TasksetConfig.task`.
-    Hooks and signals read the row off `self.data` and the knobs off `self.config`; one
-    instance is shared across a group's rollouts, so per-rollout state lives on
-    `trace.state`, never on `self`."""
+    Parameterize as `Task[MyData, MyState, MyConfig]`. Construction accepts the row
+    and an optional config; omitting config builds the declared config type. One task
+    instance is shared across a rollout group, so per-rollout state belongs on the trace.
+    """
 
     NEEDS_CONTAINER: ClassVar[bool] = False
-    """Whether this task only runs in a container runtime (docker/prime). When True the
-    Environment refuses the subprocess runtime — for tasks whose work only makes sense
-    inside a per-task image (e.g. a SWE repo sandbox)."""
 
     tools: ClassVar[tuple[type[Toolset], ...]] = ()
-    """TASK-scoped tool server classes exposing this task's tools to the model —
-    `vf.Toolset`s (classes with `@vf.tool` methods), each launched per rollout (its
-    `ToolsetConfig`: colocated in the harness's runtime, or its own). Declarative: name
-    the classes; the framework builds each instance with the config `server_config`
-    resolves off `self.config`. Empty by default. An eval-wide server is declared on
-    `Taskset.tools` instead — scope is where you register, not a flag."""
 
     user: ClassVar[type[User] | None] = None
-    """The task's user simulator class — structurally a tool server (an MCP server
-    with a runtime), but driven by the framework, not exposed to the model. After
-    each model turn the interception server calls its `respond` tool and injects the
-    reply as a user turn. Declarative like `tools`; None by default — set it to make
-    the task a simulated multi-turn conversation (e.g. a TextArena game)."""
 
     def __init__(self, data: DataT, config: ConfigT | None = None) -> None:
         self.data = data
-        if config is None:
-            # Default to the *declared* config type's defaults, so a task constructed
-            # anywhere is complete out of the box; a config that can't default fails
-            # eagerly, at construction.
-            try:
-                config = task_config_cls(type(self))()  # type: ignore[assignment]
-            except Exception as exc:
-                raise TaskError(
-                    f"{type(self).__name__} was built without a config and its "
-                    f"{task_config_cls(type(self)).__name__} can't be default-"
-                    f"constructed — pass `config=...`"
-                ) from exc
-        self.config = config
-
-    @classmethod
-    def from_trace(cls, trace: Trace, *, config: ConfigT | None = None) -> Self:
-        """Derive a task from the trace of a previous rollout — the opt-in constructor
-        for tasks that are not loaded from a taskset (e.g. a multi-agent step spawning a
-        follow-up task from a finished trajectory). The trace is a *bare* `Trace`: its
-        task/state need not be this task's declared types — the override decides what to
-        read off it and how to build the new row. Not implemented by default; a task that
-        implements it declares it can be spawned from a finished rollout. The config is
-        the explicit `config` if given, else the declared type's defaults (the trace
-        carries data only — configs come from whoever spawns the task)."""
-        raise NotImplementedError(
-            f"{cls.__name__} cannot be constructed from a trace — override "
-            f"`from_trace` to define how a finished rollout spawns this task"
-        )
+        self.config = config if config is not None else task_config_cls(type(self))()
 
     def plugged_judges(self) -> list[Judge]:
-        """The runtime `Judge` objects for this task's plugged judges — resolved from
-        `config.judges` alone (`--taskset.task.judges`; judges are config, never row
-        data). Built fresh per call — a judge is a cheap value (its HTTP client is
-        opened per call inside `Judge.complete` and closed when it returns), so nothing
-        is shared or cached."""
         from verifiers.v1.loaders import load_judge
 
         return [load_judge(config) for config in self.config.judges]
 
     def server_config(self, server_cls: type) -> BaseConfig:
-        """The config a declared server class (`tools` / `user`) is built with, resolved
-        off `self.config` (see `resolve_server_config`: exact type match, else unique
-        isinstance match, else default-constructed). Override to pair explicitly (the
-        escape hatch for exotic setups, e.g. two servers sharing one config type)."""
         return resolve_server_config(type(self).__name__, self.config, server_cls)
 
     def tool_servers(self) -> list[Toolset]:
-        """Build this task's tool servers: one instance per class in `tools`, each
-        constructed with `server_config(cls)`. Called by the framework per rollout (and
-        once per eval for `shared` placements); a Toolset instance is a launcher spec —
-        the server itself runs as its own process (see `verifiers.v1.mcp`)."""
         return [cls(self.server_config(cls)) for cls in type(self).tools]
 
     def user_server(self) -> User | None:
-        """Build this task's user simulator from the `user` declaration (None when the
-        task doesn't declare one), constructed like a tool server."""
         cls = type(self).user
         return cls(self.server_config(cls)) if cls is not None else None
 
     async def setup(self, trace: Trace, runtime: Runtime) -> None:
-        """Prepare the live runtime for this task, after `runtime.start()` and before the
-        harness runs. No-op by default; override to run per-task setup in the runtime (e.g.
-        a SWE row checking out its base commit — read the row off `self.data`). Errors
-        propagate and fail the rollout.
-
-        Like the scoring hooks, `setup` declares the inputs it needs *by parameter name* and
-        the framework injects them: any subset of `trace`, `runtime`. The trace (and its
-        per-rollout `trace.state`) already exists when `setup` runs, so an override may
-        stash per-rollout state there — e.g. `setup(self, trace, runtime)` or just
-        `setup(self, runtime)` both work."""
         return None
 
     async def finalize(self, trace: Trace, runtime: Runtime) -> None:
-        """Post-process the live runtime after the harness finishes, before scoring. No-op
-        by default; override to do per-rollout work the rewards depend on — apply/commit the
-        agent's diff, run a build, snapshot state, scrape runtime artifacts into `trace.info`.
-        Runs while the runtime is still live (after generation, before `@reward`/`@metric`); the
-        symmetric counterpart to `setup`. Declares its inputs by parameter name, like `setup`.
-        Errors propagate and fail the rollout."""
         return None
 
     async def validate(self, runtime: Runtime) -> bool:
-        """Check the task is well-formed and solvable, independent of any model rollout — run
-        by the `validate` entrypoint, never during a rollout. Valid (True) by default;
-        override to assert the ground truth holds (e.g. a SWE row applying its gold patch and
-        running its tests, or gsm8k confirming the verifier accepts the gold answer). Runs in
-        a live runtime started for the task with `setup` already applied (a pure-data check
-        can ignore it). Return False — or raise — to mark the task invalid; the entrypoint
-        records the reason (the raised error's message)."""
         return True
-
-    # ---- scoring ---------------------------------------------------------------
 
     async def score(
         self,
         trace: Trace,
         runtime: Runtime | None = None,
     ) -> None:
-        """Score one rollout: run all `@metric`, then `@reward`, then the plugged judges
-        (see `TaskConfig.judges`) over its trace, concurrently within each phase. Each
-        metric is recorded in `trace.metrics` (a number, or a mapping merged in); each
-        reward and judge verdict (weighted — likewise a number or a mapping merged in) in
-        `trace.rewards`, which `trace.reward` sums. Signals declare what they need —
-        `trace`, `runtime` (`self` is the task; the row is `self.data`) — so a reward is
-        either a pure function of the trace or runs read/write/exec in that (still-live)
-        runtime, e.g. a verifier script.
-
-        `runtime` may be `None` — the offline path taken by `replay`, which re-scores a saved
-        trace with no live runtime. Signals that declare a `runtime` parameter are then skipped
-        (they can't run without one) and logged; trace-only `@metric`/`@reward`s and the plugged
-        judges (which grade from the trace) still run, overwriting their own keys and leaving the
-        skipped signals' previously-recorded values untouched. With a runtime present (the eval
-        path) nothing is skipped."""
         judges = self.plugged_judges()
-        # Judges receive the row (`task`): they read reference fields and `prompt_text`
-        # off the data, never the behavior.
         available = {"task": self.data, "trace": trace}
         if runtime is not None:
             available["runtime"] = runtime
 
-        def can_run(fn) -> bool:
-            # A signal that *requires* a runtime can't run without one, so skip it when replaying.
-            return runtime is not None or not _requires_runtime(fn)
-
         async with boundary(TaskError, f"task {type(self).__name__} scoring"):
-            metrics = [fn for fn in discover_decorated(self, "metric") if can_run(fn)]
-            metric_results = (
-                [await invoke(fn, available) for fn in metrics]
-                if len(metrics) < 2
-                else await asyncio.gather(*(invoke(fn, available) for fn in metrics))
-            )
-            for fn, result in zip(metrics, metric_results):
-                if isinstance(result, Mapping):
-                    trace.record_metrics(result)
-                else:
-                    trace.record_metric(fn.__name__, result)
-            rewards = [fn for fn in discover_decorated(self, "reward") if can_run(fn)]
-            reward_results = (
-                [await invoke(fn, available) for fn in rewards]
-                if len(rewards) < 2
-                else await asyncio.gather(*(invoke(fn, available) for fn in rewards))
-            )
-            for fn, result in zip(rewards, reward_results):
-                weight = getattr(fn, "_vf_weight", 1.0)
-                if isinstance(result, Mapping):
-                    for name, value in result.items():
-                        trace.record_reward(name, value, weight)
-                else:
-                    trace.record_reward(fn.__name__, result, weight)
-            runnable_judges = [judge for judge in judges if can_run(judge.score)]
+            metrics = discover_decorated(self, "metric")
+            rewards = discover_decorated(self, "reward")
             if runtime is None:
-                # Exactly the signals `can_run` filtered out above — those requiring a runtime
-                # (a `runtime` param with no default). Signals whose `runtime` has a default run
-                # offline and are not reported as skipped.
-                skipped = self.offline_skipped()
+                skipped = [
+                    fn.__name__ for fn in (*metrics, *rewards) if _requires_runtime(fn)
+                ] + [
+                    judge.reward_name
+                    for judge in judges
+                    if _requires_runtime(judge.score)
+                ]
                 if skipped:
                     logger.info(
                         "score: no runtime — skipped runtime-dependent signals: %s",
                         skipped,
                     )
-            judge_results = (
-                [await invoke(judge.score, available) for judge in runnable_judges]
-                if len(runnable_judges) < 2
-                else await asyncio.gather(
-                    *(invoke(judge.score, available) for judge in runnable_judges)
+                metrics = [fn for fn in metrics if not _requires_runtime(fn)]
+                rewards = [fn for fn in rewards if not _requires_runtime(fn)]
+                judges = [
+                    judge for judge in judges if not _requires_runtime(judge.score)
+                ]
+
+            metric_results = await invoke_all(metrics, available)
+            for fn, result in zip(metrics, metric_results):
+                _record_result(trace, fn, fn.__name__, result, "signals")
+            reward_results = await invoke_all(rewards, available)
+            for fn, result in zip(rewards, reward_results):
+                _record_result(
+                    trace,
+                    fn,
+                    fn.__name__,
+                    result,
+                    "signals",
+                    getattr(fn, "_vf_weight", 1.0),
                 )
+            judge_results = await invoke_all(
+                [judge.score for judge in judges], available
             )
-            for judge, result in zip(runnable_judges, judge_results):
-                if isinstance(result, Mapping):
-                    for name, value in result.items():
-                        trace.record_reward(name, value, judge.config.weight)
-                else:
-                    trace.record_reward(judge.reward_name, result, judge.config.weight)
-            if runtime is not None and isinstance(trace.info, dict):
-                # Map each runtime-requiring signal to the reward/metric keys it actually
-                # produced — a Mapping result records under its own keys, not the method
-                # name — so an offline re-score (`replay`) can restore exactly these
-                # (`offline_skipped` names the signals; this maps them to their keys).
-                def keys(result, fallback: str) -> list[str]:
-                    return list(result) if isinstance(result, Mapping) else [fallback]
-
-                # Grouped (not a dict-comprehension union): same-named signals must
-                # merge their keys, not overwrite each other's. Signals and judges are
-                # recorded separately — on restore, a signal's keys are intrinsic to the
-                # task, while a judge's only apply if that judge is still attached.
-                # Only *returned* keys are attributable: signals run concurrently, so a
-                # direct `record_metric` write can't be traced to its writer — `replay`
-                # restores source metrics wholesale instead (fill-if-missing, after
-                # re-scoring).
-                signals: dict[str, list[str]] = {}
-                for fn, result in (
-                    *zip(metrics, metric_results),
-                    *zip(rewards, reward_results),
-                ):
-                    if _requires_runtime(fn):
-                        signals.setdefault(fn.__name__, []).extend(
-                            keys(result, fn.__name__)
-                        )
-                judge_keys: dict[str, list[str]] = {}
-                for judge, result in zip(runnable_judges, judge_results):
-                    if _requires_runtime(judge.score):
-                        judge_keys.setdefault(judge.reward_name, []).extend(
-                            keys(result, judge.reward_name)
-                        )
-                if signals or judge_keys:
-                    trace.info["offline_keys"] = {
-                        "signals": signals,
-                        "judges": judge_keys,
-                    }
-
-    def offline_skipped(self) -> list[str]:
-        """The names of the signals `score` skips when re-scoring without a runtime (they
-        declare a default-less `runtime` parameter): this task's `@metric`/`@reward`s plus
-        its plugged judges."""
-        signals = [
-            fn.__name__
-            for fn in (
-                *discover_decorated(self, "metric"),
-                *discover_decorated(self, "reward"),
-            )
-            if _requires_runtime(fn)
-        ]
-        judges = [
-            judge.reward_name
-            for judge in self.plugged_judges()
-            if _requires_runtime(judge.score)
-        ]
-        return signals + judges
+            for judge, result in zip(judges, judge_results):
+                _record_result(
+                    trace,
+                    judge.score,
+                    judge.reward_name,
+                    result,
+                    "judges",
+                    judge.config.weight,
+                )
 
     def restore_offline(
         self,
@@ -547,65 +284,47 @@ class Task(Generic[DataT, StateT, ConfigT]):
         entries survive — and trace-only signals that read them (e.g. a `@reward` reading a
         runtime `@metric`'s entry) see them while re-scoring. Restores exactly the keys the
         source run's runtime-requiring signals recorded (`info["offline_keys"]` — source-run
-        truth, so it works even on a base-`Task` fallback that carries no behavior), plus
-        `@group_reward` keys (no group context offline — see `score_group`); traces
-        predating that map fall back to the signal names (`offline_skipped`). A judge's
-        entries restore only while that judge is still attached — a removed judge leaves no
-        stale entry. This covers rewards and *returned* metric keys; metrics recorded by
-        direct `record_metric` writes are unattributable and are restored by `replay`
-        itself, wholesale, after re-scoring (fill-if-missing)."""
-        recorded = (
-            trace.info.get("offline_keys") if isinstance(trace.info, dict) else None
-        )
-        if isinstance(recorded, Mapping):
-            attached = {
-                judge.reward_name
-                for judge in self.plugged_judges()
-                if _requires_runtime(judge.score)
-            }
-            keys = (
-                [
-                    key
-                    for signal_keys in recorded.get("signals", {}).values()
-                    for key in signal_keys
-                ]
-                + [
-                    key
-                    for name, judge_keys in recorded.get("judges", {}).items()
-                    if name in attached
-                    for key in judge_keys
-                ]
-                + list(recorded.get("group", []))
-            )
-        else:
-            # Group rewards join the fallback too: like the runtime-requiring signals,
-            # an offline re-score can't recompute them (they need the whole group).
-            keys = self.offline_skipped() + [
-                fn.__name__ for fn in discover_decorated(self, "group_reward")
+        truth), plus `@group_reward` keys (no group context offline — see `score_group`). A
+        judge's entries restore only while that judge is still attached — a removed judge
+        leaves no stale entry. This covers rewards and *returned* metric keys; metrics
+        recorded by direct `record_metric` writes are unattributable and are restored by
+        `replay` itself, wholesale, after re-scoring (fill-if-missing)."""
+        recorded = trace.info.get("offline_keys")
+        if not recorded:
+            return
+        # Only restore judge keys for judges still configured.
+        attached = {
+            judge.reward_name
+            for judge in self.plugged_judges()
+            if _requires_runtime(judge.score)
+        }
+        keys = (
+            [
+                key
+                for signal_keys in recorded.get("signals", {}).values()
+                for key in signal_keys
             ]
+            + [
+                key
+                for name, judge_keys in recorded.get("judges", {}).items()
+                if name in attached
+                for key in judge_keys
+            ]
+            + list(recorded.get("group", []))
+        )
         for key in keys:
-            if key in prior_rewards and key not in trace.rewards:
+            if key in prior_rewards:
                 trace.rewards[key] = prior_rewards[key]
-            if key in prior_metrics and key not in trace.metrics:
+            if key in prior_metrics:
                 trace.metrics[key] = prior_metrics[key]
 
     async def score_group(self, traces: list[Trace]) -> None:
-        """Score a group of rollouts of this task: run every `@group_reward` over all
-        the traces at once (pairwise/preference rewards), each returning one score per
-        trace, aligned to `traces`. A group reward declares what it needs — `traces`
-        (`self` is the shared task) — and compares trace metadata (anything from the
-        runtime is recorded per rollout as a `@metric` first). Scores are weighted into
-        each trace's reward, alongside the per-rollout rewards. No-op without `@group_reward`s."""
         rewards = discover_decorated(self, "group_reward")
         if not rewards:
             return
         available = {"task": self.data, "traces": traces}
         async with boundary(TaskError, f"task {type(self).__name__} group scoring"):
-            reward_results = (
-                [await invoke(fn, available) for fn in rewards]
-                if len(rewards) < 2
-                else await asyncio.gather(*(invoke(fn, available) for fn in rewards))
-            )
+            reward_results = await invoke_all(rewards, available)
             for fn, scores in zip(rewards, reward_results):
                 if len(scores) != len(traces):
                     raise ValueError(
@@ -615,13 +334,10 @@ class Task(Generic[DataT, StateT, ConfigT]):
                 weight = getattr(fn, "_vf_weight", 1.0)
                 for trace, score in zip(traces, scores):
                     trace.record_reward(fn.__name__, score, weight)
-            # An offline re-score (`replay`) has no group context, so group rewards can
-            # never be recomputed: record their keys for `restore_offline`. Merges into
-            # the map `score` stamped (each rollout scores before the group does).
+            # Replay has no group context, so preserve these scores by key.
             group_keys = [fn.__name__ for fn in rewards]
             for trace in traces:
-                if isinstance(trace.info, dict):
-                    trace.info.setdefault("offline_keys", {})["group"] = group_keys
+                trace.info.setdefault("offline_keys", {})["group"] = group_keys
 
 
 TaskT = TypeVar("TaskT", bound=Task)

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -9,7 +9,7 @@ it in the task type with the config's task-facing subtree:
 
 Load-time knobs (dataset, split, seed) live on the taskset config; the task-facing knobs
 under its `task` subtree (`TasksetConfig.task`, a `TaskConfig`, everything under
-`--taskset.task.*`); an eval-wide shared tool server is declared on `tools` with its knobs
+`--taskset.task.*`); a worker-scoped shared tool server is declared on `tools` with its knobs
 at the taskset level (`--taskset.tools.*`). All per-task behavior — runtime prep, tools,
 user simulation, `@reward`/`@metric` scoring — lives on the `Task` (see
 `verifiers.v1.task`).
@@ -22,13 +22,13 @@ replay can rebuild every saved row as the declared type's data and re-wrap it.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar, Generic, get_args, get_origin
+from typing import TYPE_CHECKING, ClassVar, Generic
 
 from pydantic import SerializeAsAny
 from pydantic_config import BaseConfig
 from typing_extensions import TypeVar
 
-from verifiers.v1.task import Task, TaskConfig, TaskT, resolve_server_config
+from verifiers.v1.task import TaskConfig, TaskT, resolve_server_config
 from verifiers.v1.types import ID
 from verifiers.v1.utils.install import env_name
 
@@ -37,23 +37,13 @@ if TYPE_CHECKING:
 
 
 class TasksetConfig(BaseConfig):
-    """Base taskset config: load-time knobs (dataset, split, seed, ...) plus the task's own
-    config under `task`. Subclass to add task-generation knobs; narrow `task` to your
-    `TaskConfig` subclass when the task reads knobs (`task: MyTaskConfig = MyTaskConfig()`),
-    so `--taskset.task.*` flags validate against it. `load()` passes `config.task` to every
-    task it constructs."""
-
     id: ID = ""
-    """The taskset id, which selects this taskset: a local package, or an
-    `org/name[@version]` package installed on demand from the Environments Hub (see
-    `ID`). Set via `--taskset.id`."""
+    """Local package or Hub `org/name[@version]`, set with `--taskset.id`."""
     task: SerializeAsAny[TaskConfig] = TaskConfig()
-    """The task-facing config, passed to every constructed task (`Task.config`): server
-    placement, judges, scoring knobs. Everything under `--taskset.task.*`."""
+    """Config passed to each task, under `--taskset.task.*`."""
 
     @property
     def name(self) -> str:
-        """The taskset's package name (the id with any org / version stripped)."""
         return env_name(self.id)
 
 
@@ -61,19 +51,8 @@ TasksetConfigT = TypeVar("TasksetConfigT", bound=TasksetConfig, default=TasksetC
 
 
 class Taskset(Generic[TaskT, TasksetConfigT]):
-    """Generic over its task and config types, so `self.config` and `load` are fully
-    typed (and the loaders can narrow CLI flags / type the wire trace off the generics).
-    Subclass: implement `load`, constructing each task from its row's data and the
-    config's task subtree (`MyTask(data, self.config.task)`)."""
-
     tools: ClassVar[tuple[type[Toolset], ...]] = ()
-    """TASKSET-scoped (shared) tool server classes: each is launched ONCE per eval by the
-    Environment and reached by every rollout — for an expensive, task-agnostic resource (a
-    corpus, an index) built once. Declarative like `Task.tools`, but the scope is the
-    registration site: taskset = eval-wide, task = per-rollout. A shared toolset declares a
-    `SharedToolsetConfig` (no `colocated` — there's no single harness runtime), resolved off
-    the TASKSET config's fields by `server_config` (so its knobs live at `--taskset.*`, not
-    `--taskset.task.*`); it never receives a task (`setup_task` is not called)."""
+    """Tool server classes shared by one environment worker's rollouts."""
 
     def __init__(self, config: TasksetConfigT) -> None:
         self.config = config
@@ -82,27 +61,7 @@ class Taskset(Generic[TaskT, TasksetConfigT]):
         raise NotImplementedError
 
     def server_config(self, server_cls: type) -> BaseConfig:
-        """The config a `tools` entry is built with, resolved off `self.config` (the
-        taskset config; see `resolve_server_config`). Override to pair explicitly."""
         return resolve_server_config(type(self).__name__, self.config, server_cls)
 
     def tool_servers(self) -> list[Toolset]:
-        """Build this taskset's shared tool servers: one instance per class in `tools`,
-        each constructed with `server_config(cls)`. Called once per eval by
-        `Environment.shared_tools`; a Toolset instance is a launcher spec — the server
-        itself runs as its own process (see `verifiers.v1.mcp`)."""
         return [cls(self.server_config(cls)) for cls in type(self).tools]
-
-    @classmethod
-    def task_type(cls) -> type[Task]:
-        """The declared `TaskT`, read off the `Taskset[TaskT, TasksetConfigT]` generic
-        across the MRO (most-derived specialization wins, so a thin wrapper re-binding only
-        the config inherits its parent's task type). Falls back to the base `Task` when no
-        subclass is given."""
-        for klass in cls.__mro__:
-            for orig in getattr(klass, "__orig_bases__", ()):
-                if get_origin(orig) is Taskset:
-                    for arg in get_args(orig):
-                        if isinstance(arg, type) and issubclass(arg, Task):
-                            return arg
-        return Task

--- a/verifiers/v1/tasksets/__init__.py
+++ b/verifiers/v1/tasksets/__init__.py
@@ -1,8 +1,4 @@
-"""Built-in tasksets, resolved by id (`--taskset.id <id>`) as `verifiers.v1.tasksets.<id>`.
-
-Re-exports each taskset's class + config off the package. `textarena` is not re-exported
-here — it imports the optional `textarena` dependency at module load — but still resolves as
-`verifiers.v1.tasksets.textarena`."""
+"""Built-in V1 tasksets."""
 
 from verifiers.v1.tasksets.harbor import HarborConfig, HarborTaskset
 from verifiers.v1.tasksets.lean import (

--- a/verifiers/v1/tasksets/harbor/taskset.py
+++ b/verifiers/v1/tasksets/harbor/taskset.py
@@ -1,21 +1,13 @@
-"""harbor: run a Harbor (Terminal-Bench) dataset.
+"""Harbor tasksets backed by Harbor Hub packages.
 
-`dataset` is a Harbor Hub package id (e.g. "org/name" or "org/name@ref"),
-downloaded through the installed Harbor CLI and cached on first use. Each task
-dir ships task.toml + instruction.md (+ tests/, solution/, environment/).
-Defaults to the registry `harbor/hello-world` dataset.
+The Harbor CLI downloads and caches each task directory. Its verifier runs in the
+same runtime the harness edited, then writes the score to
+``/logs/verifier/reward.txt``.
 
-The harness runs in a container and edits /app; then the task's verifier
-(tests/test.sh) runs in the SAME container and the reward it writes to
-/logs/verifier/reward.txt becomes the score. The verification lives on the
-task (the `solved` reward), so a harbor task runs under ANY harness.
-
-A task's declared [environment].docker_image becomes a first-class `Task.image`
-the Environment injects into the runtime (docker/prime both pull it). A task whose
-environment is only a `Dockerfile` has no pullable image — we don't build Dockerfiles
-(a locally-built image isn't pullable by a remote sandbox) — so it's rejected unless
-`ignore_dockerfile`, which runs it on the harness runtime's image instead. A task with
-no environment at all also runs on that image, unless `require_image`.
+A pullable ``[environment].docker_image`` becomes ``TaskData.image``. Verifiers does
+not build Dockerfile-only environments, so those are rejected unless ``ignore_dockerfile``
+deliberately uses the harness runtime image. Tasks without an environment also use that
+image unless ``require_image`` is set.
 """
 
 import hashlib
@@ -77,17 +69,18 @@ class Author(StrictBaseModel):
 
 
 class HarborData(TaskData):
-    """A Harbor row. The base fields carry instruction.md (`prompt`), the
-    resolved container `image`, the `harness_timeout`/`scoring_timeout`/`resources`
-    (from task.toml's [harness]/[verifier]/[environment]), and [task].name/description;
-    the rest mirror [metadata]."""
+    """Parsed ``task.toml`` metadata plus the host-side verifier directory.
+
+    Base ``TaskData`` fields hold the prompt, resolved image, timeout, resources,
+    name, and description. The remaining fields mirror Harbor metadata.
+    """
 
     keywords: list[str] = []
     authors: list[Author] = []
     difficulty: str | None = None
     category: str | None = None
     tags: list[str] = []
-    task_dir: str = Field(exclude=True)
+    task_dir: str = Field("", exclude=True)
     """Host path to the task dir; used to stage tests/ to verify, not serialized."""
     verifier_env: dict[str, str] = {}
     """Raw [verifier.env] entries (literals or `${VAR}`/`${VAR:-default}` templates).
@@ -96,14 +89,10 @@ class HarborData(TaskData):
 
 
 class HarborTask(Task[HarborData]):
-    """Harbor behavior: `solved` stages the row's harbor verifier into the live
-    runtime and reads back the reward it writes."""
+    """Stage and run Harbor's verifier inside the task's live runtime."""
 
     @reward(weight=1.0)
     async def solved(self, runtime: Runtime) -> float:
-        # Stage the task's tests into the live runtime, run its harbor verifier, and
-        # read back the reward it writes — runtime-opaque (write/run/read hide whether
-        # that's the host fs or across a container boundary), so it scores under any harness.
         await runtime.write(
             "/tmp/tests.tgz", make_tar(Path(self.data.task_dir) / "tests")
         )
@@ -126,7 +115,6 @@ class HarborTask(Task[HarborData]):
 
 
 def harbor_cli() -> str:
-    """Return the Harbor CLI installed in the active Python environment."""
     scripts_dir = Path(sys.executable).parent
     harbor_bin = shutil.which("harbor", path=str(scripts_dir))
     if harbor_bin is None:
@@ -182,12 +170,7 @@ def download_command(config: HarborConfig, output_dir: Path) -> list[str]:
 
 
 def dataset_dir(config: HarborConfig) -> Path:
-    """Download a Harbor task or dataset package, cached on first use.
-
-    Harbor Hub refs are tags, integer revisions, or ``sha256:`` digests. Legacy registry
-    refs are selected through Harbor's CLI selectors (`repo`, `registry_path`,
-    `registry_url`).
-    """
+    """Download/cache a Hub or legacy-registry package selected by the config."""
     out = cache_dir(config)
     if out.is_dir():
         return out
@@ -227,13 +210,12 @@ def resolve_image(
     require_image: bool,
     ignore_dockerfile: bool = False,
 ) -> str | None:
-    """The task's declared registry image (usable by docker or prime). A pullable
-    `[environment].docker_image` is used directly. A task whose environment is a
-    `Dockerfile` is rejected — we don't build Dockerfiles, and running it on the default
-    image would silently score against the wrong environment (e.g. SWE-bench's `/testbed`
-    repo would be missing) — unless `ignore_dockerfile`, which returns None to run it on the
-    harness runtime's image. A task with no environment at all runs on that image too, unless
-    `require_image`. None means "use the runtime's own image"."""
+    """Choose a pullable image without silently ignoring a declared Dockerfile.
+
+    ``None`` tells the runtime to keep the harness image. That is the intended
+    fallback for tasks with no environment, but would score a Dockerfile task in
+    the wrong environment unless the user explicitly opts in.
+    """
     declared = config.get("environment", {}).get("docker_image")
     if declared:
         return declared
@@ -254,7 +236,8 @@ def resolve_image(
 
 
 def parse_resources(env: dict, multiplier: float = 1.0) -> TaskResources:
-    """Map a task.toml [environment] block to TaskResources (0 gpus -> unset)."""
+    # Harbor reports memory and storage in MB; TaskResources stores GB. A zero
+    # GPU count means no GPU request rather than the string "0".
     return TaskResources(
         cpu=env["cpus"] * multiplier if env.get("cpus") else None,
         memory=env["memory_mb"] / 1024 * multiplier if env.get("memory_mb") else None,
@@ -264,11 +247,10 @@ def parse_resources(env: dict, multiplier: float = 1.0) -> TaskResources:
 
 
 def parse_task(task_dir: Path, idx: int, harbor_config: HarborConfig) -> HarborData:
-    """Read a harbor task dir (task.toml + instruction.md) into a typed task,
-    handling both the [task].authors and legacy [metadata].author_name layouts."""
     config = tomllib.loads((task_dir / "task.toml").read_text())
     task, meta = config.get("task", {}), config.get("metadata", {})
     authors = [Author(**a) for a in task.get("authors", [])]
+    # Older registry entries stored one author in [metadata].
     if not authors and meta.get("author_name"):
         authors = [Author(name=meta["author_name"], email=meta.get("author_email"))]
     harness_timeout = config.get("agent", {}).get("timeout_sec")
@@ -306,23 +288,21 @@ def parse_task(task_dir: Path, idx: int, harbor_config: HarborConfig) -> HarborD
 
 
 def verifier_env(task: HarborData) -> dict[str, str]:
-    """The env a task's verifier runs with: its [verifier.env] templates resolved against
-    the host environment (`${VAR}` / `${VAR:-default}`, harbor's own semantics). Resolution
-    is deferred to scoring time so resolved secrets never land on the serialized task."""
+    """Resolve templates at scoring time so host secrets are never serialized."""
     if not task.verifier_env:
         return {}
-    # Lazy: `harbor` is the optional extra, but scoring implies the dataset was
-    # downloaded, which already required it.
+
+    # Harbor is an optional dependency, so importing this module must still work
+    # for users who do not install the Harbor extra.
     from harbor.utils.env import resolve_env_vars
 
     return resolve_env_vars(task.verifier_env)
 
 
-# Harbor test directories are immutable after download, so repeated rollouts can reuse
-# the latest archive. One entry bounds retained memory to one task.
+# Downloaded test directories are immutable. Cache only the latest archive to
+# bound memory while reusing it across rollouts of the current task.
 @lru_cache(maxsize=1)
 def make_tar(directory: Path) -> bytes:
-    """Tar a directory's contents (flat) into a gzipped tarball."""
     buffer = io.BytesIO()
     with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
         for item in sorted(directory.iterdir()):

--- a/verifiers/v1/tasksets/lean/taskset.py
+++ b/verifiers/v1/tasksets/lean/taskset.py
@@ -1,17 +1,10 @@
-"""lean: a reusable Lean 4 theorem-proving taskset base.
+"""Lean 4 theorem-proving tasks backed by Hugging Face datasets.
 
-Loads a Lean dataset (any HuggingFace dataset with a formal-statement column),
-plants a ``sorry`` starter file in a Mathlib sandbox at ``setup``, and rewards a
-clean ``lake env lean`` compile — with a reward-hacking guard that pins the
-original theorem signature — at scoring time. It exposes **no tools**: the agent
-reads, edits, and compiles ``proof.lean`` through whichever shell-capable harness
-drives the rollout (``mini-swe-agent`` / ``rlm`` / ``bash``), so a lean task runs
-under ANY harness.
-
-This is a *base*: point it at a dataset via ``--taskset.dataset-name`` (+ column
-config), or subclass it in a thin per-dataset package that just sets the config
-defaults — the way ``swebench-verified-v1`` etc. wrap ``HarborTaskset``. The
-per-dataset packages live in research-environments.
+Each task plants a ``sorry``-based starter file, lets any container-capable
+harness edit it, and rewards a clean ``lake env lean`` compile. The original
+theorem signature must remain present, which prevents replacing the assigned
+statement with an easier theorem. Dataset-specific packages can subclass this
+taskset and only supply column mappings.
 """
 
 from __future__ import annotations
@@ -23,8 +16,8 @@ from pydantic_config import BaseConfig
 from verifiers.v1.decorators import reward
 from verifiers.v1.runtimes import Runtime
 from verifiers.v1.state import State
-from verifiers.v1.task import Task, TaskData, TaskResources
-from verifiers.v1.taskset import TaskConfig, Taskset, TasksetConfig
+from verifiers.v1.task import Task, TaskConfig, TaskData, TaskResources
+from verifiers.v1.taskset import Taskset, TasksetConfig
 from verifiers.v1.tasksets.lean.scoring import (
     build_starter_file,
     expected_protected_signature,
@@ -33,8 +26,7 @@ from verifiers.v1.tasksets.lean.scoring import (
 )
 from verifiers.v1.trace import Trace
 
-# Default sandbox image: Lean v4.27 + Mathlib v4.27 (PI Research team registry).
-# A per-dataset package overrides ``docker_image`` with its version-matched image.
+# Lean v4.27 with Mathlib v4.27.
 DEFAULT_DOCKER_IMAGE = "team-clyvldofb0000gg1kx39rgzjq/lean-tactic:mathlib-v4.27.0-v3"
 LEAN_PROJECT_PATH = "/workspace/mathlib4"
 PROOF_FILE_PATH = "/tmp/proof.lean"
@@ -43,8 +35,6 @@ DEFAULT_SYSTEM_PROMPT = "You are an expert Lean 4 theorem prover working with Ma
 
 
 class LeanDatasetConfig(BaseConfig):
-    """Which HuggingFace dataset to load and how to read its columns."""
-
     name: str
     """HuggingFace dataset id (required; each per-dataset package sets it)."""
     split: str = "train"
@@ -59,9 +49,6 @@ class LeanDatasetConfig(BaseConfig):
 
 
 class LeanTaskConfig(TaskConfig):
-    """The knobs lean's hooks and reward read (``self.config``): the sandbox layout and
-    the compile budget. Everything under ``--taskset.task.*``."""
-
     lean_project_path: str = LEAN_PROJECT_PATH
     proof_file_path: str = PROOF_FILE_PATH
     compile_timeout: int = 300
@@ -89,11 +76,8 @@ class LeanData(TaskData):
 
 class LeanTask(Task[LeanData, State, LeanTaskConfig]):
     NEEDS_CONTAINER = True
-    # The row is `self.data` (LeanData); the sandbox layout + compile budget are
-    # config knobs, read off `self.config` (LeanTaskConfig).
 
     async def _compile(self, runtime: Runtime) -> tuple[bool, str, int]:
-        """Run ``lake env lean`` on the proof file; returns (compiled, output, exit_code)."""
         cmd = (
             f"cd {shlex.quote(self.config.lean_project_path)} && "
             f"timeout {self.config.compile_timeout} lake env lean "
@@ -104,7 +88,6 @@ class LeanTask(Task[LeanData, State, LeanTaskConfig]):
         return parse_compile_output((result.stdout or "") + (result.stderr or ""))
 
     async def setup(self, runtime: Runtime) -> None:
-        """Plant the ``sorry`` starter file in the sandbox before the agent runs."""
         content = build_starter_file(
             self.data.formal_statement,
             header=self.data.header,
@@ -115,21 +98,11 @@ class LeanTask(Task[LeanData, State, LeanTaskConfig]):
 
     @reward(weight=1.0)
     async def lean_compiled(self, trace: Trace, runtime: Runtime) -> float:
-        """1.0 iff the final proof compiles cleanly (exit 0, no ``sorry``) and the
-        protected theorem signature is intact; 0.0 otherwise.
-
-        Reads the final ``proof.lean`` back through the live runtime, runs the
-        host-side signature guard (with comment/string stripping), then re-runs
-        ``lake env lean``. Diagnostics land on ``trace.info`` for inspection.
-        """
+        """Require both the assigned signature and a clean Lean compile."""
         if trace.has_error:
             return 0.0
 
-        # Read the final proof back. A read failure here is genuinely exceptional
-        # (setup planted the file; the agent edits it in-sandbox), so let it
-        # propagate as a scoring error rather than swallow an infra/sandbox failure
-        # into a false-negative 0. (The prime runtime collapses every read error
-        # into SandboxError, so there's no file-not-found type to narrow to.)
+        # Setup created this file, so a read failure is an infrastructure error.
         current = (await runtime.read(self.config.proof_file_path)).decode(
             "utf-8", "replace"
         )
@@ -152,15 +125,7 @@ class LeanTask(Task[LeanData, State, LeanTaskConfig]):
         return 1.0 if compiled else 0.0
 
     async def validate(self, runtime: Runtime) -> bool:
-        """Compile the gold proof: substitute it for ``sorry`` and check it type-checks.
-
-        ``False`` is reserved for a row whose gold proof exists but **fails to
-        compile** (a genuinely bad/unprovable row). A row with **no** gold proof
-        (statement-only datasets, or an empty proof column) returns ``True`` — there
-        is nothing to refute, matching the base ``Task.validate`` no-op; flagging
-        it ``invalid`` would both swamp the report on statement-only datasets and
-        mask the rows whose gold actually fails on a sparse-gold dataset.
-        """
+        """Compile the gold proof; rows without one have nothing to preflight."""
         gold = (self.data.formal_proof or "").rstrip()
         if not gold:
             return True
@@ -190,10 +155,7 @@ class LeanTaskset(Taskset[LeanTask, LeanConfig]):
             num_proc=8,
         )
 
-        # Fail loud on a misconfigured column name — otherwise a typo is silently
-        # treated as a missing/empty field (e.g. a wrong proof_column makes every
-        # gold check vacuously fail), or a statement_column typo raises a raw
-        # KeyError on the first row instead of this clear error.
+        # Validate optional columns before empty-value fallbacks hide a typo.
         for label, col in (
             ("statement_column", ds.statement_column),
             ("header_column", ds.header_column),
@@ -209,15 +171,12 @@ class LeanTaskset(Taskset[LeanTask, LeanConfig]):
         resources = TaskResources(cpu=4, memory=4, disk=10)
         tasks: list[LeanTask] = []
         for index, row in enumerate(raw):
-            # Skip degenerate rows with no statement: there's nothing to prove, and
-            # an empty statement collapses the pinned signature to just ``:= by``,
-            # which every proof contains — so the reward-hacking guard would pass on
-            # a rewritten trivial theorem. Drop them rather than ship a free-reward task.
+            # An empty statement would reduce the signature guard to `:= by`.
             formal_statement = row[ds.statement_column]
             if not isinstance(formal_statement, str) or not formal_statement.strip():
                 continue
-            # Unset columns are None, and row.get(None) is None, so the `or`
-            # fallbacks cover both an unset column and an empty value.
+            # A disabled optional column is None; row.get(None) yields the same
+            # empty fallback as a present-but-empty column.
             header = row.get(ds.header_column) or ""
             imports = row.get(ds.imports_column) or "import Mathlib"
             gold = row.get(ds.proof_column) or ""

--- a/verifiers/v1/tasksets/textarena/taskset.py
+++ b/verifiers/v1/tasksets/textarena/taskset.py
@@ -1,18 +1,8 @@
-"""textarena — TextArena games as a v1 taskset, driven by a user simulator.
+"""Seeded TextArena games driven by a colocated user simulator.
 
-Each task is one episode of a TextArena game (the working example is Wordle). The model
-plays by emitting moves; the framework's interception server drives a `vf.User` (the game
-engine, `TextArenaUser` below) that replies with the game's feedback as a user turn — so a whole
-game is one rollout of alternating assistant/user turns, and the harness/program never see
-the simulator. The user simulator runs colocated in the harness's runtime (host-reachable
-for the subprocess/docker runtimes), so this taskset uses the subprocess runtime.
-
-Scoring is game-authoritative: when the episode ends the user simulator writes the game's
-own outcome (`env.state.rewards`) to `OUTCOME_FILE` in the runtime, and the reward reads it
-back — so the taskset needs no per-game guess parsing. Each task is reproduced from an RNG
-seed (carried in `info`): the taskset seeds the game to build the prompt and the
-simulator re-seeds to the same episode, so no per-game word-list or state-key knowledge is
-needed and any single-player TextArena game fits.
+The task prompt and simulator reset use the same seed so an episode can be
+reproduced. The simulator shares the harness runtime and writes the authoritative
+outcome there; scoring reads that file instead of trusting conversational text.
 """
 
 import copy
@@ -45,11 +35,7 @@ class TextArenaState(vf.State):
 
 
 class TextArenaUser(vf.User[vf.UserConfig, TextArenaState]):
-    """The TextArena game engine as a framework-driven conversation partner. Holds one game in
-    memory (set up from the task's `game` id + RNG `seed`, reproducing the taskset's episode) and,
-    per `respond`, steps the game with the model's move and returns the next observation as a user
-    turn plus whether the episode is over. When the game ends it writes the game's own outcome to
-    `OUTCOME_FILE` in the runtime, which the reward reads back."""
+    """Keep a seeded game alive across user turns in the harness process."""
 
     async def setup(self) -> None:
         if not self.config.colocated:
@@ -59,40 +45,26 @@ class TextArenaUser(vf.User[vf.UserConfig, TextArenaState]):
                 "back, so a non-colocated user (its own workspace) would always score 0. Set "
                 "`--taskset.task.user.colocated true` (the default)."
             )
-        import nltk
-
         nltk.download("words", quiet=True)
         nltk.download("averaged_perceptron_tagger_eng", quiet=True)
 
     async def setup_task(self, task) -> None:
-        # textarena derives a game's whole setup from the global RNG at reset, so seeding it
-        # reproduces the exact episode the taskset built the prompt from — no per-game keys.
-        import random
-
-        import textarena
-
-        self.env = textarena.make(
-            env_id=task.info["game"]
-        )  # per-task input, from the task
-        random.seed(task.info["seed"])  # per-task input
+        # TextArena uses Python's process-global RNG during reset.
+        random.seed(task.info["seed"])
+        self.env = ta.make(env_id=task.info["game"])
         self.env.reset(num_players=1)
 
     @staticmethod
     def _latest_feedback(observation: str) -> str:
-        """Trim feedback to the latest block (after `Feedback:` in the last `[GAME]` message) so
-        each injected user turn stays small and doesn't duplicate the history."""
+        """Drop repeated game history before sending the next user turn."""
         latest = observation.split("[GAME]")[-1].strip()
         return (
             latest.split("Feedback:")[-1].strip() if "Feedback:" in latest else latest
         )
 
     async def respond(self, message: str) -> vf.Messages:
-        import json
-
         env = self.env
-        env.step(
-            message
-        )  # TextArena parses the bracketed move out of the message itself
+        env.step(message)
         if env.state.done:
             reward = float((env.state.rewards or {}).get(0, 0.0))
             reason = str(env.state.game_info[0]["reason"])
@@ -106,9 +78,6 @@ class TextArenaUser(vf.User[vf.UserConfig, TextArenaState]):
 
 class TextArenaTaskConfig(vf.TaskConfig):
     user: vf.UserConfig = vf.UserConfig(colocated=True)
-    """Colocated is required, not a default: the simulator hands the game outcome to scoring by
-    writing `OUTCOME_FILE` into the runtime workspace that `game_reward` reads back, so it must share
-    the harness's runtime/workdir (a non-colocated user runs in its own workspace → reward always 0)."""
 
 
 class TextArenaConfig(vf.TasksetConfig):
@@ -119,24 +88,17 @@ class TextArenaConfig(vf.TasksetConfig):
         "WordLadder-v0",
         "WordSearch-v0",
     ]
-    """The TextArena game (required). The tested single-player games: Wordle / Wordle-long
-    and Hangman (guess a hidden word), WordLadder (change one letter at a time to reach a
-    target), and WordSearch (find words in a grid)."""
     num_tasks: int = 1000
-    """How many seeded episodes to generate; the eval/orchestrator selects from these."""
     task: TextArenaTaskConfig = TextArenaTaskConfig()
 
 
 class TextArenaData(vf.TaskData):
     info: dict
-    """What the user simulator needs to set up the game: the `game` id and the RNG `seed`
-    that reproduces the exact episode this task's prompt was built from."""
+    """The game id and RNG seed used by the simulator."""
 
 
 class TextArenaTask(vf.Task[TextArenaData, TextArenaState, TextArenaTaskConfig]):
     user = TextArenaUser
-    # Built with the task config's `user` field (resolved by `Task.server_config`);
-    # colocated is required — see `TextArenaTaskConfig.user`.
 
     @vf.stop
     async def game_over(self, trace: vf.Trace) -> bool:
@@ -144,21 +106,16 @@ class TextArenaTask(vf.Task[TextArenaData, TextArenaState, TextArenaTaskConfig])
 
     @vf.reward(weight=1.0)
     async def game_reward(self, runtime: vf.Runtime) -> float:
-        # The simulator wrote the game's own outcome to the runtime when the episode ended;
-        # a missing file means the game never finished (e.g. every move was invalid).
         try:
             data = await runtime.read(OUTCOME_FILE)
         except (FileNotFoundError, OSError):
+            # No outcome means the game never reached a terminal state.
             return 0.0
         return float(json.loads(data)["reward"])
 
 
 class TextArenaTaskset(vf.Taskset[TextArenaTask, TextArenaConfig]):
     def load(self) -> list[TextArenaTask]:
-        # One task per RNG seed; the simulator re-seeds to reproduce the same episode. Games
-        # that embed the per-episode setup in the prompt (WordLadder's start/target,
-        # WordSearch's grid) need the prompt built under each seed; games whose prompt
-        # is seed-invariant (Wordle, Hangman) build it once.
         nltk.download("words", quiet=True)
         nltk.download("averaged_perceptron_tagger_eng", quiet=True)
         template = ta.make(env_id=self.config.game)
@@ -169,6 +126,8 @@ class TextArenaTaskset(vf.Taskset[TextArenaTask, TextArenaConfig]):
             env.reset(num_players=1)
             return str(env.get_observation()[1])
 
+        # Reuse the first prompt when a game's initial observation is
+        # seed-invariant; otherwise each task must expose its seeded board.
         first = observation(0)
         seed_specific = observation(1) != first
         return [

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -1,13 +1,3 @@
-"""The trace: the full record of one rollout.
-
-A `Trace[DataT]` carries the typed task data plus everything produced during a
-rollout (conversation, per-turn responses, reward, metrics, timing, error). It is
-the canonical full data dump — written to disk (`traces.jsonl`) and consumed by
-the platform (visualization) and prime-rl (training). Environments subclass it to
-add typed scratch/result fields. The rollout mutates it directly; this replaces
-v1's 600-line `dict`-subclass `State` and its dual "contract version" machinery.
-"""
-
 from __future__ import annotations
 
 import logging
@@ -43,8 +33,7 @@ logger = logging.getLogger(__name__)
 
 
 class TimeSpan(StrictBaseModel):
-    """A start/end wall-clock span. `duration` is derived (seconds) — a plain property, not
-    serialized, so it never has to be stripped from a wire/disk dump (it's just `end - start`)."""
+    """Wall-clock timestamps with a derived, non-serialized duration in seconds."""
 
     start: float = 0.0
     end: float = 0.0
@@ -55,10 +44,6 @@ class TimeSpan(StrictBaseModel):
 
 
 class Timing(StrictBaseModel):
-    """Wall-clock timing for the phases of a rollout: provisioning the runtime + serving
-    (`setup`), the harness driving the conversation (`generation`), post-run work before
-    scoring (`finalize`), then scoring."""
-
     start: float = Field(default_factory=time.time)
     setup: TimeSpan = Field(default_factory=TimeSpan)
     generation: TimeSpan = Field(default_factory=TimeSpan)
@@ -67,37 +52,29 @@ class Timing(StrictBaseModel):
 
 
 class Error(StrictBaseModel):
-    """A captured error, recorded on the trace instead of crashing the rollout."""
-
     type: str
     message: str
     traceback: str | None = None
 
 
 class Branch(StrictBaseModel):
-    """A linear run of messages whose context grew without being rewritten — a root→leaf
-    path in the message graph. A conversation that compacts (or runs subagents) splits into
-    several branches; a linear one is a single branch. `messages` is the full conversation;
-    one training sample is built per branch."""
+    """A root-to-leaf graph path; each branch becomes one training sample."""
 
     index: int
     nodes: list[MessageNode]
 
     @property
     def num_turns(self) -> int:
-        """Model turns (sampled responses) in this branch — prompt-supplied assistant
-        messages don't count."""
+        """Model-sampled turns; prompt-supplied assistant messages do not count."""
         return sum(1 for n in self.nodes if n.sampled)
 
     @property
     def messages(self) -> Messages:
-        """The branch's full conversation, in order."""
         return [n.message for n in self.nodes]
 
     @property
     def token_ids(self) -> list[int]:
-        """The branch's full token sequence — every node's tokens concatenated in order
-        (final-turn prompt + every completion). The training sample's input ids."""
+        """Training input IDs formed by concatenating node token spans."""
         tokens: list[int] = []
         # Extend node spans in bulk to avoid per-token Python work.
         for node in self.nodes:
@@ -137,10 +114,7 @@ class Branch(StrictBaseModel):
 
     @property
     def multi_modal_data(self) -> MultiModalData | None:
-        """The branch's multimodal sidecar — every node's images concatenated in path (token)
-        order. None when the branch has no images. Drives the training `mm_kwargs` (the renderer
-        items per modality); the per-token `mm_token_type_ids` come from the token ids, so no
-        placeholder offsets are carried. Never persisted (node mm is transient)."""
+        """Node image data concatenated in token order for training; never persisted."""
         merged = MultiModalData()
         found = False
         for node in self.nodes:
@@ -156,11 +130,7 @@ class Branch(StrictBaseModel):
 
     @property
     def routed_experts(self) -> np.ndarray | None:
-        """The branch's MoE expert-routing array — every node's expert ids concatenated in path
-        (token) order, uint8 `[len(token_ids), layers, top_k]` aligned 1:1 with `token_ids`.
-        All-or-nothing: returns None unless every token-bearing node carries routing and the
-        concatenation matches the branch length (partial routing can't be safely aligned, so the
-        trainer skips replay). None when the rollout ran without `enable_return_routed_experts`."""
+        """uint8 `[tokens, layers, top_k]` routing; partial data returns None."""
         nodes = [n for n in self.nodes if n.token_ids]
         if not nodes or any(n.routed_experts is None for n in nodes):
             return None
@@ -170,19 +140,15 @@ class Branch(StrictBaseModel):
 
     @property
     def num_total_tokens(self) -> int:
-        """This branch's full sequence length (final-turn prompt + every completion)."""
         return sum(len(n.token_ids) for n in self.nodes)
 
     @property
     def usage(self) -> Usage | None:
-        """Provider-reported usage summed over model calls in this branch."""
         return Usage.aggregate(n.usage for n in self.nodes if n.usage is not None)
 
     @property
     def num_input_tokens(self) -> int:
-        """Input-context size: the final-turn prompt (full sequence minus the last completion).
-        Read from token ids when present (training), else from provider-reported usage so eval
-        clients that return no token ids don't report 0."""
+        """Final-turn prompt size, falling back to provider usage without token IDs."""
         last_completion = next(
             (sum(n.mask) for n in reversed(self.nodes) if any(n.mask)), 0
         )
@@ -196,9 +162,7 @@ class Branch(StrictBaseModel):
 
     @property
     def num_output_tokens(self) -> int:
-        """All assistant-generated (completion) tokens across this branch (reasoning included, so
-        it can exceed the final context). Read from token ids when present (training), else from
-        provider-reported usage so eval clients that return no token ids don't report 0."""
+        """Sampled tokens, falling back to provider usage without token IDs."""
         token_len = sum(sum(n.mask) for n in self.nodes)
         if token_len:
             return token_len
@@ -209,56 +173,28 @@ class Branch(StrictBaseModel):
 _NODE_DUMP_EXCLUDE: dict = {
     "nodes": {"__all__": {"multi_modal_data", "routed_experts"}}
 }
-"""The per-node fields `Trace.to_record` strips from a JSON dump: the multimodal `mm_kwargs`
-carrier and the router-replay `routed_experts` array. Both hold raw numpy bytes (msgpack `bin`)
-that the env-server wire carries fine but JSON cannot — `model_dump(mode="json")` raises
-`UnicodeDecodeError` on real (>0x7F) expert ids — and they bloat every record line besides.
-Lives with the schema it excludes so a new tensor field can't silently start crashing dumps."""
+"""Raw tensor fields kept on the msgpack wire but excluded from JSON records."""
 
 
 class Trace(StrictBaseModel, Generic[DataT, StateT]):
-    """The full record of one rollout. Subclass to add typed fields."""
-
     id: str = Field(default_factory=lambda: uuid.uuid4().hex)
-    """Unique id for this rollout, auto-generated per trace."""
     task: DataT
-    """The (immutable) task being solved — fully typed, flows into scoring."""
     runtime: RuntimeInfo | None = None
-    """Where the rollout ran: the runtime's full config plus the provisioned resource's `id`
-    (subprocess workdir / docker container id / prime or modal sandbox id). The rollout assigns
-    the live runtime's `info` object the moment it makes the runtime, so the config is recorded
-    from the start and `id` appears as soon as the runtime is up. None only for traces created
-    outside a rollout."""
+    """The runtime's full config plus its provisioned resource ID."""
     nodes: list[MessageNode] = Field(default_factory=list)
-    """The message graph — one node per distinct message, linked to its predecessor (see
-    `graph`). The ground truth; `branches` is a view over it. Stores each message once, so
-    size is linear (not quadratic) in turns."""
+    """The message graph; branches are derived views and storage stays linear in turns."""
 
     rewards: dict[str, float] = Field(default_factory=dict)
-    """Per-`@reward`-function contributions, with each function's weight applied."""
+    """Weighted contributions from task rewards, group rewards, and judges."""
     metrics: dict[str, float] = Field(default_factory=dict)
-    """Per-`@metric`-function values (unweighted; not summed into the reward)."""
+    """Unweighted metrics from tasks, harnesses, and judges."""
     info: dict[str, Any] = Field(default_factory=dict)
-    """Free-form, JSON-serializable scratch space for taskset-specific metadata that is neither
-    a reward nor a metric — anything an author wants to scrape off the live runtime and persist
-    with the trace (captured logs, command output, container/runtime state, artifact paths).
-    Populate it from the runtime in `finalize` (or a `@reward`/`@metric`) by assigning into the
-    dict (`trace.info["build_log"] = ...`); it round-trips through the wire to `traces.jsonl`.
-    Use `metrics` for numbers that aggregate, this for everything else. Values must be
-    JSON-serializable — a non-serializable value fails the trace dump rather than being dropped."""
+    """Persistent JSON scratch space for task metadata that is not a reward or metric."""
     state: StateT = Field(default_factory=State, exclude=True)
-    """Transient per-rollout runtime state (see `verifiers.v1.state.State`): shared with the tool/user
-    servers as `self.state` (synced over the interception server) and read+written by scoring. Runtime
-    scratch (counters, game progress, end-of-trajectory flags) — excluded from every dump (`model_dump`
-    / `to_record`), unlike `info` which persists. Type it via `Task[..., MyState, ...]`; defaults
-    to the base `State`."""
+    """Transient state shared with servers and scoring; excluded from every dump."""
 
     extra_usage: list[Usage] = Field(default_factory=list)
-    """Token usage from model calls that aren't part of the message graph — LLM judges and other
-    auxiliary scoring calls (see `verifiers.v1.judge`). Kept separate from `usage` (the agent's own
-    spend) and off the graph, so branch/turn counts and the trainer's token math (`num_total_tokens`,
-    `branches`) see only sampled nodes; consumers that want a grand total add the two (e.g. the eval
-    dashboard shows the agent's usage and `+judge` separately)."""
+    """Usage from judges and other calls outside the agent's message graph."""
 
     is_completed: bool = False
     stop_condition: str | None = None
@@ -277,7 +213,6 @@ class Trace(StrictBaseModel, Generic[DataT, StateT]):
 
     @property
     def error(self) -> Error | None:
-        """The most recent captured error (the rest are earlier retry attempts)."""
         return self.errors[-1] if self.errors else None
 
     @property
@@ -285,26 +220,22 @@ class Trace(StrictBaseModel, Generic[DataT, StateT]):
         return bool(self.errors)
 
     def _last_assistant(self) -> MessageNode | None:
-        """The most recent sampled (model-produced) node, or None for a trace with no
-        responses."""
+        """Most recent model-produced node, ignoring prompt-supplied assistant messages."""
         return next((n for n in reversed(self.nodes) if n.sampled), None)
 
     @property
     def num_input_tokens(self) -> int:
-        """Total input context summed over branches (each branch's final-turn prompt) —
-        the trajectory yields one training sample per branch, so totals aggregate them."""
+        """Final-turn prompt sizes summed across training branches."""
         return sum(branch.num_input_tokens for branch in self.branches)
 
     @property
     def num_output_tokens(self) -> int:
-        """Total assistant-generated (completion) tokens summed over branches — every token
-        the model produced (reasoning included), so it can exceed the final context size."""
+        """Model-sampled tokens summed across training branches."""
         return sum(branch.num_output_tokens for branch in self.branches)
 
     @property
     def num_total_tokens(self) -> int:
-        """Total sequence length summed over branches (each branch's final-turn prompt +
-        completion) — used for token batching."""
+        """Sequence lengths summed across training branches for token batching."""
         return sum(branch.num_total_tokens for branch in self.branches)
 
     @property
@@ -314,15 +245,12 @@ class Trace(StrictBaseModel, Generic[DataT, StateT]):
 
     @property
     def has_response(self) -> bool:
-        """Whether the most recent assistant message produced non-empty content."""
         last = self._last_assistant()
         return bool(last and last.message.content)
 
     @property
     def branches(self) -> list[Branch]:
-        """The conversation segmented into linear branches — a view over the graph: each
-        leaf's root→leaf path is a branch (one when linear, several under compaction or
-        subagents). Branching falls out of walking each leaf's parents back to its root."""
+        """One root-to-leaf path per graph leaf."""
         branches: list[Branch] = []
         for i, leaf in enumerate(graph.leaves(self)):
             path: list[int] = []
@@ -336,7 +264,6 @@ class Trace(StrictBaseModel, Generic[DataT, StateT]):
 
     @property
     def num_branches(self) -> int:
-        """How many branches (1 = linear; >1 = compaction/subagents)."""
         return len(graph.leaves(self))
 
     @property
@@ -347,11 +274,7 @@ class Trace(StrictBaseModel, Generic[DataT, StateT]):
 
     @property
     def is_truncated(self) -> bool:
-        """Whether the rollout was cut off by a budget/limit rather than ending on its
-        own terms: the framework halted it (`max_turns`, a token budget, or
-        `harness_timeout`), the prompt outgrew the model's context window
-        (`context_length`), or the final turn hit the token cap (`finish_reason ==
-        "length"`)."""
+        """True for framework limits or a length-finished final response."""
         if self.stop_condition in (
             "max_turns",
             "max_input_tokens",
@@ -376,20 +299,12 @@ class Trace(StrictBaseModel, Generic[DataT, StateT]):
 
     @property
     def last_reply(self) -> str:
-        """The model's final reply as plain text — the last assistant message's
-        `content` (whitespace-stripped), or ``""`` when there are no assistant
-        messages or the last one has no text. Convenience over
-        ``(assistant_messages[-1].content or "").strip()`` for last-turn scoring."""
         msgs = self.assistant_messages
         return (msgs[-1].content or "").strip() if msgs else ""
 
     @property
     def transcript(self) -> str:
-        """The rollout's final branch as a plain-text transcript — one `[role]` block per
-        message with its text content (image parts dropped), assistant tool calls as
-        `[tool_call name(arguments)]` lines, and tool results under `[tool <name>]`.
-        Reasoning content is excluded. What a built-in judge with `view="full_trace"`
-        grades (vs. the default `last_reply`)."""
+        """Final-branch text and tool calls for judges; images and reasoning are omitted."""
         branches = self.branches
         blocks: list[str] = []
         for message in branches[-1].messages if branches else []:
@@ -418,9 +333,6 @@ class Trace(StrictBaseModel, Generic[DataT, StateT]):
         return [m for m in messages if isinstance(m, ToolMessage)]
 
     def record_metric(self, name: str, value: float) -> None:
-        """Record a single `@metric` result under `name`. Warns if it overrides an
-        existing metric (a name collision, e.g. an harness and a task metric sharing
-        a name) — last writer wins, but loudly."""
         if name in self.metrics:
             logger.warning(
                 "metric %r overridden: %s -> %s", name, self.metrics[name], value
@@ -428,23 +340,15 @@ class Trace(StrictBaseModel, Generic[DataT, StateT]):
         self.metrics[name] = float(value)
 
     def record_metrics(self, values: Mapping[str, float]) -> None:
-        """Merge a family of `@metric` results (so one method can report several,
-        e.g. an harness's depth/calls/tokens). Each key warns on override as above."""
         for name, value in values.items():
             self.record_metric(name, value)
 
     def record_judge(self, response: JudgeResponse) -> None:
-        """Persist a judge call (`Judge.evaluate` / `Judge.complete` is pure): append the typed
-        response to `info["judge"]` for debugging and fold its tokens + cost into `extra_usage`
-        (→ `usage`)."""
         self.info.setdefault("judge", []).append(response.model_dump())
         if response.usage is not None:
             self.extra_usage.append(response.usage)
 
     def record_reward(self, name: str, value: float, weight: float = 1.0) -> None:
-        """Record a `@reward`/`@group_reward` contribution under `name` (weight
-        applied; summed into `reward`). Warns on override — a per-rollout reward and
-        a group reward sharing a name would otherwise silently clobber."""
         contribution = float(value) * float(weight)
         if name in self.rewards:
             logger.warning(
@@ -458,7 +362,6 @@ class Trace(StrictBaseModel, Generic[DataT, StateT]):
             self.stop_condition = condition
 
     def capture_error(self, error: Exception) -> None:
-        """Record a caught error and stop the rollout."""
         self.errors.append(
             Error(
                 type=type(error).__name__,
@@ -473,22 +376,11 @@ class Trace(StrictBaseModel, Generic[DataT, StateT]):
         self.stop("error")
 
     def to_record(self) -> dict[str, Any]:
-        """A JSON-serializable record of this rollout for `traces.jsonl` / W&B tables.
-
-        `model_dump(mode="json")` minus the per-node training tensors (`_NODE_DUMP_EXCLUDE`):
-        those carry raw numpy bytes that JSON can't encode (the plain dump raises
-        `UnicodeDecodeError` on real expert ids) and that bloat every line. Everything else —
-        including `token_ids` / `mask` / `logprobs` / `is_content` and provider `usage` — is
-        kept; `state` and the computed-property views (`reward`, `branches`, `duration`) are
-        absent by construction (excluded / never serialized). The tensors still reach the
-        trainer over the env-server wire (msgpack raw bytes); only this record path strips them."""
+        """JSON record without raw tensors, which remain available on the msgpack wire."""
         return self.model_dump(mode="json", exclude=_NODE_DUMP_EXCLUDE)
 
 
 TraceT = TypeVar("TraceT", bound=Trace)  # type: ignore[type-arg]
 
 WireTrace = Trace[WireTaskData]
-"""A `Trace` typed for loading a dump without the originating taskset: taskset-specific task fields
-ride in `task.model_extra` (`WireTaskData` allows extras); `state` is never serialized so it needs no
-permissive type. The dump is plain pydantic (no derived computed fields), so load it directly:
-`WireTrace.model_validate(json.loads(line))`."""
+"""Trace loader that preserves unknown task fields in `task.model_extra`."""

--- a/verifiers/v1/types.py
+++ b/verifiers/v1/types.py
@@ -1,11 +1,3 @@
-"""Provider-agnostic wire types: messages, tools, model responses.
-
-These are the only types that cross the boundary between verifiers and a model
-provider. They are pydantic models — never dicts with normalizers. The single
-place raw provider dicts enter is the client implementation, which validates
-them into these models explicitly.
-"""
-
 from collections.abc import Iterable
 from typing import Annotated, Any, Literal
 
@@ -15,30 +7,19 @@ from typing_extensions import TypedDict
 
 
 class StrictBaseModel(BaseModel):
-    """A pydantic base that rejects unknown fields. Use for all closed data types."""
-
     model_config = ConfigDict(extra="forbid")
 
 
-# --- messages -----------------------------------------------------------------
-
-
 class TextContentPart(StrictBaseModel):
-    """A text span in a multimodal message body."""
-
     type: Literal["text"] = "text"
     text: str
 
 
 class ImageUrlSource(StrictBaseModel):
-    """An image reference — a URL or a `data:` URI."""
-
     url: str
 
 
 class ImageUrlContentPart(StrictBaseModel):
-    """An image in a multimodal message body (OpenAI `image_url` shape)."""
-
     type: Literal["image_url"] = "image_url"
     image_url: ImageUrlSource
 
@@ -47,13 +28,11 @@ ContentPart = Annotated[
     TextContentPart | ImageUrlContentPart, Field(discriminator="type")
 ]
 MessageContent = str | list[ContentPart]
-"""A message body: plain text, or a list of content parts (text + images)."""
+"""Plain text or typed multimodal content parts."""
 
 
 def content_to_parts(content) -> MessageContent:
-    """Parse raw OpenAI message content into typed content — a `str` stays a `str`; a list of
-    parts becomes typed `ContentPart`s (text + image_url), dropping unknown part types. The
-    shared multimodal-ingress parser used by the interception server and the v0 legacy bridge."""
+    """Type OpenAI content parts, dropping unsupported part types."""
     if not isinstance(content, list):
         return content or ""
     parts: list[ContentPart] = []
@@ -69,9 +48,7 @@ def content_to_parts(content) -> MessageContent:
 
 
 def content_text(content: "MessageContent | None") -> str:
-    """The plain text of a message body — a `str` as-is, a parts list joined to its text
-    parts (images dropped), `""` for `None`. The shared text view used by `Task.prompt_text`
-    and `Trace.transcript`."""
+    """Extract text from message content, dropping images."""
     if isinstance(content, str):
         return content
     return "\n".join(
@@ -80,22 +57,16 @@ def content_text(content: "MessageContent | None") -> str:
 
 
 class SystemMessage(StrictBaseModel):
-    """A system instruction message."""
-
     role: Literal["system"] = "system"
     content: MessageContent
 
 
 class UserMessage(StrictBaseModel):
-    """A user message (text, or text + images)."""
-
     role: Literal["user"] = "user"
     content: MessageContent
 
 
 class ToolCall(StrictBaseModel):
-    """A tool/function call requested by the model."""
-
     id: str
     name: str
     arguments: str
@@ -103,8 +74,6 @@ class ToolCall(StrictBaseModel):
 
 
 class AssistantMessage(StrictBaseModel):
-    """An assistant message, optionally carrying reasoning and tool calls."""
-
     role: Literal["assistant"] = "assistant"
     content: str | None = None
     reasoning_content: str | None = None
@@ -114,20 +83,11 @@ class AssistantMessage(StrictBaseModel):
 
 
 class ToolMessage(StrictBaseModel):
-    """The result of a tool call, keyed to the originating call id."""
-
     role: Literal["tool"] = "tool"
     tool_call_id: str
     content: MessageContent
     name: str | None = None
-    """The originating tool/function name, recovered from the prompt's matching tool call.
-
-    Most renderers key a tool result off `tool_call_id` alone, but some render the function name into
-    the template (GPT-OSS Harmony emits `functions.<name>`, falling back to `functions.unknown`
-    without it — which breaks token parity). The bridge makes this load-bearing: it renders only the
-    new tail (e.g. `[tool, user]`), so the issuing assistant's tool call sits in the already-reused
-    prefix and isn't re-sent — the name can't be recovered from the tail. So the dialect recovers it
-    once while parsing the full prompt and attaches it here, where it rides along into later bridge tails."""
+    """Needed by templates such as Harmony when bridge tails omit the issuing call."""
 
 
 Message = Annotated[
@@ -137,32 +97,21 @@ Message = Annotated[
 Messages = list[Message]
 
 
-# --- tools --------------------------------------------------------------------
-
-
 class Tool(StrictBaseModel):
-    """A function tool advertised to the model."""
-
     name: str
     description: str
     parameters: dict[str, Any]
     strict: bool | None = None
 
 
-# --- responses ----------------------------------------------------------------
-
-
 FinishReason = Literal["stop", "length", "tool_calls"] | None
 
 
 class Usage(StrictBaseModel):
-    """Token usage for one model response.
+    """Provider token accounting.
 
-    ``prompt_tokens`` excludes cache-read tokens; ``cached_input_tokens`` carries that
-    disjoint portion when the provider reports it. ``input_tokens`` and ``total_tokens``
-    reconstruct the full logical sequence sizes. ``reasoning_tokens`` is an optional subset
-    of ``completion_tokens`` and is not added again to totals. ``cost`` is the optional
-    provider-reported cost for the response.
+    `prompt_tokens` excludes cache reads; `input_tokens` adds them back. Reasoning tokens
+    are a subset of completion tokens and are not added to totals again.
     """
 
     prompt_tokens: int
@@ -173,9 +122,7 @@ class Usage(StrictBaseModel):
 
     @classmethod
     def from_openai(cls, usage: Any | None) -> "Usage | None":
-        """Build from an OpenAI chat-completion `usage` object (the `.usage` on a
-        `ChatCompletion`), or `None` when the provider reported none. Splits cache-read tokens
-        out of `prompt_tokens` and carries the reasoning subset + provider-reported `cost`."""
+        """Build usage while splitting cached tokens out of `prompt_tokens`."""
         if usage is None:
             return None
         prompt_details = getattr(usage, "prompt_tokens_details", None)
@@ -224,10 +171,7 @@ class Usage(StrictBaseModel):
 
 
 class RoutedExperts(TypedDict):
-    """The raw MoE expert-routing data a `generate` response carries for router replay:
-    base64 `data` (uint8 `[tokens, layers, top_k]`), its `shape`, and `start` — the prompt
-    offset where the routing begins (0 = full prompt+completion). Kept opaque (`Any` data)
-    so pydantic never validates the encoded blob."""
+    """Base64 uint8 `[tokens, layers, top_k]` routing and its prompt offset."""
 
     data: Any
     shape: list[int]
@@ -235,9 +179,7 @@ class RoutedExperts(TypedDict):
 
 
 class TurnTokens(StrictBaseModel):
-    """Token ids + sampling logprobs for one response, for training. Populated by the
-    renderer client (client-side tokenization) or the chat client (parsed from vLLM's
-    token ids); None when the provider returns neither."""
+    """Training tokens from renderer tokenization or provider-returned token IDs."""
 
     model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
 
@@ -261,8 +203,6 @@ class TurnTokens(StrictBaseModel):
 
 
 class Response(StrictBaseModel):
-    """One model completion, provider-agnostic."""
-
     id: str
     created: int
     model: str
@@ -270,14 +210,8 @@ class Response(StrictBaseModel):
     finish_reason: FinishReason
     usage: Usage | None = None
     tokens: TurnTokens | None = None
-    """Token ids + logprobs for training (set by the renderer client)."""
     raw: dict | None = Field(default=None, exclude=True, repr=False)
-    """The wire response the interception server hands back to the program 1:1: the provider's
-    verbatim bytes (proxy, so no field is lost) or the client's serialized completion (renderer,
-    which generates and has none to relay). Transient: excluded from the trace dump."""
-
-
-# --- sampling -----------------------------------------------------------------
+    """Full native response object returned to the program; excluded from traces."""
 
 
 class SamplingConfig(BaseModel):
@@ -293,15 +227,9 @@ class SamplingConfig(BaseModel):
 
 
 Sampling = SamplingConfig
-"""Alias for `SamplingConfig` — the terse name for a `sampling` field/arg."""
-
-
-# --- ids ----------------------------------------------------------------------
 
 
 def _validate_id(plugin_id: str) -> str:
-    """Validate the id's shape — a hub id must be a well-formed ``org/name[@version]``; a
-    local id is any module name. Returns it unchanged (the value stays a plain ``str``)."""
     from verifiers.utils.install_utils import is_hub_env, parse_env_id
 
     if is_hub_env(plugin_id):
@@ -310,6 +238,4 @@ def _validate_id(plugin_id: str) -> str:
 
 
 ID = Annotated[str, AfterValidator(_validate_id)]
-"""A plugin id — a taskset / harness / judge / environment: ``name``, ``org/name``, or
-``org/name@version``. A plain validated ``str``; derive its package/module name with
-`env_name` / `env_module` (`verifiers.v1.utils.install`)."""
+"""Plugin id: `name`, `org/name`, or `org/name@version`."""

--- a/verifiers/v1/utils/__init__.py
+++ b/verifiers/v1/utils/__init__.py
@@ -1,3 +1,1 @@
-"""Small shared helpers for v1, by concern: `format` (display), `install` (env-id /
-on-demand hub install), `logging` (route stdlib logs through loguru), `memory` (worker RSS).
-Import from the submodule, e.g. `from verifiers.v1.utils.format import format_mean`."""
+"""Shared v1 utilities."""

--- a/verifiers/v1/utils/generic.py
+++ b/verifiers/v1/utils/generic.py
@@ -1,0 +1,19 @@
+"""Generic type resolution shared by v1 plugin classes."""
+
+from typing import TypeVar, get_args, get_origin
+
+T = TypeVar("T")
+
+
+def generic_type(
+    cls: type, bound: type[T], *, origin: type | None = None
+) -> type[T] | None:
+    """Find a concrete bounded type through `cls`'s MRO, most-derived first."""
+    for klass in cls.__mro__:
+        for base in getattr(klass, "__orig_bases__", ()):
+            if origin is not None and get_origin(base) is not origin:
+                continue
+            for arg in get_args(base):
+                if isinstance(arg, type) and issubclass(arg, bound):
+                    return arg
+    return None

--- a/verifiers/v1/utils/install.py
+++ b/verifiers/v1/utils/install.py
@@ -1,8 +1,4 @@
-"""Environment/plugin id helpers + on-demand install from the Environments Hub.
-
-Thin v1 wrappers over `verifiers.utils.install_utils`: derive an id's package/module name,
-and make a hub id (`org/name[@version]`) importable on demand (the same path `prime env
-install` uses)."""
+"""Environment/plugin ID helpers and on-demand Hub installation."""
 
 import logging
 


### PR DESCRIPTION
## Summary

- simplify the task-centric v1 implementation by removing redundant wrappers, compatibility plumbing, and oversized inline documentation
- centralize repeated generic-type resolution and streamline task, trace, judge, MCP, runtime, CLI, and taskset flows
- align bundled environments, skills, generated guidance, docs, fixtures, and end-to-end coverage with the simplified API

## Why

This is a stacked follow-up to #1948. It keeps the task-centric design while reducing the amount of framework code and public surface needed to express it.

## Impact

The v1 implementation and examples are smaller and more consistent. This intentionally favors the new task-centric API and does not preserve compatibility with intermediate shapes from the parent branch.

## Validation

- `uv run ruff format`
- `uv run ruff check --fix`
- `uv run pre-commit run --all-files`
- `uv run --python 3.13 ty check verifiers`
- `uv run pytest tests/v1/` (57 passed, 144 skipped because `PRIME_API_KEY` is unavailable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core v1 rollout, scoring, replay, and MCP serving paths with intentional API breaks (no compatibility with intermediate branch shapes). Replay now fails hard on bad `TaskData` reconstruction and assumes `trace.info` is dict-like for judge clearing.
> 
> **Overview**
> This PR **tightens the v1 task-centric model**: serializable rows live on **`TaskData`**, behavior (hooks, **`@reward`**, tools, users, judges) on **`Task`**, and load-time knobs on **`Taskset.load()`** / **`TasksetConfig`**, with **`TaskConfig`** defined and exported from **`verifiers/v1/task.py`** instead of the taskset module.
> 
> **Framework behavior** shifts accordingly: **`invoke_all`** runs decorated scoring handlers concurrently in **`Task.score`** and harness metrics; **`generic_type`** centralizes generic resolution for task/harness/judge wiring; **`Environment.serving()`** and MCP **`serve_*`** helpers no longer take a per-request **`task`**; compact harnesses read **`trace.task.data.prompt`**; resume treats incomplete **group-reward** tasks as whole groups; replay tracks **`offline_keys`** in **`trace.info`** for restoring runtime-only scores. Rollout failures are labeled **`TaskError`** (replacing **`TasksetError`**), and eval artifacts are documented as **`traces.jsonl`**.
> 
> **Docs, AGENTS/skills, `vf init` scaffolding, example environments, and v1 tests** are updated to match—simpler tool/judge examples, worker-shared tool wording, **`ModelContext`** in harness docs, and shorter inline module docstrings across the CLI and core packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c169e92871314873441fb7bdbd65b91250a1ab5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor v1 task-centric APIs to centralise generic type resolution and concurrent scoring
> - Introduces `generic_type` utility in [`verifiers/v1/utils/generic.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1966/files#diff-f9bc31b07ff672903d0a89c0ffd3f04f30c7779fc2135f7117a27c33724bf662) to walk MRO and resolve concrete generic type arguments, replacing ad-hoc `__orig_bases__` parsing scattered across `task.py`, `state.py`, `judge.py`, `loaders.py`, `server.py`, and `taskset.py`.
> - Adds `invoke_all` async helper in [`verifiers/v1/decorators.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1966/files#diff-f988770651db72dcffc1d37435431286a4bde4698027b25e030e75f2424369ec) that concurrently invokes scoring handlers via `asyncio.gather`; `Harness` and `Task.score`/`score_group` now use it instead of sequential or conditional gather calls.
> - Introduces `_record_result` in [`verifiers/v1/task.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1966/files#diff-a1b4a5d6915beae41831864087ea497ed41f0b67b9091ad1ee614834cbfd9399) to unify metric/reward recording and capture offline replay keys under `trace.info['offline_keys']` for runtime-required signals, judges, and group rewards.
> - Removes `Taskset.task_type()` classmethod; task type resolution moves to call sites via `generic_type`.
> - Fixes `CompactingHarness` to pass `trace.task.data.prompt` instead of `trace.task.prompt` and defaults `HarborData.task_dir` to an empty string.
> - The scaffolded taskset from `vf init` now omits `TaskConfig` and related generics unless a tool or user simulator is requested.
> - Risk: `resolve_server_config` and `Task.__init__` no longer wrap config construction failures in `TaskError`; raw exceptions now propagate to callers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c169e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->