### PR TITLE
fix(rubrics): read JudgeRubric questions from Pydantic messages

### DIFF
--- a/verifiers/rubrics/judge_rubric.py
+++ b/verifiers/rubrics/judge_rubric.py
@@ -60,11 +60,10 @@ class JudgeRubric(Rubric):
         state: State | None = None,
     ) -> str:
         if isinstance(prompt, list):
+            # Rollouts normalize prompts to Pydantic Messages (not raw dicts).
             last_msg = prompt[-1]
-            if isinstance(last_msg, dict) and "content" in last_msg:
-                question = str(last_msg["content"])
-            else:
-                question = ""
+            content = self.parser._message_field(last_msg, "content", "")
+            question = self.parser._content_to_text(content)
         else:
             question = str(prompt)
         response = self.parser.parse_answer(completion)


### PR DESCRIPTION
## Summary
- `JudgeRubric.judge()` only extracted `question` from dict prompts (`isinstance(..., dict)`)
- Rollouts normalize prompts to Pydantic `Message` objects, so the Question block was silently empty
- Read content via parser helpers (`_message_field` / `_content_to_text`) for dict and Message prompts

## Test plan
- [x] Dict prompt still yields the last user content as `{question}`
- [x] Pydantic-like message with `.content` no longer produces an empty Question
- [x] Multimodal text parts are joined into the question string (via `_content_to_text`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to prompt parsing in judge rubric scoring with no auth or data-path changes.
> 
> **Overview**
> **Fixes judge scoring when rollouts pass Pydantic `Message` prompts instead of raw dicts.**
> 
> `JudgeRubric.judge()` previously built the `{question}` field only when the last list prompt entry was a dict with `"content"`, so normalized rollout prompts left the Question block empty and weakened judge decisions.
> 
> The last message’s content is now read through `Parser._message_field` and `Parser._content_to_text`, so dict and object messages (including multimodal text parts) populate `{question}` consistently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cd51ce23d2dfaf179a2a716c15e7b392a2e547e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `JudgeRubric.judge` to extract question text from Pydantic messages
> Previously, when `prompt` was a list, the method assumed raw dicts and fell back to empty strings for Pydantic `Message` objects. Now uses `self.parser._message_field` and `self.parser._content_to_text` in [judge_rubric.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2005/files#diff-ab7ad46c9fc5ee845bd8ac34e1348244dd23496886cd8b0f8dec7185c1cbde09) to correctly extract the question string from both dict and Pydantic message formats.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3cd51ce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->