### PR TITLE
Clean up replay dashboard progress rendering

### DIFF
--- a/verifiers/v1/cli/dashboard/replay.py
+++ b/verifiers/v1/cli/dashboard/replay.py
@@ -6,13 +6,12 @@ from dataclasses import dataclass
 
 from rich.console import Group
 from rich.markup import escape
-from rich.progress_bar import ProgressBar
 from rich.rule import Rule
 from rich.table import Table
 from rich.text import Text
 
 from verifiers.v1.cli.dashboard.base import live_view
-from verifiers.v1.cli.dashboard.validate import TaskProgress
+from verifiers.v1.cli.dashboard.validate import Progress, TaskProgress
 from verifiers.v1.utils.format import format_time
 
 
@@ -33,30 +32,21 @@ _STYLE = {
 _MARK_WIDTH = max(len(state) for state in _STYLE)
 _MARK = {state: escape(f"[{state:<{_MARK_WIDTH}}]") for state in _STYLE}
 _DONE = ("scored", "error", "skipped")
+_OUTCOMES = {
+    "scored": ("scored", _STYLE["scored"]),
+    "error": ("failed", _STYLE["error"]),
+    "skipped": ("skipped", _STYLE["skipped"]),
+}
 
 
 def _render(
     states: list[TaskProgress], taskset_name: str, source: str, out: str, start: float
 ) -> Group:
-    done = [s for s in states if s.state in _DONE]
-    scored = sum(1 for s in done if s.state == "scored")
-    skipped = sum(1 for s in done if s.state == "skipped")
     overview = Table.grid(padding=(0, 2))
     overview.add_column(style="dim")
     overview.add_column()
-    overview.add_row("replay", f"{taskset_name}  ·  {source}")
-    overview.add_row("output", out)
-
-    stats = (
-        f" {len(done)}/{len(states)} · {format_time(time.time() - start)} · "
-        f"scored {scored} · failed {len(done) - scored - skipped} · skipped {skipped}"
-    )
-    progress = Table.grid()
-    progress.add_column()
-    progress.add_column()
-    progress.add_row(
-        ProgressBar(total=len(states) or 1, completed=len(done), width=32), Text(stats)
-    )
+    overview.add_row("replay", Text(f"{taskset_name}  ·  {source}", overflow="fold"))
+    overview.add_row("output", Text(out, overflow="fold"))
 
     now = time.time()
     rows = Table.grid(expand=True, padding=(0, 1))
@@ -80,7 +70,7 @@ def _render(
             elapsed,
             style=_STYLE[s.state],
         )
-    return Group(overview, progress, Rule(style="dim"), rows)
+    return Group(overview, Progress(states, start, _OUTCOMES), Rule(style="dim"), rows)
 
 
 @contextlib.asynccontextmanager

--- a/verifiers/v1/cli/dashboard/validate.py
+++ b/verifiers/v1/cli/dashboard/validate.py
@@ -30,6 +30,8 @@ _MARK_WIDTH = max(len(state) for state in _STYLE)
 # literal: Rich parses `[name]` in a cell as markup and would otherwise drop it.
 _MARK = {state: escape(f"[{state:<{_MARK_WIDTH}}]") for state in _STYLE}
 _DONE = ("valid", "invalid", "error", "timeout")
+# State -> (visible label, color); insertion order is the summary order.
+_OUTCOMES = {state: (state, _STYLE[state]) for state in _DONE}
 
 
 @dataclass
@@ -49,13 +51,17 @@ def Overview(config: ValidateConfig) -> Table:
     return grid
 
 
-def Progress(states: list[TaskProgress], start: float) -> Table:
-    done = [s for s in states if s.state in _DONE]
+def Progress(
+    states: list[TaskProgress],
+    start: float,
+    outcomes: dict[str, tuple[str, str]] = _OUTCOMES,
+) -> Table:
+    done = [s for s in states if s.state in outcomes]
     counts = Counter(s.state for s in done)
     stats = Text(f" {len(done)}/{len(states)} · {format_time(time.time() - start)}")
-    for state in _DONE:
+    for state, (label, style) in outcomes.items():
         stats.append(" · ")
-        stats.append(f"{state} {counts[state]}", style=_STYLE[state])
+        stats.append(f"{label} {counts[state]}", style=style)
     row = Table.grid()
     row.add_column()
     row.add_column()


### PR DESCRIPTION
## Overview

This is a cleanup of existing v1 dashboard code. It reuses the validate progress-grid renderer in replay while keeping replay's established labels, counts, ordering, elapsed time, totals, and per-row display.

## Details

- Generalizes the existing validate progress renderer with an ordered outcome mapping.
- Removes replay's duplicate progress-grid construction and delegates it to the shared renderer.
- Keeps long replay source and output paths readable in narrow terminals by folding them instead of truncating their distinguishing tails.

This does not change replay or validation execution; it only consolidates and tidies the Rich dashboard presentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only refactor of Rich CLI dashboards; validate and replay execution paths are unchanged.
> 
> **Overview**
> Consolidates replay’s live progress bar and outcome counts by reusing **`Progress`** from the validate dashboard instead of a local duplicate built with **`ProgressBar`** and hand-rolled stats.
> 
> **`Progress`** in `validate.py` now takes an optional ordered **`outcomes`** map (state → display label and Rich style). Replay passes **`_OUTCOMES`** so errors still show as **failed** while scored/skipped labels and colors stay the same. Validate keeps its prior summary when the default map is used.
> 
> Replay’s header rows wrap long taskset/source and output paths with **`Text(..., overflow="fold")`** so narrow terminals stay readable without chopping distinguishing path tails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92c3d180c78f4161d03b6f2fd8e4fbac04e12bab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clean up replay dashboard progress rendering by delegating to shared `validate.Progress`
> - Refactors [replay.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2026/files#diff-8558a0cd5ec20e5dbe88150a16e0db62da49abb598b225b46fb912fe2d0afcfa) to delegate progress summary rendering to `validate.Progress` instead of computing and rendering it inline.
> - Adds an `_OUTCOMES` mapping to [validate.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2026/files#diff-2ded55a5b55a7c27d925b91343c516de853d005e99d07590ceb341bdc9e9149e) and updates `Progress` to accept a caller-provided outcomes dict, enabling custom labels, styles, and ordering.
> - The `error` state is now labeled `failed` in the replay progress summary.
> - Long `replay` and `output` strings now fold instead of overflow in the overview panel.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 92c3d18.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->