### PR TITLE
Fix harness docs env variable

### DIFF
--- a/docs/v1/harnesses.md
+++ b/docs/v1/harnesses.md
@@ -44,7 +44,7 @@ class MyHarness(Harness[MyHarnessConfig]):
         _, prompt = self.resolve_prompt(trace.task.data)
 
         # Example: Use the harness, but overwrite the endpoint to use the interception server and the custom model name
-        ENVIRONMENT_VARS = {
+        env = {
             **self.config.env,
             "HARNESS_BASE_URL": endpoint,
             "HARNESS_API_KEY": secret,


### PR DESCRIPTION
## What changed

Rename the environment mapping in the minimal harness example from `ENVIRONMENT_VARS` to `env`.

## Why

The example passes `env` to `runtime.run_program(...)`, but previously defined only `ENVIRONMENT_VARS`. Copying it therefore raised `NameError` when the harness launched.

## Impact

The documented minimal harness now uses the same variable it passes to the runtime. This is a one-line documentation-only fix.

## Validation

- `git diff --check`
- `UV_FROZEN=1 uv run pre-commit run --files docs/v1/harnesses.md`
- pre-commit and pre-push hooks (`ty` passed)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix variable name mismatch in harness docs code example
> Corrects the environment variables dict name in [harnesses.md](https://github.com/PrimeIntellect-ai/verifiers/pull/1973/files#diff-b82b252f7ac154fd3fa359a16a557ac1c7b1082baff980585b1b1b1051a2380f) from `ENVIRONMENT_VARS` to `env` so it matches the variable passed to `runtime.run_program`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8d549c1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a code sample; no runtime or application code affected.
> 
> **Overview**
> Fixes a **copy-paste bug** in the minimal harness doc example: the dict passed to `runtime.run_program(..., env)` is now defined as `env` instead of `ENVIRONMENT_VARS`, which would have caused a `NameError` when following the snippet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d549c1e5b48deb87075b2ea8c52597705e6b3b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->