### PR TITLE
fix(v1): recover env pool after worker exit

### DIFF
--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -185,7 +185,6 @@ class EnvServerPool:
         if self._poller is not None:
             self._poller.unregister(worker["dealer"])
             self._poller.unregister(worker["sentinel"])
-        self.workers.remove(worker)
 
         # The process sentinel and its final DEALER reply can become readable in
         # adjacent loop iterations. Honor every reply already queued before failing
@@ -198,23 +197,28 @@ class EnvServerPool:
             ).model_dump(mode="python"),
             use_bin_type=True,
         )
+        failed_responses = []
         for request_id, entry in list(pending.items()):
             if entry["worker"] is not worker:
                 continue
             pending.pop(request_id)
             released += entry["rollout_slots"]
-            with contextlib.suppress(zmq.ZMQError):
-                await self.frontend.send_multipart(
-                    [entry["client_id"], request_id, data]
-                )
+            failed_responses.append([entry["client_id"], request_id, data])
 
+        # Keep the dead worker under shutdown's ownership until all of its resources
+        # are closed, then restore capacity before sending failures can suspend.
         with contextlib.suppress(Exception):
             worker["pipe"].close()
         worker["dealer"].close()
         with contextlib.suppress(OSError):
             os.unlink(self._worker_path(worker["index"]))
         process.close()
+        self.workers.remove(worker)
         self._spawn_worker(worker["index"])
+
+        for response in failed_responses:
+            with contextlib.suppress(zmq.ZMQError):
+                await self.frontend.send_multipart(response)
         return released
 
     def _maybe_scale_up(self, in_flight: int) -> None:

--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -16,9 +16,8 @@ worker.
 Scaling is elastic but upscale-only: a new worker is spawned when in-flight requests
 reach 90% of current capacity (`workers * multiplex`). Workers are spawned `spawn`-style
 (own env, own loop) and monitor a death pipe so an orphaned worker self-exits if the
-broker dies. TODO: downscale idle workers, per-worker restart-on-death, stats/lag
-monitors (v0 had them; omitted here — rollout errors are returned as data, not crashes,
-so worker death is rare).
+broker dies. The broker monitors each process sentinel, fails requests owned by a dead
+worker, and replaces it. TODO: downscale idle workers and stats/lag monitors.
 """
 
 import asyncio
@@ -37,7 +36,7 @@ import zmq.asyncio
 
 from verifiers.v1.env import EnvConfig
 from verifiers.v1.serve.server import EnvServer
-from verifiers.v1.serve.types import HealthResponse, RunGroupRequest
+from verifiers.v1.serve.types import BaseResponse, HealthResponse, RunGroupRequest
 
 logger = logging.getLogger(__name__)
 
@@ -112,8 +111,8 @@ class EnvServerPool:
     def _worker_path(self, i: int) -> str:
         return f"/tmp/vf-pool-{self.session}-{i}"
 
-    def _spawn_worker(self) -> None:
-        i = len(self.workers)  # upscale-only, so the next index is the current count
+    def _spawn_worker(self, index: int | None = None) -> None:
+        i = len(self.workers) if index is None else index
         address = f"ipc://{self._worker_path(i)}"
         parent_conn, child_conn = self._mpctx.Pipe()
         proc = self._mpctx.Process(
@@ -136,6 +135,7 @@ class EnvServerPool:
         self.workers.append(
             {
                 "process": proc,
+                "sentinel": proc.sentinel,
                 "dealer": dealer,
                 "pipe": parent_conn,
                 "active": 0,
@@ -144,6 +144,78 @@ class EnvServerPool:
         )
         if self._poller is not None:
             self._poller.register(dealer, zmq.POLLIN)
+            self._poller.register(proc.sentinel, zmq.POLLIN)
+
+    async def _drain_worker_replies(
+        self, worker: dict, pending: dict[bytes, dict]
+    ) -> int:
+        """Relay every queued reply and return the rollout slots it completed."""
+        released = 0
+        while True:
+            try:
+                request_id, data = await worker["dealer"].recv_multipart(
+                    flags=zmq.NOBLOCK, copy=False
+                )
+            except zmq.Again:
+                return released
+            # Copy only the routing key; relay the response Frames unchanged.
+            entry = pending.pop(request_id.bytes, None)
+            if entry is None:
+                continue
+            entry["worker"]["active"] -= entry["rollout_slots"]
+            released += entry["rollout_slots"]
+            with contextlib.suppress(zmq.ZMQError):
+                await self.frontend.send_multipart(
+                    [entry["client_id"], request_id, data], copy=False
+                )
+
+    async def _worker_died(self, worker: dict, pending: dict[bytes, dict]) -> int:
+        """Remove a dead worker, fail its requests, and start its replacement.
+
+        Returns the rollout slots released from the pool's in-flight count.
+        """
+        process = worker["process"]
+        process.join()
+        logger.error(
+            "EnvServerPool worker %d (pid=%s) exited with code %s; restarting",
+            worker["index"],
+            process.pid,
+            process.exitcode,
+        )
+        if self._poller is not None:
+            self._poller.unregister(worker["dealer"])
+            self._poller.unregister(worker["sentinel"])
+        self.workers.remove(worker)
+
+        # The process sentinel and its final DEALER reply can become readable in
+        # adjacent loop iterations. Honor every reply already queued before failing
+        # requests that the dead worker can no longer complete.
+        released = await self._drain_worker_replies(worker, pending)
+        data = msgpack.packb(
+            BaseResponse(
+                success=False,
+                error=f"env server worker exited unexpectedly (exit code {process.exitcode})",
+            ).model_dump(mode="python"),
+            use_bin_type=True,
+        )
+        for request_id, entry in list(pending.items()):
+            if entry["worker"] is not worker:
+                continue
+            pending.pop(request_id)
+            released += entry["rollout_slots"]
+            with contextlib.suppress(zmq.ZMQError):
+                await self.frontend.send_multipart(
+                    [entry["client_id"], request_id, data]
+                )
+
+        with contextlib.suppress(Exception):
+            worker["pipe"].close()
+        worker["dealer"].close()
+        with contextlib.suppress(OSError):
+            os.unlink(self._worker_path(worker["index"]))
+        process.close()
+        self._spawn_worker(worker["index"])
+        return released
 
     def _maybe_scale_up(self, in_flight: int) -> None:
         """Spawn one more worker when in-flight rollout slots reach 90% of capacity.
@@ -187,6 +259,16 @@ class EnvServerPool:
             in_flight = 0
             while True:
                 events = dict(await self._poller.poll())
+                # Drain replies before handling a simultaneous process exit: data already
+                # handed to ZMQ is a completed request, not a worker failure.
+                for w in list(self.workers):
+                    if w["dealer"] in events:
+                        in_flight -= await self._drain_worker_replies(w, pending)
+
+                for w in list(self.workers):
+                    if w["sentinel"] in events:
+                        in_flight -= await self._worker_died(w, pending)
+
                 if self.frontend in events:
                     (
                         client_id,
@@ -222,19 +304,6 @@ class EnvServerPool:
                         )
                         if self.elastic:
                             self._maybe_scale_up(in_flight)
-                for w in self.workers:
-                    if w["dealer"] in events:
-                        request_id, data = await w["dealer"].recv_multipart(copy=False)
-                        # Copy only the routing key; relay the response Frames unchanged.
-                        entry = pending.pop(request_id.bytes, None)
-                        if entry is None:
-                            continue
-                        entry["worker"]["active"] -= entry["rollout_slots"]
-                        in_flight -= entry["rollout_slots"]
-                        with contextlib.suppress(zmq.ZMQError):
-                            await self.frontend.send_multipart(
-                                [entry["client_id"], request_id, data], copy=False
-                            )
         except (asyncio.CancelledError, KeyboardInterrupt):
             pass
         finally:


### PR DESCRIPTION
## Description

Fixes #1991.

The v1 env-server broker now registers each worker's process sentinel with its existing PyZMQ poller. When a worker exits, the broker:

- drains replies already queued by that worker;
- returns an explicit failure for its remaining requests;
- releases their rollout-slot accounting;
- closes the dead worker's broker-side pipe, socket, process handle, and IPC path;
- starts a replacement in the same worker slot.

Requests are failed rather than transparently replayed because a rollout may have made model calls or other external changes before its worker exited.

Hard-shutdown ownership of worker subprocess trees is tracked separately in #1992. This change does not claim to reclaim descendants or remote resources after `SIGKILL`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing

- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

Validation performed:

- `uv run ruff check --fix .` — passed
- focused worker-death proof — the base timed out; this branch returned `env server worker exited unexpectedly (exit code -9)`, replaced the worker, served a subsequent request, and kept the broker alive
- `uv run pytest tests/v1/test_configs.py tests/v1/test_taskset.py tests/test_env_server.py` — 32 passed
- `uv run pytest tests/` — 956 passed, 148 skipped, 6 unrelated failures: four from the incomplete `environments/hello_mcp_harbor` directory and two environment-load checks requiring OpenAI credentials
- `uv run pre-commit run --all-files` — Ruff passed; the generated-guide check reported pre-existing stale `environments/AGENTS.md` outputs
- focused cleanup-cancellation proof — PR head `7d07537a8` lost dead-worker cleanup ownership when cancellation interrupted the final-reply relay; this branch kept cleanup under `_shutdown` ownership and restored a replacement before an interrupted failure send
- autoreview against `origin/main` — clean, with no accepted or actionable findings

## Checklist

- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

Suggested review order:

1. `_spawn_worker()` sentinel registration
2. `_drain_worker_replies()` and `_worker_died()` lifecycle handling
3. `run()` ordering for replies, worker exits, and new frontend requests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes broker request lifecycle and client-visible errors on worker crash; behavior is intentional but affects rollout reliability and in-flight accounting in the env-server pool.
> 
> **Overview**
> The v1 **EnvServerPool** broker now watches each worker’s **process sentinel** on the existing ZMQ poller and recovers when a worker dies instead of leaving in-flight rollouts stuck.
> 
> On exit it **drains** any replies already queued on that worker’s DEALER, **fails** remaining requests with an explicit `BaseResponse` error (no silent replay), **releases** rollout-slot accounting, tears down IPC/socket/pipe state, and **spawns a replacement** in the same worker index. The main loop handles **dealer replies before sentinel exits** so a final successful reply is not treated as a failure.
> 
> `_spawn_worker` accepts an optional **index** for slot-preserving restarts; workers register both dealer and sentinel with the poller.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d07537a87fe60ea8db4ad66df80d449afc190dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Recover env pool after worker exit in `EnvServerPool` broker
> - Adds process sentinel tracking to `_spawn_worker` so the broker can detect when a worker process dies via poller events.
> - Adds `_drain_worker_replies` to non-blockingly flush queued replies from a dead worker's DEALER socket before failing remaining requests.
> - Adds `_worker_died` to join the dead process, drain remaining replies, send `BaseResponse(success=False)` failure responses to all pending clients, and immediately respawn a replacement worker at the same pool index.
> - Reworks the broker poll loop in [pool.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1993/files#diff-0c9c59578214be2580d340bc524321e352f48038207a68945637d00fc399600c) to drain replies first, then handle sentinel-triggered worker exits.
> - Risk: pending requests owned by a dead worker receive a synthetic failure response; any in-flight work that was not yet queued on the socket is lost.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 767add9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
