### PR TITLE
Use Luna for tool response image CI test

### DIFF
--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -172,6 +172,7 @@ def _eval_config(
     harness_overrides: dict | None = None,
     pool: dict | None = None,
     model: str | None = None,
+    reasoning_effort: str | None = None,
 ) -> EvalConfig:
     """Build the smallest `EvalConfig` that still exercises the path, shared by the in-process
     (`run_v1`) and env-server (`run_v1_server`) fixtures. `taskset_overrides` / `harness_overrides`
@@ -192,7 +193,11 @@ def _eval_config(
         num_rollouts=n,
         max_turns=max_turns,
         max_output_tokens=max_tokens,
-        sampling={"max_tokens": max_tokens, "temperature": 0},
+        sampling={
+            "max_tokens": max_tokens,
+            "temperature": 0,
+            "reasoning_effort": reasoning_effort,
+        },
         timeout={"rollout": rollout_timeout, "scoring": 60},
         retries={"rollout": {"max_retries": 2, "include": ["ProviderError"]}},
         rich=False,

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -145,7 +145,8 @@ async def test_tool_response_image(run_v1, tmp_path):
         "tool-response-image-v1",
         harness="null",
         harness_overrides={"runtime": {"type": "subprocess"}},
-        model="qwen/qwen3-vl-8b-instruct",
+        model="openai/gpt-5.6-luna",
+        reasoning_effort="none",
         output_dir=tmp_path,
         max_turns=4,
     )


### PR DESCRIPTION
## Overview

Use GPT-5.6 Luna for the image-bearing MCP tool-response end-to-end test and disable reasoning for that focused model call.

## Details

- Switch `tool-response-image-v1` from Qwen3-VL to `openai/gpt-5.6-luna`.
- Thread an optional `reasoning_effort` through the shared v1 test config helper.
- Set `reasoning_effort="none"` only for this test, leaving all other test defaults unchanged.

This keeps the test focused on preserving an image returned in a tool message through the provider and into the v1 trace.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to model choice and sampling overrides; no production eval or runtime behavior changes.
> 
> **Overview**
> Switches the **`tool-response-image-v1`** e2e test from **Qwen3-VL** to **`openai/gpt-5.6-luna`** and sets **`reasoning_effort="none"`** so the run stays focused on vision + MCP image-in-tool-message plumbing rather than extended reasoning.
> 
> The shared **`_eval_config`** helper gains an optional **`reasoning_effort`** argument threaded into **`sampling`**; only this test sets it—other e2e defaults are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bcafdcf2305afe50c9e69d4f804f3beb4d374c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch `test_tool_response_image` CI test to use Luna model
> Updates the `test_tool_response_image` test in [test_e2e.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1980/files#diff-ebbbd919487889487f891b359a756e6c4630e106b16ddaef8ccddc6b900a96e1) to use `openai/gpt-5.6-luna` instead of `qwen/qwen3-vl-8b-instruct`, passing `reasoning_effort="none"` to skip reasoning overhead. Adds a `reasoning_effort` parameter to the `_eval_config` helper in [conftest.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1980/files#diff-bc28790d38dc6e7e4f2c44639d40bc33dea724d6c73149abf7ba82b37d14f40b) so it is propagated into `EvalConfig.sampling`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6bcafdc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->