### PR TITLE
fix(v1): strip the harness's bootstrap venv from run_bash's PATH

### DIFF
--- a/verifiers/v1/harnesses/default/program.py
+++ b/verifiers/v1/harnesses/default/program.py
@@ -7,6 +7,7 @@
 import argparse
 import asyncio
 import json
+import os
 import subprocess
 from contextlib import AsyncExitStack
 from pathlib import Path
@@ -130,8 +131,24 @@ def run_search(query: str, api_key: str, num_results: int = 5) -> str:
 
 def run_bash(command: str) -> str:
     try:
+        # The harness bootstraps itself in a uv-managed venv (VIRTUAL_ENV set, its bin prepended
+        # to PATH). Don't leak that bootstrap env into the agent's shell — otherwise `python`/
+        # `python3` resolve to the harness venv (openai/mcp deps, no project deps) instead of the
+        # container's real interpreter. Strip it so the agent sees the runtime's actual default
+        # env (extends the existing "agent bash doesn't inherit harness-private state" intent from
+        # secrets to the bootstrap venv).
+        env = dict(os.environ)
+        venv = env.pop("VIRTUAL_ENV", None)
+        if venv:
+            env["PATH"] = ":".join(
+                p for p in env.get("PATH", "").split(":") if p and p != f"{venv}/bin"
+            )
         result = subprocess.run(
-            ["bash", "-c", command], capture_output=True, text=True, timeout=3600
+            ["bash", "-c", command],
+            capture_output=True,
+            text=True,
+            timeout=3600,
+            env=env,
         )
         return result.stdout + result.stderr
     except Exception as e:


### PR DESCRIPTION
## Summary

The default harness bootstraps itself as a uv script, running inside a uv-managed venv
(`VIRTUAL_ENV` set, its `bin/` prepended to `PATH`). `run_bash`'s subprocess inherited that
environment unchanged, so an agent invoking bare `python`/`python3` resolved to the **harness's
own venv** — which only has the harness's deps (openai, mcp, httpx) — instead of the task
container's provisioned interpreter or packages.

This produces misleading failures that look like sandbox/network issues: an agent running
`python -m pip install X` sees `No module named pip` (the harness venv has no pip) and
concludes the sandbox has no internet access, when a working interpreter is one directory
away the whole time (`/usr/local/bin/python`, for example). We traced this after several eval
rollouts appeared to fail on "no network" while other rollouts in the *same sandbox, same run*
succeeded at outbound network calls once they stumbled onto a working interpreter — the
harness venv leak was silently distorting model scores.

## Fix

Strip `VIRTUAL_ENV` and its `bin/` entry from `run_bash`'s env before exec, so the agent's
shell sees the runtime's actual default environment. This extends the existing `run_bash`
precedent of not leaking harness-private state into the agent's subprocess (secrets already
arrive via argv, not env, for the same reason) to the bootstrap venv.

## Test plan

- [x] `ruff check` / `ruff format` pass
- [x] Verified against real eval rollouts in a downstream project (taskgen/codebase-repair-v1):
      before the fix, `python -m pip` inside `run_bash` resolved to the harness venv and
      failed; after, it resolves to the container's provisioned interpreter.
- [ ] Would appreciate a maintainer sanity-check on whether stripping at `run_bash` vs. scrubbing
      at the bootstrap/launch layer is the preferred fix location — happy to move it if so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to the default harness bash tool env; improves eval fidelity with no auth or data-path impact.
> 
> **Overview**
> **Agent `bash` tool commands no longer inherit the harness’s uv bootstrap virtualenv**, so bare `python`/`python3` resolve to the task container’s interpreter instead of the harness-only venv (openai/mcp/httpx, often without pip).
> 
> `run_bash` now builds a copy of the process environment, removes `VIRTUAL_ENV`, and drops that venv’s `bin` from `PATH` before `subprocess.run`, matching the existing pattern of not leaking harness-private state into agent shells (same rationale as passing secrets via argv rather than env).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 259e729555b10606b48b68e704395115ff83c301. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Strip harness bootstrap venv from `run_bash` PATH in v1 default harness
> The harness's own virtualenv was leaking into commands spawned by `run_bash`, causing incorrect interpreter resolution. [program.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2011/files#diff-4cb67cb50bf655658944c055a7e88bcf71e08b1112043d946c684ac2d51a2d80) now builds a filtered environment before calling `subprocess.run`: it removes `VIRTUAL_ENV` and strips the venv's `bin` directory from `PATH`. Behavioral Change: commands run via `run_bash` now resolve binaries against the system PATH instead of the harness venv.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 259e729. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->