### PR TITLE
fix(rubrics): align RubricGroup.score_group metrics and advantages with score_rollout

### DIFF
--- a/verifiers/rubrics/rubric_group.py
+++ b/verifiers/rubrics/rubric_group.py
@@ -117,7 +117,8 @@ class RubricGroup(Rubric):
 
         Mirrors ``score_rollout`` for metrics (full replace) and ``Rubric.score_group``
         for advantages: child rubrics may write per-rubric advantages/trajectory fields,
-        so the group recomputes them from the aggregated rewards and overwrites leftovers.
+        so the group recomputes state advantages from aggregated rewards and only fills
+        trajectory fields that are still ``None`` (preserving intentional step values).
         """
         num_states = len(states)
         if num_states == 0:
@@ -132,6 +133,14 @@ class RubricGroup(Rubric):
             for state in states
         ]
         original_advantages = [state.get("advantage") for state in states]
+        # Snapshot traj fields so child if-None fills can be rolled back between rubrics.
+        original_traj_fields = [
+            [
+                (step.get("reward"), step.get("advantage"))
+                for step in state.get("trajectory") or []
+            ]
+            for state in states
+        ]
         for rubric in self.rubrics:
             await rubric.score_group(states)
             for i, state in enumerate(states):
@@ -148,15 +157,22 @@ class RubricGroup(Rubric):
                 state["reward"] = original_rewards[i]
                 state["metrics"] = original_metrics[i].copy()
                 state["advantage"] = original_advantages[i]
+                for step, (reward, advantage) in zip(
+                    state.get("trajectory") or [], original_traj_fields[i]
+                ):
+                    step["reward"] = reward
+                    step["advantage"] = advantage
 
         avg_reward = sum(aggregated_rewards) / num_states
         for i, state in enumerate(states):
             state["reward"] = aggregated_rewards[i]
             state["advantage"] = aggregated_rewards[i] - avg_reward
-            # Children fill traj via if-None; overwrite with the aggregate.
+            # Same as Rubric.score_group: fill only unset traj fields.
             for step in state.get("trajectory") or []:
-                step["advantage"] = state["advantage"]
-                step["reward"] = state["reward"]
+                if step.get("advantage") is None:
+                    step["advantage"] = state["advantage"]
+                if step.get("reward") is None:
+                    step["reward"] = state["reward"]
             state["metrics"] = {
                 key: values[i] for key, values in aggregated_metrics.items()
             }

--- a/verifiers/rubrics/rubric_group.py
+++ b/verifiers/rubrics/rubric_group.py
@@ -114,14 +114,24 @@ class RubricGroup(Rubric):
     async def score_group(self, states: list[State]):
         """
         Evaluate all reward functions in-place for a group of rollouts.
+
+        Mirrors ``score_rollout`` for metrics (full replace) and ``Rubric.score_group``
+        for advantages: child rubrics may write per-rubric advantages/trajectory fields,
+        so the group recomputes them from the aggregated rewards and overwrites leftovers.
         """
-        aggregated_rewards = [0.0] * len(states)
+        num_states = len(states)
+        if num_states == 0:
+            self.logger.warning("No states to score")
+            return
+
+        aggregated_rewards = [0.0] * num_states
         aggregated_metrics: dict[str, list[float]] = {}
         original_rewards = [state.get("reward", 0.0) for state in states]
         original_metrics = [
             state.get("metrics", {}).copy() if state.get("metrics") else {}
             for state in states
         ]
+        original_advantages = [state.get("advantage") for state in states]
         for rubric in self.rubrics:
             await rubric.score_group(states)
             for i, state in enumerate(states):
@@ -132,14 +142,21 @@ class RubricGroup(Rubric):
                 aggregated_rewards[i] += rubric_reward
                 for key, value in rubric_metrics.items():
                     if key not in aggregated_metrics:
-                        aggregated_metrics[key] = [0.0] * len(states)
+                        aggregated_metrics[key] = [0.0] * num_states
                     aggregated_metrics[key][i] += value
+                # Restore so the next rubric sees the same pre-group inputs.
                 state["reward"] = original_rewards[i]
                 state["metrics"] = original_metrics[i].copy()
+                state["advantage"] = original_advantages[i]
+
+        avg_reward = sum(aggregated_rewards) / num_states
         for i, state in enumerate(states):
             state["reward"] = aggregated_rewards[i]
-            if aggregated_metrics:
-                if "metrics" not in state:
-                    state["metrics"] = {}
-                for key, values in aggregated_metrics.items():
-                    state["metrics"][key] = values[i]
+            state["advantage"] = aggregated_rewards[i] - avg_reward
+            # Children fill traj via if-None; overwrite with the aggregate.
+            for step in state.get("trajectory") or []:
+                step["advantage"] = state["advantage"]
+                step["reward"] = state["reward"]
+            state["metrics"] = {
+                key: values[i] for key, values in aggregated_metrics.items()
+            }


### PR DESCRIPTION
## Summary
- `RubricGroup.score_group` summed child rewards correctly but left per-child `advantage` on state (last child wins) and often left trajectory `advantage`/`reward` from an earlier child, because children fill those fields via if-None.
- Metrics were merged into preexisting keys, unlike `score_rollout` (and `Rubric.score_group`), which fully replace `state["metrics"]` — stale keys could survive group scoring.
- After aggregation, advantages are recomputed from the summed rewards; trajectory `reward`/`advantage` are filled only when still `None` (intentional step values preserved); metrics are replaced to match `score_rollout`.
- After Bugbot feedback: restore trajectory step reward/advantage between child rubrics and only fill fields that are still `None` after aggregation (same as `Rubric.score_group`), so intentional step rewards are not wiped.

## Risk / notes
- Aggregate **rewards** were already correct; this fixes leftover advantage/trajectory fields and metrics-shape inconsistency between `score_group` and `score_rollout`.
- Default `Rubric.has_advantages` is still `False`, so trainers that recompute advantages from rewards are largely unaffected. Pitch is contract/consistency, not “RL used wrong advantages.”

## Test plan
- [x] Manual: children `[[1,0],[0,1]]` → rewards `[1,1]`, advantages `[0,0]`, traj advantage/reward overwritten to match
- [x] Manual: preexisting `metrics={"stale": ...}` cleared/replaced after group scoring (same shape as `score_rollout`)
- [x] Manual: child with empty metrics → `state["metrics"] == {}`
- [x] Manual: preset trajectory step reward survives group scoring; unset steps still get aggregate fill

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoring-contract fix in rubric aggregation only; summed rewards were already correct and default trainers often recompute advantages from rewards.
> 
> **Overview**
> **`RubricGroup.score_group`** now matches **`score_rollout`** and single-rubric **`Rubric.score_group`** for how advantages, trajectory fields, and metrics are written after summing child rubrics.
> 
> While iterating children, the group **snapshots and restores** each state’s **`advantage`** and per-step trajectory **`reward`/`advantage`** (along with reward and metrics), so later rubrics don’t see partial writes from earlier ones. After aggregation it sets **`advantage`** to **`reward - mean(reward)`** across the group, **fills trajectory fields only when still `None`**, and **replaces `state["metrics"]`** with the aggregated dict instead of merging into stale keys. Empty **`states`** returns early with a warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dde8b444bdeaf7808f29d9516afd96432b2e099. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `RubricGroup.score_group` to align metrics and advantage computation with `score_rollout`
> - Restores each state's `reward`, `metrics`, `advantage`, and per-step trajectory fields to their original values between child rubric evaluations, so only aggregated values affect the final result.
> - Recomputes each state's `advantage` as its aggregated reward minus the group average after all child rubrics have scored.
> - Fills trajectory step `reward` and `advantage` only when `None`, leaving pre-existing values unchanged.
> - Replaces the final `metrics` dict with only the aggregated metric keys, rather than merging into pre-existing metrics.
> - Adds an early return with a warning when the `states` list is empty.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2dde8b4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->