### PR TITLE
Make Codex multi-agent configurable

### DIFF
--- a/verifiers/v1/harnesses/codex/harness.py
+++ b/verifiers/v1/harnesses/codex/harness.py
@@ -93,8 +93,9 @@ class CodexHarness(Harness[CodexHarnessConfig]):
             "plugins",
             "--disable",
             "multi_agent",
-            "--enable" if self.config.multi_agent else "--disable",
-            "multi_agent_v2",
+            # Preserve any user-supplied multi-agent v2 tool and limit settings.
+            "-c",
+            f"features.multi_agent_v2.enabled={str(self.config.multi_agent).lower()}",
             "-m",
             ctx.model,
             "-c",

--- a/verifiers/v1/harnesses/codex/harness.py
+++ b/verifiers/v1/harnesses/codex/harness.py
@@ -35,6 +35,8 @@ chmod +x {bin}
 class CodexHarnessConfig(HarnessConfig):
     version: str = "0.137.0"
     """Codex release to install (the `rust-v<version>` GitHub release); pinned for reproducibility."""
+    multi_agent: bool = False
+    """Enable Codex's native multi-agent v2 tools."""
 
 
 class CodexHarness(Harness[CodexHarnessConfig]):
@@ -84,16 +86,15 @@ class CodexHarness(Harness[CodexHarnessConfig]):
             "exec",
             "--dangerously-bypass-approvals-and-sandbox",
             "--skip-git-repo-check",
-            # Server-driven feature tools (codex apps, plugins, multi-agent) land in the
-            # Responses `tools` array with definitions non-OpenAI providers reject
-            # (upstream 400 on every call) — and they can flip on remotely under a pinned
-            # CLI. The agent's own tools (exec_command, plan, view_image) stay.
+            # Apps/plugins can flip on remotely and advertise definitions custom providers reject.
             "--disable",
             "apps",
             "--disable",
             "plugins",
             "--disable",
             "multi_agent",
+            "--enable" if self.config.multi_agent else "--disable",
+            "multi_agent_v2",
             "-m",
             ctx.model,
             "-c",


### PR DESCRIPTION
## Overview

Adds an explicit `multi_agent` option to `CodexHarnessConfig`, disabled by default. When enabled, the harness activates Codex's native `multi_agent_v2` tools while continuing to disable the legacy multi-agent feature.

## Details

Codex can expose server-driven feature tool definitions that are not accepted by every Responses-compatible provider. Keeping multi-agent off by default preserves provider compatibility, while the opt-in v2 path uses ordinary function tools that pass through the existing interception layer unchanged.

## User impact

Environments can enable native Codex multi-agent support with `harness.multi_agent = true` without requiring OpenAI credentials. Apps, plugins, and legacy multi-agent remain disabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small harness argv/config change with safe defaults; only affects Codex launch behavior when `multi_agent` is enabled.
> 
> **Overview**
> Adds **`multi_agent`** on `CodexHarnessConfig` (default **`false`**) so runs can opt into Codex’s native **multi-agent v2** tools without changing other provider-safety defaults.
> 
> `CodexHarness.launch` still passes **`--disable`** for **apps**, **plugins**, and legacy **`multi_agent`**, and now also sets **`features.multi_agent_v2.enabled`** via a **`-c`** TOML override from that flag. Launch comments are shortened to match this split (remote feature tools vs. explicit v2 toggle).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f010f408ceabf2541df2a56f30825f7a7c1b8eba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make Codex multi-agent v2 support configurable in `CodexHarnessConfig`
> Adds a `multi_agent` boolean field (default `False`) to `CodexHarnessConfig` in [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1979/files#diff-904c37fe437bb3b42e0238258ed85a8c6cede02461216bcf9c7417c5f3b72b7b). The `CodexHarness.launch` method now passes `-c features.multi_agent_v2.enabled={true|false}` to the Codex CLI based on this field, making the feature explicitly opt-in rather than relying on CLI defaults.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f010f40. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->