### PR TITLE
Reorder interception operations

### DIFF
--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -36,6 +36,7 @@ from verifiers.v1.types import (
     Response,
     StrictBaseModel,
     TextContentPart,
+    Tool,
     ToolMessage,
     Usage,
 )
@@ -341,8 +342,10 @@ class PendingTurn:
             for span in tail_spans
         ]
 
-    def commit(self, response: Response) -> None:
+    def commit(self, response: Response, tools: list[Tool] | None = None) -> None:
         _commit_turn(self, response)
+        if tools:
+            self.trace.tools = tools
 
 
 def prepare_turn(trace: Trace, prompt: list[Message]) -> PendingTurn:

--- a/verifiers/v1/interception/pool.py
+++ b/verifiers/v1/interception/pool.py
@@ -62,14 +62,11 @@ class StaticInterceptionPool(Interception):
 
     @asynccontextmanager
     async def acquire(self, session: RolloutSession) -> AsyncIterator[Slot]:
-        # min + register have no await between them, so concurrent acquires can't all
-        # land on the same "least-loaded" server.
+        # server.acquire registers before its first yield, so concurrent acquires see the
+        # updated load before choosing their own least-loaded server.
         server = min(self.servers, key=lambda s: s.load)
-        secret = server.register(session)
-        try:
-            yield server.base_url, secret
-        finally:
-            server.unregister(secret)
+        async with server.acquire(session) as slot:
+            yield slot
 
 
 class ElasticInterceptionPoolConfig(BaseInterceptionConfig):

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -335,14 +335,8 @@ class InterceptionServer(Interception):
                 session.trace.id,
                 len(response.message.tool_calls or []),
             )
-            turn.commit(response)  # one node per new message;
+            turn.commit(response, tools)  # one node per new message;
             # branches fall out of walking the graph (see Trace.branches / verifiers.v1.graph)
-            if tools:
-                # Persist the advertised tools now that the model actually saw them (see
-                # `Trace.tools`). Only a tools-bearing turn updates it (truthy, so an empty
-                # parse or a trailing tool-less call never erases the schemas the recorded
-                # tool calls need).
-                session.trace.tools = tools
             # Hand back to the program when the model wants a tool (the program runs it) or
             # when there's no user simulator to keep the conversation going.
             if response.message.tool_calls or session.user is None:
@@ -489,9 +483,7 @@ class InterceptionServer(Interception):
         try:
             if parser_error is not None:
                 raise parser_error
-            turn.commit(parser.finish())
-            if tools:  # record only on commit, like the non-streaming path
-                session.trace.tools = tools
+            turn.commit(parser.finish(), tools)
             logger.debug("intercept stream turn: id=%s", session.trace.id)
         finally:
             # Release the withheld events only now — after the commit — then close.


### PR DESCRIPTION
## Overview

This PR is just a reordering of the existing interception operations.

## Details

- Move advertised-tool persistence into `PendingTurn.commit` so it remains immediately after a successful turn graph commit.
- Route both normal and streaming interception paths through that same operation.
- Delegate static-pool registration and teardown to `InterceptionServer.acquire` while preserving least-loaded selection.

The resulting trace and acquisition behavior is unchanged; ownership of the existing operations is centralized.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor that centralizes existing commit and session lifecycle logic without changing intended trace or pool behavior.
> 
> **Overview**
> **Tool schema persistence** moves into `PendingTurn.commit` so advertised tools are written to `trace.tools` immediately after a successful graph commit. Both non-streaming and streaming interception paths now pass `tools` into that single call instead of duplicating the assignment in `server.py`.
> 
> **Static interception pool** acquisition is routed through `InterceptionServer.acquire` (register → yield slot → unregister) rather than calling `register`/`unregister` on the pool. Least-loaded server selection is unchanged; the comment documents that registration happens before the context manager yields so concurrent acquires see updated load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0f696f8e56a349d986458fa88411e0dfa11ab94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reorder interception operations to consolidate tool persistence into `PendingTurn.commit`
> - Adds an optional `tools` parameter to `PendingTurn.commit` in [graph.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2025/files#diff-64c9d635eb215902a512c9e8ab316fd9b9967c36db03d4049aacc812cdfbd740), so tool schema persistence onto the trace is handled inside `commit` rather than inline after it.
> - Updates both the streaming and non-streaming paths in [server.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2025/files#diff-84e2f8d027d609e8760ef6d533535ec9d99dfc6384d5ddb6111b4001b2010f35) to pass `tools` directly to `turn.commit(...)`, removing the separate conditional assignments.
> - Refactors `StaticInterceptionPool.acquire` in [pool.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2025/files#diff-7d8dba863adfb436c11d0a61224983c6b89a257397b973237ab96de3c67952b0) to use `async with server.acquire(session)` instead of manual `register`/`unregister` calls.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b0f696f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->