### PR TITLE
fix: reset entrypoint when starting docker sandboxes

### DIFF
--- a/verifiers/v1/runtimes/docker.py
+++ b/verifiers/v1/runtimes/docker.py
@@ -101,10 +101,11 @@ class DockerRuntime(Runtime):
             *limits,
             "--workdir",
             self.config.workdir,
+            "--entrypoint",
+            "sleep",
             "--name",
             self._container,
             self.config.image,
-            "sleep",
             "infinity",
         )
         if run.exit_code != 0:


### PR DESCRIPTION
## Summary
- The local docker runtime keeps sandboxes alive with `docker run --detach <image> sleep infinity`, which only overrides CMD, not ENTRYPOINT.
- Images that declare an ENTRYPOINT run `<entrypoint> sleep infinity` instead. SWEAP's images (`jefzda/sweap-images`, used by `swebench-pro-v1`) set `ENTRYPOINT ["/bin/bash"]`, so the container runs `/bin/bash sleep infinity`, fails with `sleep: cannot execute binary file`, exits 126 immediately, and every subsequent `docker exec` (e.g. the rlm harness install) fails with "container is not running".
- Fix: pass `--entrypoint sleep <image> infinity` so the keepalive command runs regardless of the image's entrypoint.

## Verification
Reproduced directly on a SWEAP image:
- `docker run -d <sweap-image> sleep infinity` → `running=false, exit=126`
- `docker run -d --entrypoint sleep <sweap-image> infinity` → `running=true`

End-to-end, one `swebench-pro-v1` rollout on the docker runtime (rlm harness, deepseek-v4-flash):
- **before:** `HarnessError: rlm install failed: ... container <id> is not running`, 0 turns
- **after:** `stop_condition=agent_completed`, `errors=[]`, 75 turns, `rewards={solved: 1.0}`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `DockerRuntime.start` to override container entrypoint with `sleep`
> Docker images with a custom `ENTRYPOINT` would previously receive `sleep infinity` as arguments to that entrypoint rather than running `sleep infinity` directly. [docker.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2015/files#diff-4df997a8b44780bf5b15ae16719b567680966c44f2df46b3553158661a131b97) now passes `--entrypoint sleep` with `infinity` as the sole command argument, ensuring the sandbox container always idles under `sleep` regardless of the image's default entrypoint.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5ff168a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change to local Docker `run` invocation; low blast radius and aligns with intended sandbox lifecycle behavior.
> 
> **Overview**
> **Docker sandboxes** that use `sleep infinity` as a detached keepalive were failing on images with a custom `ENTRYPOINT` (e.g. SWEAP’s `/bin/bash`), because `sleep infinity` was passed as CMD arguments to that entrypoint instead of running `sleep` directly.
> 
> `DockerRuntime.start` now runs `docker run` with **`--entrypoint sleep`** and **`infinity`** as the sole command argument, so the container idles under `sleep` regardless of the image’s default entrypoint. `docker exec` for harness work can proceed on a running container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ff168abadd573bfbf8123af46b71c7924945177. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->