### PR TITLE
Prefer pip for uv bootstrap

### DIFF
--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -19,13 +19,10 @@ from verifiers.v1.utils.aio import run_shielded
 
 logger = logging.getLogger(__name__)
 
-# Ensure `uv` is available to run our PEP 723 scripts (the harness + tool servers): use it
-# if present, else bootstrap it — via pip; else via the standalone installer (curl/wget),
-# first installing curl + CA certs from the distro package manager when the image has no
-# downloader at all (bare task images, e.g. Harbor's). It installs to ~/.local/bin, which
-# we prepend to PATH so the provisioning command finds it; uv resolves each script's inline
-# deps into its own cache, isolated from the eval process. (Needs network + one of
-# uv / pip / curl / wget / apt-get / apk.)
+# Ensure the latest `uv` is available for our PEP 723 scripts: prefer pip on Python images,
+# then fall back to the standalone installer (curl/wget), installing curl + CA certs when a
+# bare image has no downloader. Both paths install to ~/.local/bin, which we prepend to PATH.
+# (Needs network + one of pip / curl / wget / apt-get / apk.)
 _INSTALL_CURL = (  # only when the image has no downloader; needs a known package manager
     "{ command -v curl >/dev/null 2>&1 || command -v wget >/dev/null 2>&1; } "
     "|| { apt-get update -qq && apt-get install -y -qq curl ca-certificates; } "
@@ -37,12 +34,8 @@ _DOWNLOAD_UV = (
 )
 _ENSURE_UV = (
     'export PATH="$HOME/.local/bin:$PATH" UV_INSTALL_DIR="$HOME/.local/bin"; '
-    # Always install the latest uv into $HOME/.local/bin (ahead of any image uv on PATH) rather
-    # than reusing whatever the image ships: base images carry wildly varying uvs (too old for the
-    # `uv sync --script` / `uv python find --script` that prepare_uv_script runs, or stale/shadowed
-    # on PATH). Installing fresh sidesteps all version probing. Falls back to pip when no downloader.
-    f"{{ {_INSTALL_CURL}; {_DOWNLOAD_UV}; }} "
-    "|| pip install -q -U uv 2>/dev/null"
+    "pip install -q -U --user uv 2>/dev/null "
+    f"|| {{ {_INSTALL_CURL}; {_DOWNLOAD_UV}; }}"
 )
 
 # The single port a self-publishing runtime (modal/prime) forwards to a public URL for a server


### PR DESCRIPTION
## Overview

Prefer pip when bootstrapping `uv` for PEP 723 scripts in runtime sandboxes.

## Change

Python base images already provide pip, so the bootstrap now tries `pip install --user` before falling back to the standalone installer. Bare images retain the existing curl/wget and package-manager fallback.

Both paths install `uv` into `$HOME/.local/bin`, which is placed first on `PATH`. This also ensures a stale standalone binary at that path is replaced by the pip installation.

## Impact

- Reduces fresh `uv` bootstrap time on the default Prime Python VM from approximately 4.18 seconds to 2.46 seconds, a 1.72-second or 41% reduction.
- Avoids downloader and package-manager setup on normal Python images.
- Requires no custom runtime image or dependency metadata changes.

The frequency of installation and per-script environment behavior are unchanged in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Provisioning-only shell change with the same target install path; main risk is edge images where pip succeeds but installs an incompatible uv version.
> 
> **Overview**
> **Reorders how sandboxes install `uv` before PEP 723 script prep** in `_ENSURE_UV`: it now tries `pip install -q -U --user uv` first, and only runs the curl/wget standalone installer (with optional apt/apk curl setup) if pip fails.
> 
> Previously the standalone download ran first and pip was the fallback. On Python-based images this should skip slower network installer work when pip is already available, while bare images still get the same downloader path. Comments were tightened to match the new order; install location remains `$HOME/.local/bin` on `PATH`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1e7ef644ec77b702d74d8d820a542f9e3698dea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prefer pip over curl/wget for uv bootstrap in runtime provisioning
> Changes the uv installation order in [base.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1996/files#diff-0811c040a163eb5a3212208f1e3a6c6388d7690fcc4780c081cc7754036232b9) to try `pip install -q -U --user uv` first, falling back to the standalone curl/wget installer only if pip fails. Previously, curl/wget was attempted first with pip as the fallback. The `--user` flag ensures uv is installed in the user's local bin rather than system-wide.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a1e7ef6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->