### PR TITLE
fix(v1): reap env pool worker subprocesses

### DIFF
--- a/verifiers/utils/process_utils.py
+++ b/verifiers/utils/process_utils.py
@@ -85,8 +85,35 @@ def terminate_processes(
         t.join()
 
 
-def _session_processes(session: int) -> set[int]:
-    """Return the current members of a POSIX session."""
+def _proc_session_processes(session: int) -> set[int] | None:
+    """Read session membership from procfs, or return None when unavailable."""
+    try:
+        entries = os.scandir("/proc")
+    except OSError:
+        return None
+
+    members: set[int] = set()
+    with entries:
+        for entry in entries:
+            if not entry.name.isdigit():
+                continue
+            try:
+                with open(f"/proc/{entry.name}/stat") as stat:
+                    fields = stat.read().rsplit(")", 1)[1].split()
+                if int(fields[3]) == session:
+                    members.add(int(entry.name))
+            except (IndexError, OSError, ValueError):
+                # Processes can exit between scandir and opening their stat file. A live
+                # member is seen on the next fixed-point scan below.
+                continue
+    return members
+
+
+def _session_processes(session: int) -> set[int] | None:
+    """Return current POSIX session members, or None if discovery is unavailable."""
+    if (members := _proc_session_processes(session)) is not None:
+        return members
+
     try:
         listing = subprocess.run(
             ["ps", "-A", "-o", "pid=,sid="],
@@ -95,15 +122,19 @@ def _session_processes(session: int) -> set[int]:
             text=True,
             timeout=5,
         ).stdout
-        return {
-            pid
-            for line in listing.splitlines()
-            for pid, sid in [map(int, line.split())]
-            if sid == session
-        }
-    except (OSError, subprocess.SubprocessError, ValueError):
+    except (OSError, subprocess.SubprocessError):
         logger.warning("Could not read POSIX session %d", session)
-        return set()
+        return None
+
+    members = set()
+    for line in listing.splitlines():
+        try:
+            pid, sid = map(int, line.split())
+        except ValueError:
+            continue
+        if sid == session:
+            members.add(pid)
+    return members
 
 
 def kill_process_session(process: BaseProcess, timeout: float = 10.0) -> None:
@@ -123,17 +154,33 @@ def kill_process_session(process: BaseProcess, timeout: float = 10.0) -> None:
     # The caller waits on the process sentinel without joining first.  An exited worker
     # therefore remains a zombie and keeps its PID/SID reserved until this cleanup joins it.
     members = _session_processes(root)
+    if members is None:
+        logger.error(
+            "Cannot discover worker session %d; killing only the worker process", root
+        )
+        with contextlib.suppress(Exception):
+            process.kill()
+        process.join(timeout=timeout)
+        return
     if root not in members:
         with contextlib.suppress(Exception):
             process.kill()
         process.join(timeout=timeout)
         return
 
+    discovery_failures = 0
     while members:
         for pid in members:
             with contextlib.suppress(ProcessLookupError, PermissionError):
                 os.kill(pid, signal.SIGSTOP)
         discovered = _session_processes(root)
+        if discovered is None:
+            discovery_failures += 1
+            if discovery_failures < 3:
+                continue
+            logger.error("Could not verify stopped worker session %d", root)
+            break
+        discovery_failures = 0
         if discovered <= members:
             break
         members.update(discovered)

--- a/verifiers/utils/process_utils.py
+++ b/verifiers/utils/process_utils.py
@@ -6,6 +6,7 @@ import os
 import signal
 import subprocess
 import threading
+import time
 from multiprocessing.connection import Connection
 from multiprocessing.process import BaseProcess
 
@@ -171,39 +172,65 @@ def kill_process_session(process: BaseProcess, timeout: float = 10.0) -> None:
 
     live = {pid for pid, is_live in members.items() if is_live}
     discovery_failures = 0
+    deadline = time.monotonic() + timeout
+    old_mask = signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGINT, signal.SIGTERM})
     try:
-        while live:
-            for pid in live:
-                with contextlib.suppress(ProcessLookupError, PermissionError):
-                    os.kill(pid, signal.SIGSTOP)
-            discovered = _session_processes(root)
-            if discovered is None:
-                discovery_failures += 1
-                if discovery_failures < 3:
-                    continue
-                logger.error("Could not verify stopped worker session %d", root)
-                break
-            discovery_failures = 0
-            current = {pid for pid, is_live in discovered.items() if is_live}
-            if current <= live:
-                live = current
-                break
-            live = current
-    finally:
-        # Refresh away exited/zombie PIDs before killing. The nested finally guarantees
-        # that even KeyboardInterrupt during discovery cannot strand a stopped worker.
         try:
-            if (current := _session_processes(root)) is not None:
-                live = {pid for pid, is_live in current.items() if is_live}
+            while live and time.monotonic() < deadline:
+                for pid in live:
+                    with contextlib.suppress(ProcessLookupError, PermissionError):
+                        os.kill(pid, signal.SIGSTOP)
+                discovered = _session_processes(root)
+                if discovered is None:
+                    discovery_failures += 1
+                    if discovery_failures < 3:
+                        continue
+                    logger.error("Could not verify stopped worker session %d", root)
+                    break
+                discovery_failures = 0
+                current = {pid for pid, is_live in discovered.items() if is_live}
+                if current <= live:
+                    live = current
+                    break
+                live = current
+            else:
+                if live:
+                    logger.warning("Timed out freezing worker session %d", root)
         finally:
-            for pid in live:
+            # Drain rather than kill one snapshot: a member that forked just before SIGSTOP or
+            # the freeze deadline may have added a process that only the next scan can see.
+            # Every successful SIGKILL round removes possible forkers, so this converges without
+            # letting an unfreezable member keep the bounded freeze phase alive forever.
+            try:
+                kill_deadline = time.monotonic() + timeout
+                while live and time.monotonic() < kill_deadline:
+                    signaled = False
+                    for pid in live:
+                        with contextlib.suppress(ProcessLookupError, PermissionError):
+                            if os.getsid(pid) == root:
+                                os.kill(pid, signal.SIGKILL)
+                                signaled = True
+                    if not signaled:
+                        logger.error("Could not kill worker session %d", root)
+                        break
+                    current = _session_processes(root)
+                    if current is None:
+                        logger.error("Could not verify killed worker session %d", root)
+                        break
+                    live = {pid for pid, is_live in current.items() if is_live}
+                if live:
+                    logger.error(
+                        "Worker session %d still has %d live process(es) after SIGKILL",
+                        root,
+                        len(live),
+                    )
+            finally:
                 with contextlib.suppress(BaseException):
-                    if os.getsid(pid) == root:
-                        os.kill(pid, signal.SIGKILL)
-            with contextlib.suppress(BaseException):
-                process.kill()
-            with contextlib.suppress(BaseException):
-                process.join(timeout=timeout)
+                    process.kill()
+                with contextlib.suppress(BaseException):
+                    process.join(timeout=timeout)
+    finally:
+        signal.pthread_sigmask(signal.SIG_SETMASK, old_mask)
 
 
 def use_threading_tqdm_lock() -> None:

--- a/verifiers/utils/process_utils.py
+++ b/verifiers/utils/process_utils.py
@@ -1,8 +1,10 @@
 """Process lifecycle utilities."""
 
+import contextlib
 import logging
 import os
 import signal
+import subprocess
 import threading
 from multiprocessing.connection import Connection
 from multiprocessing.process import BaseProcess
@@ -81,6 +83,65 @@ def terminate_processes(
         t.start()
     for t in threads:
         t.join()
+
+
+def _session_processes(session: int) -> set[int]:
+    """Return the current members of a POSIX session."""
+    try:
+        listing = subprocess.run(
+            ["ps", "-A", "-o", "pid=,sid="],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        ).stdout
+        return {
+            pid
+            for line in listing.splitlines()
+            for pid, sid in [map(int, line.split())]
+            if sid == session
+        }
+    except (OSError, subprocess.SubprocessError, ValueError):
+        logger.warning("Could not read POSIX session %d", session)
+        return set()
+
+
+def kill_process_session(process: BaseProcess, timeout: float = 10.0) -> None:
+    """Kill a worker-owned POSIX session, including its separate process groups.
+
+    Pool workers are session leaders, and framework subprocess runtimes create their own
+    process groups inside that session.  Session membership therefore survives worker
+    exit and does not rely on a stale parent-PID snapshot.  Members are stopped until the
+    session is stable, preventing new forks between discovery and ``SIGKILL``.
+
+    Call this only after giving the process a chance to terminate gracefully.  It is a
+    POSIX helper; if the process did not become its own session leader, only its PID is
+    killed so an unrelated caller session is never targeted.
+    """
+    root = process.pid
+    assert root is not None
+    # The caller waits on the process sentinel without joining first.  An exited worker
+    # therefore remains a zombie and keeps its PID/SID reserved until this cleanup joins it.
+    members = _session_processes(root)
+    if root not in members:
+        with contextlib.suppress(Exception):
+            process.kill()
+        process.join(timeout=timeout)
+        return
+
+    while members:
+        for pid in members:
+            with contextlib.suppress(ProcessLookupError, PermissionError):
+                os.kill(pid, signal.SIGSTOP)
+        discovered = _session_processes(root)
+        if discovered <= members:
+            break
+        members.update(discovered)
+
+    for pid in members:
+        with contextlib.suppress(ProcessLookupError, PermissionError):
+            os.kill(pid, signal.SIGKILL)
+    process.join(timeout=timeout)
 
 
 def use_threading_tqdm_lock() -> None:

--- a/verifiers/utils/process_utils.py
+++ b/verifiers/utils/process_utils.py
@@ -85,14 +85,14 @@ def terminate_processes(
         t.join()
 
 
-def _proc_session_processes(session: int) -> set[int] | None:
+def _proc_session_processes(session: int) -> dict[int, bool] | None:
     """Read session membership from procfs, or return None when unavailable."""
     try:
         entries = os.scandir("/proc")
     except OSError:
         return None
 
-    members: set[int] = set()
+    members: dict[int, bool] = {}
     with entries:
         for entry in entries:
             if not entry.name.isdigit():
@@ -101,7 +101,7 @@ def _proc_session_processes(session: int) -> set[int] | None:
                 with open(f"/proc/{entry.name}/stat") as stat:
                     fields = stat.read().rsplit(")", 1)[1].split()
                 if int(fields[3]) == session:
-                    members.add(int(entry.name))
+                    members[int(entry.name)] = fields[0] != "Z"
             except (IndexError, OSError, ValueError):
                 # Processes can exit between scandir and opening their stat file. A live
                 # member is seen on the next fixed-point scan below.
@@ -109,14 +109,14 @@ def _proc_session_processes(session: int) -> set[int] | None:
     return members
 
 
-def _session_processes(session: int) -> set[int] | None:
-    """Return current POSIX session members, or None if discovery is unavailable."""
+def _session_processes(session: int) -> dict[int, bool] | None:
+    """Map current POSIX session PIDs to whether each process is non-zombie."""
     if (members := _proc_session_processes(session)) is not None:
         return members
 
     try:
         listing = subprocess.run(
-            ["ps", "-A", "-o", "pid=,sid="],
+            ["ps", "-A", "-o", "pid=,sid=,stat="],
             check=True,
             capture_output=True,
             text=True,
@@ -126,14 +126,15 @@ def _session_processes(session: int) -> set[int] | None:
         logger.warning("Could not read POSIX session %d", session)
         return None
 
-    members = set()
+    members = {}
     for line in listing.splitlines():
         try:
-            pid, sid = map(int, line.split())
+            raw_pid, raw_sid, state = line.split()
+            pid, sid = int(raw_pid), int(raw_sid)
         except ValueError:
             continue
         if sid == session:
-            members.add(pid)
+            members[pid] = not state.startswith("Z")
     return members
 
 
@@ -168,27 +169,41 @@ def kill_process_session(process: BaseProcess, timeout: float = 10.0) -> None:
         process.join(timeout=timeout)
         return
 
+    live = {pid for pid, is_live in members.items() if is_live}
     discovery_failures = 0
-    while members:
-        for pid in members:
-            with contextlib.suppress(ProcessLookupError, PermissionError):
-                os.kill(pid, signal.SIGSTOP)
-        discovered = _session_processes(root)
-        if discovered is None:
-            discovery_failures += 1
-            if discovery_failures < 3:
-                continue
-            logger.error("Could not verify stopped worker session %d", root)
-            break
-        discovery_failures = 0
-        if discovered <= members:
-            break
-        members.update(discovered)
-
-    for pid in members:
-        with contextlib.suppress(ProcessLookupError, PermissionError):
-            os.kill(pid, signal.SIGKILL)
-    process.join(timeout=timeout)
+    try:
+        while live:
+            for pid in live:
+                with contextlib.suppress(ProcessLookupError, PermissionError):
+                    os.kill(pid, signal.SIGSTOP)
+            discovered = _session_processes(root)
+            if discovered is None:
+                discovery_failures += 1
+                if discovery_failures < 3:
+                    continue
+                logger.error("Could not verify stopped worker session %d", root)
+                break
+            discovery_failures = 0
+            current = {pid for pid, is_live in discovered.items() if is_live}
+            if current <= live:
+                live = current
+                break
+            live = current
+    finally:
+        # Refresh away exited/zombie PIDs before killing. The nested finally guarantees
+        # that even KeyboardInterrupt during discovery cannot strand a stopped worker.
+        try:
+            if (current := _session_processes(root)) is not None:
+                live = {pid for pid, is_live in current.items() if is_live}
+        finally:
+            for pid in live:
+                with contextlib.suppress(BaseException):
+                    if os.getsid(pid) == root:
+                        os.kill(pid, signal.SIGKILL)
+            with contextlib.suppress(BaseException):
+                process.kill()
+            with contextlib.suppress(BaseException):
+                process.join(timeout=timeout)
 
 
 def use_threading_tqdm_lock() -> None:

--- a/verifiers/v1/runtimes/subprocess.py
+++ b/verifiers/v1/runtimes/subprocess.py
@@ -54,14 +54,14 @@ class SubprocessRuntime(Runtime):
             cwd=self.workdir,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            start_new_session=True,  # own process group, so we can reap the whole tree
+            process_group=0,  # own group inside the pool worker's cleanup session
         )
         try:
             stdout, stderr = await proc.communicate()
         finally:
             # If the await didn't finish, the caller cancelled it (e.g. the rollout's
             # scoring_timeout / harness_timeout fired): communicate() leaves the process
-            # running, so SIGKILL its whole group (start_new_session => pgid == pid) — otherwise
+            # running, so SIGKILL its whole group (process_group=0 => pgid == pid) — otherwise
             # a hung child (a wedged uv/sympy verify) outlives the rollout and leaks CPU. A
             # no-op once it has exited on its own.
             if proc.returncode is None:
@@ -88,7 +88,7 @@ class SubprocessRuntime(Runtime):
                 cwd=self.workdir,
                 stdout=f,
                 stderr=asyncio.subprocess.STDOUT,
-                start_new_session=True,  # own process group, so cleanup() reaps the whole tree
+                process_group=0,  # own group inside the pool worker's cleanup session
             )
         self._background.append(
             proc
@@ -104,7 +104,7 @@ class SubprocessRuntime(Runtime):
 
     def cleanup(self) -> None:
         for proc in self._background:
-            # Kill the whole group (start_new_session => pgid == pid), not just proc.pid, so a
+            # Kill the whole group (process_group=0 => pgid == pid), not just proc.pid, so a
             # background server's children (sh -> uv -> python) are reaped too.
             with contextlib.suppress(ProcessLookupError, PermissionError):
                 os.killpg(os.getpgid(proc.pid), signal.SIGTERM)

--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -244,29 +244,37 @@ class EnvServerPool:
             self._shutdown()
 
     def _shutdown(self) -> None:
-        for w in self.workers:
-            with contextlib.suppress(Exception):
-                w["pipe"].close()
-            with contextlib.suppress(Exception):
-                w["process"].terminate()
+        old_handlers = {
+            sig: signal.signal(sig, signal.SIG_IGN)
+            for sig in (signal.SIGINT, signal.SIGTERM)
+        }
+        try:
+            for w in self.workers:
+                with contextlib.suppress(Exception):
+                    w["pipe"].close()
+                with contextlib.suppress(Exception):
+                    w["process"].terminate()
 
-        # Wait on sentinels rather than join/is_alive: an exited worker remains a zombie,
-        # reserving the PID that identifies its cleanup session until that session is reaped.
-        pending = {w["process"].sentinel for w in self.workers}
-        deadline = time.monotonic() + 10
-        while pending and (remaining := deadline - time.monotonic()) > 0:
-            pending.difference_update(wait(pending, timeout=remaining))
+            # Wait on sentinels rather than join/is_alive: an exited worker remains a zombie,
+            # reserving the PID that identifies its cleanup session until that session is reaped.
+            pending = {w["process"].sentinel for w in self.workers}
+            deadline = time.monotonic() + 10
+            while pending and (remaining := deadline - time.monotonic()) > 0:
+                pending.difference_update(wait(pending, timeout=remaining))
 
-        for w in self.workers:
-            with contextlib.suppress(Exception):
-                kill_process_session(w["process"])
-            with contextlib.suppress(Exception):
-                w["dealer"].close()
-            with contextlib.suppress(OSError):
-                os.unlink(self._worker_path(w["index"]))
-        self.frontend.close()
-        self.ctx.term()
-        logger.info("EnvServerPool down")
+            for w in self.workers:
+                with contextlib.suppress(Exception):
+                    kill_process_session(w["process"])
+                with contextlib.suppress(Exception):
+                    w["dealer"].close()
+                with contextlib.suppress(OSError):
+                    os.unlink(self._worker_path(w["index"]))
+            self.frontend.close()
+            self.ctx.term()
+            logger.info("EnvServerPool down")
+        finally:
+            for sig, handler in old_handlers.items():
+                signal.signal(sig, handler)
 
 
 def _serve_pool_worker(**kwargs) -> None:

--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -28,8 +28,10 @@ import multiprocessing as mp
 import os
 import signal
 import threading
+import time
 import uuid
 from collections.abc import Callable
+from multiprocessing.connection import wait
 
 import msgpack
 import zmq
@@ -38,6 +40,7 @@ import zmq.asyncio
 from verifiers.v1.env import EnvConfig
 from verifiers.v1.serve.server import EnvServer
 from verifiers.v1.serve.types import HealthResponse, RunGroupRequest
+from verifiers.utils.process_utils import kill_process_session
 
 logger = logging.getLogger(__name__)
 
@@ -117,7 +120,7 @@ class EnvServerPool:
         address = f"ipc://{self._worker_path(i)}"
         parent_conn, child_conn = self._mpctx.Pipe()
         proc = self._mpctx.Process(
-            target=serve_env,
+            target=_serve_pool_worker,
             kwargs=dict(
                 max_workers=1,
                 address=address,
@@ -246,12 +249,17 @@ class EnvServerPool:
                 w["pipe"].close()
             with contextlib.suppress(Exception):
                 w["process"].terminate()
+
+        # Wait on sentinels rather than join/is_alive: an exited worker remains a zombie,
+        # reserving the PID that identifies its cleanup session until that session is reaped.
+        pending = {w["process"].sentinel for w in self.workers}
+        deadline = time.monotonic() + 10
+        while pending and (remaining := deadline - time.monotonic()) > 0:
+            pending.difference_update(wait(pending, timeout=remaining))
+
         for w in self.workers:
             with contextlib.suppress(Exception):
-                w["process"].join(timeout=10)
-            if w["process"].is_alive():
-                with contextlib.suppress(Exception):
-                    w["process"].kill()
+                kill_process_session(w["process"])
             with contextlib.suppress(Exception):
                 w["dealer"].close()
             with contextlib.suppress(OSError):
@@ -259,6 +267,12 @@ class EnvServerPool:
         self.frontend.close()
         self.ctx.term()
         logger.info("EnvServerPool down")
+
+
+def _serve_pool_worker(**kwargs) -> None:
+    """Run a pool worker as the leader of the session that owns its subprocesses."""
+    os.setsid()
+    serve_env(**kwargs)
 
 
 def env_config_data(config) -> dict:


### PR DESCRIPTION
## Description

Fixes #1992.

Env-server pool workers now lead a POSIX session that owns their local subprocesses. `SubprocessRuntime` still gives each rollout its own process group, but those groups remain inside the worker session. Pool shutdown keeps the existing graceful `SIGTERM` window, then freezes and kills any processes left in the worker session.

Shutdown waits on multiprocessing sentinels without joining first. This keeps an exited worker's PID and session ID reserved until session cleanup finishes, avoiding stale descendant-PID snapshots and PID-reuse races.

Provider-side sandbox and tunnel registrations are outside the OS session and remain tracked in #1994.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing

- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

Validation performed:

- focused regression proof: PID-only escalation left a separate process group alive; this branch reaped it both when the worker ignored `SIGTERM` and when the worker exited during the grace period
- `uv run pytest tests/test_env_server.py` — 15 passed
- `uv run ruff check --fix .` — passed
- `uv run pre-commit run --all-files` — Ruff passed; the generated-guide check reported pre-existing stale `environments/AGENTS.md` outputs
- `uv run ty check verifiers/utils/process_utils.py verifiers/v1/serve/pool.py` — passed
- autoreview — clean after resolving session ownership, late-fork, and PID-reuse findings

The repository asks contributors not to add unit tests; the regression proof was run as a temporary process-level script.

## Checklist

- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

Suggested review order:

1. `verifiers/v1/serve/pool.py`: worker session creation and sentinel-based shutdown ordering
2. `verifiers/v1/runtimes/subprocess.py`: per-rollout process groups remain inside the worker session
3. `verifiers/utils/process_utils.py`: freeze-and-kill session cleanup

PR #1993 also changes `pool.py` for worker-death recovery. The changes are independent but may require a small rebase after either PR merges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes POSIX signal handling and process-tree teardown during pool shutdown; mistakes could affect unrelated processes if session discovery misidentifies leaders, though the code guards non-leader workers by killing only the worker PID.
> 
> **Overview**
> Fixes leaked rollout subprocesses when env-server pool workers shut down by treating each worker as a **POSIX session leader** and reaping the whole session instead of killing only the worker PID.
> 
> **Pool workers** now enter via `_serve_pool_worker`, which calls `os.setsid()` before `serve_env`, so the worker PID doubles as the session ID for cleanup. **`EnvServerPool._shutdown`** still sends graceful `SIGTERM`, then waits on multiprocessing **sentinels** (without joining first, so the zombie keeps the session identity stable), and escalates with **`kill_process_session`** rather than a bare `process.kill()`. Shutdown temporarily ignores `SIGINT`/`SIGTERM` on the broker while tearing workers down.
> 
> **`kill_process_session`** (new in `process_utils`) discovers session members via `/proc` with a `ps` fallback, freezes live PIDs with `SIGSTOP` until membership stabilizes (late forks), then iteratively `SIGKILL`s session members and joins the worker.
> 
> **`SubprocessRuntime`** switches from `start_new_session=True` to **`process_group=0`**, so each rollout still gets its own process group for `killpg` on cancel/cleanup, but those groups stay **inside** the worker session for pool-level reaping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55e7b71d6807c051e83c53fed6bf7f4eb5ca1432. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reap env pool worker subprocesses by killing entire POSIX sessions on shutdown
> - Each pool worker now calls `os.setsid()` via a new `_serve_pool_worker` wrapper in [pool.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1995/files#diff-0c9c59578214be2580d340bc524321e352f48038207a68945637d00fc399600c), making it a session leader so all its descendants share a session ID.
> - `EnvServerPool._shutdown` waits on worker sentinels (10s timeout), then calls a new `kill_process_session` utility to freeze and SIGKILL every process in the worker's session, ensuring no orphaned subprocesses remain.
> - `kill_process_session` in [process_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1995/files#diff-e7e2f39a29599ddb467d2fa197a4f4bfc58a0a67049b3174b3ac10e5d7de6d1a) discovers session members via `/proc` (or `ps -A` as fallback), SIGSTOPs live members to prevent forking, then iteratively SIGKILLs until the session is drained or a timeout is reached.
> - Subprocess children in [subprocess.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1995/files#diff-f36f9994618d7a28baaf498b61eb6f129dcfda77500d165d18537426dfcdd6e2) now use `process_group=0` instead of `start_new_session=True`, keeping them inside the worker's session so they are caught by session-level cleanup.
> - Behavioral Change: subprocesses spawned by the runtime are no longer in their own session; they share the worker's session and will be killed during pool shutdown.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 55e7b71.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
