### PR TITLE
fix(v1): a raising group reward must not discard the group's completed traces

### DIFF
--- a/verifiers/v1/episode.py
+++ b/verifiers/v1/episode.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import traceback
 from collections.abc import Awaitable, Callable
 from contextlib import nullcontext
 from typing import TYPE_CHECKING
@@ -10,7 +11,7 @@ from typing import TYPE_CHECKING
 from verifiers.v1.decorators import discover_decorated
 from verifiers.v1.retries import run_with_retry
 from verifiers.v1.rollout import Phase, Rollout
-from verifiers.v1.trace import Trace
+from verifiers.v1.trace import Error, Trace
 from verifiers.v1.utils.memory import trim_memory_periodically
 
 if TYPE_CHECKING:
@@ -46,10 +47,34 @@ class Episode:
 
         traces = await asyncio.gather(*(run_one(r) for r in self.rollouts))
         if group_scored:
-            await self.task.score_group(traces)  # cross-rollout @group_rewards
-            for rollout in self.rollouts:
-                rollout.phase = Phase.DONE
-            for trace in traces:
-                if on_complete is not None:
-                    await on_complete(trace)
+            group_error: Exception | None = None
+            group_traceback: str | None = None
+            try:
+                await self.task.score_group(traces)  # cross-rollout @group_rewards
+            except Exception as exc:
+                group_error = exc
+                group_traceback = "".join(
+                    traceback.format_exception(type(exc), exc, exc.__traceback__)
+                )
+            finally:
+                # A raising group reward must not discard the completed traces: mark
+                # every rollout done, record the scoring failure, and run the completion
+                # callbacks before re-raising. Recording the error stops a later resume
+                # from treating a failed group-scored run as complete.
+                for rollout in self.rollouts:
+                    rollout.phase = Phase.DONE
+                if group_error is not None and group_traceback is not None:
+                    for trace in traces:
+                        trace.errors.append(
+                            Error(
+                                type=type(group_error).__name__,
+                                message=str(group_error),
+                                traceback=group_traceback,
+                            )
+                        )
+                for trace in traces:
+                    if on_complete is not None:
+                        await on_complete(trace)
+                if group_error is not None:
+                    raise group_error
         return traces


### PR DESCRIPTION
## Description

`Episode.run` marked each rollout `Phase.DONE` and ran `on_complete` only after `score_group` returned. If `score_group` raised, the `finally` block was skipped and every completed trace in the group was lost, not just the group score.

This change wraps `score_group` in `try/finally`. If it raises, every rollout is still marked `Phase.DONE`, the scoring failure is recorded as an `Error` on each trace, and every `on_complete` callback runs before the exception re-raises. The caller still sees the scoring failure, but the traces are persisted for debugging and resume.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing

- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

`uv run pytest tests/v1/test_scoring.py -q` and the full `uv run pytest tests/v1 -m 'not e2e'` pass. A manual reproduction confirms the exception still propagates, `on_complete` runs for every trace, and rollouts reach `Phase.DONE`.

## Checklist

- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

- Rebased onto the current `PrimeIntellect-ai/verifiers:main` (commit `9b01a8172`).
- No documentation, recipe, config, or hardware-support changes were required: `docs/v1/evaluation.md` and the resume reference already describe group-scored tasks as being rerun as a whole group when incomplete. Recording the scoring error on each trace makes a failed group-score resume-safe.
- Per `AGENTS.md`, no unit tests were added.
