### PR TITLE
feat: add ART MCP-RL taskset adapter

### DIFF
--- a/verifiers/v1/tasksets/art_mcp/__init__.py
+++ b/verifiers/v1/tasksets/art_mcp/__init__.py
@@ -1,0 +1,19 @@
+"""ART MCP-RL scenario taskset adapter."""
+
+from verifiers.v1.tasksets.art_mcp.taskset import (
+    ArtMCPTask,
+    ArtMCPTaskData,
+    ArtMCPTaskset,
+    ArtMCPTasksetConfig,
+    art_rows_from_tasks,
+    load_art_rows,
+)
+
+__all__ = [
+    "ArtMCPTask",
+    "ArtMCPTaskData",
+    "ArtMCPTaskset",
+    "ArtMCPTasksetConfig",
+    "art_rows_from_tasks",
+    "load_art_rows",
+]

--- a/verifiers/v1/tasksets/art_mcp/taskset.py
+++ b/verifiers/v1/tasksets/art_mcp/taskset.py
@@ -24,9 +24,7 @@ class ArtMCPTaskData(vf.TaskData):
 
 
 class ArtMCPTask(vf.Task[ArtMCPTaskData]):
-    @vf.stop
-    async def single_turn(self, trace: vf.Trace) -> bool:
-        return trace.num_turns >= 1
+    pass
 
 
 class ArtMCPTasksetConfig(vf.TasksetConfig):

--- a/verifiers/v1/tasksets/art_mcp/taskset.py
+++ b/verifiers/v1/tasksets/art_mcp/taskset.py
@@ -1,0 +1,97 @@
+"""Taskset adapter for OpenPipe ART MCP-RL scenario files.
+
+ART MCP-RL stores generated scenarios as JSON/JSONL rows with a natural-language
+``task`` and optional metadata such as ``difficulty``. This module maps those
+rows into native verifiers v1 tasks while preserving enough structured data to
+export them back to ART-style rows.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+from pydantic import Field
+
+import verifiers.v1 as vf
+
+
+class ArtMCPTaskData(vf.TaskData):
+    source_task: str
+    difficulty: int = 1
+    art_metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class ArtMCPTask(vf.Task[ArtMCPTaskData]):
+    @vf.stop
+    async def single_turn(self, trace: vf.Trace) -> bool:
+        return trace.num_turns >= 1
+
+
+class ArtMCPTasksetConfig(vf.TasksetConfig):
+    path: str
+    system_prompt: str | None = None
+
+
+def _read_rows(path: Path) -> Iterable[dict[str, Any]]:
+    if path.suffix == ".jsonl":
+        for line in path.read_text().splitlines():
+            if line.strip():
+                yield json.loads(line)
+        return
+
+    data = json.loads(path.read_text())
+    if isinstance(data, list):
+        yield from data
+        return
+    if isinstance(data, dict):
+        rows = data.get("scenarios", data.get("tasks"))
+        if isinstance(rows, list):
+            yield from rows
+            return
+    raise ValueError(f"unsupported ART scenario file shape: {path}")
+
+
+def load_art_rows(path: str | Path) -> list[dict[str, Any]]:
+    rows = list(_read_rows(Path(path)))
+    for idx, row in enumerate(rows):
+        task = row.get("task")
+        if not isinstance(task, str) or not task.strip():
+            raise ValueError(f"row {idx} missing non-empty 'task'")
+        difficulty = row.get("difficulty", 1)
+        if not isinstance(difficulty, int) or difficulty < 1:
+            raise ValueError(f"row {idx} has invalid difficulty: {difficulty!r}")
+    return rows
+
+
+def art_rows_from_tasks(tasks: Iterable[ArtMCPTask]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for task in tasks:
+        row = dict(task.data.art_metadata)
+        row["task"] = task.data.source_task
+        row["difficulty"] = task.data.difficulty
+        rows.append(row)
+    return rows
+
+
+class ArtMCPTaskset(vf.Taskset[ArtMCPTask, ArtMCPTasksetConfig]):
+    def load(self) -> list[ArtMCPTask]:
+        return [
+            ArtMCPTask(
+                ArtMCPTaskData(
+                    idx=i,
+                    prompt=row["task"],
+                    system_prompt=self.config.system_prompt,
+                    source_task=row["task"],
+                    difficulty=row.get("difficulty", 1),
+                    art_metadata={
+                        key: value
+                        for key, value in row.items()
+                        if key not in {"task", "difficulty"}
+                    },
+                ),
+                self.config.task,
+            )
+            for i, row in enumerate(load_art_rows(self.config.path))
+        ]

--- a/verifiers/v1/tasksets/art_mcp/taskset.py
+++ b/verifiers/v1/tasksets/art_mcp/taskset.py
@@ -46,7 +46,9 @@ def _read_rows(path: Path) -> Iterable[dict[str, Any]]:
         yield from data
         return
     if isinstance(data, dict):
-        rows = data.get("scenarios", data.get("tasks"))
+        rows = data.get("scenarios")
+        if not isinstance(rows, list):
+            rows = data.get("tasks")
         if isinstance(rows, list):
             yield from rows
             return
@@ -56,6 +58,8 @@ def _read_rows(path: Path) -> Iterable[dict[str, Any]]:
 def load_art_rows(path: str | Path) -> list[dict[str, Any]]:
     rows = list(_read_rows(Path(path)))
     for idx, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise ValueError(f"row {idx} must be a JSON object")
         task = row.get("task")
         if not isinstance(task, str) or not task.strip():
             raise ValueError(f"row {idx} missing non-empty 'task'")


### PR DESCRIPTION
## Description

Adds a Verifiers v1 taskset adapter for OpenPipe ART MCP-RL scenario files.

The adapter:

- loads ART JSON/JSONL scenarios as typed Verifiers v1 tasks;
- preserves scenario metadata and difficulty;
- exports tasks back to ART-compatible rows;
- validates malformed tasks and unsupported input shapes.

This targets the two-way ART ↔ Verifiers portability track in the [ART-E / ART bounty](https://algora.io/PrimeIntellect-ai/bounties/cxptwFoEv2up9Qjm).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing

- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

Validation performed:

- `uvx ruff check verifiers/v1/tasksets/art_mcp` — passed
- `uvx ruff format --check verifiers/v1/tasksets/art_mcp` — passed
- `python -m compileall` for the adapter — passed
- Round-trip smoke test using ART’s checked-in `mcp_balldontlie/scenarios/val.jsonl` fixture — all 8 scenarios loaded and exported without losing `task` or `difficulty`

The full test suite was not run because the local environment cannot build the existing `pycosat` dependency without a C compiler. No unit tests were added because the repository’s `AGENTS.md` explicitly asks contributors not to add unit tests for v1 changes and recommends temporary validation scripts instead.

## Checklist

- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

No dependencies or configuration files are changed. Documentation was not modified because the new adapter is self-contained and does not alter existing APIs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, isolated taskset adapter with no changes to existing APIs, auth, or runtime paths; failures are limited to explicit validation errors on malformed scenario files.
> 
> **Overview**
> Adds a new **`verifiers/v1/tasksets/art_mcp`** package so OpenPipe ART MCP-RL scenario files can be used as native Verifiers v1 tasks.
> 
> **`ArtMCPTaskset`** reads a configured file path and builds **`ArtMCPTask`** instances whose prompts come from each row’s `task`, with optional **`system_prompt`** on the taskset config. **`ArtMCPTaskData`** keeps **`source_task`**, **`difficulty`**, and extra fields in **`art_metadata`** for round-trip export.
> 
> **`load_art_rows`** / **`_read_rows`** accept JSONL, a top-level JSON array, or a JSON object with **`scenarios`** or **`tasks`**, and reject bad shapes or rows (missing non-empty `task`, invalid `difficulty`). **`art_rows_from_tasks`** writes ART-compatible dicts back from loaded tasks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e6ade2da027ca9414c38c21aecd51e3d6363b0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add ART MCP-RL taskset adapter with JSONL and JSON file support
> - Adds a new `ArtMCPTaskset` under [verifiers/v1/tasksets/art_mcp/](https://github.com/PrimeIntellect-ai/verifiers/pull/2003/files#diff-394ab53ae24638ae5f83c6cf775df99e33146c799ed49e29fabacfe243311c71) that loads ART scenario files and constructs `ArtMCPTask` instances from them.
> - Supports `.jsonl` files (one JSON object per line) and `.json` files (top-level list or dict with a `scenarios`/`tasks` key); raises `ValueError` for unsupported shapes or invalid rows.
> - Each task carries the original ART `task` string as its prompt, an integer `difficulty` (default 1), an optional system prompt from config, and arbitrary ART metadata preserved on `ArtMCPTaskData`.
> - Includes `art_rows_from_tasks` to convert in-memory `ArtMCPTask` instances back to ART-compatible dicts for export.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9e6ade2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->