### PR TITLE
docs(v1): document GEPA prompt optimization

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -14,7 +14,8 @@
             "v1/environments",
             "v1/evaluation",
             "v1/harnesses",
-            "v1/harbor"
+            "v1/harbor",
+            "v1/gepa"
           ]
         },
         {

--- a/docs/v1/gepa.md
+++ b/docs/v1/gepa.md
@@ -1,0 +1,50 @@
+# GEPA Prompt Optimization
+
+verifiers offers built in support for GEPA, an algorithm that optimizes a system prompt to maximize the downstream reward for a given taskset:
+
+```bash
+uv run gepa reverse-text-v1 --model google/gemini-3-flash-preview
+```
+
+`gepa` runs [GEPA](https://github.com/gepa-ai/gepa) where a number of rollouts are done then a teacher LLM reflects on the results to propose a better `Task.system_prompt` without any gradient based training. It runs against native v1 tasksets. Legacy v0 environments can be run with `vf-gepa`.
+
+GEPA reuses the same `taskset` / `harness` / `client` / `sampling` config as eval, so the `.toml` config remains very similar:
+
+```toml
+model = "google/gemini-3-flash-preview"
+
+[taskset]
+id = "reverse-text-v1"
+
+[harness]
+id = "default"
+
+[sampling]
+temperature = 1.0
+```
+
+Validate the config by using `uv run gepa @ config.toml --dry-run`. To run GEPA, use `uv run gepa @ config.toml`. CLI arguments overwrite toml arguments when both are present.
+
+## Common config values
+- `model` / `-m` — model for the rollouts under optimization (required; no default, since a run can spend a large budget)
+- `reflection_model` / `reflection_client` - the model/endpoint that proposes new prompts (default: reuse `model` / `client`)
+- `num_train` - tasks reserved for reflection minibatches (default: 100)
+- `num_val` - tasks held out to score each prompt candidate for the pareto frontier (default: 50)
+- `max_metric_calls` - total rollouts the run may spend (default: 500)
+- `reflection_minibatch_size` - train tasks sampled per reflection step (default: 3)
+- `initial_prompt` - seed system prompt (default: first task's `Task.system_prompt`)
+- `reflection_columns` - extra per-trace fields (from the `trace.info`, else the task) to surface to the reflection model
+- `max_concurrent` / `-c` - caps how many rollouts are in flight at once (default: 128)
+- `shuffle` - shuffle tasks before the train/val split (fixed seed, so the split is reproducible)
+
+The seed system prompt comes from `--initial-prompt`, or else the first task that sets `Task.system_prompt`. Tasksets that bake instructions into the user `prompt` instead (e.g. `gsm8k-v1`) need an explicit `--initial-prompt`.
+
+## Output
+
+The output from gepa runs are written into `outputs/<taskset>--<model>--<harness>/<uuid>/`, matching `eval`. The folder holds the used `config.toml`, every rollout's trace in `traces.jsonl`, and GEPA's own artifacts (`candidates.json`, `run_log.json`, ...). The best performing system prompt is printed to stdout when the run finishes.
+
+## Limitations
+
+- **Group-reward tasksets are not supported** -- GEPA scores one rollout per task, but `@group_reward` compares two or more, so tasksets like these are rejected upfront.
+- **Single taskset per run**
+- **v1-native only** - legacy v0 environments are rejected; those should be run with `vf-gepa`

--- a/docs/v1/gepa.md
+++ b/docs/v1/gepa.md
@@ -1,12 +1,12 @@
 # GEPA Prompt Optimization
 
-verifiers offers built in support for GEPA, an algorithm that optimizes a system prompt to maximize the downstream reward for a given taskset:
+verifiers offers built in support for [GEPA](https://github.com/gepa-ai/gepa), an algorithm that optimizes a system prompt to maximize the downstream reward for a given taskset:
 
 ```bash
 uv run gepa reverse-text-v1
 ```
 
-`gepa` runs [GEPA](https://github.com/gepa-ai/gepa) where a number of rollouts are done then a teacher LLM reflects on the results to propose a better `Task.system_prompt` without any gradient based training. It runs against native v1 tasksets. Legacy v0 environments can be run with `vf-gepa`.
+`gepa` runs GEPA where a number of rollouts are done before a teacher LLM reflects on the results to propose a better `Task.system_prompt` without any gradient based training. It runs against native v1 tasksets.
 
 GEPA reuses the same `taskset` / `harness` / `client` / `sampling` config as eval, so the `.toml` config remains very similar:
 
@@ -26,24 +26,19 @@ temperature = 1.0
 Validate the config by using `uv run gepa @ config.toml --dry-run`. To run GEPA, use `uv run gepa @ config.toml`. CLI arguments overwrite toml arguments when both are present.
 
 ## Common config values
-- `model` / `-m` — model for the rollouts under optimization (default: `deepseek/deepseek-v4-flash`, same as eval)
-- `reflection_model` / `reflection_client` - the model/endpoint that proposes new prompts (default: reuse `model` / `client`)
-- `num_train` - tasks reserved for reflection minibatches (default: 100)
-- `num_val` - tasks held out to score each prompt candidate for the pareto frontier (default: 50)
-- `max_metric_calls` - total rollouts the run may spend (default: 500)
-- `reflection_minibatch_size` - train tasks sampled per reflection step (default: 3)
-- `initial_prompt` - seed system prompt (default: first task's `Task.system_prompt`)
-- `reflection_columns` - extra per-trace fields (from the `trace.info`, else the task) to surface to the reflection model
-- `max_concurrent` / `-c` - caps how many rollouts are in flight at once (default: 128)
-- `shuffle` - shuffle tasks before the train/val split (fixed seed, so the split is reproducible)
 
-The seed system prompt comes from `--initial-prompt`, or else the first task that sets `Task.system_prompt`. Tasksets that bake instructions into the user `prompt` instead (e.g. `gsm8k-v1`) need an explicit `--initial-prompt`.
+- `model` / `-m` — model for the rollouts under optimization (default: `deepseek/deepseek-v4-flash`, same as eval)
+- `reflection_model` / `reflection_client` — model/endpoint that proposes new prompts (default: reuse `model` / `client`)
+- `num_train` / `num_val` — train tasks for reflection minibatches and held-out val tasks for the pareto frontier (defaults: 100 / 50)
+- `max_total_rollouts` — total rollouts the run may spend (default: 500)
+- `max_concurrent` / `-c` — caps how many rollouts are in flight at once (default: 128)
 
 ## Output
 
-The output from gepa runs are written into `outputs/<taskset>--<model>--<harness>/<uuid>/`, matching `eval`. The folder holds the used `config.toml`, every rollout's trace in `traces.jsonl`, and GEPA's own artifacts (`candidates.json`, `run_log.json`, ...). The best performing system prompt is printed to stdout when the run finishes.
+Results go under `outputs/<taskset>--<model>--<harness>/<uuid>/`, matching `eval`. The best system prompt is printed when the run finishes.
 
 ## Limitations
 
-- **Group-reward tasksets are not supported** -- GEPA scores one rollout per task, but `@group_reward` compares two or more, so tasksets like these are rejected upfront.
+**Tasksets** — GEPA optimizes `Task.system_prompt`, so the taskset must provide one. Tasksets that bake instructions into the user `prompt` instead (e.g. `gsm8k-v1`) are not supported out of the box.
 
+**Harnesses** — any eval harness works. With `APPENDS_SYSTEM_PROMPT`, the optimized prompt is used as a system message but otherwise is folded into the user prompt.

--- a/docs/v1/gepa.md
+++ b/docs/v1/gepa.md
@@ -3,7 +3,7 @@
 verifiers offers built in support for GEPA, an algorithm that optimizes a system prompt to maximize the downstream reward for a given taskset:
 
 ```bash
-uv run gepa reverse-text-v1 --model google/gemini-3-flash-preview
+uv run gepa reverse-text-v1
 ```
 
 `gepa` runs [GEPA](https://github.com/gepa-ai/gepa) where a number of rollouts are done then a teacher LLM reflects on the results to propose a better `Task.system_prompt` without any gradient based training. It runs against native v1 tasksets. Legacy v0 environments can be run with `vf-gepa`.
@@ -11,7 +11,7 @@ uv run gepa reverse-text-v1 --model google/gemini-3-flash-preview
 GEPA reuses the same `taskset` / `harness` / `client` / `sampling` config as eval, so the `.toml` config remains very similar:
 
 ```toml
-model = "google/gemini-3-flash-preview"
+model = "deepseek/deepseek-v4-flash"
 
 [taskset]
 id = "reverse-text-v1"
@@ -46,5 +46,4 @@ The output from gepa runs are written into `outputs/<taskset>--<model>--<harness
 ## Limitations
 
 - **Group-reward tasksets are not supported** -- GEPA scores one rollout per task, but `@group_reward` compares two or more, so tasksets like these are rejected upfront.
-- **Single taskset per run**
-- **v1-native only** - legacy v0 environments are rejected; those should be run with `vf-gepa`
+

--- a/docs/v1/gepa.md
+++ b/docs/v1/gepa.md
@@ -26,7 +26,7 @@ temperature = 1.0
 Validate the config by using `uv run gepa @ config.toml --dry-run`. To run GEPA, use `uv run gepa @ config.toml`. CLI arguments overwrite toml arguments when both are present.
 
 ## Common config values
-- `model` / `-m` — model for the rollouts under optimization (required; no default, since a run can spend a large budget)
+- `model` / `-m` — model for the rollouts under optimization (default: `deepseek/deepseek-v4-flash`, same as eval)
 - `reflection_model` / `reflection_client` - the model/endpoint that proposes new prompts (default: reuse `model` / `client`)
 - `num_train` - tasks reserved for reflection minibatches (default: 100)
 - `num_val` - tasks held out to score each prompt candidate for the pareto frontier (default: 50)

--- a/docs/v1/overview.md
+++ b/docs/v1/overview.md
@@ -36,5 +36,6 @@ A trace records the message graph, rewards, metrics, errors, etc. When using ver
   - [Harbor Environments](harbor.md) — How to create Harbor-based environments
 - [Evaluation](evaluation.md) — How to run said environments
 - [Harnesses](harnesses.md) — How to build custom harnesses
+- [GEPA](gepa.md) — How to optimize system prompts with GEPA
 
 For the documentation for legacy environments, go to [the v0 documentation](../v0/overview.md).

--- a/verifiers/v1/gepa/config.py
+++ b/verifiers/v1/gepa/config.py
@@ -49,9 +49,7 @@ class GEPAConfig(EnvConfig):
     """Seed for GEPA's optimizer (candidate selection / minibatch sampling). Task shuffling
     uses a fixed seed, matching eval — so this doesn't change the train/val split."""
 
-    max_metric_calls: int = Field(
-        500, validation_alias=AliasChoices("max_metric_calls", "B")
-    )
+    max_total_rollouts: int = Field(500)
     """Total rollouts GEPA may spend across the whole optimization run."""
     reflection_minibatch_size: int = 3
     """Train tasks sampled per reflection step."""

--- a/verifiers/v1/gepa/config.py
+++ b/verifiers/v1/gepa/config.py
@@ -54,8 +54,6 @@ class GEPAConfig(EnvConfig):
     """Total rollouts GEPA may spend across the whole optimization run."""
     reflection_minibatch_size: int = 3
     """Train tasks sampled per reflection step."""
-    perfect_score: float | None = None
-    """Skip reflecting on a minibatch that already scores this well."""
     reflection_columns: list[str] = Field(default_factory=list)
     """Extra per-trace fields (from `trace.info`, else `task`) to surface to the teacher LM."""
     initial_prompt: str | None = None

--- a/verifiers/v1/gepa/config.py
+++ b/verifiers/v1/gepa/config.py
@@ -21,13 +21,14 @@ from verifiers.v1.types import SamplingConfig
 class GEPAConfig(EnvConfig):
     """The GEPA run plus its environment. `model` runs the rollouts under optimization;
     `reflection_model` (defaults to `model`) proposes new system prompts from the reflective
-    dataset. No default for `model` — a GEPA run can spend a large eval budget, so pick it
-    explicitly rather than silently optimizing (and spending) against a fallback."""
+    dataset. `model` defaults to the same id as `EvalConfig`."""
 
     uuid: str = Field(default_factory=lambda: str(uuid4()), exclude=True)
     """Auto-generated run id — the leaf of the output dir, so runs never overwrite.
     Excluded from the saved config so re-running `@ config.toml` lands in a fresh dir."""
-    model: str = Field(..., validation_alias=AliasChoices("model", "m"))
+    model: str = Field(
+        "deepseek/deepseek-v4-flash", validation_alias=AliasChoices("model", "m")
+    )
     """Model id for rollouts under optimization."""
     client: EvalClientConfig = EvalClientConfig()
     sampling: SamplingConfig = SamplingConfig()

--- a/verifiers/v1/gepa/runner.py
+++ b/verifiers/v1/gepa/runner.py
@@ -101,7 +101,7 @@ def run_gepa(env: Environment, config: GEPAConfig) -> GEPAResult:
                 valset=[task.data.idx for task in val_tasks],
                 adapter=adapter,
                 reflection_lm=reflection_lm,
-                max_metric_calls=config.max_metric_calls,
+                max_metric_calls=config.max_total_rollouts,
                 reflection_minibatch_size=config.reflection_minibatch_size,
                 run_dir=str(run_dir) if run_dir is not None else None,
                 seed=config.seed,

--- a/verifiers/v1/gepa/runner.py
+++ b/verifiers/v1/gepa/runner.py
@@ -106,11 +106,9 @@ def run_gepa(env: Environment, config: GEPAConfig) -> GEPAResult:
                 run_dir=str(run_dir) if run_dir is not None else None,
                 seed=config.seed,
                 display_progress_bar=False,
-                skip_perfect_score=config.perfect_score is not None,
+                skip_perfect_score=False,
                 logger=_GEPALog(),
             )
-            if config.perfect_score is not None:
-                optimize_kwargs["perfect_score"] = config.perfect_score
             return optimize(**optimize_kwargs)
         finally:
             loop.run_until_complete(serving.__aexit__(None, None, None))


### PR DESCRIPTION
## Summary
- Add a v1 GEPA docs page covering CLI usage, shared eval-style config, common knobs, outputs, and limitations
- Wire GEPA into Mintlify nav and link it from the v1 overview
- Align GEPA defaults with eval (`deepseek/deepseek-v4-flash`), rename `max_metric_calls` → `max_total_rollouts`, and drop the unused `perfect_score` knob

## Test plan
- [ ] Confirm `docs/v1/gepa.md` renders and the overview / Mintlify nav links resolve
- [ ] `uv run gepa --help` shows the documented defaults (`model`, `max_total_rollouts`)
- [ ] `uv run gepa @ <config.toml> --dry-run` validates without requiring `perfect_score` / `max_metric_calls`


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document GEPA prompt optimization and update `GEPAConfig` defaults
> - Adds [docs/v1/gepa.md](https://github.com/PrimeIntellect-ai/verifiers/pull/2037/files#diff-8fc7e1d6c7d03f573f07bb82368f301c6fdbe5aa0de53cef3c7d08a7838f983b) covering GEPA usage, configuration, output, and limitations, with a link added to the [overview](https://github.com/PrimeIntellect-ai/verifiers/pull/2037/files#diff-3f90b7dcac1242e83c61cac02bf2a16838ae5689be635e6d313210b4911c0896) and sidebar navigation.
> - Replaces the `max_metric_calls` field in [`GEPAConfig`](https://github.com/PrimeIntellect-ai/verifiers/pull/2037/files#diff-abc707c6e29756605e33e7a299a7f9509d6cc02afce3ae195d8213e01d9b66d5) with `max_total_rollouts` (default 500) and removes the `perfect_score` field.
> - `GEPAConfig.model` now defaults to `"deepseek/deepseek-v4-flash"` instead of being required.
> - [`run_gepa`](https://github.com/PrimeIntellect-ai/verifiers/pull/2037/files#diff-72527cee23f87ec016ae39839508cf7826ce3ffdc3f6556c55f8aaa66c90e952) now passes `max_total_rollouts` as `max_metric_calls` to `optimize()` and unconditionally sets `skip_perfect_score=False`.
> - Behavioral Change: configs using `max_metric_calls` or `perfect_score` keys will no longer be recognized; reflection steps are never skipped on perfect scores.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 99cfabb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->