### PR TITLE
fix(serve): run env server on Windows (tcp sockets + tornado for zmq async)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "aiohttp>=3.9.0",
     "prime-pydantic-config[toml]>=0.3.0.dev86",
     "uvloop>=0.21.0; sys_platform != 'win32' and sys_platform != 'cygwin' and platform_python_implementation != 'PyPy'",
+    "tornado>=6.1; sys_platform == 'win32'",
     "loguru>=0.7.0",
     "tomli-w>=1.0.0",
     "renderers>=0.1.8.dev40",

--- a/verifiers/serve/server/env_router.py
+++ b/verifiers/serve/server/env_router.py
@@ -422,7 +422,7 @@ class EnvRouter:
         for path in self.ipc_paths:
             try:
                 os.unlink(path)
-            except FileNotFoundError:
+            except OSError:
                 pass
 
         self.logger.info("Router shut down")

--- a/verifiers/utils/serve_utils.py
+++ b/verifiers/utils/serve_utils.py
@@ -118,7 +118,13 @@ def walk_decode_tensors(obj: Any, *, to_torch: bool = True):
 
 
 def make_ipc_address(session_id: str, name: str) -> str:
-    """Build an IPC address for inter-process communication."""
+    """Build an inter-process address.
+
+    POSIX uses a ZMQ ipc:// socket. Windows has no ipc:// transport, so fall back to a
+    loopback tcp:// socket on a free port.
+    """
+    if sys.platform == "win32":
+        return f"tcp://127.0.0.1:{get_free_port()}"
     return f"ipc:///tmp/vf-{session_id}-{name.replace('/', '--')}"
 
 


### PR DESCRIPTION
Fixes #2030.

On Windows, `prime eval run` (anything that starts the env server) fails before any
rollout: the server can't bind its internal ZMQ sockets, and the client's receive loop
errors out.

Two causes:

- `serve_utils.make_ipc_address` returns an `ipc:///tmp/...` address. ZMQ `ipc://` is a
  Unix-domain-socket transport and isn't supported on Windows, so `EnvRouter` fails at
  `bind()` with `Protocol not supported`.
- ZMQ's async sockets need `add_reader`, which Windows' default Proactor event loop
  doesn't implement. (On other platforms this never comes up because `uvloop` is used.)

### Changes

- `make_ipc_address` returns a loopback `tcp://127.0.0.1:<free_port>` on Windows and keeps
  `ipc://` on POSIX. Each address is generated once and reused, so a per-call free port is
  fine.
- Broadened the router's socket-file cleanup to `except OSError` (a tcp address has no file
  to unlink).
- Added `tornado>=6.1` as a Windows-only dependency; pyzmq uses it to drive its async
  sockets on the Proactor loop. This mirrors the existing Windows exclusion for `uvloop`.

### Validation (Windows 11, Python 3.12)

Ran a local `SingleTurnEnv` eval end to end. The env server now binds on tcp, becomes
healthy, and rollouts complete:

```
ZMQEnvServer started on tcp://127.0.0.1:49486
Env server ... is healthy
Processing 8 groups (8 total rollouts): 100% ... reward=0.783
```

Before this change it stopped at:

```
zmq.error.ZMQError: Protocol not supported (addr='ipc:///tmp/vf-...-responses')
```

### Note on scope

`v1/serve/pool.py` builds its own `ipc://` address the same way and would need the same
tcp fallback for v1 environments. I scoped this PR to the `serve/server` path that classic
environments use and that I could reproduce and validate; happy to extend it to v1 if you'd
prefer it in one change.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix env server on Windows using TCP sockets and tornado for zmq async
> - Updates [`make_ipc_address`](https://github.com/PrimeIntellect-ai/verifiers/pull/2033/files#diff-573ce1050a71bef580f9e082113a30474324c2d0e92c785579dce9d67eb1a4ca) to return `tcp://127.0.0.1:<free_port>` on Windows instead of an `ipc://` path, since Windows does not support Unix domain sockets.
> - Adds a conditional dependency on `tornado>=6.1` for Windows, required for zmq async event loop integration.
> - Broadens the exception caught in [`EnvRouter.teardown`](https://github.com/PrimeIntellect-ai/verifiers/pull/2033/files#diff-5f42e5c44b82aeddf6020de01b59c5480cac9144a3f6ffc79c3ee01683ad92ec) from `FileNotFoundError` to `OSError` when removing IPC paths, preventing shutdown errors on Windows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2f2965b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->