### PR TITLE
Reuse persisted trace runtime metadata

### DIFF
--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -448,10 +448,8 @@ def Rows(groups: list[list[Rollout]], now: float, runtime_type: str) -> Table:
                         stop = f"{stop} (truncated)".strip()
             else:
                 state, result, stop = rollout.phase, "", ""
-            descriptor = (
-                rollout.runtime.descriptor if rollout.runtime is not None else None
-            )
-            runtime = f"{runtime_type}({descriptor})" if descriptor else runtime_type
+            runtime_id = t.runtime.id if t.runtime is not None else None
+            runtime = f"{runtime_type}({runtime_id})" if runtime_id else runtime_type
             turns = t.num_turns
             start = t.timing.boot.start or t.timing.setup.start
             end = (

--- a/verifiers/v1/cli/debug.py
+++ b/verifiers/v1/cli/debug.py
@@ -63,14 +63,6 @@ def task_info(task) -> dict[str, Any]:
     return {"idx": task.data.idx, "name": task.data.name, "workdir": task.data.workdir}
 
 
-def runtime_info(runtime: Runtime) -> dict[str, Any]:
-    return {
-        "type": runtime.type,
-        "name": runtime.name,
-        "descriptor": runtime.descriptor,
-    }
-
-
 def result_info(result: ProgramResult, start: float) -> dict[str, Any]:
     ok = result.exit_code == 0
     return {
@@ -132,7 +124,6 @@ def capture_trace_error(trace: Trace, error: BaseException) -> None:
 def record_debug_error(
     trace: Trace,
     debug: dict[str, Any],
-    runtime: Runtime,
     error: BaseException,
     setup_timeout: float | None,
     action_timeout: float | None,
@@ -152,7 +143,6 @@ def record_debug_error(
         else trace.timing.setup.start or trace.timing.boot.start
     )
     debug.update(error_info(error, error_start, timeout, stage))
-    debug.setdefault("runtime", runtime_info(runtime))
     capture_trace_error(trace, error)
 
 
@@ -223,6 +213,7 @@ async def debug_task(task: Task, config: DebugConfig) -> tuple[Trace, bool]:
         resolve_runtime_config(config.runtime, task),
         name=f"debug-{task.data.idx}-{uuid4().hex[:8]}",
     )
+    trace.runtime = runtime.info
     setup_timeout = (
         config.timeout.setup
         if config.timeout.setup is not None
@@ -234,7 +225,6 @@ async def debug_task(task: Task, config: DebugConfig) -> tuple[Trace, bool]:
         now = time.time()
         trace.timing.boot.end = now
         trace.timing.setup.start = now
-        debug["runtime"] = runtime_info(runtime)
         await asyncio.wait_for(
             invoke(task.setup, {"trace": trace, "runtime": runtime}),
             setup_timeout,
@@ -249,13 +239,9 @@ async def debug_task(task: Task, config: DebugConfig) -> tuple[Trace, bool]:
         trace.stop(str(debug["reason"]))
     except asyncio.CancelledError as e:
         cancelled = True
-        record_debug_error(
-            trace, debug, runtime, e, setup_timeout, config.timeout.total
-        )
+        record_debug_error(trace, debug, e, setup_timeout, config.timeout.total)
     except Exception as e:
-        record_debug_error(
-            trace, debug, runtime, e, setup_timeout, config.timeout.total
-        )
+        record_debug_error(trace, debug, e, setup_timeout, config.timeout.total)
     finally:
         trace.info["debug"] = debug
         try:

--- a/verifiers/v1/cli/eval/resume.py
+++ b/verifiers/v1/cli/eval/resume.py
@@ -59,7 +59,6 @@ class Finished(Rollout):
         self.trace = trace
         self.task = Task(trace.task.data)
         self.phase = Phase.DONE
-        self.runtime = None
 
 
 def load(

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -116,10 +116,6 @@ class Runtime(ABC):
     def type(self) -> str:
         return self.config.type
 
-    @property
-    def descriptor(self) -> str | None:
-        return self.info.id
-
     @abstractmethod
     async def start(self) -> None:
         pass

--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -187,7 +187,7 @@ class ModalRuntime(Runtime):
         # the sandbox via Modal's sync API so the costly resource isn't left to its max-lifetime.
         # Idempotent — the async `stop` handles the normal path, and a second terminate is a no-op.
         sandbox, self._sandbox = self._sandbox, None
-        if sandbox is not None:  # `info.id` kept so descriptor survives teardown
+        if sandbox is not None:  # keep info.id available after teardown
             with contextlib.suppress(Exception):
                 sandbox.terminate()
 

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -257,9 +257,7 @@ class PrimeRuntime(Runtime):
         client, self._client = self._client, None  # `_client` is the idempotency guard
         if client is None:
             return
-        if (
-            self.info.id is not None
-        ):  # kept (not nulled) so descriptor survives teardown
+        if self.info.id is not None:  # keep info.id available after teardown
             try:
                 await client.delete(self.info.id)
             except Exception as e:


### PR DESCRIPTION
## Overview

Reuse the runtime metadata already persisted on `Trace` as the single source of truth for debug traces and dashboard rendering.

## Details

- Attach `runtime.info` to debug traces before runtime startup, so the resolved configuration is recorded for boot failures and the provisioned resource ID flows onto the same trace object once available.
- Render dashboard resource identifiers from `trace.runtime.id`, including rollouts reloaded during resume.
- Remove the duplicate `info.debug.runtime` payload, the `Finished.runtime` placeholder, and the `Runtime.descriptor` alias.
- Keep provisioned IDs available after teardown for persisted diagnostics.

## Impact

Debug trace JSON now stores typed runtime metadata in the top-level `runtime` field instead of maintaining a smaller parallel dictionary under `info.debug`. Live dashboard output remains the same, while resumed rows retain their persisted runtime identifiers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI/trace serialization and display wiring only; no auth, scoring, or runtime provisioning logic changes beyond removing a redundant alias.
> 
> **Overview**
> **Runtime identity and config now live only on `Trace.runtime`**, instead of parallel fields (`Runtime.descriptor`, `info.debug.runtime`, `Finished.runtime`).
> 
> The **eval dashboard** shows provisioned resources as `runtime_type(trace.runtime.id)` for live and **resumed** rollouts (reloaded traces already carry persisted `runtime`).
> 
> **Debug** sets `trace.runtime = runtime.info` before `start()`, so boot failures still record resolved config and IDs update on the same object; the nested `debug.runtime` dict and `runtime_info()` helper are removed.
> 
> **Modal/Prime** teardown comments clarify that `info.id` is intentionally kept after cleanup for persisted diagnostics. **`Runtime.descriptor`** is removed—callers use `runtime.info.id` directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f284189bfc32ec5d3444b083ed1fffb3376d0611. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Store runtime metadata on trace instead of deriving it from rollout runtime
> - Moves runtime metadata from `debug["runtime"]` to `trace.runtime` by assigning `runtime.info` in [`debug_task`](https://github.com/PrimeIntellect-ai/verifiers/pull/2028/files#diff-6cbbe530b7b57522fdaa03e458c8212efb6e360e854db49d459fb9e41c1b4d5f) after setup, making it available for the full trace lifecycle.
> - Updates [`eval.Rows`](https://github.com/PrimeIntellect-ai/verifiers/pull/2028/files#diff-0a27b905958929f3ae9e01937dd7e3cf97a60dec137caddcbf87792784fc9035) to render runtime as `<type>(<id>)` using `trace.runtime.id` instead of `rollout.runtime.descriptor`.
> - Removes the `Runtime.descriptor` property from [`runtimes/base.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/2028/files#diff-0811c040a163eb5a3212208f1e3a6c6388d7690fcc4780c081cc7754036232b9) and the `runtime_info` helper from [`debug.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/2028/files#diff-6cbbe530b7b57522fdaa03e458c8212efb6e360e854db49d459fb9e41c1b4d5f) as they are no longer needed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f284189.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->