### PR TITLE
Make taskset loading lazy

### DIFF
--- a/environments/mmmu_v1/mmmu_v1/taskset.py
+++ b/environments/mmmu_v1/mmmu_v1/taskset.py
@@ -11,6 +11,7 @@ lettered A.. dynamically (MMMU rows range from 2 to 9 choices); open-ended rows
 import ast
 import base64
 import re
+from collections.abc import Iterator
 from io import BytesIO
 from typing import Literal
 
@@ -99,7 +100,7 @@ class MMMUConfig(vf.TasksetConfig):
 
 
 class MMMUTaskset(vf.Taskset[MMMUTask, MMMUConfig]):
-    def load(self) -> list[MMMUTask]:
+    def load(self) -> Iterator[MMMUTask]:
         from datasets import load_dataset
 
         c = self.config
@@ -107,7 +108,7 @@ class MMMUTaskset(vf.Taskset[MMMUTask, MMMUConfig]):
             raise ValueError(f"Invalid subset: {c.subset}")
         subsets = ALL_SUBSETS if c.subset is None else [c.subset]
 
-        tasks: list[MMMUTask] = []
+        idx = 0
         for subset in subsets:
             for row in load_dataset("MMMU/MMMU", subset, split=c.split):
                 options = ast.literal_eval(row["options"])
@@ -127,15 +128,13 @@ class MMMUTaskset(vf.Taskset[MMMUTask, MMMUConfig]):
                         )
                     elif segment:
                         parts.append(vf.TextContentPart(text=segment))
-                tasks.append(
-                    MMMUTask(
-                        MMMUData(
-                            idx=len(tasks),
-                            name=row["id"],
-                            prompt=[vf.UserMessage(content=parts)],
-                            answer=row["answer"],
-                        ),
-                        c.task,
-                    )
+                yield MMMUTask(
+                    MMMUData(
+                        idx=idx,
+                        name=row["id"],
+                        prompt=[vf.UserMessage(content=parts)],
+                        answer=row["answer"],
+                    ),
+                    c.task,
                 )
-        return tasks
+                idx += 1

--- a/verifiers/v1/tasksets/harbor/taskset.py
+++ b/verifiers/v1/tasksets/harbor/taskset.py
@@ -18,6 +18,7 @@ import sys
 import tarfile
 import tempfile
 import tomllib
+from collections.abc import Iterator
 from functools import lru_cache
 from pathlib import Path
 
@@ -311,7 +312,7 @@ def make_tar(directory: Path) -> bytes:
 
 
 class HarborTaskset(Taskset[HarborTask, HarborConfig]):
-    def load(self) -> list[HarborTask]:
+    def load(self) -> Iterator[HarborTask]:
         root = dataset_dir(self.config)
         task_dirs = [
             toml_path.parent
@@ -323,7 +324,5 @@ class HarborTaskset(Taskset[HarborTask, HarborConfig]):
         ]
         if not task_dirs:
             raise ValueError(f"no harbor tasks found in {root}")
-        return [
-            HarborTask(parse_task(task_dir, idx, self.config), self.config.task)
-            for idx, task_dir in enumerate(task_dirs)
-        ]
+        for idx, task_dir in enumerate(task_dirs):
+            yield HarborTask(parse_task(task_dir, idx, self.config), self.config.task)

--- a/verifiers/v1/tasksets/lean/taskset.py
+++ b/verifiers/v1/tasksets/lean/taskset.py
@@ -10,6 +10,7 @@ taskset and only supply column mappings.
 from __future__ import annotations
 
 import shlex
+from collections.abc import Iterator
 
 from pydantic_config import BaseConfig
 
@@ -142,7 +143,7 @@ class LeanTask(Task[LeanData, State, LeanTaskConfig]):
 
 
 class LeanTaskset(Taskset[LeanTask, LeanConfig]):
-    def load(self) -> list[LeanTask]:
+    def load(self) -> Iterator[LeanTask]:
         from datasets import load_dataset
 
         config = self.config
@@ -151,7 +152,6 @@ class LeanTaskset(Taskset[LeanTask, LeanConfig]):
             ds.name,
             ds.subset,
             split=ds.split,
-            keep_in_memory=True,
             num_proc=8,
         )
 
@@ -169,7 +169,6 @@ class LeanTaskset(Taskset[LeanTask, LeanConfig]):
                 )
 
         resources = TaskResources(cpu=4, memory=4, disk=10)
-        tasks: list[LeanTask] = []
         for index, row in enumerate(raw):
             # An empty statement would reduce the signature guard to `:= by`.
             formal_statement = row[ds.statement_column]
@@ -181,29 +180,24 @@ class LeanTaskset(Taskset[LeanTask, LeanConfig]):
             imports = row.get(ds.imports_column) or "import Mathlib"
             gold = row.get(ds.proof_column) or ""
             name = row.get(ds.name_column)
-            tasks.append(
-                LeanTask(
-                    LeanData(
-                        idx=index,
-                        name=str(name) if name else f"task_{index:05d}",
-                        prompt=self._build_prompt(formal_statement, header),
-                        system_prompt=config.system_prompt,
-                        image=config.docker_image,
-                        workdir=config.task.lean_project_path,
-                        resources=resources,
-                        formal_statement=formal_statement,
-                        header=header,
-                        imports=imports,
-                        normalize_mathlib_imports=ds.normalize_mathlib_imports,
-                        protected_signature=expected_protected_signature(
-                            formal_statement
-                        ),
-                        formal_proof=gold,
-                    ),
-                    self.config.task,
-                )
+            yield LeanTask(
+                LeanData(
+                    idx=index,
+                    name=str(name) if name else f"task_{index:05d}",
+                    prompt=self._build_prompt(formal_statement, header),
+                    system_prompt=config.system_prompt,
+                    image=config.docker_image,
+                    workdir=config.task.lean_project_path,
+                    resources=resources,
+                    formal_statement=formal_statement,
+                    header=header,
+                    imports=imports,
+                    normalize_mathlib_imports=ds.normalize_mathlib_imports,
+                    protected_signature=expected_protected_signature(formal_statement),
+                    formal_proof=gold,
+                ),
+                self.config.task,
             )
-        return tasks
 
     def _build_prompt(self, formal_statement: str, header: str) -> str:
         cfg = self.config


### PR DESCRIPTION
Taskset loaders for MMMU, Lean, and Harbor now yield tasks progressively instead of materializing every task before returning.

## Details

- Stream MMMU rows while preserving contiguous indexes across subsets.
- Stop Harbor task parsing once callers have selected enough tasks.
- Stream Lean tasks without forcing the full dataset into memory.

This allows `Taskset.select(...)` to consume only the requested task objects while retaining the same behavior when the full task set is consumed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes for code that assumed `load()` returned a list or iterated `load()` multiple times; MMMU task indices are now contiguous across subsets rather than per-build list length.
> 
> **Overview**
> **MMMU**, **Harbor**, and **Lean** tasksets now implement `load()` as lazy `Iterator` generators instead of building and returning full `list`s, matching the base `Taskset` contract that `select()` already consumes with `itertools.islice`.
> 
> **MMMU** yields each row as it is processed and keeps **contiguous `idx` values** across subsets (separate counter incremented only for kept multiple-choice rows). **Harbor** still discovers all matching task directories up front, but **`parse_task` runs only when each task is yielded**, so bounded `select(num_tasks)` avoids parsing every task. **Lean** yields tasks in the dataset loop and drops **`keep_in_memory=True`** from `load_dataset`, relying on default dataset loading while still loading the split once for iteration.
> 
> Callers that need a reusable collection must materialize explicitly (`list(taskset.load())`); a single pass through `load()` is unchanged for full runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ba7621a8a3cecf7e8739a0683f0830ce8352f80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make taskset `load()` methods return lazy iterators instead of lists
> Converts `load()` in three tasksets to use `yield` instead of building and returning full lists, reducing memory usage when loading large datasets.
>
> - [MMMUTaskset.load](https://github.com/PrimeIntellect-ai/verifiers/pull/2023/files#diff-95658c7661aa4cb893290b526c02e20380cb2ee6a0a3993b59b7073766aa0933) now yields tasks one at a time using an explicit `idx` counter instead of `len(tasks)`
> - [HarborTaskset.load](https://github.com/PrimeIntellect-ai/verifiers/pull/2023/files#diff-2bff5dabcb9a41f4d830e8bbb890e8cc6f5b8331ef2ac4c3b19ffad0e046fe00) replaces a list comprehension with a `for`/`yield` loop
> - [LeanTaskset.load](https://github.com/PrimeIntellect-ai/verifiers/pull/2023/files#diff-4e7d754229e5803fddc0fea71640b92984c26d8a2da8fb28aa8c2c86150fa25a) also drops `keep_in_memory=True` from `datasets.load_dataset`
> - Behavioral Change: callers receiving a list from `load()` will now receive an iterator, which can only be consumed once
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ba7621.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->