### PR TITLE
Prepare bundled V1 environment 0.2.0 releases

### DIFF
--- a/environments/alphabet_sort_v1/pyproject.toml
+++ b/environments/alphabet_sort_v1/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "alphabet-sort-v1"
-version = "0.1.0"
+version = "0.2.0"
 description = "alphabet-sort-v1 — maintain an alphabetically sorted list of names across turns, driven by a colocated user simulator."
 requires-python = ">=3.10"
 dependencies = ["verifiers", "datasets"]

--- a/environments/code_golf_v1/pyproject.toml
+++ b/environments/code_golf_v1/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "code-golf-v1"
-version = "0.1.0"
+version = "0.2.0"
 description = "code-golf-v1 — write a short, fast program (showcases group rewards)."
 requires-python = ">=3.10"
 dependencies = ["verifiers"]

--- a/environments/color_codeword_v1/pyproject.toml
+++ b/environments/color_codeword_v1/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "color-codeword-v1"
-version = "0.1.0"
+version = "0.2.0"
 description = "color-codeword-v1 — a multi-turn VLM codeword-decoding task, driven by a colocated user simulator."
 requires-python = ">=3.10"
 dependencies = ["verifiers", "pillow"]

--- a/environments/compact/pyproject.toml
+++ b/environments/compact/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "compact"
-version = "0.1.0"
+version = "0.2.0"
 description = "compact — a context-rewrite harness for v1 (branches every turn)."
 requires-python = ">=3.10"
 dependencies = ["verifiers"]

--- a/environments/deepwiki_v1/pyproject.toml
+++ b/environments/deepwiki_v1/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepwiki-v1"
-version = "0.1.0"
+version = "0.2.0"
 description = "deepwiki-v1 — task tools via a remote (streamable-HTTP) MCP server."
 requires-python = ">=3.10"
 dependencies = ["verifiers"]

--- a/environments/glossary_v1/pyproject.toml
+++ b/environments/glossary_v1/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "glossary-v1"
-version = "0.1.0"
+version = "0.2.0"
 description = "glossary-v1 — task-specific tools via a vf-native Toolset class."
 requires-python = ">=3.10"
 dependencies = ["verifiers"]

--- a/environments/gsm8k_v1/pyproject.toml
+++ b/environments/gsm8k_v1/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gsm8k-v1"
-version = "0.1.0"
+version = "0.2.0"
 description = "gsm8k-v1 — grade-school math word problems (single-turn, exact-match)."
 requires-python = ">=3.10"
 dependencies = ["datasets"]

--- a/environments/reverse_text_v1/pyproject.toml
+++ b/environments/reverse_text_v1/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "reverse-text-v1"
-version = "0.1.0"
+version = "0.2.0"
 description = "reverse-text-v1 — reverse a string character-by-character (single-turn, LCS reward)."
 requires-python = ">=3.10"
 dependencies = ["datasets"]

--- a/environments/scratchpad_v1/pyproject.toml
+++ b/environments/scratchpad_v1/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scratchpad-v1"
-version = "0.1.0"
+version = "0.2.0"
 description = "scratchpad-v1 — a shared, writable tool server, per-rollout isolated via self.state."
 requires-python = ">=3.10"
 dependencies = ["verifiers"]

--- a/environments/wiki_search_v1/pyproject.toml
+++ b/environments/wiki_search_v1/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wiki-search-v1"
-version = "0.1.0"
+version = "0.2.0"
 description = "wiki-search-v1 — answer trivia by searching a wiki corpus (read-only MCP tools + judge)."
 requires-python = ">=3.10"
 dependencies = ["verifiers", "chromadb", "datasets"]

--- a/environments/wordle_v1/pyproject.toml
+++ b/environments/wordle_v1/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wordle-v1"
-version = "0.1.0"
+version = "0.2.0"
 description = "Wordle — the textarena taskset pinned to Wordle-v0."
 requires-python = ">=3.10"
 dependencies = ["verifiers[ta]"]

--- a/uv.lock
+++ b/uv.lock
@@ -151,7 +151,7 @@ wheels = [
 
 [[package]]
 name = "alphabet-sort-v1"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "environments/alphabet_sort_v1" }
 dependencies = [
     { name = "datasets" },
@@ -675,7 +675,7 @@ wheels = [
 
 [[package]]
 name = "code-golf-v1"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "environments/code_golf_v1" }
 dependencies = [
     { name = "verifiers" },
@@ -686,7 +686,7 @@ requires-dist = [{ name = "verifiers" }]
 
 [[package]]
 name = "color-codeword-v1"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "environments/color_codeword_v1" }
 dependencies = [
     { name = "pillow" },
@@ -719,7 +719,7 @@ wheels = [
 
 [[package]]
 name = "compact"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "environments/compact" }
 dependencies = [
     { name = "verifiers" },
@@ -1048,7 +1048,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/24/61/5ea1c63b139fe7530
 
 [[package]]
 name = "deepwiki-v1"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "environments/deepwiki_v1" }
 dependencies = [
     { name = "verifiers" },
@@ -1696,7 +1696,7 @@ wheels = [
 
 [[package]]
 name = "glossary-v1"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "environments/glossary_v1" }
 dependencies = [
     { name = "verifiers" },
@@ -1782,7 +1782,7 @@ wheels = [
 
 [[package]]
 name = "gsm8k-v1"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "environments/gsm8k_v1" }
 dependencies = [
     { name = "datasets" },
@@ -4998,7 +4998,7 @@ wheels = [
 
 [[package]]
 name = "reverse-text-v1"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "environments/reverse_text_v1" }
 dependencies = [
     { name = "datasets" },
@@ -5291,7 +5291,7 @@ wheels = [
 
 [[package]]
 name = "scratchpad-v1"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "environments/scratchpad_v1" }
 dependencies = [
     { name = "verifiers" },
@@ -6598,7 +6598,7 @@ wheels = [
 
 [[package]]
 name = "wiki-search-v1"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "environments/wiki_search_v1" }
 dependencies = [
     { name = "chromadb" },
@@ -6624,7 +6624,7 @@ wheels = [
 
 [[package]]
 name = "wordle-v1"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "environments/wordle_v1" }
 dependencies = [
     { name = "verifiers", extra = ["ta"] },


### PR DESCRIPTION
## Overview

Prepare the bundled V1 environment packages for their 0.2.0 releases following the task-centric API update.

## Details

- Bump the ten bundled `*_v1` environment packages and the `compact` harness example from 0.1.0 to 0.2.0.
- Keep the workspace package metadata in `uv.lock` aligned with those package versions.
- Preserve the existing `exclude-newer` configuration unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bumps with a lockfile sync; no runtime or API code changes in this diff.
> 
> **Overview**
> Bumps the **bundled V1 environment packages** and the **`compact`** harness from **0.1.0** to **0.2.0** in each package’s `pyproject.toml`, ahead of releases tied to the task-centric API update.
> 
> Updates **`uv.lock`** so the workspace entries for those eleven editable packages match **0.2.0**. No dependency, source, or `exclude-newer` configuration changes beyond the version strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3513e78b90b6c1febcd9d5b59cc072ee4fbfcee1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump all bundled V1 environment packages from 0.1.0 to 0.2.0
> Increments the version field in `pyproject.toml` from `0.1.0` to `0.2.0` across all 11 bundled V1 environments (`alphabet_sort`, `code_golf`, `color_codeword`, `compact`, `deepwiki`, `glossary`, `gsm8k`, `reverse_text`, `scratchpad`, `wiki_search`, `wordle`) and updates `uv.lock` to match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3513e78.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->