### PR TITLE
fix(v1): tolerate provider usage without cache_write_tokens

### DIFF
--- a/verifiers/v1/dialects/responses.py
+++ b/verifiers/v1/dialects/responses.py
@@ -21,10 +21,6 @@ from openai.types.responses import (
     ResponseUsage,
 )
 from openai.types.responses.response_input_param import FunctionCallOutput
-from openai.types.responses.response_usage import (
-    InputTokensDetails,
-    OutputTokensDetails,
-)
 from pydantic import BaseModel, ConfigDict
 
 from verifiers.v1.dialects.base import Dialect, StreamParser, iter_sse_reverse
@@ -58,11 +54,27 @@ _TERMINAL_MARKERS = tuple(
 _SAMPLING_KEYS = frozenset({"temperature", "top_p", "max_output_tokens", "max_tokens"})
 
 
+class ProviderUsageInputTokensDetails(BaseModel):
+    """Permissive input token details: OpenAI-compatible providers may omit fields
+    the pinned SDK declares required (e.g. ``cache_write_tokens``)."""
+
+    model_config = ConfigDict(extra="allow")
+    cache_write_tokens: int | None = None
+    cached_tokens: int | None = None
+
+
+class ProviderUsageOutputTokensDetails(BaseModel):
+    """Permissive output token details: providers may omit ``reasoning_tokens``."""
+
+    model_config = ConfigDict(extra="allow")
+    reasoning_tokens: int | None = None
+
+
 class ProviderUsage(ResponseUsage):
     """Responses usage with optional detail objects for OpenAI-compatible providers."""
 
-    input_tokens_details: InputTokensDetails | None = None
-    output_tokens_details: OutputTokensDetails | None = None
+    input_tokens_details: ProviderUsageInputTokensDetails | None = None
+    output_tokens_details: ProviderUsageOutputTokensDetails | None = None
 
 
 class OpenAIResponse(BaseModel):


### PR DESCRIPTION
## Description

OpenAI SDK >= 2.45 makes `cache_write_tokens` required inside `InputTokensDetails`. Some `/responses`-compatible providers omit it, so `ProviderUsage.model_validate(...)` raises `ValidationError: input_tokens_details.cache_write_tokens Field required` and crashes the turn.

This change replaces the strict SDK detail models on `ProviderUsage` with permissive local subclasses. `cache_write_tokens`, `cached_tokens`, and `reasoning_tokens` are now optional, and `extra="allow"` keeps the model forward-compatible with any other provider-specific fields.

No other responses behavior changes; when the fields are present they are parsed normally.

Closes #1987.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing

- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

`uv run pytest tests/test_openai_responses_client.py -q` passes, including payloads that omit `cache_write_tokens`.

## Checklist

- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

- Rebased onto the current `PrimeIntellect-ai/verifiers:main` (commit `9b01a8172`).
- No documentation, recipe, config, or hardware-support changes were required: the only user-facing surface affected is the provider response parser, and the permissive models preserve the documented `Usage`/`Response` flow.
- Per `AGENTS.md`, no unit tests were added.
