### PR TITLE
fix(v1): docker runtime on macOS (Docker Desktop)

### DIFF
--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -263,7 +263,9 @@ async def serve(
         # `state_base`, which is universally reachable (the interception is exposed via a tunnel
         # whenever any consumer is remote). Eval-level shared servers get no per-rollout channel
         # (`state_base` is None for them).
-        state_url = f"{state_base.rstrip('/')}/state" if state_base else None
+        state_url = (
+            f"{runtime.host_url(state_base.rstrip('/'))}/state" if state_base else None
+        )
         port = await serve_in_runtime(
             server,
             runtime,
@@ -289,6 +291,8 @@ async def serve(
                 runtime, port, colocated=colocated, consumer_is_local=consumer_is_local
             )
         )
+        if not for_host and not colocated and harness_runtime is not None:
+            base = harness_runtime.host_url(base)
         yield f"{base.rstrip('/')}/mcp"
 
 
@@ -389,7 +393,8 @@ async def serve_tools(
                 urls[name] = server.url
                 logger.info("tool server '%s' (shared, external): %s", name, server.url)
                 continue
-            urls[name] = _shared_url_for_rollout(server.url, state_base, state_secret)
+            url = harness_runtime.host_url(server.url) if server.local else server.url
+            urls[name] = _shared_url_for_rollout(url, state_base, state_secret)
             # The tagged URL contains the bearer secret; log only the untagged base URL.
             logger.info("tool server '%s' (shared): %s", name, server.url)
         for toolset in toolsets:

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -158,7 +158,7 @@ class Rollout:
             async with self._serve_interception(
                 runtime, session, [*tool_servers, *([user] if user else [])]
             ) as (base_url, secret):
-                endpoint = f"{base_url}/v1"
+                endpoint = f"{runtime.host_url(base_url)}/v1"
                 async with (
                     serve_tools(
                         tool_servers,

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -244,6 +244,10 @@ class Runtime(ABC):
     async def write(self, path: str, data: bytes) -> None:
         pass
 
+    def host_url(self, url: str) -> str:
+        """The URL a program inside this runtime uses to reach a host-bound `url`."""
+        return url
+
     @property
     def published_port(self) -> int | None:
         """A fixed port this runtime exposes to the outside at startup, declared up front to the

--- a/verifiers/v1/runtimes/docker.py
+++ b/verifiers/v1/runtimes/docker.py
@@ -5,8 +5,10 @@ import contextlib
 import logging
 import shlex
 import subprocess
+import sys
 from pathlib import PurePosixPath
 from typing import Literal
+from urllib.parse import urlsplit
 
 from pydantic_config import BaseConfig
 
@@ -117,6 +119,14 @@ class DockerRuntime(Runtime):
             self._container,
             self.config.image,
         )
+
+    def host_url(self, url: str) -> str:
+        # Docker Desktop (macOS/Windows) runs containers in a VM, so `--network host`
+        # doesn't reach the host's loopback; `host.docker.internal` does.
+        host = urlsplit(url).hostname
+        if sys.platform != "linux" and host in ("127.0.0.1", "localhost"):
+            return url.replace(host, "host.docker.internal", 1)
+        return url
 
     async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
         env_args = [arg for k, v in env.items() for arg in ("--env", f"{k}={v}")]


### PR DESCRIPTION
## Summary

`uv run eval ... --harness.runtime.type docker` fails on macOS: Docker Desktop runs containers in a Linux VM, so `--network host` shares the VM's network, not the Mac's. Anything host-bound at `127.0.0.1` (the interception server, host-launched MCP tool servers) is unreachable from inside a container — the harness dies with `openai.APIConnectionError` / `httpx.ConnectError`. From inside the container the host is reachable as `host.docker.internal`.

Fix: a `Runtime.host_url(url)` hook (identity by default) that `DockerRuntime` overrides to rewrite a loopback hostname to `host.docker.internal` on non-Linux hosts, applied at the points where a host-bound URL crosses into a runtime:

- `rollout.py`: the model endpoint handed to the harness
- `mcp/launch.py`: the MCP URL a non-colocated tool server yields to the harness, a shared server's URL joined per rollout, and the state-channel URL handed to a server launched in a docker runtime

Linux behavior is untouched (`sys.platform` guard); subprocess/prime/modal are untouched (identity hook).

## Validation

All on macOS (arm64, Docker Desktop 29.5.3), `eval -n 1 -r 1 -m deepseek/deepseek-v4-flash --no-push`:

| env | docker before | docker after | subprocess | prime |
|---|---|---|---|---|
| gsm8k-v1 (no tools) | ProviderError (APIConnectionError) | reward 1.00 | 1.00 | 1.00 |
| glossary-v1 (task-scoped tool) | ToolsetError (httpx.ConnectError) | reward 1.00 | 1.00 | — |
| glossary-v1, `tools.colocated=true` | — | reward 1.00 | — | — |
| scratchpad-v1 `-n 2` (shared server + state isolation) | — | reward 1.00, 1.00 | 1.00 | — |
| alphabet-sort-v1 `--harness.id null -n 2` (user sim, no-prompt opening) | — | reward 1.00, 1.00 | ok | — |

Not covered (pre-existing, unrelated to macOS networking): `wordle-v1` on any sandboxed runtime fails because `_install_in_sandbox` installs verifiers without the `[ta]` extra in the sandbox venv (`ModuleNotFoundError: nltk`).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Docker runtime URL resolution on macOS (Docker Desktop)
> - Adds a `host_url(url)` method to the `Runtime` base class in [base.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2006/files#diff-0811c040a163eb5a3212208f1e3a6c6388d7690fcc4780c081cc7754036232b9); the default implementation returns the URL unchanged.
> - `DockerRuntime` overrides `host_url` in [docker.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2006/files#diff-4df997a8b44780bf5b15ae16719b567680966c44f2df46b3553158661a131b97) to rewrite `localhost`/`127.0.0.1` URLs to `host.docker.internal` on non-Linux platforms (macOS/Windows), where Docker containers cannot reach the host via localhost.
> - Applies `host_url` rewrites in [launch.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2006/files#diff-989d87123d40d48511f9e1df74594d2e30776e9a99c11eca49d9cc20bf9e2230) for the state channel URL and MCP base URL, and for shared local tool server URLs when accessed from the harness.
> - Applies `host_url` rewrite in [rollout.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2006/files#diff-f886b7f4717cf8fce9270bd4ff4790f3182aa1016abb9efb7f6e57efe18d1bf2) for the model endpoint URL used during rollout.
> - Behavioral Change: on macOS/Windows Docker, localhost URLs used for inter-process communication are now silently rewritten; no change on Linux.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 154443b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches rollout networking and MCP URL wiring; Linux and non-docker runtimes are unchanged, but incorrect rewrites would break all docker-harness connectivity.
> 
> **Overview**
> **Fixes Docker Desktop evals** where the harness runs in a container but interception and host-launched MCP servers bind to `127.0.0.1` — unreachable from the VM because `--network host` is not the Mac host.
> 
> Adds **`Runtime.host_url(url)`** (identity on subprocess/prime/modal/Linux docker). **`DockerRuntime`** rewrites `localhost` / `127.0.0.1` to **`host.docker.internal`** on non-Linux only.
> 
> Rewrites are applied when a host-bound URL is consumed **inside** the harness runtime: model **`/v1`** endpoint in `rollout.py`; MCP base URL and **state channel** URL in `mcp/launch.py`; **shared local** tool server URLs when the harness connects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 154443b1f03a9b8c8bd3372440bcf9d3e029c8f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->