### PR TITLE
fix(v1): survive sandboxes with unwritable HOME and tiny /tmp in server installs

### DIFF
--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -116,17 +116,26 @@ async def _install_in_sandbox(server: ServerBase, runtime: Runtime) -> str:
             f"server {server.server_name!r} runs in a {runtime.type} runtime but its module is not "
             "a local package (no pyproject) — sandbox launch needs a local env package to upload"
         )
-    root = "/tmp/vf-src"
+    scratch = (getattr(server.config, "scratch_dir", None) or "/tmp").rstrip("/") or "/tmp"
+    root = f"{scratch}/vf-src"
     vf, env = _verifiers_root(), Path(source_dir)
     await runtime.write(f"{root}/{vf.name}.tar.gz", _tar_source(vf, VF_BUILD_INPUTS))
     await runtime.write(f"{root}/{env.name}.tar.gz", _tar_source(env))
-    venv = "/tmp/vf-venv"
+    venv = f"{scratch}/vf-venv"
     # The upload carries no .git, so hatch-vcs falls back to version 0.0.0 — an env
     # package's `verifiers>=...` floor would then resolve PyPI verifiers OVER the local
     # build, silently running the server against a released (older) API. Pretend the
     # local version so the floor is satisfied by the build we uploaded.
     vf_version = importlib.metadata.version("verifiers")
     setup = (
+        # Some sandboxes (e.g. prime VM-image sandboxes) exec jobs with an unset or read-only
+        # HOME; uv's installer and caches need a writable one. Probe with a real write — `[ -w ]`
+        # is always true for root, even on a read-only mount.
+        '_p="$HOME/.vf-wtest.$$"; { [ -n "$HOME" ] && touch "$_p" 2>/dev/null && rm -f "$_p"; } '
+        "|| export HOME=/tmp; "
+        # The venv's dependency tree can outgrow a small tmpfs /tmp — keep uv's cache and managed
+        # pythons on the scratch dir alongside the venv.
+        f'export UV_CACHE_DIR="{scratch}/vf-uv-cache" UV_PYTHON_INSTALL_DIR="{scratch}/vf-uv-python"; '
         f"{_ENSURE_UV}; set -e; "
         f'for t in {root}/*.tar.gz; do tar -xzf "$t" -C {root}; done && '
         f"uv venv {venv} && "

--- a/verifiers/v1/mcp/toolset.py
+++ b/verifiers/v1/mcp/toolset.py
@@ -17,11 +17,16 @@ class ToolsetConfig(BaseConfig):
     colocated: bool = False
     runtime: RuntimeConfig = SubprocessConfig()
     url: str | None = None
+    scratch_dir: str = "/tmp"
+    """Where a sandbox-launched server keeps its venv and uv caches. Point it at a disk-backed
+    writable path when the sandbox's /tmp is a small tmpfs (e.g. prime VM-image sandboxes)."""
 
 
 class SharedToolsetConfig(BaseConfig):
     runtime: RuntimeConfig = SubprocessConfig()
     url: str | None = None
+    scratch_dir: str = "/tmp"
+    """See `ToolsetConfig.scratch_dir`."""
 
 
 class Toolset(ServerBase[ConfigT, StateT]):


### PR DESCRIPTION
## Summary

- `_install_in_sandbox` now probes `HOME` with a real write and falls back to `/tmp` — prime VM-image sandboxes exec background jobs with an unset (or effectively read-only) `HOME`, so uv's installer died appending shell rc files (`cannot create /.zshrc: Read-only file system`). `test -w` is not enough: it is always true for root, even on a read-only mount.
- Adds `ToolsetConfig.scratch_dir` / `SharedToolsetConfig.scratch_dir` (default `/tmp`, fully backward-compatible): where a sandbox-launched tool server keeps its `vf-src`/`vf-venv` plus uv cache and managed pythons (`UV_CACHE_DIR`/`UV_PYTHON_INSTALL_DIR` now pinned alongside). Prime VM-image sandboxes mount `/tmp` as a ~1 GB tmpfs regardless of sandbox memory — too small for a venv carrying verifiers' dependency tree (pyarrow/transformers/pandas), which died with `No space left on device`. A taskset can now point it at a disk-backed path (e.g. `/workspace/.vf`).

Both failure modes were hit porting Toolathlon (PrimeIntellect-ai/research-environments#669, colocated MCP proxy toolset on the prime runtime); with this branch plus a disk-backed `scratch_dir`, 8/8 sandbox installs succeed and rollouts score end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sandbox installs to survive unwritable HOME and limited /tmp space
> - Adds a `scratch_dir` config field (default `/tmp`) to `ToolsetConfig` and `SharedToolsetConfig` in [toolset.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2016/files#diff-1638e398acc8de97e9696063f280512b575057ce9126369ae93434a75b921c99), allowing sandbox-launched servers to redirect writes to a writable location.
> - Updates `_install_in_sandbox` in [launch.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2016/files#diff-989d87123d40d48511f9e1df74594d2e30776e9a99c11eca49d9cc20bf9e2230) to place source tarballs, virtualenvs, and uv caches under `scratch_dir` instead of hardcoded `/tmp` paths.
> - The setup script now probes HOME for writability and exports `HOME=/tmp` if needed, and sets `UV_CACHE_DIR` and `UV_PYTHON_INSTALL_DIR` to paths under `scratch_dir`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 2a3fcaf. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->