### PR TITLE
feat(default): auto-compaction via summarize_at_tokens

### DIFF
--- a/verifiers/v1/harnesses/default/harness.py
+++ b/verifiers/v1/harnesses/default/harness.py
@@ -1,6 +1,9 @@
 import json
 import os
+import random
 from pathlib import Path
+
+from pydantic import model_validator
 
 from verifiers.v1.harness import Harness, HarnessConfig
 from verifiers.v1.clients import ModelContext
@@ -35,6 +38,30 @@ class DefaultHarnessConfig(HarnessConfig):
     eval environment; the key is handed to the program over argv (like the interception secret) so
     the agent's `bash` subprocesses don't inherit it."""
 
+    summarize_at_tokens: int | tuple[int, int] | None = None
+    """Auto-compaction threshold: once the context grows past this many tokens, the program asks
+    the model to summarize its progress and restarts the message list from the initial prompt plus
+    that summary. An int is a fixed threshold; a `(lo, hi)` pair draws a per-group threshold
+    (seeded by the task index, so a task's rollouts share one draw and tasks vary). `None`
+    disables auto-compaction; ints must be positive."""
+
+    @model_validator(mode="after")
+    def validate_limits(self) -> "DefaultHarnessConfig":
+        value = self.summarize_at_tokens
+        if isinstance(value, tuple):
+            lo, hi = value
+            if lo <= 0 or hi <= 0:
+                raise ValueError("`summarize_at_tokens` range bounds must be positive.")
+            if lo > hi:
+                raise ValueError(
+                    "`summarize_at_tokens` range must be (lo, hi) with lo <= hi."
+                )
+        elif value is not None and value <= 0:
+            raise ValueError(
+                "`summarize_at_tokens` must be positive, or None to disable."
+            )
+        return self
+
 
 class DefaultHarness(Harness[DefaultHarnessConfig]):
     APPENDS_SYSTEM_PROMPT = True
@@ -44,6 +71,17 @@ class DefaultHarness(Harness[DefaultHarnessConfig]):
 
     async def setup(self, runtime: Runtime) -> None:
         await runtime.prepare_uv_script(PROGRAM_SOURCE, self.config.resolved_env)
+
+    def summarize_threshold(self, task_idx: int) -> int:
+        """The resolved auto-compaction threshold: a range draws per-group (seeded by task index,
+        so a task's rollouts share one threshold). 0 when disabled."""
+        value = self.config.summarize_at_tokens
+        if value is None:
+            return 0
+        if isinstance(value, tuple):
+            lo, hi = value
+            return random.Random(task_idx).randint(lo, hi)
+        return value
 
     async def launch(
         self,
@@ -72,6 +110,9 @@ class DefaultHarness(Harness[DefaultHarnessConfig]):
         ]
         if self.config.edit:
             args.append("--edit")
+        threshold = self.summarize_threshold(trace.task.idx)
+        if threshold:
+            args.append(f"--summarize-at-tokens={threshold}")
         if self.config.search:
             # Resolve the key and keep it OUT of the program env: it's handed to the program over
             # argv (--serper-key), so popping it here stops the agent's `bash` subprocesses from

--- a/verifiers/v1/harnesses/default/program.py
+++ b/verifiers/v1/harnesses/default/program.py
@@ -17,6 +17,28 @@ from openai import AsyncOpenAI
 
 SERPER_URL = "https://google.serper.dev/search"
 
+# rlm-parity compaction prompts (mirrors rlm's engine.py).
+CHECKPOINT_COMPACTION_PROMPT = (
+    "You are performing a CONTEXT CHECKPOINT COMPACTION. "
+    "Create a handoff summary for another LLM that will resume the task.\n"
+    "\n"
+    "Include:\n"
+    "- Current progress and key decisions made\n"
+    "- Important context, constraints, or user preferences\n"
+    "- What remains to be done (clear next steps)\n"
+    "- Any critical data, examples, or references needed to continue\n"
+    "\n"
+    "Be concise, structured, and focused on helping the next LLM "
+    "seamlessly continue the work."
+)
+POST_COMPACTION_FRAMING = (
+    "Another language model started to solve this problem and produced "
+    "a summary of its thinking process. Use this to build on the work "
+    "that has already been done and avoid duplicating work. Here is "
+    "the summary produced by the other language model, use the "
+    "information in this summary to assist with your own analysis:"
+)
+
 BASH_TOOL = {
     "type": "function",
     "function": {
@@ -170,12 +192,20 @@ def run_edit(path: str, old_str: str, new_str: str) -> str:
 
 
 async def chat(
-    client: AsyncOpenAI, model: str, messages: list[dict], tools: list[dict]
+    client: AsyncOpenAI,
+    model: str,
+    messages: list[dict],
+    tools: list[dict],
+    tool_choice: str | None = None,
 ):
-    completion = await client.chat.completions.create(
-        model=model, messages=messages, tools=tools or None
-    )
-    return completion.choices[0].message
+    """One completion; returns (message, prompt tokens) — `usage.prompt_tokens` is the
+    context size this turn conditioned on (rlm's compaction trigger)."""
+    kwargs = {"model": model, "messages": messages, "tools": tools or None}
+    if tools and tool_choice is not None:
+        kwargs["tool_choice"] = tool_choice
+    completion = await client.chat.completions.create(**kwargs)
+    usage = completion.usage
+    return completion.choices[0].message, usage.prompt_tokens if usage else 0
 
 
 async def connect_mcp(stack: AsyncExitStack, config: dict) -> tuple[list[dict], dict]:
@@ -248,6 +278,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--edit", action="store_true")
     parser.add_argument("--search", action="store_true")
     parser.add_argument("--serper-key", default="")
+    parser.add_argument("--summarize-at-tokens", type=int, default=0)
     return parser.parse_args()
 
 
@@ -284,8 +315,11 @@ async def main() -> None:
             messages.extend(initial)
         elif args.prompt:
             messages.append({"role": "user", "content": args.prompt})
+        # Compaction keeps only the system message (rlm semantics: the original task
+        # prompt is dropped; the summary carries the goal).
+        system_messages = [m for m in messages if m.get("role") == "system"]
         while True:
-            message = await chat(client, args.model, messages, tools)
+            message, context_tokens = await chat(client, args.model, messages, tools)
             messages.append(message.model_dump(exclude_none=True))
             if not message.tool_calls:
                 break
@@ -338,6 +372,15 @@ async def main() -> None:
                 messages.append(
                     {"role": "tool", "tool_call_id": call.id, "content": content}
                 )
+            # Compact after the turn's tool results land, so the summary sees them (rlm
+            # semantics: tools stay in the request with tool_choice="none" so the prompt
+            # renders like a regular turn; tool calls in the reply are ignored; the rebuilt
+            # list is system + framed summary, dropping the original prompt).
+            if args.summarize_at_tokens and context_tokens >= args.summarize_at_tokens:
+                messages.append({"role": "user", "content": CHECKPOINT_COMPACTION_PROMPT})
+                summary, _ = await chat(client, args.model, messages, tools, tool_choice="none")
+                framed = POST_COMPACTION_FRAMING + "\n\n" + (summary.content or "")
+                messages = system_messages + [{"role": "user", "content": framed}]
 
 
 if __name__ == "__main__":

--- a/verifiers/v1/harnesses/default/program.py
+++ b/verifiers/v1/harnesses/default/program.py
@@ -377,8 +377,12 @@ async def main() -> None:
             # renders like a regular turn; tool calls in the reply are ignored; the rebuilt
             # list is system + framed summary, dropping the original prompt).
             if args.summarize_at_tokens and context_tokens >= args.summarize_at_tokens:
-                messages.append({"role": "user", "content": CHECKPOINT_COMPACTION_PROMPT})
-                summary, _ = await chat(client, args.model, messages, tools, tool_choice="none")
+                messages.append(
+                    {"role": "user", "content": CHECKPOINT_COMPACTION_PROMPT}
+                )
+                summary, _ = await chat(
+                    client, args.model, messages, tools, tool_choice="none"
+                )
                 framed = POST_COMPACTION_FRAMING + "\n\n" + (summary.content or "")
                 messages = system_messages + [{"role": "user", "content": framed}]
 

--- a/verifiers/v1/runtimes/limiters.py
+++ b/verifiers/v1/runtimes/limiters.py
@@ -15,8 +15,13 @@ import tempfile
 import time
 
 # User-scoped: a fixed shared path breaks on multi-user hosts (another user's bucket
-# file -> Permission denied on every tunnel).
-_LIMITER_DIR = os.path.join(tempfile.gettempdir(), f"vf-rate-limiters-{getpass.getuser()}")
+# file -> Permission denied on every tunnel). getuser() can raise in containers running
+# under an arbitrary UID with no passwd entry — fall back to the numeric UID.
+try:
+    _user = getpass.getuser()
+except Exception:
+    _user = str(os.getuid())
+_LIMITER_DIR = os.path.join(tempfile.gettempdir(), f"vf-rate-limiters-{_user}")
 
 
 class CreationLimiter:

--- a/verifiers/v1/runtimes/limiters.py
+++ b/verifiers/v1/runtimes/limiters.py
@@ -9,19 +9,11 @@ host). Keyed by name: one bucket file per name, shared by every process (and run
 
 import asyncio
 import fcntl
-import getpass
 import os
 import tempfile
 import time
 
-# User-scoped: a fixed shared path breaks on multi-user hosts (another user's bucket
-# file -> Permission denied on every tunnel). getuser() can raise in containers running
-# under an arbitrary UID with no passwd entry — fall back to the numeric UID.
-try:
-    _user = getpass.getuser()
-except Exception:
-    _user = str(os.getuid())
-_LIMITER_DIR = os.path.join(tempfile.gettempdir(), f"vf-rate-limiters-{_user}")
+_LIMITER_DIR = os.path.join(tempfile.gettempdir(), "vf-rate-limiters")
 
 
 class CreationLimiter:

--- a/verifiers/v1/runtimes/limiters.py
+++ b/verifiers/v1/runtimes/limiters.py
@@ -9,11 +9,14 @@ host). Keyed by name: one bucket file per name, shared by every process (and run
 
 import asyncio
 import fcntl
+import getpass
 import os
 import tempfile
 import time
 
-_LIMITER_DIR = os.path.join(tempfile.gettempdir(), "vf-rate-limiters")
+# User-scoped: a fixed shared path breaks on multi-user hosts (another user's bucket
+# file -> Permission denied on every tunnel).
+_LIMITER_DIR = os.path.join(tempfile.gettempdir(), f"vf-rate-limiters-{getpass.getuser()}")
 
 
 class CreationLimiter:


### PR DESCRIPTION
Auto-compaction for the default harness, validated in multi-day production RL runs (GLM-4.5-Air on `scaleswe-v1` / `swebench-verified-v1` at 131k context, ~100k rollouts).

## Auto-compaction (`summarize_at_tokens`)

rlm-parity context compaction, matching rlm's engine semantics exactly:

- **Trigger**: `usage.prompt_tokens >= threshold` after a turn's tool results land.
- **Summary request**: rlm's `CHECKPOINT_COMPACTION_PROMPT`, with tools kept in the request under `tool_choice="none"` so the prompt renders like a regular turn; tool calls in the reply are ignored.
- **Rebuild**: system message + the summary wrapped in rlm's `POST_COMPACTION_FRAMING` — the original task prompt is dropped and the summary carries the goal, exactly as rlm does.
- **Config**: mirrors rlm's `summarize_at_tokens` — fixed int, or a `(lo, hi)` per-task draw seeded by task index so a group's rollouts share one threshold.

Long multi-turn episodes survive past the context window; observed in production that agents resume coherently across the boundary (including completing tasks post-compaction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default agent chat loop and issues extra model calls when compaction fires; behavior is gated behind config but affects long-running eval/RL rollouts and trace continuity.
> 
> **Overview**
> Adds **optional context auto-compaction** to the default harness so long agent episodes can continue past the context window without manual truncation.
> 
> **Harness config:** New `summarize_at_tokens` on `DefaultHarnessConfig` — fixed positive int, `(lo, hi)` range (per-task threshold seeded by `task_idx` so rollouts on the same task share one draw), or `None` to disable. Pydantic validation rejects invalid bounds. `DefaultHarness.summarize_threshold()` resolves the value and passes `--summarize-at-tokens` into the uv program when enabled.
> 
> **Program loop:** After each tool-using turn, if `usage.prompt_tokens` meets the threshold, the agent runs an extra completion with rlm-style checkpoint prompts (`CHECKPOINT_COMPACTION_PROMPT`, `POST_COMPACTION_FRAMING`), using `tool_choice="none"` for the summary call. The message list is then rebuilt to **system messages only** plus a single user message with the framed summary — the original task user prompt is dropped, matching rlm semantics. `chat()` now returns prompt token usage to drive the trigger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85f56fbec18b6323ce492e04508c6d856c12626e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add auto-compaction via `--summarize-at-tokens` to the default harness
> - Adds a `summarize_at_tokens` field to `DefaultHarnessConfig` that accepts a fixed int or a `(lo, hi)` range; invalid values raise a validation error at config instantiation.
> - When non-zero, the harness passes `--summarize-at-tokens={threshold}` to the launched program, with per-task thresholds drawn deterministically from the range using `random.Random(task_idx)`.
> - In [program.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1983/files#diff-4cb67cb50bf655658944c055a7e88bcf71e08b1112043d946c684ac2d51a2d80), the interactive loop now tracks prompt token counts per turn; once the count meets the threshold, it requests a summary with `tool_choice='none'`, then rebuilds the conversation to system messages plus a framed summary, discarding prior history.
> - Behavioral Change: after compaction, the model conditions only on system messages and the summary rather than the full conversation history.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 85f56fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->