### PR TITLE
fix(v1): prefer Final Judgment over draft boxed answers in parse_judge_choice

### DIFF
--- a/verifiers/v1/scoring.py
+++ b/verifiers/v1/scoring.py
@@ -55,9 +55,6 @@ def parse_judge_choice(
         return None
 
     text = content.rsplit("</think>", 1)[-1].strip()
-    text = extract_boxed_answer(text, strict=True).strip() or text
-
-    text_upper = text.upper()
     choices_by_upper = {choice.upper(): choice for choice in choices}
     allowed = "|".join(re.escape(choice) for choice in choices_by_upper)
     choice_re = rf"(?<!\w)({allowed})(?!\w)"
@@ -66,12 +63,18 @@ def parse_judge_choice(
         r"JUDGMENT|VERDICT|ANSWER)\s*(?:IS\s*)?[:\-]?\s*"
     )
 
+    # Prefer an explicit verdict marker on the full reply so a draft \boxed{...}
+    # cannot shadow a later Final Judgment / Final Answer line.
+    text_upper = text.upper()
     verdict = re.search(verdict_re, text_upper)
     if verdict:
         match = re.search(choice_re, text_upper[verdict.end() :])
         return choices_by_upper.get(match.group(1)) if match else None
 
-    matches = re.findall(choice_re, text_upper)
+    # No marker: keep boxed answers preferred over CoT mentions, then last match.
+    boxed = extract_boxed_answer(text, strict=True).strip()
+    search_upper = (boxed or text).upper()
+    matches = re.findall(choice_re, search_upper)
     return choices_by_upper.get(matches[-1]) if matches else None
 
 

--- a/verifiers/v1/scoring.py
+++ b/verifiers/v1/scoring.py
@@ -64,14 +64,17 @@ def parse_judge_choice(
     )
 
     # Prefer an explicit verdict marker on the full reply so a draft \boxed{...}
-    # cannot shadow a later Final Judgment / Final Answer line.
+    # cannot shadow a later Final Judgment / Final Answer line. If the marker has
+    # no choice after it, fall through to boxed / last-match instead of failing.
     text_upper = text.upper()
     verdict = re.search(verdict_re, text_upper)
     if verdict:
         match = re.search(choice_re, text_upper[verdict.end() :])
-        return choices_by_upper.get(match.group(1)) if match else None
+        if match:
+            return choices_by_upper.get(match.group(1))
 
-    # No marker: keep boxed answers preferred over CoT mentions, then last match.
+    # No usable marker choice: keep boxed answers preferred over CoT mentions,
+    # then last match.
     boxed = extract_boxed_answer(text, strict=True).strip()
     search_upper = (boxed or text).upper()
     matches = re.findall(choice_re, search_upper)


### PR DESCRIPTION
## Summary
- `parse_judge_choice` previously unwrapped the last `\boxed{...}` before looking for verdict markers, so a draft box could wipe a later `Final Judgment` / `Final Answer` line and return the wrong choice.
- Search order is now: explicit verdict marker on the full reply → boxed answer (if present) → last choice match.
- If a verdict marker is present but has no choice after it, fall through to boxed / last-match instead of returning `None`.

## Test plan
- [x] Manual: `Draft: \boxed{A}` + `Final Judgment: B` → `B`
- [x] Manual: verdict-marker-only, boxed-only, boxed-over-CoT, last-match, incomplete `<think>` cases still behave as expected
- [x] Manual: `Final Judgment:` (empty) + earlier `\boxed{A}` → `A`

## Risk
Low. Only flips scores when a reply has both a draft `\boxed{...}` and a later explicit Final Judgment / Final Answer (or an empty marker that previously failed after this PR’s first commit). Default yes/no-only reference prompts are mostly unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how v1 judge rubric responses are scored when both boxed drafts and verdict lines appear; behavior is intentional but can flip rewards on existing model outputs.
> 
> **Overview**
> Fixes **`parse_judge_choice`** so judge scoring no longer picks a draft `\boxed{...}` over a later explicit verdict line.
> 
> Previously the function unwrapped the last boxed answer **before** searching for markers like `Final Judgment` / `Final Answer`, so the search window could exclude the real verdict and return the wrong A/B/C choice.
> 
> **New order:** scan the full post-`</think>` reply for a verdict marker and take the first allowed choice after it; if that fails, use strict boxed content (still preferred over chain-of-thought mentions); otherwise use the **last** choice match in that search text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59835b8ed93b8a07aab8f7c02457dd88a0b970de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `parse_judge_choice` to prefer explicit verdict markers over boxed answers
> - `parse_judge_choice` in [scoring.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2008/files#diff-12aeb6693b9bcb1ec5230be5cc55bd35170a03cb44fcd091021e56448b998b21) now searches the full reply for a choice following an explicit verdict marker (FINAL JUDGMENT/ANSWER/VERDICT) before considering boxed answers.
> - Previously, a boxed answer could override a later verdict marker, and a marker with no following choice caused the function to return `None`; both cases are now handled correctly.
> - If no choice follows a verdict marker, the function falls back to searching within a boxed answer (if present) or the full reply, returning the last matching choice.
> - Behavioral Change: functions that previously returned `None` on a bare verdict marker, or were overridden by a boxed answer, now return a choice from the fallback path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 59835b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->