### PR TITLE
fix: disambiguate errors and invalids in validate --rich summary

### DIFF
--- a/verifiers/v1/cli/dashboard/validate.py
+++ b/verifiers/v1/cli/dashboard/validate.py
@@ -9,6 +9,7 @@ this reads them each tick.
 
 import contextlib
 import time
+from collections import Counter
 from dataclasses import dataclass
 
 from rich.console import Group
@@ -60,16 +61,16 @@ def Overview(config: ValidateConfig) -> Table:
 
 def Progress(states: list[TaskProgress], start: float) -> Table:
     done = [s for s in states if s.state in _DONE]
-    valid = sum(1 for s in done if s.state == "valid")
-    stats = (
-        f" {len(done)}/{len(states)} · {format_time(time.time() - start)} · "
-        f"valid {valid} · invalid {len(done) - valid}"
-    )
+    counts = Counter(s.state for s in done)
+    stats = Text(f" {len(done)}/{len(states)} · {format_time(time.time() - start)}")
+    for state in _DONE:
+        stats.append(" · ")
+        stats.append(f"{state} {counts[state]}", style=_STYLE[state])
     row = Table.grid()
     row.add_column()
     row.add_column()
     row.add_row(
-        ProgressBar(total=len(states) or 1, completed=len(done), width=32), Text(stats)
+        ProgressBar(total=len(states) or 1, completed=len(done), width=32), stats
     )
     return row
 


### PR DESCRIPTION
## Problem

The `validate --rich` dashboard's headline summary computed the invalid count as `total - valid`:

```python
valid = sum(1 for s in done if s.state == "valid")
stats = f"... valid {valid} · invalid {len(done) - valid}"
```

So **every** non-valid outcome — `error` (e.g. sandbox provisioning timeouts, teardown failures) and `timeout` — was tallied under **`invalid`**. During a provisioning storm on a `--only-gold` pass this reads as e.g. "70% invalid", implying the taskset is broken, when in fact the tasks are fine and the infra was overloaded. The per-task rows already distinguish `[error]`/`[timeout]`/`[invalid]` (each its own colour), so only the aggregate line was misleading.

## Fix

Count each outcome in its own colour-coded bucket, reusing the dashboard's existing `_STYLE`/`_DONE` and matching the per-row markers:

```
6/7 · 12s · valid 2 · invalid 1 · error 2 · timeout 1
```

`invalid` now means only tasks whose gold check genuinely returned `False`; infra failures land in `error`/`timeout` where they belong.

## Notes

- Purely a display change in `Progress()`; the underlying `_classify` reasons (`valid`/`invalid`/`error`/`timeout`) and result rows are unchanged, as are the non-rich per-task log lines.
- Buckets are always shown (including zeros) so the layout is stable across a run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show per-state counts in `validate` rich summary progress display
> Updates the `progress` function in [validate.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2013/files#diff-2ded55a5b55a7c27d925b91343c516de853d005e99d07590ceb341bdc9e9149e) to display counts for each state in `_DONE` separately, rather than only showing combined 'valid' and 'invalid' totals. Uses a `Counter` to compute per-state counts and a Rich `Text` object with `_STYLE` styling per state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea88e40.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->