### PR TITLE
fix(v1): install a server's package extras in sandbox venvs

### DIFF
--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -125,13 +125,15 @@ async def _install_in_sandbox(server: ServerBase, runtime: Runtime) -> str:
     # build, silently running the server against a released (older) API. Pretend the
     # local version so the floor is satisfied by the build we uploaded.
     vf_version = importlib.metadata.version("verifiers")
+    extras = ",".join(type(server).EXTRAS)
     setup = (
         f"{_ENSURE_UV}; set -e; "
         f'for t in {root}/*.tar.gz; do tar -xzf "$t" -C {root}; done && '
         f"uv venv {venv} && "
         f"SETUPTOOLS_SCM_PRETEND_VERSION={shlex.quote(vf_version)} "
         f"uv pip install --python {venv} {root}/{shlex.quote(vf.name)} && "
-        f"uv pip install --python {venv} {root}/{shlex.quote(env.name)}"
+        f"uv pip install --python {venv} "
+        f"{shlex.quote(f'{root}/{env.name}' + (f'[{extras}]' if extras else ''))}"
     )
     result = await runtime.run(["sh", "-c", setup], {})
     if result.exit_code != 0:

--- a/verifiers/v1/mcp/server.py
+++ b/verifiers/v1/mcp/server.py
@@ -116,6 +116,9 @@ class ServerBase(Generic[ConfigT, StateT]):
     # The empty value falls back to the snake-cased class name.
     TOOL_PREFIX: ClassVar[str] = ""
 
+    EXTRAS: ClassVar[tuple[str, ...]] = ()
+    """Package extras the server's module needs, applied at sandbox install."""
+
     def __init__(self, config: ConfigT) -> None:
         self.config = config
         self._state_cls = state_cls(type(self))

--- a/verifiers/v1/tasksets/textarena/taskset.py
+++ b/verifiers/v1/tasksets/textarena/taskset.py
@@ -39,6 +39,8 @@ class TextArenaState(vf.State):
 class TextArenaUser(vf.User[vf.UserConfig, TextArenaState]):
     """Keep a seeded game alive across user turns in the harness process."""
 
+    EXTRAS = ("ta",)
+
     async def setup(self) -> None:
         if not self.config.colocated:
             raise ValueError(


### PR DESCRIPTION
## Summary

A sandboxed tool/user server (`_install_in_sandbox`) uploads the source tree and installs the env package bare, dropping any extras its module needs. The textarena user simulator imports `nltk`/`textarena` at module load, so `wordle-v1` with a non-colocated user sim (or any sandboxed textarena server) dies at launch:

```
ToolsetError: server did not report its port ...
ModuleNotFoundError: No module named 'nltk'
```

Fix: let a server class declare the extras its module needs — `ServerBase.EXTRAS: ClassVar[tuple[str, ...]] = ()` — and apply them to the env-package install spec in `_install_in_sandbox` (`pkg[extra1,extra2]`). `TextArenaUser` declares `EXTRAS = ("ta",)`.

## Validation

`eval wordle-v1 -n 1 -r 1 -m deepseek/deepseek-v4-flash --no-push` with `--taskset.task.user.colocated false` semantics exercised via prime/docker harness runtimes:

- before: `ModuleNotFoundError: No module named 'nltk'` at server launch (prime and docker)
- after: the sandbox venv installs `verifiers[ta]`, the server module imports and the server starts on both prime and docker — the run proceeds past install to the connect stage
- subprocess runtime (server runs from the host venv, extras path not taken): wordle-v1 reward 1.00, unchanged

Full end-to-end wordle on sandboxed runtimes is still blocked by two pre-existing, unrelated infra issues (also present on `main`): prime port-exposure hostnames (`*.service.sandbox.pinfra.io`) currently don't resolve (NXDOMAIN, also via 1.1.1.1/8.8.8.8), and a host-driven user sim colocated in a docker container needs host→container connectivity that Docker Desktop's `--network host` doesn't provide (see #2006 for the macOS docker networking scope).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Install server package extras in sandbox venvs
> - Adds a `EXTRAS: ClassVar[tuple[str, ...]] = ()` class variable to `ServerBase` in [server.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2007/files#diff-5eaeab5d19ee732e16b066ff6689f954f6743833a907a129acc0df250cee5b2a) for servers to declare their required package extras.
> - Updates `_install_in_sandbox` in [launch.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2007/files#diff-989d87123d40d48511f9e1df74594d2e30776e9a99c11eca49d9cc20bf9e2230) to append `[<extras>]` to the env package path when `EXTRAS` is non-empty, passing the quoted string to `uv pip install`.
> - Sets `EXTRAS = ("ta",)` on `TextArenaUser` in [taskset.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2007/files#diff-2a395fbba37fe437fb8cd561858b2e30854482fe5b990fa1a3050f748efdd402) so its `ta` dependencies are installed in the sandbox.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd6e9d5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to sandbox install wiring in launch.py; default empty EXTRAS preserves prior behavior for servers that do not declare extras.
> 
> **Overview**
> Sandboxed MCP/user servers used to install the env package without optional **extras**, so modules that depend on them (e.g. `nltk` for TextArena) failed at import with `ModuleNotFoundError` even when the host had `verifiers[ta]` installed.
> 
> **`ServerBase`** now exposes **`EXTRAS: ClassVar[tuple[str, ...]]`** so a server class can declare which package extras its module needs. **`_install_in_sandbox`** in **`launch.py`** appends `[extra1,extra2]` to the env-package **`uv pip install`** spec when that tuple is non-empty. **`TextArenaUser`** sets **`EXTRAS = ("ta",)`** so sandbox venvs pull in the TextArena stack.
> 
> Subprocess (host) launches are unchanged—the extras path only runs for non-subprocess runtimes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd6e9d5c95d0761f90fc133a280567931549ddaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->