### PR TITLE
Use direct command for Prime workdir setup

### DIFF
--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -138,7 +138,7 @@ class PrimeRuntime(Runtime):
             logger.info(
                 "prime: sandbox %s up (image=%s)", self.info.id, self.config.image
             )
-            await self._client.run_background_job(
+            await self._client.execute_command(
                 self.info.id, f"mkdir -p {shlex.quote(self.config.workdir)}"
             )
         except (


### PR DESCRIPTION
## Overview

Create the Prime sandbox work directory through the SDK's direct command API.

## Change

The workdir `mkdir` is a short, idempotent provisioning operation. It now uses `execute_command` instead of the background-job helper and its fixed polling interval.

Long-running harness programs and general runtime commands remain on their existing execution paths.

## Impact

- Removes roughly 3 seconds of background-job polling from every Prime sandbox boot.
- Keeps workdir creation synchronous, so rollout setup still starts only after the directory exists.
- Requires no runtime image or configuration changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single synchronous API swap for an idempotent mkdir during provisioning; no auth, config, or long-running execution path changes.
> 
> **Overview**
> Prime sandbox boot now creates the configured workdir with **`execute_command`** instead of **`run_background_job`**, matching how other short provisioning steps (e.g. composable env `mkdir`) already talk to the SDK.
> 
> **`run()`** and other long-running paths are unchanged—they still use background jobs and direct polling so rollout timeouts stay under local control.
> 
> This should cut roughly **~3 seconds** of fixed background-job polling from every Prime sandbox startup while keeping workdir creation **blocking** before rollout setup continues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b65c7353ba30652b3a60ff6d41ca1b1a7141013. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use `execute_command` instead of `run_background_job` for workdir setup in `PrimeRuntime.start`
> In [prime.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1998/files#diff-d22d61279ff7587a2b14c72ab1a0fc9d3f805a735338a70f8efc7fe19aaa8502), the `mkdir -p <workdir>` call after sandbox creation now uses `execute_command` instead of `run_background_job`, making the directory creation synchronous rather than a background job.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b65c73.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->