### PR TITLE
fix(v1): give Trace.num_total_tokens a provider-usage fallback

### DIFF
--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -292,8 +292,24 @@ class Trace(StrictBaseModel, Generic[DataT, StateT]):
 
     @property
     def num_total_tokens(self) -> int:
-        """Sequence lengths summed across training branches for token batching."""
-        return sum(branch.num_total_tokens for branch in self.branches)
+        """Sequence lengths summed across training branches for token batching.
+
+        Falls back to the last provider usage on each branch when token IDs are absent
+        (relay/eval). This mirrors the final sequence length and avoids double-counting
+        repeated prompt context across turns, while still counting each training branch.
+        """
+        total = sum(branch.num_total_tokens for branch in self.branches)
+        if total:
+            return total
+        usages: list[Usage] = []
+        for branch in self.branches:
+            last = next(
+                (n.usage for n in reversed(branch.nodes) if n.usage is not None), None
+            )
+            if last is not None:
+                usages.append(last)
+        usage = Usage.aggregate(usages) if usages else None
+        return usage.total_tokens if usage is not None else 0
 
     @property
     def usage(self) -> Usage | None:


### PR DESCRIPTION
## Description

`Trace.num_total_tokens` summed branch token-id lengths. On relay/eval clients there are no token IDs, so it always returned `0`. That made `max_total_tokens` a dead cap, while `max_input_tokens` and `max_output_tokens` already fell back to provider usage.

This change makes `Trace.num_total_tokens` fall back to `Usage.aggregate()` of the last provider usage on each branch when the token-id sum is zero. When token IDs are present the existing path still takes precedence.

This closes the gap left by #1894, which renamed the property but did not add the usage fallback.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing

- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

`uv run pytest tests/v1/test_trace.py -q` and the full `uv run pytest tests/v1 -m 'not e2e'` pass. A manual regression check confirms the token-id path still takes precedence when IDs are present.

## Checklist

- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

- Rebased onto the current `PrimeIntellect-ai/verifiers:main` (commit `9b01a8172`).
- No documentation, recipe, config, or hardware-support changes were required: `skills/evaluate-environments/references/REFERENCE.md` already maps `RolloutLimits.max_total_tokens` to `Trace.num_total_tokens`. The fix makes that documented cap work for relay/eval traces.
- Per `AGENTS.md`, no unit tests were added.
