### PR TITLE
Add Pi harness support

### DIFF
--- a/verifiers/v1/harnesses/__init__.py
+++ b/verifiers/v1/harnesses/__init__.py
@@ -6,6 +6,7 @@ from verifiers.v1.harnesses.mini_swe_agent import (
     MiniSWEAgentHarnessConfig,
 )
 from verifiers.v1.harnesses.null import NullHarness, NullHarnessConfig
+from verifiers.v1.harnesses.pi import PiHarness, PiHarnessConfig
 from verifiers.v1.harnesses.rlm import RLMHarness, RLMHarnessConfig
 from verifiers.v1.harnesses.terminus_2 import Terminus2Harness, Terminus2HarnessConfig
 
@@ -18,6 +19,8 @@ __all__ = [
     "KimiCodeHarnessConfig",
     "NullHarness",
     "NullHarnessConfig",
+    "PiHarness",
+    "PiHarnessConfig",
     "MiniSWEAgentHarness",
     "MiniSWEAgentHarnessConfig",
     "RLMHarness",

--- a/verifiers/v1/harnesses/pi/__init__.py
+++ b/verifiers/v1/harnesses/pi/__init__.py
@@ -1,0 +1,3 @@
+from verifiers.v1.harnesses.pi.harness import PiHarness, PiHarnessConfig
+
+__all__ = ["PiHarness", "PiHarnessConfig"]

--- a/verifiers/v1/harnesses/pi/harness.py
+++ b/verifiers/v1/harnesses/pi/harness.py
@@ -1,0 +1,211 @@
+"""Pi reaches interception through a custom OpenAI-compatible provider.
+
+Pi intentionally leaves MCP to extensions, so the harness always installs and loads the
+pi-mcp-adapter package.
+"""
+
+import base64
+import json
+import logging
+import re
+import shlex
+
+from verifiers.v1.clients import ModelContext
+from verifiers.v1.harness import Harness, HarnessConfig
+from verifiers.v1.runtimes import ProgramResult, Runtime
+from verifiers.v1.trace import Trace
+from verifiers.v1.types import SystemMessage, TextContentPart, UserMessage
+
+logger = logging.getLogger(__name__)
+
+PROVIDER = "intercept"
+KEY_VAR = "PI_INTERCEPT_KEY"
+
+PI_DIR = "/tmp/vf-pi"
+PI_BIN = f"{PI_DIR}/pi"
+MCP_VERSION = "2.11.0"
+MCP_EXTENSION = f"{PI_DIR}/mcp/node_modules/pi-mcp-adapter/index.ts"
+
+INSTALL = r"""
+set -e
+dir=/tmp/vf-pi
+bin="$dir/pi"
+mcp="$dir/mcp"
+
+if ! command -v curl >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
+    { apt-get update -qq && apt-get install -y -qq curl ca-certificates nodejs npm >/dev/null; } \
+        || apk add --no-cache curl ca-certificates nodejs npm >/dev/null
+fi
+
+if [ ! -x "$bin" ] || [ "$("$bin" --version 2>/dev/null)" != "{version}" ]; then
+    case "$(uname -m)" in aarch64|arm64) arch=arm64 ;; *) arch=x64 ;; esac
+    curl -fsSL "https://github.com/earendil-works/pi/releases/download/v{version}/pi-linux-${arch}.tar.gz" \
+        | tar -xz -C "$dir" --strip-components=1
+fi
+
+[ "$(node -p "require('$mcp/node_modules/pi-mcp-adapter/package.json').version" 2>/dev/null)" = "{mcp_version}" ] \
+    || npm install --prefix "$mcp" --ignore-scripts --no-audit --no-fund --omit=dev \
+        "pi-mcp-adapter@{mcp_version}" >/dev/null
+"""
+
+
+class PiHarnessConfig(HarnessConfig):
+    version: str = "0.80.6"
+    """Pi release to install, pinned for reproducibility."""
+
+
+class PiHarness(Harness[PiHarnessConfig]):
+    APPENDS_SYSTEM_PROMPT = True
+    SUPPORTS_MCP = True
+    SUPPORTS_MESSAGE_PROMPT = True
+
+    async def setup(self, runtime: Runtime) -> None:
+        logger.info(
+            "pi: ensuring Pi %s and pi-mcp-adapter %s are installed",
+            self.config.version,
+            MCP_VERSION,
+        )
+        script = INSTALL.replace("{version}", self.config.version).replace(
+            "{mcp_version}", MCP_VERSION
+        )
+        lock = f"{PI_DIR}/installing"
+        guarded = (
+            f"mkdir -p {PI_DIR} && "
+            f"until mkdir {lock} 2>/dev/null; do sleep 0.1; done; "
+            f"trap 'rmdir {lock}' EXIT; sh -c {shlex.quote(script)}"
+        )
+        install = await runtime.run(["sh", "-c", guarded], {})
+        if install.exit_code != 0:
+            raise RuntimeError(f"pi install failed: {install.stderr.strip()[-500:]}")
+
+    async def launch(
+        self,
+        ctx: ModelContext,
+        trace: Trace,
+        runtime: Runtime,
+        endpoint: str,
+        secret: str,
+        mcp_urls: dict[str, str],
+    ) -> ProgramResult:
+        system_prompt, prompt = self.resolve_prompt(trace.task.data)
+
+        agent_dir = f"{PI_DIR}/agent-{trace.id}"
+        image_args: list[str] = []
+        if prompt is not None and not isinstance(prompt, str):
+            system_texts = [system_prompt] if system_prompt else []
+            texts: list[str] = []
+            image_index = 0
+            for message in prompt:
+                if not isinstance(message, (SystemMessage, UserMessage)):
+                    raise ValueError(
+                        "Pi print mode only supports system and user initial messages"
+                    )
+                parts = (
+                    [TextContentPart(text=message.content)]
+                    if isinstance(message.content, str)
+                    else message.content
+                )
+                for part in parts:
+                    if isinstance(part, TextContentPart):
+                        (system_texts if message.role == "system" else texts).append(
+                            part.text
+                        )
+                        continue
+                    metadata, separator, encoded = part.image_url.url.partition(",")
+                    media_type, *parameters = metadata.removeprefix("data:").split(";")
+                    if (
+                        not separator
+                        or not metadata.startswith("data:image/")
+                        or not any(p.lower() == "base64" for p in parameters)
+                    ):
+                        raise ValueError(
+                            "Pi image prompts require base64 data:image URLs"
+                        )
+                    extension = re.sub(
+                        r"[^a-zA-Z0-9]+", "_", media_type.removeprefix("image/")
+                    ).strip("_")
+                    path = (
+                        f"{agent_dir}/images/image_{image_index}.{extension or 'image'}"
+                    )
+                    await runtime.write(path, base64.b64decode(encoded))
+                    image_args.append(f"@{path}")
+                    image_index += 1
+            system_prompt = "\n\n".join(system_texts) or None
+            prompt = "\n\n".join(texts)
+        if prompt is None:
+            raise ValueError("Pi requires a task prompt (it has no user simulator)")
+
+        reasoning = ctx.sampling.reasoning_effort not in (
+            None,
+            "none",
+        ) or ctx.model.rsplit("/", 1)[-1].startswith(("gpt-5", "o1", "o3", "o4"))
+        models = {
+            "providers": {
+                PROVIDER: {
+                    "baseUrl": endpoint,
+                    "api": "openai-completions",
+                    "apiKey": f"${KEY_VAR}",
+                    "models": [
+                        {
+                            "id": ctx.model,
+                            "reasoning": reasoning,
+                            "input": ["text", "image"],
+                        }
+                    ],
+                }
+            }
+        }
+        mcp = {
+            "mcpServers": {
+                name: {"url": url, "lifecycle": "eager"}
+                for name, url in mcp_urls.items()
+            }
+        }
+        prompt_path = f"{agent_dir}/prompt.txt"
+        await runtime.write(prompt_path, prompt.encode())
+        await runtime.write(f"{agent_dir}/models.json", json.dumps(models).encode())
+        await runtime.write(f"{agent_dir}/mcp.json", json.dumps(mcp).encode())
+
+        env = {
+            **self.config.resolved_env,
+            KEY_VAR: secret,
+            "PI_CODING_AGENT_DIR": agent_dir,
+            "PI_OFFLINE": "1",
+            "PI_TELEMETRY": "0",
+        }
+        tool_args = (
+            ["--exclude-tools", ",".join(self.config.disabled_tools)]
+            if self.config.disabled_tools
+            else []
+        )
+        system_args = ["--append-system-prompt", system_prompt] if system_prompt else []
+        argv = [
+            "sh",
+            "-c",
+            # Pi has no `--` terminator, so the prompt must not be parsed as argv.
+            'exec "$@" < "$0"',
+            prompt_path,
+            PI_BIN,
+            "--print",
+            "--no-session",
+            "--approve",
+            "--offline",
+            "--provider",
+            PROVIDER,
+            "--model",
+            ctx.model,
+            "--extension",
+            MCP_EXTENSION,
+            "--mcp-config",
+            f"{agent_dir}/mcp.json",
+            *tool_args,
+            *system_args,
+            *image_args,
+        ]
+        try:
+            return await runtime.run_program(argv, env)
+        finally:
+            try:
+                await runtime.run(["rm", "-rf", agent_dir], {})
+            except Exception:
+                logger.warning("failed to clean up Pi agent directory", exc_info=True)

--- a/verifiers/v1/harnesses/pi/harness.py
+++ b/verifiers/v1/harnesses/pi/harness.py
@@ -193,7 +193,7 @@ class PiHarness(Harness[PiHarnessConfig]):
             PI_BIN,
             "--print",
             "--no-session",
-            "--approve",
+            "--no-approve",
             "--offline",
             "--provider",
             PROVIDER,

--- a/verifiers/v1/harnesses/pi/harness.py
+++ b/verifiers/v1/harnesses/pi/harness.py
@@ -20,11 +20,14 @@ logger = logging.getLogger(__name__)
 
 PROVIDER = "intercept"
 KEY_VAR = "PI_INTERCEPT_KEY"
+VERSION_VAR = "VF_PI_VERSION"
+MCP_VERSION_VAR = "VF_PI_MCP_VERSION"
+HOME_VAR = "VF_PI_ORIGINAL_HOME"
 
 PI_DIR = "/tmp/vf-pi"
 PI_BIN = f"{PI_DIR}/pi"
 MCP_VERSION = "2.11.0"
-MCP_EXTENSION = f"{PI_DIR}/mcp/node_modules/pi-mcp-adapter/index.ts"
+MCP_ADAPTER = f"{PI_DIR}/mcp/node_modules/pi-mcp-adapter/index.ts"
 
 INSTALL = r"""
 set -e
@@ -37,16 +40,50 @@ if ! command -v curl >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
         || apk add --no-cache curl ca-certificates nodejs npm >/dev/null
 fi
 
-if [ ! -x "$bin" ] || [ "$("$bin" --version 2>/dev/null)" != "{version}" ]; then
+if [ ! -x "$bin" ] || [ "$("$bin" --version 2>/dev/null)" != "$VF_PI_VERSION" ]; then
     case "$(uname -m)" in aarch64|arm64) arch=arm64 ;; *) arch=x64 ;; esac
-    curl -fsSL "https://github.com/earendil-works/pi/releases/download/v{version}/pi-linux-${arch}.tar.gz" \
+    curl -fsSL "https://github.com/earendil-works/pi/releases/download/v$VF_PI_VERSION/pi-linux-${arch}.tar.gz" \
         | tar -xz -C "$dir" --strip-components=1
 fi
 
-[ "$(node -p "require('$mcp/node_modules/pi-mcp-adapter/package.json').version" 2>/dev/null)" = "{mcp_version}" ] \
+[ "$(node -p "require('$mcp/node_modules/pi-mcp-adapter/package.json').version" 2>/dev/null)" = "$VF_PI_MCP_VERSION" ] \
     || npm install --prefix "$mcp" --ignore-scripts --no-audit --no-fund --omit=dev \
-        "pi-mcp-adapter@{mcp_version}" >/dev/null
+        "pi-mcp-adapter@$VF_PI_MCP_VERSION" >/dev/null
 """
+
+# pi-mcp-adapter treats --mcp-config as additive, so isolate its automatic discovery
+# roots, then restore Pi's task environment before agent tools run.
+MCP_WRAPPER = f"""
+export default async function isolatedMcp(pi) {{
+  const agentDir = process.env.PI_CODING_AGENT_DIR;
+  if (!agentDir) throw new Error("PI_CODING_AGENT_DIR is required");
+
+  const cwd = process.cwd();
+  const home = process.env.{HOME_VAR};
+  process.chdir(agentDir);
+  process.env.HOME = agentDir;
+  try {{
+    const {{ default: mcpAdapter }} = await import("{MCP_ADAPTER}");
+    const isolatedPi = {{
+      ...pi,
+      on(event, handler) {{
+        pi.on(
+          event,
+          event === "session_start"
+            ? (event, ctx) => handler(event, {{ ...ctx, cwd: agentDir }})
+            : handler,
+        );
+      }},
+    }};
+    mcpAdapter(isolatedPi);
+  }} finally {{
+    process.chdir(cwd);
+    if (home === undefined) delete process.env.HOME;
+    else process.env.HOME = home;
+    delete process.env.{HOME_VAR};
+  }}
+}}
+""".strip()
 
 
 class PiHarnessConfig(HarnessConfig):
@@ -65,9 +102,6 @@ class PiHarness(Harness[PiHarnessConfig]):
             self.config.version,
             MCP_VERSION,
         )
-        script = INSTALL.replace("{version}", self.config.version).replace(
-            "{mcp_version}", MCP_VERSION
-        )
         lock = f"{PI_DIR}/install.lock"
         guarded = (
             f"mkdir -p {PI_DIR} && "
@@ -77,9 +111,12 @@ class PiHarness(Harness[PiHarnessConfig]):
             f'[ "$(readlink {lock})" != "$owner" ] || rm -f {lock}; fi; '
             f"sleep 0.1; done; "
             f'trap \'[ "$(readlink {lock})" != "$$" ] || rm -f {lock}\' EXIT; '
-            f"sh -c {shlex.quote(script)}"
+            f"sh -c {shlex.quote(INSTALL)}"
         )
-        install = await runtime.run(["sh", "-c", guarded], {})
+        install = await runtime.run(
+            ["sh", "-c", guarded],
+            {VERSION_VAR: self.config.version, MCP_VERSION_VAR: MCP_VERSION},
+        )
         if install.exit_code != 0:
             raise RuntimeError(f"pi install failed: {install.stderr.strip()[-500:]}")
 
@@ -167,9 +204,11 @@ class PiHarness(Harness[PiHarnessConfig]):
             }
         }
         prompt_path = f"{agent_dir}/prompt.txt"
+        extension_path = f"{agent_dir}/mcp.js"
         await runtime.write(prompt_path, prompt.encode())
         await runtime.write(f"{agent_dir}/models.json", json.dumps(models).encode())
         await runtime.write(f"{agent_dir}/mcp.json", json.dumps(mcp).encode())
+        await runtime.write(extension_path, MCP_WRAPPER.encode())
 
         env = {
             **self.config.resolved_env,
@@ -187,7 +226,9 @@ class PiHarness(Harness[PiHarnessConfig]):
         argv = [
             "sh",
             "-c",
-            # Pi has no `--` terminator, so the prompt must not be parsed as argv.
+            # Isolate adapter global discovery before Bun caches HOME; Pi has no `--`
+            # terminator, so the prompt must not be parsed as argv either.
+            f'export {HOME_VAR}="$HOME"; export HOME="$PI_CODING_AGENT_DIR"; '
             'exec "$@" < "$0"',
             prompt_path,
             PI_BIN,
@@ -200,7 +241,7 @@ class PiHarness(Harness[PiHarnessConfig]):
             "--model",
             ctx.model,
             "--extension",
-            MCP_EXTENSION,
+            extension_path,
             "--mcp-config",
             f"{agent_dir}/mcp.json",
             *tool_args,

--- a/verifiers/v1/harnesses/pi/harness.py
+++ b/verifiers/v1/harnesses/pi/harness.py
@@ -197,18 +197,30 @@ class PiHarness(Harness[PiHarnessConfig]):
                 }
             }
         }
-        mcp = {
-            "mcpServers": {
-                name: {"url": url, "lifecycle": "eager"}
-                for name, url in mcp_urls.items()
-            }
-        }
         prompt_path = f"{agent_dir}/prompt.txt"
-        extension_path = f"{agent_dir}/mcp.js"
         await runtime.write(prompt_path, prompt.encode())
         await runtime.write(f"{agent_dir}/models.json", json.dumps(models).encode())
-        await runtime.write(f"{agent_dir}/mcp.json", json.dumps(mcp).encode())
-        await runtime.write(extension_path, MCP_WRAPPER.encode())
+
+        launch = 'exec "$@" < "$0"'
+        mcp_args: list[str] = []
+        if mcp_urls:
+            extension_path = f"{agent_dir}/mcp.js"
+            mcp = {
+                "mcpServers": {
+                    name: {"url": url, "lifecycle": "eager"}
+                    for name, url in mcp_urls.items()
+                }
+            }
+            await runtime.write(f"{agent_dir}/mcp.json", json.dumps(mcp).encode())
+            await runtime.write(extension_path, MCP_WRAPPER.encode())
+            mcp_args = [
+                "--extension",
+                extension_path,
+                "--mcp-config",
+                f"{agent_dir}/mcp.json",
+            ]
+            # Isolate adapter global discovery before Bun caches HOME.
+            launch = f'export {HOME_VAR}="$HOME"; export HOME="$PI_CODING_AGENT_DIR"; {launch}'
 
         env = {
             **self.config.resolved_env,
@@ -226,10 +238,8 @@ class PiHarness(Harness[PiHarnessConfig]):
         argv = [
             "sh",
             "-c",
-            # Isolate adapter global discovery before Bun caches HOME; Pi has no `--`
-            # terminator, so the prompt must not be parsed as argv either.
-            f'export {HOME_VAR}="$HOME"; export HOME="$PI_CODING_AGENT_DIR"; '
-            'exec "$@" < "$0"',
+            # Pi has no `--` terminator, so the prompt must not be parsed as argv.
+            launch,
             prompt_path,
             PI_BIN,
             "--print",
@@ -240,10 +250,7 @@ class PiHarness(Harness[PiHarnessConfig]):
             PROVIDER,
             "--model",
             ctx.model,
-            "--extension",
-            extension_path,
-            "--mcp-config",
-            f"{agent_dir}/mcp.json",
+            *mcp_args,
             *tool_args,
             *system_args,
             *image_args,

--- a/verifiers/v1/harnesses/pi/harness.py
+++ b/verifiers/v1/harnesses/pi/harness.py
@@ -68,11 +68,16 @@ class PiHarness(Harness[PiHarnessConfig]):
         script = INSTALL.replace("{version}", self.config.version).replace(
             "{mcp_version}", MCP_VERSION
         )
-        lock = f"{PI_DIR}/installing"
+        lock = f"{PI_DIR}/install.lock"
         guarded = (
             f"mkdir -p {PI_DIR} && "
-            f"until mkdir {lock} 2>/dev/null; do sleep 0.1; done; "
-            f"trap 'rmdir {lock}' EXIT; sh -c {shlex.quote(script)}"
+            f'until ln -s "$$" {lock} 2>/dev/null; do '
+            f"owner=$(readlink {lock}); "
+            f'if ! kill -0 "$owner" 2>/dev/null; then '
+            f'[ "$(readlink {lock})" != "$owner" ] || rm -f {lock}; fi; '
+            f"sleep 0.1; done; "
+            f'trap \'[ "$(readlink {lock})" != "$$" ] || rm -f {lock}\' EXIT; '
+            f"sh -c {shlex.quote(script)}"
         )
         install = await runtime.run(["sh", "-c", guarded], {})
         if install.exit_code != 0:


### PR DESCRIPTION
## Overview

Adds a built-in Verifiers v1 harness for [earendil-works/pi](https://github.com/earendil-works/pi), with MCP available by default.

## Details

- Installs a pinned Pi release and `pi-mcp-adapter` inside the selected harness runtime.
- Connects Pi to the Verifiers OpenAI-compatible interception endpoint and forwards system prompts, reasoning settings, disabled tools, and multimodal prompts.
- Generates the MCP adapter configuration from each rollout's MCP server URLs.
- Sends task prompts through stdin because Pi has no `--` argument terminator, keeping dash-prefixed, at-prefixed, and long prompts out of CLI argument parsing.

This makes Pi selectable through `--harness.id pi` across local and sandbox runtimes while preserving the existing v1 harness contract.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New harness runs third-party install scripts (curl/npm) and executes the Pi CLI with MCP extensions in the eval runtime; intercept credentials are passed via env, but scope is limited to the new harness path.
> 
> **Overview**
> Adds **`PiHarness`** / **`PiHarnessConfig`** (default Pi `0.80.6`) and exports them from `verifiers.v1.harnesses`, so Pi can be selected via **`--harness.id pi`**.
> 
> **Setup** downloads a pinned Pi Linux binary and **`pi-mcp-adapter@2.11.0`** under `/tmp/vf-pi`, using a PID symlink lock to serialize concurrent installs.
> 
> **Launch** writes per-trace files (`models.json`, `prompt.txt`, optional `mcp.json` + extension) and runs Pi in offline print mode against a custom **`intercept`** OpenAI-compatible provider (`PI_INTERCEPT_KEY`). It forwards reasoning settings, optional **`--append-system-prompt`**, disabled tools, and message prompts with base64 **`data:image`** parts (written to disk as `@` paths). Task text is fed via **stdin** (shell `exec` wrapper) because Pi has no `--` terminator. When MCP URLs are present, a generated **`MCP_WRAPPER`** extension isolates adapter auto-discovery by temporarily pointing **`HOME`** / cwd at the agent dir, then restores the original environment; the agent dir is removed after the run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67b107010d2a32483b878015c85c04dedad96a02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Pi harness support for running Pi CLI agents via a custom OpenAI-compatible endpoint
> - Adds `PiHarness` and `PiHarnessConfig` in [verifiers/v1/harnesses/pi/harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2004/files#diff-d9ee2431b7427a96633e83be4179a971f5a199c76bb0f603d70bb44147476ace), exported from the `verifiers.v1.harnesses` package.
> - `PiHarnessConfig` exposes a `version` field (default `0.80.6`) to control which Pi release is installed.
> - `PiHarness.setup` installs the Pi CLI and `pi-mcp-adapter` (v2.11.0) via a shell script, serializing concurrent installs with a directory lock under `/tmp/vf-pi/installing`.
> - `PiHarness.launch` writes per-run config files (`models.json`, `mcp.json`, `prompt.txt`) to a temp directory, runs the Pi binary in offline/no-session mode, supports inline base64 images and MCP servers, and cleans up the agent directory on exit.
> - Risk: the intercept API key is sourced from the `PI_INTERCEPT_KEY` environment variable; if absent, runs will fail at runtime.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #2004 opened
>
> - Replaced directory-based installation lock with PID symlink-based lock in `PiHarness.setup` method [afe9540]
> - Changed the command-line flag passed to the Pi binary from `--approve` to `--no-approve` in the `PiHarness.launch` method [21ae2c0]
> - Introduced a new `MCP_WRAPPER` JavaScript module that wraps the `pi-mcp-adapter` to isolate MCP auto-discovery by temporarily changing `process.cwd()` and `HOME` to the agent directory during adapter initialization, wrapping the `pi.on` method to adjust the `session_start` event context `cwd` to the agent directory, and restoring the original environment after adapter invocation [066d406]
> - Replaced version template string interpolation with environment variable-based configuration for the Pi binary and `pi-mcp-adapter` installation [066d406]
> - Modified `PiHarness.launch` to override `HOME` to the agent directory and preserve the original `HOME` in `VF_PI_ORIGINAL_HOME` before process execution [066d406]
> - Made MCP integration conditional in `PiHarness.launch` method based on `mcp_urls` configuration [67b1070]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 0667a64. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->