### PR TITLE
feat(v1): TOOL_PREFIX = None for bare tool names

### DIFF
--- a/verifiers/v1/harnesses/default/program.py
+++ b/verifiers/v1/harnesses/default/program.py
@@ -198,7 +198,8 @@ async def connect_mcp(stack: AsyncExitStack, config: dict) -> tuple[list[dict], 
         session = await stack.enter_async_context(ClientSession(read, write))
         await session.initialize()
         for tool in (await session.list_tools()).tools:
-            full = f"{name}_{tool.name}"
+            # A server named "" (TOOL_PREFIX = None) advertises its tools bare.
+            full = f"{name}_{tool.name}" if name else tool.name
             tool_schemas.append(
                 {
                     "type": "function",

--- a/verifiers/v1/harnesses/null/harness.py
+++ b/verifiers/v1/harnesses/null/harness.py
@@ -11,7 +11,9 @@ PROGRAM_SOURCE = (Path(__file__).resolve().parent / "program.py").read_text()
 
 
 class NullHarnessConfig(HarnessConfig):
-    pass
+    qualify_tools: bool = True
+    """Advertise MCP tools as `<server>_<tool>`. Disable to expose raw tool names (useful for
+    benchmark fidelity); requires names to be unique across the rollout's tool servers."""
 
 
 class NullHarness(Harness[NullHarnessConfig]):
@@ -54,6 +56,8 @@ class NullHarness(Harness[NullHarnessConfig]):
                     }
                 )
             )
+            if not self.config.qualify_tools:
+                args.append("--bare-tools")
         if isinstance(prompt, str):
             args.append(f"--prompt={prompt}")
         elif prompt is not None:

--- a/verifiers/v1/harnesses/null/harness.py
+++ b/verifiers/v1/harnesses/null/harness.py
@@ -11,9 +11,7 @@ PROGRAM_SOURCE = (Path(__file__).resolve().parent / "program.py").read_text()
 
 
 class NullHarnessConfig(HarnessConfig):
-    qualify_tools: bool = True
-    """Advertise MCP tools as `<server>_<tool>`. Disable to expose raw tool names (useful for
-    benchmark fidelity); requires names to be unique across the rollout's tool servers."""
+    pass
 
 
 class NullHarness(Harness[NullHarnessConfig]):
@@ -56,8 +54,6 @@ class NullHarness(Harness[NullHarnessConfig]):
                     }
                 )
             )
-            if not self.config.qualify_tools:
-                args.append("--bare-tools")
         if isinstance(prompt, str):
             args.append(f"--prompt={prompt}")
         elif prompt is not None:

--- a/verifiers/v1/harnesses/null/program.py
+++ b/verifiers/v1/harnesses/null/program.py
@@ -22,13 +22,11 @@ async def chat(
     return completion.choices[0].message
 
 
-async def connect_mcp(
-    stack: AsyncExitStack, config: dict, bare_tools: bool = False
-) -> tuple[list[dict], dict]:
+async def connect_mcp(stack: AsyncExitStack, config: dict) -> tuple[list[dict], dict]:
     """Connect to each configured MCP server (a streamable-HTTP `url`); return
     (tool schemas, dispatch mapping advertised name -> (session, raw tool name)). Tools are
-    advertised as `<server>_<tool>`, or raw with `bare_tools` (names must then be unique
-    across servers)."""
+    advertised as `<server>_<tool>`; a server named `""` (TOOL_PREFIX = None) advertises its
+    tools bare, so names must be unique across the rollout's servers."""
     from mcp import ClientSession
     from mcp.client.streamable_http import (
         create_mcp_http_client,
@@ -47,7 +45,7 @@ async def connect_mcp(
         session = await stack.enter_async_context(ClientSession(read, write))
         await session.initialize()
         for tool in (await session.list_tools()).tools:
-            full = tool.name if bare_tools else f"{name}_{tool.name}"
+            full = f"{name}_{tool.name}" if name else tool.name
             if full in dispatch:
                 raise ValueError(
                     f"duplicate tool name {full!r} across servers; keep qualified names"
@@ -98,7 +96,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--prompt", default="")
     parser.add_argument("--initial-messages-file", default="")
     parser.add_argument("--mcp-config", default="")
-    parser.add_argument("--bare-tools", action="store_true")
     return parser.parse_args()
 
 
@@ -117,7 +114,7 @@ async def main() -> None:
         # `stack` must be exited by this task, not a wait_for-spawned child task.
         if config.get("mcpServers"):
             async with asyncio.timeout(60):
-                tools, dispatch = await connect_mcp(stack, config, args.bare_tools)
+                tools, dispatch = await connect_mcp(stack, config)
         else:
             tools, dispatch = [], {}
         messages = (

--- a/verifiers/v1/harnesses/null/program.py
+++ b/verifiers/v1/harnesses/null/program.py
@@ -22,9 +22,13 @@ async def chat(
     return completion.choices[0].message
 
 
-async def connect_mcp(stack: AsyncExitStack, config: dict) -> tuple[list[dict], dict]:
+async def connect_mcp(
+    stack: AsyncExitStack, config: dict, bare_tools: bool = False
+) -> tuple[list[dict], dict]:
     """Connect to each configured MCP server (a streamable-HTTP `url`); return
-    (tool schemas, dispatch mapping `<server>_<tool>` -> (session, raw tool name))."""
+    (tool schemas, dispatch mapping advertised name -> (session, raw tool name)). Tools are
+    advertised as `<server>_<tool>`, or raw with `bare_tools` (names must then be unique
+    across servers)."""
     from mcp import ClientSession
     from mcp.client.streamable_http import (
         create_mcp_http_client,
@@ -43,7 +47,11 @@ async def connect_mcp(stack: AsyncExitStack, config: dict) -> tuple[list[dict], 
         session = await stack.enter_async_context(ClientSession(read, write))
         await session.initialize()
         for tool in (await session.list_tools()).tools:
-            full = f"{name}_{tool.name}"
+            full = tool.name if bare_tools else f"{name}_{tool.name}"
+            if full in dispatch:
+                raise ValueError(
+                    f"duplicate tool name {full!r} across servers; keep qualified names"
+                )
             tool_schemas.append(
                 {
                     "type": "function",
@@ -90,6 +98,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--prompt", default="")
     parser.add_argument("--initial-messages-file", default="")
     parser.add_argument("--mcp-config", default="")
+    parser.add_argument("--bare-tools", action="store_true")
     return parser.parse_args()
 
 
@@ -108,7 +117,7 @@ async def main() -> None:
         # `stack` must be exited by this task, not a wait_for-spawned child task.
         if config.get("mcpServers"):
             async with asyncio.timeout(60):
-                tools, dispatch = await connect_mcp(stack, config)
+                tools, dispatch = await connect_mcp(stack, config, args.bare_tools)
         else:
             tools, dispatch = [], {}
         messages = (

--- a/verifiers/v1/mcp/server.py
+++ b/verifiers/v1/mcp/server.py
@@ -113,8 +113,10 @@ def _import_ref(ref: str) -> object:
 
 
 class ServerBase(Generic[ConfigT, StateT]):
-    # The empty value falls back to the snake-cased class name.
-    TOOL_PREFIX: ClassVar[str] = ""
+    # The empty value falls back to the snake-cased class name. None advertises the server's
+    # tools bare (no `<server>_` prefix); name collisions across servers are then the
+    # taskset author's concern.
+    TOOL_PREFIX: ClassVar[str | None] = ""
 
     EXTRAS: ClassVar[tuple[str, ...]] = ()
     """Package extras the server's module needs, applied at sandbox install."""
@@ -214,6 +216,8 @@ class ServerBase(Generic[ConfigT, StateT]):
 
     @property
     def server_name(self) -> str:
+        if self.TOOL_PREFIX is None:
+            return ""
         return self.TOOL_PREFIX or "".join(
             ("_" + c.lower() if c.isupper() else c) for c in type(self).__name__
         ).lstrip("_")

--- a/verifiers/v1/mcp/server.py
+++ b/verifiers/v1/mcp/server.py
@@ -113,10 +113,10 @@ def _import_ref(ref: str) -> object:
 
 
 class ServerBase(Generic[ConfigT, StateT]):
-    # The empty value falls back to the snake-cased class name. None advertises the server's
-    # tools bare (no `<server>_` prefix); name collisions across servers are then the
-    # taskset author's concern.
     TOOL_PREFIX: ClassVar[str | None] = ""
+    """The empty value falls back to the snake-cased class name. None advertises the server's
+    tools bare (no `<server>_` prefix); name collisions across servers are then the taskset
+    author's concern."""
 
     EXTRAS: ClassVar[tuple[str, ...]] = ()
     """Package extras the server's module needs, applied at sandbox install."""


### PR DESCRIPTION
## Summary

- `ServerBase.TOOL_PREFIX` accepts `None`: the server's `server_name` becomes `""` and the null/default harness programs advertise its tools by their raw names instead of `<server>_<tool>`.
- Cross-server name collisions are the taskset author's concern; the null program raises on duplicate advertised names instead of silently shadowing.
- Motivation: benchmark-port fidelity — upstream benchmarks (e.g. AutomationBench, PrimeIntellect-ai/research-environments#667) expose bare tool names (`api_fetch`), and the forced prefix is a gratuitous deviation when a taskset runs a single tool server. Declaring it on the toolset (`TOOL_PREFIX = None`) keeps it a property of the environment, not per-run harness config.
- Note: the rlm harness names skills in `rlm-harness` (`_skill_name`), which turns an empty server name into a leading-underscore skill (`_api_fetch`) — functional, can be polished there separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to tool naming and MCP wiring; duplicate names are explicitly rejected in the null harness but not in the default harness.
> 
> **Overview**
> **`ServerBase.TOOL_PREFIX = None`** makes `server_name` an empty string so MCP tools can be exposed to the model under their **raw names** (e.g. `api_fetch`) instead of `<server>_<tool>`, matching upstream benchmarks that use bare tool names on single-server tasksets.
> 
> The **default** and **null** harness `connect_mcp` paths now build advertised names with `f"{name}_{tool.name}" if name else tool.name`. The **null** harness additionally **fails fast** with `ValueError` when two servers would advertise the same name, instead of silently overwriting the dispatch map.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd38791f0006145a88fd569b0e72f60b64797642. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support bare tool names in MCP servers by setting `TOOL_PREFIX = None`
> - Adds `None` as a valid value for `TOOL_PREFIX` on `ServerBase` in [server.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2035/files#diff-5eaeab5d19ee732e16b066ff6689f954f6743833a907a129acc0df250cee5b2a): `None` causes `server_name` to return `''`, advertising tools without a `<server>_` prefix. An empty string `''` retains the existing fallback to a snake-cased class name.
> - Updates `connect_mcp` in both [default/program.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2035/files#diff-4cb67cb50bf655658944c055a7e88bcf71e08b1112043d946c684ac2d51a2d80) and [null/program.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2035/files#diff-d4e93ef3c6afb0d7441cceeef2d60bd8618168a7d72b8d1df78f16dbe0289304) to skip the prefix when the server name is empty, dispatching tools under their bare names.
> - Adds a duplicate-name guard in the null harness's `connect_mcp` that raises `ValueError` if the computed tool name already exists in the dispatch mapping.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fd38791.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->