### PR TITLE
Reuse uv across runtime provisioning

### DIFF
--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -125,8 +125,12 @@ async def _install_in_sandbox(server: ServerBase, runtime: Runtime) -> str:
     # build, silently running the server against a released (older) API. Pretend the
     # local version so the floor is satisfied by the build we uploaded.
     vf_version = importlib.metadata.version("verifiers")
-    async with runtime._uv_lock if not runtime._uv_ready else contextlib.nullcontext():
-        ensure_uv = _UV_ENV if runtime._uv_ready else _ENSURE_UV
+    async with (
+        runtime._uv_lock
+        if None not in runtime._uv_ready_homes
+        else contextlib.nullcontext()
+    ):
+        ensure_uv = _UV_ENV if None in runtime._uv_ready_homes else _ENSURE_UV
         setup = (
             f'{ensure_uv}; set -e; for t in {root}/*.tar.gz; do tar -xzf "$t" -C {root}; done && '
             f"uv venv {venv} && "
@@ -136,7 +140,7 @@ async def _install_in_sandbox(server: ServerBase, runtime: Runtime) -> str:
         )
         result = await runtime.run(["sh", "-c", setup], {})
         if result.exit_code == 0:
-            runtime._uv_ready = True
+            runtime._uv_ready_homes.add(None)
     if result.exit_code != 0:
         raise ToolsetError(
             f"server {server.server_name!r} install failed in runtime: "

--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -132,7 +132,7 @@ async def _install_in_sandbox(server: ServerBase, runtime: Runtime) -> str:
     ):
         ensure_uv = _UV_ENV if None in runtime._uv_ready_homes else _ENSURE_UV
         setup = (
-            f'{ensure_uv}; set -e; for t in {root}/*.tar.gz; do tar -xzf "$t" -C {root}; done && '
+            f'{{ {ensure_uv}; }} && set -e; for t in {root}/*.tar.gz; do tar -xzf "$t" -C {root}; done && '
             f"uv venv {venv} && "
             f"SETUPTOOLS_SCM_PRETEND_VERSION={shlex.quote(vf_version)} "
             f"uv pip install --python {venv} {root}/{shlex.quote(vf.name)} && "

--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -25,7 +25,7 @@ from verifiers.v1.runtimes import (
     make_runtime,
     runtime_is_local,
 )
-from verifiers.v1.runtimes.base import _ENSURE_UV
+from verifiers.v1.runtimes.base import _ENSURE_UV, _UV_ENV
 from verifiers.v1.types import Messages
 
 if TYPE_CHECKING:
@@ -125,15 +125,18 @@ async def _install_in_sandbox(server: ServerBase, runtime: Runtime) -> str:
     # build, silently running the server against a released (older) API. Pretend the
     # local version so the floor is satisfied by the build we uploaded.
     vf_version = importlib.metadata.version("verifiers")
-    setup = (
-        f"{_ENSURE_UV}; set -e; "
-        f'for t in {root}/*.tar.gz; do tar -xzf "$t" -C {root}; done && '
-        f"uv venv {venv} && "
-        f"SETUPTOOLS_SCM_PRETEND_VERSION={shlex.quote(vf_version)} "
-        f"uv pip install --python {venv} {root}/{shlex.quote(vf.name)} && "
-        f"uv pip install --python {venv} {root}/{shlex.quote(env.name)}"
-    )
-    result = await runtime.run(["sh", "-c", setup], {})
+    async with runtime._uv_lock if not runtime._uv_ready else contextlib.nullcontext():
+        ensure_uv = _UV_ENV if runtime._uv_ready else _ENSURE_UV
+        setup = (
+            f'{ensure_uv}; set -e; for t in {root}/*.tar.gz; do tar -xzf "$t" -C {root}; done && '
+            f"uv venv {venv} && "
+            f"SETUPTOOLS_SCM_PRETEND_VERSION={shlex.quote(vf_version)} "
+            f"uv pip install --python {venv} {root}/{shlex.quote(vf.name)} && "
+            f"uv pip install --python {venv} {root}/{shlex.quote(env.name)}"
+        )
+        result = await runtime.run(["sh", "-c", setup], {})
+        if result.exit_code == 0:
+            runtime._uv_ready = True
     if result.exit_code != 0:
         raise ToolsetError(
             f"server {server.server_name!r} install failed in runtime: "

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -32,8 +32,9 @@ _DOWNLOAD_UV = (
     "{ command -v curl >/dev/null 2>&1 && curl -LsSf https://astral.sh/uv/install.sh | sh; } "
     "|| { command -v wget >/dev/null 2>&1 && wget -qO- https://astral.sh/uv/install.sh | sh; }"
 )
+_UV_ENV = 'export PATH="$HOME/.local/bin:$PATH" UV_INSTALL_DIR="$HOME/.local/bin"'
 _ENSURE_UV = (
-    'export PATH="$HOME/.local/bin:$PATH" UV_INSTALL_DIR="$HOME/.local/bin"; '
+    f"{_UV_ENV}; "
     "pip install -q -U --user uv 2>/dev/null "
     f"|| {{ {_INSTALL_CURL}; {_DOWNLOAD_UV}; }}"
 )
@@ -109,6 +110,8 @@ class Runtime(ABC):
 
     def __init__(self, name: str | None = None) -> None:
         self.name = name or f"vf-{uuid.uuid4().hex[:12]}"
+        self._uv_ready = False
+        self._uv_lock = asyncio.Lock()
         self._uv_interpreters: dict[str, str] = {}
         self._uv_script_locks: dict[str, asyncio.Lock] = {}
 
@@ -180,13 +183,21 @@ class Runtime(ABC):
                 if digest not in self._uv_interpreters:
                     tmp = f"{path}.{uuid.uuid4().hex}.tmp"
                     await self.write(tmp, data)
-                    command = (
-                        f"mv -f {shlex.quote(tmp)} {shlex.quote(path)} "
-                        f"&& {{ {_ENSURE_UV}; }} "
-                        f"&& uv sync --script {shlex.quote(path)} -q --no-config "
-                        f"&& uv python find --script {shlex.quote(path)} --no-config"
-                    )
-                    result = await self.run(["sh", "-c", command], env or {})
+                    async with (
+                        self._uv_lock
+                        if not self._uv_ready
+                        else contextlib.nullcontext()
+                    ):
+                        setup = _UV_ENV if self._uv_ready else _ENSURE_UV
+                        command = (
+                            f"mv -f {shlex.quote(tmp)} {shlex.quote(path)} "
+                            f"&& {{ {setup}; }} "
+                            f"&& uv sync --script {shlex.quote(path)} -q --no-config "
+                            f"&& uv python find --script {shlex.quote(path)} --no-config"
+                        )
+                        result = await self.run(["sh", "-c", command], env or {})
+                        if result.exit_code == 0:
+                            self._uv_ready = True
                     if result.exit_code != 0:
                         raise RuntimeError(
                             "failed to prepare uv script: "

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -110,7 +110,8 @@ class Runtime(ABC):
 
     def __init__(self, name: str | None = None) -> None:
         self.name = name or f"vf-{uuid.uuid4().hex[:12]}"
-        self._uv_ready = False
+        # uv installs under each command's HOME; None represents the runtime default.
+        self._uv_ready_homes: set[str | None] = set()
         self._uv_lock = asyncio.Lock()
         self._uv_interpreters: dict[str, str] = {}
         self._uv_script_locks: dict[str, asyncio.Lock] = {}
@@ -183,12 +184,15 @@ class Runtime(ABC):
                 if digest not in self._uv_interpreters:
                     tmp = f"{path}.{uuid.uuid4().hex}.tmp"
                     await self.write(tmp, data)
+                    uv_home = (env or {}).get("HOME")
                     async with (
                         self._uv_lock
-                        if not self._uv_ready
+                        if uv_home not in self._uv_ready_homes
                         else contextlib.nullcontext()
                     ):
-                        setup = _UV_ENV if self._uv_ready else _ENSURE_UV
+                        setup = (
+                            _UV_ENV if uv_home in self._uv_ready_homes else _ENSURE_UV
+                        )
                         command = (
                             f"mv -f {shlex.quote(tmp)} {shlex.quote(path)} "
                             f"&& {{ {setup}; }} "
@@ -197,7 +201,7 @@ class Runtime(ABC):
                         )
                         result = await self.run(["sh", "-c", command], env or {})
                         if result.exit_code == 0:
-                            self._uv_ready = True
+                            self._uv_ready_homes.add(uv_home)
                     if result.exit_code != 0:
                         raise RuntimeError(
                             "failed to prepare uv script: "


### PR DESCRIPTION
## Overview

Reuse a successful `uv` installation across provisioning consumers within the same runtime and `HOME`.

## Change

The runtime records which `HOME` values have completed a uv-backed command successfully. The first caller for each value performs the existing bootstrap under a lock; later PEP 723 scripts and colocated sandbox server installs using the same `HOME` only restore `PATH` and `UV_INSTALL_DIR`.

Per-script dependency synchronization, content-addressed script paths, and sandbox server virtual environments remain unchanged. A different `HOME` receives its own bootstrap, and a failed first command remains unready so the next caller retries.

## Impact

- Avoids one complete uv bootstrap for GSM8K's later verifier script, reducing its scoring path by approximately 1.3 seconds.
- Avoids approximately 0.49 seconds of redundant uv installation checks for each later colocated MCP or user server using the same `HOME`.
- Prevents concurrent first users of the same install directory from installing uv more than once.
- Requires no custom image and does not share dependency environments between scripts or servers.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reuse uv across runtime provisioning by caching and serializing setup per HOME
> - Adds `_uv_lock` (an `asyncio.Lock`) and `_uv_ready_homes` (a set) to `Runtime.__init__` in [base.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2001/files#diff-0811c040a163eb5a3212208f1e3a6c6388d7690fcc4780c081cc7754036232b9) to serialize uv installation and skip re-running it for already-provisioned HOME directories.
> - Extracts a new `_UV_ENV` shell constant containing the `PATH` and `UV_INSTALL_DIR` exports, so that already-ready environments only export env vars instead of re-running the full installer.
> - Applies the same locking and readiness-cache logic to `_install_in_sandbox` in [launch.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2001/files#diff-989d87123d40d48511f9e1df74594d2e30776e9a99c11eca49d9cc20bf9e2230).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 357c5b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Provisioning-only optimization with serialized first-time uv install per HOME; no auth or data-path changes, though concurrent cold starts now queue on the lock.
> 
> **Overview**
> **Reuses a successful `uv` install** within a single runtime instance so later PEP 723 script prep and colocated sandbox server installs do not repeat pip/curl bootstrap when they share the same `HOME`.
> 
> `Runtime` now tracks **`_uv_ready_homes`** (keyed by `env["HOME"]`, with `None` for the default in sandbox installs) and serializes the **first** bootstrap per key with **`_uv_lock`**. That first run still uses **`_ENSURE_UV`**; follow-ups only apply the extracted **`_UV_ENV`** (`PATH` / `UV_INSTALL_DIR`). A failed bootstrap is not marked ready, so the next caller retries. Per-script `uv sync`, content-addressed script paths, and separate server venvs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 357c5b14e45e84167d8b07e29f1fef3dbfa151c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->