### PR TITLE
feat(v1): DockerConfig.network_access to block the workload's internet

### DIFF
--- a/verifiers/v1/runtimes/docker.py
+++ b/verifiers/v1/runtimes/docker.py
@@ -38,6 +38,11 @@ class DockerConfig(BaseConfig):
     disk: float | None = None
     """Advisory disk request in GB. Docker has no portable per-container size limit, so
     this is accepted (so a task can declare it without a warning) but not enforced."""
+    network_access: bool = True
+    """Whether the workload can reach the internet. When False, the container's DNS is disabled
+    so hostname fetches (pip, git clone, curl) fail, while the model tunnel still works — it
+    egresses from the host, which the container reaches DNS-lessly. A DNS block, not an IP
+    airgap. Mirrors prime/modal (which also sever the tunnel)."""
 
 
 class DockerRuntimeInfo(DockerConfig, BaseRuntimeInfo):
@@ -98,8 +103,7 @@ class DockerRuntime(Runtime):
         run = await docker(
             "run",
             "--detach",
-            "--network",
-            "host",
+            *self._network_args(),
             *limits,
             "--workdir",
             self.config.workdir,
@@ -115,10 +119,24 @@ class DockerRuntime(Runtime):
             :12
         ]  # `docker run -d` prints the container id
         logger.info(
-            "docker: started container %s (image=%s)",
+            "docker: started container %s (image=%s%s)",
             self._container,
             self.config.image,
+            "" if self.config.network_access else ", internet blocked",
         )
+
+    def _network_args(self) -> list[str]:
+        """`docker run` networking. network_access=False breaks DNS to block the workload's
+        internet while keeping the DNS-less host route the model tunnel needs."""
+        if self.config.network_access:
+            return ["--network", "host"]
+        if sys.platform == "linux":
+            # Host netns reaches the interception at 127.0.0.1; only DNS is broken. --dns writes
+            # a container-private resolv.conf, so the host's DNS is untouched.
+            return ["--network", "host", "--dns", "0.0.0.0"]
+        # Docker Desktop: bridge instead of host, host.docker.internal pinned via /etc/hosts
+        # (host_url() already routes the tunnel there off-Linux).
+        return ["--dns", "0.0.0.0", "--add-host", "host.docker.internal:host-gateway"]
 
     def host_url(self, url: str) -> str:
         # Docker Desktop (macOS/Windows) runs containers in a VM, so `--network host`


### PR DESCRIPTION
## Summary

Adds `network_access: bool = True` to `DockerConfig` — mirroring `PrimeConfig`/`ModalConfig`, so `--harness.runtime.network-access false` now works uniformly across all three runtimes (docker was the only one missing it).

When `false`, the container's DNS resolver is disabled, so every hostname-based fetch (`pip install`, `git clone`, `curl <host>`) fails — **while the interception model tunnel keeps working**, because it egresses from the *host*, not the container: the container only reaches `host.docker.internal` / host loopback, which needs no DNS.

The motivating use case is local-docker eval of tasks on public seed repos, where the agent must not be able to fetch upstream source / packages (a leakage / cheating vector) but must still reach the model.

## How

Platform-specific, matching the existing `host_url()` split:

- **Docker Desktop (macOS/Windows):** drop `--network host` for the default bridge, add `--dns 0.0.0.0` and `--add-host=host.docker.internal:host-gateway` (the host route is pinned in `/etc/hosts`, so it resolves without DNS; `host_url()` already points the tunnel there on non-Linux).
- **Linux:** keep `--network host` (interception is reachable at `127.0.0.1`) and add `--dns 0.0.0.0`. `--dns` writes a *container-private* `resolv.conf` (Docker marks it "Overrides: [nameservers]"), so the host's own DNS is untouched.

Default stays `True`, so existing behavior is unchanged.

## Scope / caveat

This is a **DNS-level block, not an IP-level airgap** — a hardcoded raw IP could still egress. It's aimed at the real leak vectors (all hostname-based: pip / git / curl-by-host). For a hard airgap, an iptables egress allowlist would be needed; that's deliberately out of scope here.

`--network none` / `--internal` networks were rejected during design: on Docker Desktop they sever the host route along with the internet, killing the tunnel too (verified).

## Test plan

- [x] Linux path (simulated via two `--network host` containers sharing the Docker VM netns — same daemon/netns code as a real Linux host): daemon **accepts** `--network host --dns 0.0.0.0`; host-loopback service reachable (200); pypi unreachable; container-private resolv.conf confirmed.
- [x] macOS path (native): host tunnel reachable (200) via `host.docker.internal`; `pip install` / `git clone` to public hosts fail.
- [x] **End-to-end**: a local-docker eval with `--harness.runtime.type docker --harness.runtime.network-access false` **solves a task (reward 1.0, 59 model calls over the tunnel, no errors)** while pip/git to public hosts fail from inside the container.

### Note for reviewers: offline harness bootstrap

A blocked run needs an image whose harness can bootstrap offline. Currently `_ENSURE_UV` (runtimes/base.py) runs `pip install -U uv` unconditionally at harness setup — which needs the network even when `uv` is already present in the image (its curl fallback needs network too). So a `network_access=false` run only boots on an image with a pre-warmed uv cache. Making `_ENSURE_UV` short-circuit when `uv` is already on PATH would let any uv-bearing image boot offline; happy to send that as a small follow-up if you'd like it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `network_access` field to `DockerConfig` to block internet access in workloads
> - Adds a `network_access` boolean field (default `True`) to `DockerConfig` in [docker.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2014/files#diff-4df997a8b44780bf5b15ae16719b567680966c44f2df46b3553158661a131b97); setting it to `False` disables DNS to block internet access.
> - Extracts a `_network_args()` helper that generates the appropriate `docker run` networking flags based on `network_access` and the host platform.
> - On Linux, `network_access=False` uses `--network host --dns 0.0.0.0`; on non-Linux, it omits host networking and uses `--dns 0.0.0.0 --add-host host.docker.internal:host-gateway`.
> - Startup logs now append `, internet blocked` when `network_access=False`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b11fbf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->