### PR TITLE
fix(v1): resume must match saved rollouts by load position, not data.idx

### DIFF
--- a/verifiers/v1/cli/eval/resume.py
+++ b/verifiers/v1/cli/eval/resume.py
@@ -62,7 +62,11 @@ class Finished(Rollout):
 
 
 def load(
-    resume_dir: Path, selected_idxs: list[int], num_rollouts: int, group: bool
+    resume_dir: Path,
+    selected_idxs: list[int],
+    num_rollouts: int,
+    group: bool,
+    data_idx_to_pos: dict[int, int] | None = None,
 ) -> tuple[list[Trace], dict[int, int]]:
     """Load the good saved rollouts back into memory as finished traces and diff them against
     the run's target (`num_rollouts` per selected task): returns (the kept traces, rollouts
@@ -70,7 +74,11 @@ def load(
     only if fully complete, else its whole group is redone. Rewrites `traces.jsonl` to just
     the kept rows — verbatim, via a temp file + atomic rename, so an interrupted resume can't
     corrupt the prior good results — and the resumed rollouts then append. `WireTrace` reads
-    any taskset's saved traces without importing it."""
+    any taskset's saved traces without importing it.
+
+    For traces written before `info.task_idx` existed, `data_idx_to_pos` maps the saved
+    `task.data.idx` to its current load position. If the mapping is absent, `data.idx` is
+    compared directly against `selected_idxs` (the legacy behavior)."""
     path = resume_dir / TRACES_FILE
     selected = set(selected_idxs)
     good: dict[int, list[bytes]] = defaultdict(list)
@@ -83,9 +91,16 @@ def load(
                     row = from_json(line)
                 except ValueError:
                     row = json.loads(line)
-                idx = row["task"]["data"]["idx"]
+                idx = (row.get("info") or {}).get("task_idx")
+                if idx is None:
+                    data_idx = row["task"]["data"]["idx"]
+                    if data_idx_to_pos is not None:
+                        idx = data_idx_to_pos.get(data_idx)
+                    else:
+                        idx = data_idx
                 if (
-                    idx in selected
+                    idx is not None
+                    and idx in selected
                     and not row.get("errors")
                     and len(good[idx]) < num_rollouts
                 ):

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -32,21 +32,30 @@ async def run_eval(env: Environment, config: EvalConfig) -> list[Trace]:
     # Write config.toml up front, then persist each trace as it completes (so the results are
     # durable mid-run, not only at the end). One lock serializes worker-thread appends from
     # concurrent rollouts while keeping large trace serialization off the event loop.
-    owed: dict[str, int] | None = None
+    owed: dict[int, int] | None = None
     # On resume, the kept (good) on-disk rollouts rejoin the run as finished traces: displayed,
     # returned, pushed, and printed alongside this session's, with only the owed rollouts re-run
     # — so the resumed run is indistinguishable from one that was never interrupted.
+    # Map each task's `data.idx` to its load position in the selected slice; this
+    # is what the runner dispatches by and what resume must match (not the raw
+    # dataset row index a taskset like Lean may use for `data.idx`).
+    task_positions = {task.data.idx: pos for pos, task in enumerate(tasks)}
+
     finished: list[Trace] = []
     if config.resume is not None:
         # Resume incomplete group-reward tasks whole so every rollout is present.
         group = bool(tasks) and bool(discover_decorated(tasks[0], "group_reward"))
         finished, owed = resume.load(
-            out, [t.data.idx for t in tasks], config.num_rollouts, group
+            out,
+            [task_positions[t.data.idx] for t in tasks],
+            config.num_rollouts,
+            group,
+            task_positions,
         )
         if not owed:  # already complete - report it and exit successfully
             print(resume.nothing_to_resume_msg(out, len(tasks), config.num_rollouts))
             raise SystemExit(0)
-        tasks = [task for task in tasks if owed.get(task.data.idx)]
+        tasks = [task for task in tasks if owed.get(task_positions[task.data.idx])]
         logger.info(
             "resuming %s: %d task(s), %d rollout(s) owed",
             out,
@@ -67,7 +76,10 @@ async def run_eval(env: Environment, config: EvalConfig) -> list[Trace]:
     write_lock = asyncio.Lock()
 
     async def on_complete(trace: Trace) -> None:
-        trace.stamp(EvalRunInfo(id=config.uuid))
+        trace.stamp(
+            EvalRunInfo(id=config.uuid),
+            task_idx=task_positions.get(trace.task.data.idx),
+        )
         await append_trace(out, trace, write_lock)
 
     # Shared tool servers (if any) come up once here and their URLs flow into every rollout
@@ -77,7 +89,9 @@ async def run_eval(env: Environment, config: EvalConfig) -> list[Trace]:
     async with env.serving():
         episodes = [
             env.episode(
-                task, ctx, n=owed[task.data.idx] if owed else config.num_rollouts
+                task,
+                ctx,
+                n=owed[task_positions[task.data.idx]] if owed else config.num_rollouts,
             )
             for task in tasks
         ]
@@ -222,7 +236,7 @@ async def run_eval_server(config: EvalConfig) -> list[Trace]:
                     sampling=config.sampling,
                 )
             for trace in traces:
-                trace.stamp(EvalRunInfo(id=config.uuid))
+                trace.stamp(EvalRunInfo(id=config.uuid), task_idx=idx)
                 await append_trace(out, trace, write_lock)
             return traces
 
@@ -234,7 +248,7 @@ async def run_eval_server(config: EvalConfig) -> list[Trace]:
                     model=config.model,
                     sampling=config.sampling,
                 )
-            trace.stamp(EvalRunInfo(id=config.uuid))
+            trace.stamp(EvalRunInfo(id=config.uuid), task_idx=idx)
             await append_trace(out, trace, write_lock)
             return [trace]
 


### PR DESCRIPTION
## Description

The runner selects and dispatches tasks by load position (`enumerate(tasks)`), but `resume.load` matched saved `traces.jsonl` rows by `task.data.idx`. In `LeanTaskset`, `data.idx` is the raw dataset enumeration index and empty statements are filtered out, so `data.idx` and the load position diverge. On resume, finished rollouts were dropped and the wrong tasks reran.

This change:

1. Records the load position in `trace.info["task_idx"]` in both the local and server eval paths.
2. Makes `resume.load` prefer `info["task_idx"]` and fall back to `task.data.idx` mapped to the current load position via a new `data_idx_to_pos` argument.
3. Leaves `LeanTaskset.data.idx` as the stable raw dataset index; the runner builds a `data.idx -> load-position` map from the selected task slice and passes it to `resume.load`, so legacy traces without `info.task_idx` still resume correctly.

#1962 rewrote `resume.load` to reload finished traces, but it did not fix this load-position mismatch. This PR is a follow-up to that work.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing

- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

`uv run pytest tests/v1/test_taskset.py tests/test_eval_utils.py tests/test_eval_display.py -q` and the full `uv run pytest tests/v1 -m 'not e2e'` pass.

## Checklist

- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

- Rebased onto the current `PrimeIntellect-ai/verifiers:main` (commit `9b01a8172`).
- No documentation, recipe, config, or hardware-support changes were required: `docs/v1/evaluation.md` and `skills/evaluate-environments/references/REFERENCE.md` already describe resume as keeping good rollouts and rerunning missing/errored ones, including group-scored tasks being resumed as a whole group. This fix aligns the implementation with that documented behavior.
- Per `AGENTS.md`, no unit tests were added.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix resume in v1 eval to match saved rollouts by load position instead of `data.idx`
> - Resume logic in [`resume.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/2017/files#diff-fa57536955ac6c644296a0f3317271ffdc94b2611e7ad3d0c2266c436b96a4f8) previously matched saved traces by `task.data.idx`, which broke when the selected task slice didn't align with raw data indices. It now matches by `info.task_idx` (position) when present, falling back to a `data_idx_to_pos` mapping for legacy traces.
> - [`runner.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/2017/files#diff-65be4a576330571f2729a3bbcdbe92ac81bbcba450c313597c1bdca3a1c3f2e4) builds a `task_positions` map from `task.data.idx` to enumerated position within the selected tasks, passes it to `resume.load`, and keys all owed/completed rollout tracking by position.
> - All trace stamping paths (direct eval, env-server group, and single-rollout) now include `task_idx` set to the task's position in the run, enabling correct future resume matching.
> - Behavioral Change: resumed runs now count owed rollouts against task position indices rather than raw data indices, so partial runs with non-zero start offsets resume correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ba45491.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eval resume and trace identity semantics for interrupted runs; wrong matching could drop good rollouts or rerun wrong tasks, though scope is limited to the v1 eval CLI resume path.
> 
> **Overview**
> Fixes **eval resume** matching saved `traces.jsonl` rows to the tasks the runner actually runs. Previously resume keyed traces on `task.data.idx`, while dispatch uses **position in the selected task slice**—they diverge when a taskset keeps a raw dataset index but filters rows (e.g. Lean).
> 
> The runner now builds a **`data.idx → load position`** map and drives resume, owed-rollout counts, and post-resume task filtering from those positions. **`resume.load`** takes optional `data_idx_to_pos`, prefers **`info.task_idx`** on saved traces, and falls back to remapping legacy `data.idx` (or raw `data.idx` if no map). Traces without a resolvable index are skipped instead of matched incorrectly.
> 
> New and resumed traces are stamped with **`task_idx`** on write (local `on_complete` and env-server group/rollout paths) so future resumes align with dispatch. `owed` typing is normalized to **`dict[int, int]`** on the local path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba4549154a691aa603ebca3b5747f384b9c197ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->