### PR TITLE
feat: warn and block a second Ctrl-C during eval cleanup

### DIFF
--- a/verifiers/v1/cli/dashboard/base.py
+++ b/verifiers/v1/cli/dashboard/base.py
@@ -9,6 +9,8 @@ from collections.abc import Callable, Iterator
 from rich.console import Group
 from rich.live import Live
 
+from verifiers.v1.utils.interrupt import cleaning_up
+
 try:  # POSIX-only terminal control; absent on Windows, where key reading is skipped.
     import termios
     import tty
@@ -82,10 +84,19 @@ async def live_view(
     """Refresh `render()` every 0.25s until the block exits, then draw one final frame. When
     `on_key` is given, left/right arrow presses are dispatched to it (and redraw at once)."""
     with Live(render(), auto_refresh=False) as live:
+        stopping = False
 
         async def loop() -> None:
             while True:
-                await asyncio.sleep(0.25)
+                try:
+                    await asyncio.sleep(0.25)
+                except asyncio.CancelledError:
+                    # On Ctrl-C, asyncio cancels every task at once. Keep refreshing through
+                    # graceful shutdown so the "cleaning up" banner stays live during teardown;
+                    # only really stop when live_view itself tears down (`stopping`), else the
+                    # dashboard would freeze for the whole (possibly slow) container teardown.
+                    if stopping or not cleaning_up():
+                        raise
                 live.update(render(), refresh=True)
 
         task = asyncio.create_task(loop())
@@ -93,6 +104,7 @@ async def live_view(
             try:
                 yield
             finally:
+                stopping = True
                 task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     await task

--- a/verifiers/v1/cli/dashboard/base.py
+++ b/verifiers/v1/cli/dashboard/base.py
@@ -91,10 +91,8 @@ async def live_view(
                 try:
                     await asyncio.sleep(0.25)
                 except asyncio.CancelledError:
-                    # On Ctrl-C, asyncio cancels every task at once. Keep refreshing through
-                    # graceful shutdown so the "cleaning up" banner stays live during teardown;
-                    # only really stop when live_view itself tears down (`stopping`), else the
-                    # dashboard would freeze for the whole (possibly slow) container teardown.
+                    # Ctrl-C cancels every task at once; keep refreshing so the cleanup notice
+                    # stays live through teardown, stopping only when live_view tears down.
                     if stopping or not cleaning_up():
                         raise
                 live.update(render(), refresh=True)

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -111,16 +111,19 @@ def _aligned(rows: list[list[str]]) -> list[str]:
     ]
 
 
-def _interrupt_banner() -> Text | None:
-    """Shown atop the dashboard once Ctrl-C has begun teardown — the on-screen echo of the
-    graceful-shutdown notice (console logging is silenced in rich mode); further Ctrl-C is
-    ignored while it shows."""
+def _interrupt_footer() -> Group | None:
+    """The graceful-shutdown notice under the rollouts once Ctrl-C has begun teardown — the
+    on-screen echo of the warning (console logging is silenced in rich mode); a further Ctrl-C
+    is ignored while it shows. Sits beside the `--push` line, mirroring its placement."""
     if not cleaning_up():
         return None
-    return Text(
-        "interrupted  Cleaning up — tearing down containers/sandboxes. "
-        "Please wait; further Ctrl-C is ignored.",
-        style="bold red",
+    return Group(
+        Rule(style="dim"),
+        Text(
+            "interrupted — cleaning up, tearing down containers/sandboxes. "
+            "please wait; a further ctrl-c is ignored.",
+            style="yellow",
+        ),
     )
 
 
@@ -573,13 +576,13 @@ def _render(
     push: "PushState | None" = None,
 ) -> Group:
     now = time.time()
-    banners = [b for b in (_interrupt_banner(), _warning(config)) if b is not None]
-    header = Group(*(part for b in banners for part in (b, Text(""))), Overview(config))
-    # The --push status line appears under the rollouts once the upload starts (None during the run
-    # / when off). Measure the fixed top (header + progress + rule) and the footer so the rollout
-    # rows fill what's left; page through them (timer / arrows) when they'd overflow (else rich
-    # truncates).
-    footer = _push_footer(push)
+    warning = _warning(config)
+    header = Group(warning, Text(""), Overview(config)) if warning else Overview(config)
+    # The --push status line (and, on Ctrl-C, the cleanup notice) appear under the rollouts. Measure
+    # the fixed top (header + progress + rule) and the footer so the rollout rows fill what's left;
+    # page through them (timer / arrows) when they'd overflow (else rich truncates).
+    footers = [f for f in (_push_footer(push), _interrupt_footer()) if f is not None]
+    footer = Group(*footers) if footers else None
     top = Group(header, Progress(rollouts, start), Rule(style="dim"))
     reserved = len(_CONSOLE.render_lines(top))
     if footer is not None:

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -14,6 +14,7 @@ from rich.text import Text
 
 from verifiers.v1.cli.dashboard.base import live_view
 from verifiers.v1.cli.output import output_path
+from verifiers.v1.utils.interrupt import cleaning_up
 from verifiers.v1.configs.eval import EvalConfig
 from verifiers.v1.rollout import Phase, Rollout
 from verifiers.v1.trace import Trace
@@ -108,6 +109,19 @@ def _aligned(rows: list[list[str]]) -> list[str]:
         )
         for row in rows
     ]
+
+
+def _interrupt_banner() -> Text | None:
+    """Shown atop the dashboard once Ctrl-C has begun teardown — the on-screen echo of the
+    graceful-shutdown notice (console logging is silenced in rich mode); further Ctrl-C is
+    ignored while it shows."""
+    if not cleaning_up():
+        return None
+    return Text(
+        "interrupted  Cleaning up — tearing down containers/sandboxes. "
+        "Please wait; further Ctrl-C is ignored.",
+        style="bold red",
+    )
 
 
 def _warning(config: EvalConfig) -> Text | None:
@@ -559,8 +573,8 @@ def _render(
     push: "PushState | None" = None,
 ) -> Group:
     now = time.time()
-    warning = _warning(config)
-    header = Group(warning, Text(""), Overview(config)) if warning else Overview(config)
+    banners = [b for b in (_interrupt_banner(), _warning(config)) if b is not None]
+    header = Group(*(part for b in banners for part in (b, Text(""))), Overview(config))
     # The --push status line appears under the rollouts once the upload starts (None during the run
     # / when off). Measure the fixed top (header + progress + rule) and the footer so the rollout
     # rows fill what's left; page through them (timer / arrows) when they'd overflow (else rich

--- a/verifiers/v1/cli/eval/main.py
+++ b/verifiers/v1/cli/eval/main.py
@@ -84,7 +84,7 @@ def main(argv: list[str] | None = None) -> None:
     # runs each rollout's `finally` (tears down containers/sandboxes) and any worker pool it
     # spawned; further signals during that cleanup are swallowed so an impatient second Ctrl-C
     # can't orphan those resources.
-    install_interrupt(rich)
+    install_interrupt()
 
     try:
         if (

--- a/verifiers/v1/cli/eval/main.py
+++ b/verifiers/v1/cli/eval/main.py
@@ -2,12 +2,12 @@
 
 import asyncio
 import logging
-import signal
 import sys
 
 from pydantic_config import cli
 
 import verifiers.v1 as vf
+from verifiers.v1.utils.interrupt import install as install_interrupt
 from verifiers.v1.utils.logging import setup_logging
 from verifiers.v1.cli.output import output_path, write_config
 from verifiers.v1.cli.resolve import (
@@ -80,21 +80,30 @@ def main(argv: list[str] | None = None) -> None:
         logging.lastResort = None
     else:
         setup_logging(level, log_file=log_file, console=True)
-    # Make SIGTERM behave like Ctrl-C (SIGINT) so a killed/timed-out eval still runs each
-    # rollout's `finally` (tears down containers/sandboxes) and any worker pool it spawned.
-    signal.signal(signal.SIGTERM, lambda *_: (_ for _ in ()).throw(KeyboardInterrupt()))
+    # First Ctrl-C / SIGTERM warns and raises KeyboardInterrupt so a killed/timed-out eval still
+    # runs each rollout's `finally` (tears down containers/sandboxes) and any worker pool it
+    # spawned; further signals during that cleanup are swallowed so an impatient second Ctrl-C
+    # can't orphan those resources.
+    install_interrupt(rich)
 
-    if config.is_legacy:  # v0 backwards-compat: run the classic env, bridged to Traces
-        from verifiers.v1.legacy import run_legacy_eval
+    try:
+        if (
+            config.is_legacy
+        ):  # v0 backwards-compat: run the classic env, bridged to Traces
+            from verifiers.v1.legacy import run_legacy_eval
 
-        traces = asyncio.run(run_legacy_eval(config))
-    elif config.server:  # opt-in: drive rollouts through the env-server worker pool
-        from verifiers.v1.cli.eval.runner import run_eval_server
+            traces = asyncio.run(run_legacy_eval(config))
+        elif config.server:  # opt-in: drive rollouts through the env-server worker pool
+            from verifiers.v1.cli.eval.runner import run_eval_server
 
-        traces = asyncio.run(run_eval_server(config))
-    else:  # in-process (default), with or without the live dashboard
-        env = vf.Environment(config)
-        traces = asyncio.run(run_eval(env, config))
+            traces = asyncio.run(run_eval_server(config))
+        else:  # in-process (default), with or without the live dashboard
+            env = vf.Environment(config)
+            traces = asyncio.run(run_eval(env, config))
+    except KeyboardInterrupt:
+        # Graceful cleanup has already run (each rollout's `finally`); partial results are on
+        # disk. Exit on the conventional Ctrl-C code without a traceback.
+        raise SystemExit(130)
     if config.push and not rich:
         from verifiers.v1.push import push_traces
 

--- a/verifiers/v1/utils/interrupt.py
+++ b/verifiers/v1/utils/interrupt.py
@@ -1,0 +1,44 @@
+"""Graceful-shutdown signal handling for the eval CLI.
+
+The first Ctrl-C (or SIGTERM) flips `cleaning_up()` on and raises KeyboardInterrupt so
+asyncio unwinds each rollout's `finally` — the path that tears down containers/sandboxes
+and any worker pool the run spawned. Any further shutdown signal during that window is
+swallowed, so an impatient second Ctrl-C can't cut cleanup short and orphan those
+resources. A genuinely stuck run is still killable with SIGKILL.
+
+In rich mode the dashboard renders the notice from `cleaning_up()` (console logging is
+silenced there); otherwise the handler echoes it to stderr, where teardown logs stream
+alongside it. The flag is a process-level shutdown latch — signals are process-global, so
+it sits with the atexit runtime backstop rather than any per-run object."""
+
+import signal
+import sys
+
+_cleaning_up = False
+
+
+def cleaning_up() -> bool:
+    """True once a shutdown signal has started graceful cleanup."""
+    return _cleaning_up
+
+
+def install(rich: bool) -> None:
+    """Route SIGINT/SIGTERM through the graceful-shutdown handler."""
+
+    def handle(*_) -> None:
+        global _cleaning_up
+        first, _cleaning_up = not _cleaning_up, True
+        if (
+            not rich
+        ):  # rich shows the notice in the dashboard; the console is silenced there
+            sys.stderr.write(
+                "\ninterrupted — cleaning up, please wait...\n"
+                if first
+                else "cleanup in progress — please wait (Ctrl-C ignored)\n"
+            )
+            sys.stderr.flush()
+        if first:
+            raise KeyboardInterrupt
+
+    signal.signal(signal.SIGINT, handle)
+    signal.signal(signal.SIGTERM, handle)

--- a/verifiers/v1/utils/interrupt.py
+++ b/verifiers/v1/utils/interrupt.py
@@ -1,40 +1,31 @@
-"""Graceful-shutdown signal handling for the eval CLI.
+"""Graceful-shutdown signal handling for the eval CLI: the first Ctrl-C/SIGTERM warns and
+raises KeyboardInterrupt so asyncio unwinds each rollout's teardown `finally`; further signals
+are swallowed so a second Ctrl-C can't orphan containers/sandboxes mid-cleanup."""
 
-The first Ctrl-C (or SIGTERM) flips `cleaning_up()` on and raises KeyboardInterrupt so
-asyncio unwinds each rollout's `finally` — the path that tears down containers/sandboxes
-and any worker pool the run spawned. Any further shutdown signal during that window is
-swallowed, so an impatient second Ctrl-C can't cut cleanup short and orphan those
-resources. A genuinely stuck run is still killable with SIGKILL.
-
-In rich mode the dashboard renders the notice from `cleaning_up()` (console logging is
-silenced there); otherwise the handler echoes it to stderr, where teardown logs stream
-alongside it. The flag is a process-level shutdown latch — signals are process-global, so
-it sits with the atexit runtime backstop rather than any per-run object."""
-
+import logging
 import signal
-import sys
+
+logger = logging.getLogger(__name__)
 
 _cleaning_up = False
 
 
 def cleaning_up() -> bool:
-    """True once a shutdown signal has started graceful cleanup."""
+    """Whether a shutdown signal has begun graceful cleanup (read by the dashboard)."""
     return _cleaning_up
 
 
-def install(rich: bool) -> None:
+def install() -> None:
     """Route SIGINT/SIGTERM through the graceful-shutdown handler."""
 
     def handle(*_) -> None:
         global _cleaning_up
         first, _cleaning_up = not _cleaning_up, True
-        if not rich:
-            sys.stderr.write(
-                "\ninterrupted — cleaning up, please wait...\n"
-                if first
-                else "cleanup in progress — please wait (ctrl-c ignored)\n"
-            )
-            sys.stderr.flush()
+        logger.warning(
+            "interrupted — cleaning up, please wait..."
+            if first
+            else "cleanup in progress — please wait (ctrl-c ignored)"
+        )
         if first:
             raise KeyboardInterrupt
 

--- a/verifiers/v1/utils/interrupt.py
+++ b/verifiers/v1/utils/interrupt.py
@@ -28,9 +28,7 @@ def install(rich: bool) -> None:
     def handle(*_) -> None:
         global _cleaning_up
         first, _cleaning_up = not _cleaning_up, True
-        if (
-            not rich
-        ):  # rich shows the notice in the dashboard; the console is silenced there
+        if not rich:
             sys.stderr.write(
                 "\ninterrupted — cleaning up, please wait...\n"
                 if first

--- a/verifiers/v1/utils/interrupt.py
+++ b/verifiers/v1/utils/interrupt.py
@@ -34,7 +34,7 @@ def install(rich: bool) -> None:
             sys.stderr.write(
                 "\ninterrupted — cleaning up, please wait...\n"
                 if first
-                else "cleanup in progress — please wait (Ctrl-C ignored)\n"
+                else "cleanup in progress — please wait (ctrl-c ignored)\n"
             )
             sys.stderr.flush()
         if first:


### PR DESCRIPTION
## Summary

- On the first Ctrl-C (`SIGINT`) or `SIGTERM` during `eval`, warn that cleanup is in progress and raise `KeyboardInterrupt` so asyncio unwinds each rollout's `finally` — the path that tears down containers/sandboxes and any worker pool the run spawned.
- Swallow any further shutdown signal during that window, so an impatient second Ctrl-C can't cut cleanup short and orphan those resources. A genuinely stuck run is still killable with `SIGKILL`.
- Works in both display modes:
  - **non-rich**: the handler echoes the notice to stderr, alongside the teardown logs streaming to the console.
  - **rich**: the dashboard shows a yellow, all-lowercase "interrupted — cleaning up" line as a footer under the rollouts (beside the `--push` line; console logging is silenced in rich mode), and the live refresh loop keeps repainting through teardown instead of freezing on the last frame.
- The CLI now exits on the conventional `130` code without dumping a `KeyboardInterrupt` traceback; partial results remain on disk (traces are persisted incrementally).
- Replaces the previous SIGTERM-only remap with a single `verifiers/v1/utils/interrupt.py` handler covering `SIGINT` + `SIGTERM`.

## Related

Overlaps with #1925 (open, follow-up to the merged #1920). That PR surfaces the teardown drain from the runtime layer (`Runtime.stop` aggregate warning + `run_shielded`) and explicitly leaves the `--rich` dashboard surfacing as future work — which this PR implements.

Note the deliberate divergence on the **second Ctrl-C**: #1925 makes a second press abort immediately ("never subordinate a user abort"), whereas this PR blocks it so cleanup always runs to completion. These two policies are mutually exclusive and should be reconciled before both land.

## Verification

Signal handler and rendering (unit-level):
- First signal warns + raises `KeyboardInterrupt`, `cleaning_up()` flips true, second signal is swallowed with a "ctrl-c ignored" notice (rich mode: no stderr spam, footer shows instead).
- Dashboard `_interrupt_footer()` is hidden before Ctrl-C and renders below the rollouts (yellow, lowercase) after.
- `live_view` keeps refreshing during a shielded teardown (simulating asyncio's cancel-all-tasks on Ctrl-C) and terminates cleanly without hanging.

End-to-end (real `eval` CLI, rollout hung on an unresponsive endpoint so teardown is in-flight):
- First `SIGINT` → `interrupted — cleaning up, please wait...`, teardown runs to completion (`interception down`).
- Second `SIGINT` mid-teardown does **not** abort — the process finishes cleanup and exits `130` (verified the handler runs on the 2nd/3rd signal and teardown completes uninterrupted).

## Breaking

None. `--server` and legacy paths are unaffected (both run non-rich); `server + rich` remains rejected at config validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process-wide signal handling and shutdown semantics (second Ctrl-C no longer kills immediately), which affects container/sandbox teardown reliability but is limited to the eval CLI paths that call install_interrupt.
> 
> **Overview**
> Introduces **`verifiers/v1/utils/interrupt.py`** so the eval CLI handles **SIGINT** and **SIGTERM** in one place: the first signal logs a warning, sets a global **`cleaning_up`** flag, and raises **`KeyboardInterrupt`** so asyncio can run rollout teardown; later signals during cleanup are ignored (with a “ctrl-c ignored” warning in non-rich mode).
> 
> The eval entrypoint calls **`install_interrupt()`** instead of remapping only SIGTERM, catches **`KeyboardInterrupt`**, and exits with code **130** without a traceback. Partial traces on disk are unchanged.
> 
> In **rich** mode, **`_interrupt_footer()`** shows a yellow cleanup line under the rollouts (alongside **`--push`** status), and **`live_view`** keeps repainting while **`cleaning_up()`** is true even when Ctrl-C cancels the refresh task—so the dashboard does not freeze mid-teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e8df73d0aa562176f7bb5c66757e5dc9f466855. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Warn and block a second Ctrl-C during eval cleanup
> - Adds [interrupt.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1972/files#diff-be94dbb2960d4153bbf1793f1e05c7154974a12099d78696a3016009607ffb9f) with `install_interrupt()` and `cleaning_up()` helpers; the first SIGINT/SIGTERM sets a cleanup flag and raises `KeyboardInterrupt`, subsequent signals during cleanup are silently ignored.
> - Replaces ad-hoc SIGTERM handling in [eval/main.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1972/files#diff-1335625d1379d7f1a4bf6a2f961d4b5fde5f3a9bfb8eb4cc736859f08698a8c8) with `install_interrupt()` and catches `KeyboardInterrupt` to exit with code 130.
> - Adds a yellow cleanup footer to the eval dashboard in [dashboard/eval.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1972/files#diff-0a27b905958929f3ae9e01937dd7e3cf97a60dec137caddcbf87792784fc9035) that displays once shutdown starts, with pagination adjusted to account for the extra footer height.
> - Keeps the live dashboard refreshing in [dashboard/base.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1972/files#diff-fb360a9433a4bee692a56c4539e1f78cbf911a5c7fe2f735f3b67c4f85d95419) during Ctrl-C so cleanup notices remain visible until teardown begins.
> - Behavioral Change: process now exits with code 130 after a clean shutdown; repeated Ctrl-C during cleanup is ignored rather than escalating.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e8df73.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->