### PR TITLE
feat(v1): add InternBootcamp taskset

### DIFF
--- a/environments/internbootcamp_v1/README.md
+++ b/environments/internbootcamp_v1/README.md
@@ -1,0 +1,65 @@
+# internbootcamp-v1
+
+### Overview
+
+- **Environment ID**: `internbootcamp-v1`
+- **Description**: seeded Verifiers v1 adapter for the procedural reasoning tasks in InternBootcamp.
+- **Tags**: reasoning, procedural, single-turn, train, eval
+
+The environment discovers Bootcamp classes from a pinned Apache-2.0 snapshot of
+[`dmihal/InternBootcamp`](https://github.com/dmihal/InternBootcamp/tree/2b2d388f4f056cd9bd0cc91b130f0b54b15572b4),
+uses the selected class's native `case_generator` and `prompt_func`, and delegates
+reward calculation to its native `verify_score` implementation.
+
+### Security model
+
+InternBootcamp contains task-specific verifiers that may evaluate model-produced
+expressions. For that reason, `InternBootcampTask` declares `NEEDS_CONTAINER = True`
+and executes the pinned scorer inside the rollout runtime. The scorer never receives
+model output in the environment host process. Use a Docker or Prime runtime; the
+subprocess runtime is intentionally rejected.
+
+### Quickstart
+
+Validate the default Game24 configuration:
+
+```bash
+uv run validate internbootcamp-v1 --runtime.type docker -n 1
+```
+
+Run another Bootcamp by class name or canonical key:
+
+```bash
+uv run eval internbootcamp-v1 \
+  --harness.runtime.type docker -n 20 \
+  --taskset.bootcamp Sudoku --taskset.num-examples 50 --taskset.seed 123
+```
+
+### Environment arguments
+
+| Argument | Type | Default | Description |
+| --- | --- | --- | --- |
+| `bootcamp` | string | `"game24"` | Bootcamp class name or normalized canonical key. |
+| `num_examples` | integer | `50` | Number of procedural cases generated before run-time selection. |
+| `seed` | integer | `0` | Seed for Python, NumPy, Faker, and constructors that accept `seed`. |
+| `system_prompt` | string | `"Think step by step to solve the puzzle."` | System instruction for every task. |
+| `task.verifier_timeout` | integer | `180` | Maximum scoring-call time in seconds. |
+
+Only Bootcamps with a `case_generator`, a default constructor, and JSON-serializable
+generated identities are supported. Unsupported classes fail during taskset loading
+with a descriptive error instead of silently changing their data.
+
+### Task and scoring
+
+Each case is single-turn. Output formatting depends on the selected Bootcamp and is
+described in its generated prompt. The only reward, `upstream_score`, is the selected
+Bootcamp's native scalar score clamped to `[0, 1]`. Empty completions are scored during
+validation to preflight the pinned scorer without a model call.
+
+### Reproducibility and provenance
+
+Generation and scoring use the exact commit
+[`2b2d388`](https://github.com/dmihal/InternBootcamp/commit/2b2d388f4f056cd9bd0cc91b130f0b54b15572b4).
+The environment seeds common randomness sources and passes `seed` to Bootcamp
+constructors that expose it. The original project and task data remain subject to
+their upstream license and dataset terms.

--- a/environments/internbootcamp_v1/internbootcamp_v1/__init__.py
+++ b/environments/internbootcamp_v1/internbootcamp_v1/__init__.py
@@ -1,0 +1,3 @@
+from internbootcamp_v1.taskset import InternBootcampConfig, InternBootcampTaskset
+
+__all__ = ["InternBootcampConfig", "InternBootcampTaskset"]

--- a/environments/internbootcamp_v1/internbootcamp_v1/taskset.py
+++ b/environments/internbootcamp_v1/internbootcamp_v1/taskset.py
@@ -1,0 +1,253 @@
+"""InternBootcamp tasks backed by the benchmark's native generators and scorers.
+
+The selected Bootcamp generates seeded single-turn tasks on the environment
+host. Scoring happens inside the rollout container because some upstream verifiers
+evaluate model-produced expressions; model output must never reach them in the host
+process. The scorer dependency is pinned to the same Apache-2.0 snapshot as the task
+generator, so generation and verification cannot drift independently.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import inspect
+import json
+import math
+import random
+import re
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from pydantic import Field
+
+import verifiers.v1 as vf
+
+DEFAULT_SYSTEM_PROMPT = "Think step by step to solve the puzzle."
+DEFAULT_BOOTCAMP = "game24"
+MAX_COMPLETION_BYTES = 100_000
+VERIFY = (Path(__file__).parent / "verify.py").read_bytes()
+
+
+def _canonical_key(class_name: str) -> str:
+    base = re.sub(r"bootcamp$", "", class_name, flags=re.IGNORECASE)
+    return re.sub(r"[^0-9a-z]+", "", base.lower())
+
+
+@lru_cache(maxsize=1)
+def _discover_bootcamps() -> dict[str, type]:
+    import internbootcamp
+
+    classes: dict[str, type] = {}
+    for name, candidate in vars(internbootcamp).items():
+        if (
+            inspect.isclass(candidate)
+            and name.lower().endswith("bootcamp")
+            and callable(getattr(candidate, "case_generator", None))
+            and callable(getattr(candidate, "prompt_func", None))
+            and callable(getattr(candidate, "verify_score", None))
+        ):
+            key = getattr(candidate, "canonical_name", None) or _canonical_key(name)
+            classes[_canonical_key(str(key))] = candidate
+    return classes
+
+
+def _resolve_bootcamp(name: str) -> tuple[str, type]:
+    key = _canonical_key(name)
+    classes = _discover_bootcamps()
+    if key not in classes:
+        sample = ", ".join(sorted(classes)[:25])
+        raise ValueError(
+            f"unknown InternBootcamp task {name!r}; examples include: {sample}"
+        )
+    return key, classes[key]
+
+
+def _new_bootcamp(name: str, seed: int):
+    key, cls = _resolve_bootcamp(name)
+    signature = inspect.signature(cls)
+    required = [
+        parameter.name
+        for parameter in signature.parameters.values()
+        if parameter.default is inspect.Parameter.empty
+        and parameter.kind
+        in (parameter.POSITIONAL_ONLY, parameter.POSITIONAL_OR_KEYWORD)
+    ]
+    kwargs: dict[str, Any] = {}
+    if "seed" in signature.parameters:
+        kwargs["seed"] = seed
+        required = [name for name in required if name != "seed"]
+    if required:
+        raise ValueError(
+            f"InternBootcamp task {key!r} requires constructor arguments {required}; "
+            "select a task with a default constructor"
+        )
+    return key, cls(**kwargs)
+
+
+def _json_value(value: Any) -> Any:
+    """Convert an upstream identity to stable JSON without lossy string fallbacks."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        if isinstance(value, float) and not math.isfinite(value):
+            raise ValueError("InternBootcamp identity contains a non-finite number")
+        return value
+    if isinstance(value, dict):
+        if not all(isinstance(key, str) for key in value):
+            raise TypeError("InternBootcamp identity contains a non-string object key")
+        return {key: _json_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    if isinstance(value, set):
+        return sorted((_json_value(item) for item in value), key=repr)
+    if dataclasses.is_dataclass(value):
+        return _json_value(dataclasses.asdict(value))
+
+    try:
+        import numpy as np
+
+        if isinstance(value, np.ndarray):
+            return _json_value(value.tolist())
+        if isinstance(value, np.generic):
+            return _json_value(value.item())
+    except ImportError:
+        pass
+    raise TypeError(
+        f"InternBootcamp identity contains unsupported {type(value).__name__}; "
+        "choose a JSON-serializable Bootcamp"
+    )
+
+
+class InternBootcampTaskConfig(vf.TaskConfig):
+    verifier_timeout: int = Field(default=180, ge=30, le=600)
+    """Maximum wall time for one upstream scoring call inside the container."""
+
+
+class InternBootcampConfig(vf.TasksetConfig):
+    bootcamp: str = DEFAULT_BOOTCAMP
+    """Bootcamp class name or canonical key (for example ``Game24`` or ``game24``)."""
+
+    num_examples: int = Field(default=50, ge=1, le=10_000)
+    seed: int = 0
+    system_prompt: str = DEFAULT_SYSTEM_PROMPT
+    task: InternBootcampTaskConfig = InternBootcampTaskConfig()
+
+
+class InternBootcampData(vf.TaskData):
+    bootcamp: str
+    """Canonical upstream Bootcamp key used by the isolated scorer."""
+
+    identity: dict[str, Any]
+    """JSON form of the generated case consumed by the upstream scorer."""
+
+
+class InternBootcampTask(
+    vf.Task[InternBootcampData, vf.State, InternBootcampTaskConfig]
+):
+    NEEDS_CONTAINER = True
+
+    @vf.stop
+    async def single_turn(self, trace: vf.Trace) -> bool:
+        return trace.num_turns >= 1
+
+    async def _score(self, completion: str, runtime: vf.Runtime) -> float:
+        raw = completion.encode("utf-8", "replace")
+        if len(raw) > MAX_COMPLETION_BYTES:
+            return 0.0
+
+        digest = hashlib.sha256(raw).hexdigest()[:16]
+        stem = f"/tmp/internbootcamp/{self.data.idx}-{digest}"
+        identity_path = f"{stem}.identity.json"
+        completion_path = f"{stem}.completion.txt"
+        await runtime.write(
+            identity_path,
+            json.dumps(
+                self.data.identity,
+                ensure_ascii=False,
+                allow_nan=False,
+                sort_keys=True,
+            ).encode(),
+        )
+        await runtime.write(completion_path, raw)
+        result = await runtime.run_uv_script(
+            VERIFY,
+            args=[self.data.bootcamp, identity_path, completion_path],
+            env={"INTERNBOOTCAMP_VERIFY_TIMEOUT": str(self.config.verifier_timeout)},
+        )
+        if result.exit_code != 0:
+            detail = (
+                result.stderr or result.stdout or "unknown verifier error"
+            ).strip()
+            raise RuntimeError(f"InternBootcamp verifier failed: {detail[-2000:]}")
+        lines = [line for line in result.stdout.splitlines() if line.strip()]
+        if not lines:
+            raise RuntimeError("InternBootcamp verifier produced no result")
+        payload = json.loads(lines[-1])
+        score = float(payload["score"])
+        return min(1.0, max(0.0, score)) if math.isfinite(score) else 0.0
+
+    @vf.reward(weight=1.0)
+    async def upstream_score(self, trace: vf.Trace, runtime: vf.Runtime) -> float:
+        return await self._score(trace.last_reply or "", runtime)
+
+    async def validate(self, runtime: vf.Runtime) -> bool:
+        """Preflight the pinned scorer on this generated identity without a model call."""
+        score = await self._score("", runtime)
+        return 0.0 <= score <= 1.0
+
+
+class InternBootcampTaskset(vf.Taskset[InternBootcampTask, InternBootcampConfig]):
+    def load(self) -> list[InternBootcampTask]:
+        config = self.config
+        random.seed(config.seed)
+        try:
+            import numpy as np
+
+            np.random.seed(config.seed)
+        except ImportError:
+            pass
+        try:
+            from faker import Faker
+
+            Faker.seed(config.seed)
+        except ImportError:
+            pass
+
+        key, bootcamp = _new_bootcamp(config.bootcamp, config.seed)
+        tasks: list[InternBootcampTask] = []
+        resources = vf.TaskResources(cpu=2, memory=4, disk=4)
+        for idx in range(config.num_examples):
+            raw_identity = bootcamp.case_generator()
+            prompt = bootcamp.prompt_func(raw_identity)
+            identity = _json_value(raw_identity)
+            if not isinstance(identity, dict):
+                raise TypeError(
+                    f"InternBootcamp task {key!r} returned a non-object identity"
+                )
+            if not isinstance(prompt, str) or not prompt.strip():
+                raise ValueError(
+                    f"InternBootcamp task {key!r} returned an empty prompt"
+                )
+            tasks.append(
+                InternBootcampTask(
+                    InternBootcampData(
+                        idx=idx,
+                        name=f"{key}_{idx:05d}",
+                        prompt=prompt,
+                        system_prompt=config.system_prompt,
+                        resources=resources,
+                        bootcamp=key,
+                        identity=identity,
+                    ),
+                    config.task,
+                )
+            )
+        return tasks
+
+
+__all__ = [
+    "InternBootcampConfig",
+    "InternBootcampData",
+    "InternBootcampTask",
+    "InternBootcampTaskset",
+]

--- a/environments/internbootcamp_v1/internbootcamp_v1/verify.py
+++ b/environments/internbootcamp_v1/internbootcamp_v1/verify.py
@@ -1,0 +1,74 @@
+# /// script
+# requires-python = ">=3.10,<3.13"
+# dependencies = [
+#   "internbootcamp @ https://github.com/dmihal/InternBootcamp/archive/2b2d388f4f056cd9bd0cc91b130f0b54b15572b4.tar.gz",
+# ]
+# ///
+"""Run an InternBootcamp scorer inside the rollout container."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import math
+import os
+import random
+import re
+import signal
+import sys
+
+
+def canonical_key(class_name: str) -> str:
+    base = re.sub(r"bootcamp$", "", class_name, flags=re.IGNORECASE)
+    return re.sub(r"[^0-9a-z]+", "", base.lower())
+
+
+def discover(module) -> dict[str, type]:
+    classes: dict[str, type] = {}
+    for name, candidate in vars(module).items():
+        if (
+            inspect.isclass(candidate)
+            and name.lower().endswith("bootcamp")
+            and callable(getattr(candidate, "case_generator", None))
+            and callable(getattr(candidate, "prompt_func", None))
+            and callable(getattr(candidate, "verify_score", None))
+        ):
+            key = getattr(candidate, "canonical_name", None) or canonical_key(name)
+            classes[canonical_key(str(key))] = candidate
+    return classes
+
+
+def _timeout(_signum, _frame) -> None:
+    raise TimeoutError("InternBootcamp verifier timed out")
+
+
+def main() -> None:
+    if len(sys.argv) != 4:
+        raise SystemExit("usage: verify.py BOOTCAMP IDENTITY_JSON COMPLETION_TEXT")
+    if hasattr(signal, "SIGALRM"):
+        signal.signal(signal.SIGALRM, _timeout)
+        signal.alarm(int(os.environ.get("INTERNBOOTCAMP_VERIFY_TIMEOUT", "180")))
+
+    import internbootcamp
+    import numpy as np
+
+    random.seed(0)
+    np.random.seed(0)
+
+    bootcamp_name, identity_path, completion_path = sys.argv[1:]
+    classes = discover(internbootcamp)
+    if bootcamp_name not in classes:
+        raise ValueError(f"unknown InternBootcamp task: {bootcamp_name}")
+    bootcamp = classes[bootcamp_name]()
+    with open(identity_path, encoding="utf-8") as handle:
+        identity = json.load(handle)
+    with open(completion_path, encoding="utf-8", errors="replace") as handle:
+        completion = handle.read()
+    score = float(bootcamp.verify_score(completion, identity))
+    if not math.isfinite(score):
+        score = 0.0
+    print(json.dumps({"score": min(1.0, max(0.0, score))}))
+
+
+if __name__ == "__main__":
+    main()

--- a/environments/internbootcamp_v1/pyproject.toml
+++ b/environments/internbootcamp_v1/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "internbootcamp-v1"
+description = "Seeded, container-isolated Verifiers v1 adapter for InternBootcamp tasks."
+tags = ["reasoning", "procedural", "single-turn", "train", "eval"]
+version = "0.1.0"
+requires-python = ">=3.10,<3.13"
+dependencies = [
+    "internbootcamp @ https://github.com/dmihal/InternBootcamp/archive/2b2d388f4f056cd9bd0cc91b130f0b54b15572b4.tar.gz",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["internbootcamp_v1"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
+
+[tool.verifiers.eval]
+num_examples = 5
+rollouts_per_example = 3


### PR DESCRIPTION
## Summary

- Adds a seeded Verifiers v1 taskset for InternBootcamp using its native case generators, prompts, and scoring implementation.
- Pins the upstream Apache-2.0 snapshot to commit `2b2d388` for both generation and scoring.
- Executes model-output scoring inside the rollout container and rejects non-container runtimes.

## Validation

- `ruff check environments/internbootcamp_v1`
- `ruff format --check environments/internbootcamp_v1`
- Built source distribution and wheel for `environments/internbootcamp_v1`
- Installed the task package with its pinned upstream dependency on Python 3.12.
- Verified deterministic Game24 generation (same seed gives the same identities; a different seed changes them).
- Ran the native pinned scorer against a generated Game24 identity; it returned valid JSON with a score in `[0, 1]`.

Full container E2E validation could not be run locally because Docker is unavailable on this Windows host. The taskset deliberately declares `NEEDS_CONTAINER = True`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add InternBootcamp taskset environment for multi-domain puzzle verification
> - Adds a new `internbootcamp-v1` environment in [environments/internbootcamp_v1](https://github.com/PrimeIntellect-ai/verifiers/pull/2022/files#diff-68ee67f429bebfbe4bc640da5c113cd813130a72fcea0697e885eeb8c73847d3) that generates single-turn RL tasks from the [InternBootcamp](https://github.com/InternLM/InternBootcamp) library of reasoning puzzles.
> - Dynamically discovers available bootcamps by inspecting the pinned `internbootcamp` module for classes exposing `case_generator`, `prompt_func`, and `verify_score`; defaults to the `game24` bootcamp.
> - Scoring runs entirely inside a container via [verify.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2022/files#diff-5e2644ed746f148f7faa52bd9b0becbe1b1f09b0f665cdc734fbec0b4e186d7c) using `runtime.run_uv_script`, producing a clamped [0,1] score from the bootcamp's `verify_score`.
> - Completions exceeding 100 KB are clamped to score 0; non-finite or invalid verifier outputs are coerced to 0; verifier failures raise `RuntimeError` with stderr detail.
> - Risk: verifier execution requires container isolation (`NEEDS_CONTAINER=True`); the environment cannot be evaluated outside a supported container runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3dbebff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->