### PR TITLE
fix(v1): structure env server worker failures

### DIFF
--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -69,27 +69,6 @@ def _arm_teardown(death_pipe=None) -> None:
     threading.Thread(target=_watch, daemon=True).start()
 
 
-def _worker_entry(
-    *, server_kwargs: dict, address: str, death_pipe, legacy: bool, log_setup=None
-) -> None:
-    """Spawned worker: an ordinary EnvServer/LegacyEnvServer bound to `address` (ipc).
-    A native config arrives as a dict (`config_data`): the eval/serve CLI's narrowed
-    config type is dynamic and unpicklable, so we rebuild it here via EnvConfig's
-    id-resolving validator. `log_setup` (if given) configures this fresh process's
-    logging so per-rollout logs surface — a spawned worker inherits no handlers."""
-    from verifiers.v1.legacy import LegacyEnvServer
-
-    _arm_teardown(death_pipe)
-    if log_setup is not None:
-        log_setup()
-    if "config_data" in server_kwargs:
-        server_kwargs = {
-            "config": EnvConfig.model_validate(server_kwargs["config_data"])
-        }
-    cls = LegacyEnvServer if legacy else EnvServer
-    cls.run_server(address=address, **server_kwargs)
-
-
 class EnvServerPool:
     """ROUTER broker that elastically scales worker processes (least-busy dispatch).
 
@@ -138,13 +117,14 @@ class EnvServerPool:
         address = f"ipc://{self._worker_path(i)}"
         parent_conn, child_conn = self._mpctx.Pipe()
         proc = self._mpctx.Process(
-            target=_worker_entry,
+            target=serve_env,
             kwargs=dict(
-                server_kwargs=self.server_kwargs,
+                max_workers=1,
                 address=address,
                 death_pipe=child_conn,
                 legacy=self.legacy,
                 log_setup=self.log_setup,
+                **self.server_kwargs,
             ),
             daemon=False,
         )
@@ -363,3 +343,6 @@ def serve_env(
             )
     except KeyboardInterrupt:
         pass
+    except Exception:
+        logger.exception("Env server failed")
+        raise


### PR DESCRIPTION
## Summary

- remove the dedicated env-server pool worker wrapper
- spawn pool workers through the existing `serve_env(max_workers=1)` lifecycle
- route uncaught server startup failures through the configured structured logger before preserving the nonzero worker exit

## Root cause

Pool workers previously called `EnvServer.run_server` through a thin multiprocessing target. Exceptions escaping that target were printed directly by multiprocessing to raw stderr, so hosted training's JSON-only pretty log view hid the traceback.

Reusing `serve_env` keeps teardown, logging setup, config reconstruction, legacy/native selection, and failure logging in one lifecycle owner.

Companion PrimeRL queue-drain change: https://github.com/PrimeIntellect-ai/prime-rl/pull/3005

## Validation

- spawned a real worker with a missing environment and verified a structured traceback plus exit code 1
- Verifiers pre-push checks passed with frozen dependency resolution
- Ruff formatting and lint checks passed
- Python compilation passed

No tests or lockfile changes are included.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Log and re-raise unhandled exceptions in `serve_env` worker processes
> - Adds a broad exception handler in `serve_env` ([pool.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1976/files#diff-0c9c59578214be2580d340bc524321e352f48038207a68945637d00fc399600c)) that logs `'Env server failed'` before re-raising, so worker failures are visible in logs rather than silent.
> - Removes the `_worker_entry` helper and updates `EnvServerPool._spawn_worker` to target `serve_env` directly, passing `max_workers=1` and expanding `server_kwargs` inline.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c9c6163.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Process-lifecycle and logging changes only; worker behavior should match the old entry path while improving failure visibility for ops.
> 
> **Overview**
> Pool workers no longer use the removed **`_worker_entry`** helper that called `EnvServer` / `LegacyEnvServer` directly. **`EnvServerPool._spawn_worker`** now starts each worker with **`serve_env(max_workers=1, …)`**, passing the IPC address, death pipe, logging setup, and the same **`server_kwargs`** so teardown, logging, config reconstruction, and legacy vs native selection live in one place.
> 
> **`serve_env`** now catches non-**`KeyboardInterrupt`** exceptions, logs **`Env server failed`** with a full traceback via the configured logger, then re-raises so the process still exits nonzero. That makes worker startup/runtime failures visible in structured logs (e.g. hosted training) instead of only on multiprocessing’s raw stderr.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9c6163b4f80a193b464dbbdeae81870c405bb23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->