### PR TITLE
feat(v1): support image-bearing Messages prompts

### DIFF
--- a/verifiers/v1/harnesses/codex/harness.py
+++ b/verifiers/v1/harnesses/codex/harness.py
@@ -86,9 +86,9 @@ class CodexHarness(Harness[CodexHarnessConfig]):
             texts = [system_prompt] if system_prompt else []
             image_index = 0
             for message in prompt:
-                if message.role != "user":
+                if message.role not in ("system", "user"):
                     raise ValueError(
-                        "codex exec only supports user messages in the initial prompt"
+                        "codex exec only supports system and user initial messages"
                     )
                 parts = (
                     [TextContentPart(text=message.content)]

--- a/verifiers/v1/harnesses/codex/harness.py
+++ b/verifiers/v1/harnesses/codex/harness.py
@@ -3,13 +3,16 @@
 The static musl binary runs in Linux containers without additional runtime dependencies.
 """
 
+import base64
 import logging
+import re
 import shlex
 
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.harness import Harness, HarnessConfig
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.trace import Trace
+from verifiers.v1.types import TextContentPart
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +43,7 @@ class CodexHarnessConfig(HarnessConfig):
 class CodexHarness(Harness[CodexHarnessConfig]):
     APPENDS_SYSTEM_PROMPT = False  # TODO
     SUPPORTS_MCP = False  # TODO
+    SUPPORTS_MESSAGE_PROMPT = True
 
     async def setup(self, runtime: Runtime) -> None:
         logger.info("codex: ensuring codex %s is installed", self.config.version)
@@ -66,7 +70,53 @@ class CodexHarness(Harness[CodexHarnessConfig]):
         secret: str,
         mcp_urls: dict[str, str],
     ) -> ProgramResult:
-        _, prompt = self.resolve_prompt(trace.task.data)
+        task = trace.task.data
+        if (
+            task.system_prompt is not None
+            and task.prompt is not None
+            and not isinstance(task.prompt, str)
+        ):
+            system_prompt, prompt = task.system_prompt, task.prompt
+        else:
+            system_prompt, prompt = self.resolve_prompt(task)
+        image_args: list[str] = []
+        image_dir = f".vf-codex-images-{trace.id}"
+        if prompt is not None and not isinstance(prompt, str):
+            # Codex seeds one initial turn, so Messages system text joins its prompt.
+            texts = [system_prompt] if system_prompt else []
+            image_index = 0
+            for message in prompt:
+                if message.role != "user":
+                    raise ValueError(
+                        "codex exec only supports user messages in the initial prompt"
+                    )
+                parts = (
+                    [TextContentPart(text=message.content)]
+                    if isinstance(message.content, str)
+                    else message.content
+                )
+                for part in parts:
+                    if isinstance(part, TextContentPart):
+                        texts.append(part.text)
+                        continue
+                    metadata, separator, encoded = part.image_url.url.partition(",")
+                    media_type, *parameters = metadata.removeprefix("data:").split(";")
+                    if (
+                        not separator
+                        or not metadata.startswith("data:image/")
+                        or not any(p.lower() == "base64" for p in parameters)
+                    ):
+                        raise ValueError(
+                            "codex image prompts require base64 data:image URLs"
+                        )
+                    extension = re.sub(
+                        r"[^a-zA-Z0-9]+", "_", media_type.removeprefix("image/")
+                    ).strip("_")
+                    path = f"{image_dir}/image_{image_index}.{extension or 'image'}"
+                    await runtime.write(path, base64.b64decode(encoded))
+                    image_args += ["-i", path]
+                    image_index += 1
+            prompt = "\n\n".join(texts)
         # codex authenticates to the interception server with the session secret (its provider
         # api key) and posts Responses calls to `{endpoint}/responses`.
         env = {**self.config.resolved_env, KEY_VAR: secret}
@@ -109,7 +159,18 @@ class CodexHarness(Harness[CodexHarnessConfig]):
             "-c",
             f"model_providers.{PROVIDER}.requires_openai_auth=false",
             *tool_config,
+            *image_args,
             "--",
             prompt,
         ]
-        return await runtime.run_program(argv, env)
+        try:
+            return await runtime.run_program(argv, env)
+        finally:
+            if image_args:
+                try:
+                    await runtime.run(["rm", "-rf", image_dir], {})
+                except Exception:
+                    # Runtime teardown is the fallback; preserve the rollout result.
+                    logger.warning(
+                        "failed to clean up Codex prompt images", exc_info=True
+                    )

--- a/verifiers/v1/harnesses/default/harness.py
+++ b/verifiers/v1/harnesses/default/harness.py
@@ -103,13 +103,16 @@ class DefaultHarness(Harness[DefaultHarnessConfig]):
                     }
                 )
             )
-        # A Messages prompt (e.g. an image-bearing prompt) seeds the chat loop directly via env
-        # (it can be large multimodal content that overflows argv); a plain string is the single
-        # first user message; None means the task has no prompt and the user simulator opens it.
         if isinstance(prompt, str):
             args.append(f"--prompt={prompt}")
         elif prompt is not None:
-            env["INITIAL_MESSAGES"] = json.dumps([message_to_wire(m) for m in prompt])
+            # Base64 images can exceed exec limits, so hand Messages off through a file.
+            path = f".vf-initial-messages-{trace.id}.json"
+            await runtime.write(
+                path,
+                json.dumps([message_to_wire(m) for m in prompt]).encode(),
+            )
+            args.append(f"--initial-messages-file={path}")
         program = await runtime.prepare_uv_script(
             PROGRAM_SOURCE, self.config.resolved_env
         )

--- a/verifiers/v1/harnesses/default/program.py
+++ b/verifiers/v1/harnesses/default/program.py
@@ -7,7 +7,6 @@
 import argparse
 import asyncio
 import json
-import os
 import subprocess
 from contextlib import AsyncExitStack
 from pathlib import Path
@@ -244,6 +243,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--model", required=True)
     parser.add_argument("--system-prompt", default="")
     parser.add_argument("--prompt", default="")
+    parser.add_argument("--initial-messages-file", default="")
     parser.add_argument("--mcp-config", default="")
     parser.add_argument("--edit", action="store_true")
     parser.add_argument("--search", action="store_true")
@@ -253,6 +253,12 @@ def parse_args() -> argparse.Namespace:
 
 async def main() -> None:
     args = parse_args()
+    initial = []
+    if args.initial_messages_file:
+        path = Path(args.initial_messages_file)
+        payload = path.read_bytes()
+        path.unlink()
+        initial = json.loads(payload)
     # No client-side retries: re-sending a request whose turn the interception already committed
     # re-samples it and forks the trace into an extra dead-end branch. A generous timeout lets a
     # slow turn finish instead of timing out and re-sending; genuine failures surface as error rows.
@@ -275,11 +281,6 @@ async def main() -> None:
             if args.system_prompt
             else []
         )
-        # A Messages prompt (e.g. an image-bearing prompt) arrives pre-built as OpenAI wire dicts
-        # via INITIAL_MESSAGES (kept in env: it can be large multimodal content that overflows
-        # argv, and it's prompt content, not a credential); otherwise --prompt is the opening
-        # message. Both empty means the task has no prompt — the user simulator seeds the opening.
-        initial = json.loads(os.environ.get("INITIAL_MESSAGES", "[]"))
         if initial:
             messages.extend(initial)
         elif args.prompt:

--- a/verifiers/v1/harnesses/null/harness.py
+++ b/verifiers/v1/harnesses/null/harness.py
@@ -54,13 +54,16 @@ class NullHarness(Harness[NullHarnessConfig]):
                     }
                 )
             )
-        # A Messages prompt (e.g. an image-bearing prompt) seeds the chat loop directly via env
-        # (it can be large multimodal content that overflows argv); a plain string is the single
-        # first user message; None means the task has no prompt and the user simulator opens it.
         if isinstance(prompt, str):
             args.append(f"--prompt={prompt}")
         elif prompt is not None:
-            env["INITIAL_MESSAGES"] = json.dumps([message_to_wire(m) for m in prompt])
+            # Base64 images can exceed exec limits, so hand Messages off through a file.
+            path = f".vf-initial-messages-{trace.id}.json"
+            await runtime.write(
+                path,
+                json.dumps([message_to_wire(m) for m in prompt]).encode(),
+            )
+            args.append(f"--initial-messages-file={path}")
         program = await runtime.prepare_uv_script(
             PROGRAM_SOURCE, self.config.resolved_env
         )

--- a/verifiers/v1/harnesses/null/program.py
+++ b/verifiers/v1/harnesses/null/program.py
@@ -7,8 +7,8 @@
 import argparse
 import asyncio
 import json
-import os
 from contextlib import AsyncExitStack
+from pathlib import Path
 
 from openai import AsyncOpenAI
 
@@ -88,12 +88,19 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--model", required=True)
     parser.add_argument("--system-prompt", default="")
     parser.add_argument("--prompt", default="")
+    parser.add_argument("--initial-messages-file", default="")
     parser.add_argument("--mcp-config", default="")
     return parser.parse_args()
 
 
 async def main() -> None:
     args = parse_args()
+    initial = []
+    if args.initial_messages_file:
+        path = Path(args.initial_messages_file)
+        payload = path.read_bytes()
+        path.unlink()
+        initial = json.loads(payload)
     client = AsyncOpenAI(base_url=args.base_url, api_key=args.api_key)
     config = json.loads(args.mcp_config or "{}")
     async with AsyncExitStack() as stack:
@@ -105,11 +112,6 @@ async def main() -> None:
             if args.system_prompt
             else []
         )
-        # A Messages prompt (e.g. an image-bearing prompt) arrives pre-built as OpenAI wire dicts
-        # via INITIAL_MESSAGES (kept in env: it can be large multimodal content that overflows
-        # argv, and it's prompt content, not a credential); otherwise --prompt is the opening
-        # message. Both empty means the task has no prompt — the user simulator seeds the opening.
-        initial = json.loads(os.environ.get("INITIAL_MESSAGES", "[]"))
         if initial:
             messages.extend(initial)
         elif args.prompt:


### PR DESCRIPTION
## Overview

Support image-bearing `Messages` prompts across the default, null, and Codex harnesses.

- Default and null serialize `Messages` to a trace-specific transient file, pass only its path to the harness program, and delete the file immediately after parsing arguments, before MCP setup.
- Codex folds system and user-message text into its initial prompt, materializes each base64 data-URL image in a trace-specific rollout directory, and attaches every image with a repeated `-i` argument.

## Why

Default and null previously put the full serialized prompt in `INITIAL_MESSAGES`. Base64 image data can exceed process-launch limits because argv and environment data share the same budget, causing `E2BIG` before the harness program starts.

Codex accepts image files rather than OpenAI-style `image_url` content. Materializing those image parts bridges the existing `Messages` representation onto the Codex CLI while preserving system instructions and multiple images in their original order.

Trace-specific paths avoid task-file collisions. Prompt handoff files are removed before setup work, and Codex image files use best-effort cleanup when the program exits with runtime teardown as a fallback.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add image-bearing Messages prompt support to harnesses
> - `CodexHarness` now accepts structured message prompts containing image parts. Text parts are concatenated into the prompt string; base64 `data:image` URLs are decoded to temporary files and passed via `-i` arguments. Only `system` and `user` roles are accepted; invalid roles or non-base64 image URLs raise `ValueError`. Temporary files are cleaned up on exit.
> - All harnesses ([default](https://github.com/PrimeIntellect-ai/verifiers/pull/1974/files#diff-8da7b2f062c6d46854a8e31ee1b3b3dc34cd62aa9e8e8fd282a5607a585912c8), [null](https://github.com/PrimeIntellect-ai/verifiers/pull/1974/files#diff-3a22fc74c4c14bfe87584d18fe476635e861b1b33232a5ed977f72ef3d5f5204)) switch from passing initial Messages via the `INITIAL_MESSAGES` environment variable to writing them to a per-trace JSON file and passing `--initial-messages-file=<path>` on the CLI. The file is deleted after reading.
> - Behavioral Change: programs that previously read `INITIAL_MESSAGES` from the environment will no longer receive it there.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cb1c6d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change removes INITIAL_MESSAGES for default/null; Codex adds new prompt parsing and temp file I/O on the rollout path, with validation errors for unsupported message shapes.
> 
> **Overview**
> Adds **multimodal `Messages` prompt** handling so base64 images no longer blow process launch limits (`E2BIG`) when prompts are passed through argv or environment.
> 
> **Default and null harnesses** stop using the `INITIAL_MESSAGES` environment variable. For non-string prompts they write wire-format JSON to a trace-specific `.vf-initial-messages-{trace.id}.json` file, pass only `--initial-messages-file`, and the harness program loads that file and deletes it immediately on startup.
> 
> **Codex harness** advertises `SUPPORTS_MESSAGE_PROMPT = True`, can take structured `Messages` when both `system_prompt` and a non-string `prompt` are set, folds system/user text into Codex’s single initial prompt string, decodes `data:image/...;base64,...` parts into a per-trace image directory, passes them with repeated `-i` flags, and best-effort removes that directory after `codex exec` finishes. Non–system/user roles or non–base64 image URLs raise `ValueError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb1c6d265a9b96675745e01ad01293716c94a481. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->