### PR TITLE
feat(v1): time runtime boot separately from setup

### DIFF
--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -40,6 +40,7 @@ _LABEL_WIDTH = len("timeouts")
 
 _STYLE = {
     "pending": "dim",
+    "boot": "bright_yellow",
     "setup": "yellow",
     "running": "cyan",
     "finalize": "magenta",
@@ -49,6 +50,7 @@ _STYLE = {
 }
 _MARK_LABEL = {
     "pending": "pending",
+    "boot": "boot",
     "setup": "setup",
     "running": "rollout",
     "finalize": "finalize",
@@ -317,7 +319,7 @@ def _breakdown(done: list[Trace]) -> Table | None:
             if judge.cost is not None:
                 total_judge_cost += judge.cost
             have_judge = True
-        for phase in ("setup", "generation", "finalize", "scoring"):
+        for phase in ("boot", "setup", "generation", "finalize", "scoring"):
             span = getattr(trace.timing, phase)
             if span.end:  # phase was timed for this rollout
                 phase_secs[phase] = phase_secs.get(phase, 0.0) + span.duration
@@ -351,7 +353,7 @@ def _breakdown(done: list[Trace]) -> Table | None:
         grid.add_row("usage", "  ·  ".join(usage))
     time_segments = [
         f"{phase} {format_time(phase_secs[phase] / phase_count[phase])}"
-        for phase in ("setup", "generation", "finalize", "scoring")
+        for phase in ("boot", "setup", "generation", "finalize", "scoring")
         if phase_count.get(phase)
     ]
     if time_segments:
@@ -383,11 +385,12 @@ def _tokens(trace: Trace) -> tuple[int, int, int | None, int | None, int]:
 
 
 def _started(rollout: Rollout) -> float:
-    # Sort key: when a rollout began (its setup start). A still-pending rollout has no trace
-    # yet, so it sorts last (+inf) — behind everything already in flight, in task order.
-    return (
-        rollout.trace.timing.setup.start if rollout.trace is not None else float("inf")
-    )
+    # Sort key: when a rollout began (its boot start; setup for pre-boot-span traces on
+    # resume). A still-pending rollout has no trace yet, so it sorts last (+inf) — behind
+    # everything already in flight, in task order.
+    if rollout.trace is None:
+        return float("inf")
+    return rollout.trace.timing.boot.start or rollout.trace.timing.setup.start
 
 
 def _groups(rollouts: list[Rollout]) -> list[list[Rollout]]:
@@ -450,14 +453,14 @@ def Rows(groups: list[list[Rollout]], now: float, runtime_type: str) -> Table:
             )
             runtime = f"{runtime_type}({descriptor})" if descriptor else runtime_type
             turns = t.num_turns
-            start = t.timing.setup.start
+            start = t.timing.boot.start or t.timing.setup.start
             end = (
                 t.timing.scoring.end
                 or t.timing.finalize.end
                 or t.timing.generation.end
-                # a rollout that errored in setup has only setup.end — freeze there once done,
-                # else (still running) the timer would grow off `now` forever
-                or (t.timing.setup.end if t.is_completed else 0)
+                # a rollout that errored in boot/setup has only that span's end — freeze there
+                # once done, else (still running) the timer would grow off `now` forever
+                or ((t.timing.setup.end or t.timing.boot.end) if t.is_completed else 0)
                 or now
             )
             prompt, completion, cached, reasoning, nbranches = _tokens(t)

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -40,7 +40,7 @@ _LABEL_WIDTH = len("timeouts")
 
 _STYLE = {
     "pending": "dim",
-    "boot": "bright_yellow",
+    "boot": "orange3",
     "setup": "yellow",
     "running": "cyan",
     "finalize": "magenta",

--- a/verifiers/v1/cli/debug.py
+++ b/verifiers/v1/cli/debug.py
@@ -138,15 +138,19 @@ def record_debug_error(
     setup_timeout: float | None,
     action_timeout: float | None,
 ) -> None:
-    if not trace.timing.setup.end:
-        trace.timing.setup.end = time.time()
-    if trace.timing.generation.start and not trace.timing.generation.end:
-        trace.timing.generation.end = time.time()
+    now = time.time()
+    for span in (trace.timing.boot, trace.timing.setup, trace.timing.generation):
+        if span.start and not span.end:
+            span.end = now
     in_action = bool(trace.timing.generation.start)
-    stage = "debug action" if in_action else "setup"
+    stage = (
+        "debug action" if in_action else "setup" if trace.timing.setup.start else "boot"
+    )
     timeout = action_timeout if in_action else setup_timeout
     error_start = (
-        trace.timing.generation.start if in_action else trace.timing.setup.start
+        trace.timing.generation.start
+        if in_action
+        else trace.timing.setup.start or trace.timing.boot.start
     )
     debug.update(error_info(error, error_start, timeout, stage))
     debug.setdefault("runtime", runtime_info(runtime))
@@ -226,8 +230,11 @@ async def debug_task(task: Task, config: DebugConfig) -> tuple[Trace, bool]:
         else task.data.timeout.setup
     )
     try:
-        trace.timing.setup.start = time.time()
+        trace.timing.boot.start = time.time()
         await runtime.start()
+        now = time.time()
+        trace.timing.boot.end = now
+        trace.timing.setup.start = now
         debug["runtime"] = runtime_info(runtime)
         await asyncio.wait_for(
             invoke(task.setup, {"trace": trace, "runtime": runtime}),

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -37,6 +37,7 @@ logger = logging.getLogger(__name__)
 
 class Phase(StrEnum):
     PENDING = "pending"
+    BOOT = "boot"
     SETUP = "setup"
     RUNNING = "running"
     FINALIZE = "finalize"
@@ -108,8 +109,8 @@ class Rollout:
             state=state_cls(type(self.task))(),
         )
         self.trace = trace  # expose for the --rich dashboard
-        self.phase = Phase.SETUP  # leaving the queue: provisioning starts now
-        trace.timing.setup.start = time.time()
+        self.phase = Phase.BOOT  # leaving the queue: the runtime boots now
+        trace.timing.boot.start = time.time()
         self.runtime = make_runtime(self.runtime_config, name=trace.id)
         runtime = self.runtime
         trace.runtime = runtime.info
@@ -125,6 +126,10 @@ class Rollout:
         try:
             session = RolloutSession(ctx, trace, stops, self.limits)
             await runtime.start()
+            now = time.time()
+            trace.timing.boot.end = now
+            trace.timing.setup.start = now
+            self.phase = Phase.SETUP
             # Task setup and harness provisioning share one setup-stage deadline.
             setup_deadline = (
                 None
@@ -228,6 +233,7 @@ class Rollout:
             trace.is_completed = True
             now = time.time()
             for span in (
+                trace.timing.boot,
                 trace.timing.setup,
                 trace.timing.generation,
                 trace.timing.finalize,

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -47,7 +47,10 @@ class TimeSpan(StrictBaseModel):
 
 class Timing(StrictBaseModel):
     start: float = Field(default_factory=time.time)
+    boot: TimeSpan = Field(default_factory=TimeSpan)
+    """The runtime coming up (`Runtime.start`) — e.g. a sandbox/VM booting."""
     setup: TimeSpan = Field(default_factory=TimeSpan)
+    """Provisioning on the booted runtime: task setup, harness install, servers."""
     generation: TimeSpan = Field(default_factory=TimeSpan)
     finalize: TimeSpan = Field(default_factory=TimeSpan)
     scoring: TimeSpan = Field(default_factory=TimeSpan)

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -48,9 +48,7 @@ class TimeSpan(StrictBaseModel):
 class Timing(StrictBaseModel):
     start: float = Field(default_factory=time.time)
     boot: TimeSpan = Field(default_factory=TimeSpan)
-    """The runtime coming up (`Runtime.start`) — e.g. a sandbox/VM booting."""
     setup: TimeSpan = Field(default_factory=TimeSpan)
-    """Provisioning on the booted runtime: task setup, harness install, servers."""
     generation: TimeSpan = Field(default_factory=TimeSpan)
     finalize: TimeSpan = Field(default_factory=TimeSpan)
     scoring: TimeSpan = Field(default_factory=TimeSpan)


### PR DESCRIPTION
## Summary

Discriminate the runtime's boot time from the rest of a rollout's setup — until now one `setup` span covered both, so a slow sandbox/VM boot was indistinguishable from slow harness/task provisioning.

- **`Timing.boot`** is a new `TimeSpan` on the trace, covering exactly `Runtime.start()` (e.g. a prime sandbox/VM booting). **`Timing.setup` now starts when boot ends** and covers provisioning on the booted runtime: `task.setup`, the harness install, and tool/user server bring-up. The two spans are disjoint and contiguous; old traces (no `boot` key) still deserialize (defaulted span), so `--resume` of pre-split runs keeps working.
- **`Phase.BOOT`** joins the rollout phases, so the eval dashboard's live mark shows `[boot]` (orange — distinct from setup's yellow even on terminals where bright colors render as bold) while the runtime comes up, then `[setup]` for provisioning.
- **The dashboard's `time` breakdown row** now leads with `boot` (mean over rollouts that timed it, like the other stages), and the per-rollout elapsed/sort logic anchors on `boot.start` (falling back to `setup.start` for pre-split traces).
- The `debug` entrypoint stamps the same split (`boot` around `runtime.start()`), and its error recorder closes whichever spans are open and reports a `boot`-stage error when the runtime never came up.

## Verification

`uv run eval gsm8k-v1 -n 8 --harness.runtime.type prime --harness.runtime.vm` (prime VM sandboxes, default harness):

- All 8 rollouts scored `correct 1.0`, 0 errors. Per rollout, **boot 4.9–5.1s** (the VM coming up; remarkably uniform) vs **setup 7.7–7.9s** (default-harness install + provisioning) — the split is real and would previously have read as one ~13s `setup`.
- The spans are exactly contiguous on every trace (`boot.end == setup.start`), and the summary's `time` row renders the new segment: `boot 5s  ·  setup 8s  ·  generation 20s  ·  finalize 0.0s  ·  scoring …`.

- `pytest tests/v1 -m "not e2e"`: all pass; `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and phase labeling only; setup timeout semantics are unchanged and timing fields remain backward compatible on load.
> 
> **Overview**
> **Runtime boot is no longer folded into setup timing.** Traces gain `Timing.boot` for `Runtime.start()` only; `Timing.setup` begins when boot ends and still covers task setup, harness install, and tool/user servers. Rollouts enter **`Phase.BOOT`** before setup, and error teardown closes boot/setup/generation spans consistently.
> 
> The **eval dashboard** shows an orange `[boot]` mark, includes **boot** in the aggregate `time` row, and uses `boot.start` (with `setup.start` fallback for older traces) for sorting and elapsed time. The **debug** CLI mirrors the same boot/setup stamps and can attribute failures to a **boot** stage when the runtime never finished starting.
> 
> Old traces without a `boot` field still deserialize via a default empty span, so resume and mixed runs keep working.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c1390cfbab26afd39f5b9ced8467453fc8e91eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Track runtime boot separately from setup in v1 rollout traces
> - Adds a `boot` phase and `TimeSpan` to the `Timing` model in [trace.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1990/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e) and a `BOOT` enum member to [rollout.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1990/files#diff-f886b7f4717cf8fce9270bd4ff4790f3182aa1016abb9efb7f6e57efe18d1bf2), capturing the time spent starting the runtime before setup begins.
> - Updates [rollout.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1990/files#diff-f886b7f4717cf8fce9270bd4ff4790f3182aa1016abb9efb7f6e57efe18d1bf2) and [debug.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1990/files#diff-6cbbe530b7b57522fdaa03e458c8212efb6e360e854db49d459fb9e41c1b4d5f) to record `boot.start` before `runtime.start` and `boot.end`/`setup.start` immediately after, splitting what was previously a single setup span.
> - Updates the dashboard in [eval.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1990/files#diff-0a27b905958929f3ae9e01937dd7e3cf97a60dec137caddcbf87792784fc9035) to display `boot` as a distinct orange state, include boot time in the breakdown, and sort/time rows from `boot.start` when available.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c1390c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->