### PR TITLE
fix: make Trace token counts usage-based and consistent

### DIFF
--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -363,17 +363,14 @@ def _breakdown(done: list[Trace]) -> Table | None:
 
 def _tokens(trace: Trace) -> tuple[int, int, int | None, int | None, int]:
     """Input/output tokens summed across all branches: per branch, output is every assistant
-    (completion) token generated across its turns and input is its last turn's prompt — the full
-    final context the model saw. A rollout yields one training sample per branch (a linear trace
-    is a single branch; compaction and subagents add more), so the totals sum them — matching
-    `Trace.num_input_tokens` / `Trace.num_output_tokens`. (Output can exceed the final context —
-    reasoning tokens count toward completions but aren't re-fed — so it's not derived by
-    subtraction.)
+    (completion) token generated across its turns and input is the fed-in tokens counted once
+    (system + user + tool) — the final sequence minus everything the model generated. A rollout
+    yields one training sample per branch (a linear trace is a single branch; compaction and
+    subagents add more), so the totals sum them — matching `Trace.num_input_tokens` /
+    `Trace.num_output_tokens`, whose sum is `num_total_tokens`.
 
-    Both counts read token ids when present and fall back to provider-reported usage when the
-    endpoint returns no token ids (e.g. plain OpenAI completions), so the counts aren't shown as
-    0/0. Returns the branch count from the same derived view so each dashboard tick materializes
-    it once."""
+    Both counts come from provider-reported usage. Returns the branch count from the same derived
+    view so each dashboard tick materializes it once."""
     usage = trace.usage
     cached = usage.cached_input_tokens if usage else None
     reasoning = usage.reasoning_tokens if usage else None

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -168,35 +168,36 @@ class Branch(StrictBaseModel):
         return KeptTokens(ids=ids, counts=np.concatenate(counts_parts))
 
     @property
-    def num_total_tokens(self) -> int:
-        return sum(len(n.token_ids) for n in self.nodes)
-
-    @property
     def usage(self) -> Usage | None:
         return Usage.aggregate(n.usage for n in self.nodes if n.usage is not None)
 
     @property
-    def num_input_tokens(self) -> int:
-        """Final-turn prompt size, falling back to provider usage without token IDs."""
-        last_completion = next(
-            (sum(n.mask) for n in reversed(self.nodes) if any(n.mask)), 0
-        )
-        token_len = self.num_total_tokens - last_completion
-        if token_len:
-            return token_len
-        last = next(
+    def last_usage(self) -> Usage | None:
+        """Provider usage from the final model call on this branch — the full context it saw."""
+        return next(
             (n.usage for n in reversed(self.nodes) if n.usage is not None), None
         )
-        return last.input_tokens if last else 0
+
+    @property
+    def num_total_tokens(self) -> int:
+        """Final sequence length: the last call's prompt + completion. Earlier turns' context
+        is already contained in that prompt, so re-sent tokens are counted once rather than
+        summed per turn."""
+        last = self.last_usage
+        return last.total_tokens if last is not None else 0
 
     @property
     def num_output_tokens(self) -> int:
-        """Sampled tokens, falling back to provider usage without token IDs."""
-        token_len = sum(sum(n.mask) for n in self.nodes)
-        if token_len:
-            return token_len
+        """Every model-generated token across all turns (completions, reasoning included)."""
         usage = self.usage
-        return usage.completion_tokens if usage else 0
+        return usage.completion_tokens if usage is not None else 0
+
+    @property
+    def num_input_tokens(self) -> int:
+        """Tokens fed to the model, counted once: the final sequence minus everything the model
+        generated (i.e. system + user + tool inputs). Not the last prompt — re-sent context is
+        not double-counted."""
+        return self.num_total_tokens - self.num_output_tokens
 
 
 _NODE_DUMP_EXCLUDE: dict = {
@@ -282,17 +283,17 @@ class Trace(StrictBaseModel, Generic[DataT, StateT]):
 
     @property
     def num_input_tokens(self) -> int:
-        """Final-turn prompt sizes summed across training branches."""
+        """Fed-in tokens (system + user + tool), counted once, summed across branches."""
         return sum(branch.num_input_tokens for branch in self.branches)
 
     @property
     def num_output_tokens(self) -> int:
-        """Model-sampled tokens summed across training branches."""
+        """Model-generated tokens across all turns, summed across branches."""
         return sum(branch.num_output_tokens for branch in self.branches)
 
     @property
     def num_total_tokens(self) -> int:
-        """Sequence lengths summed across training branches for token batching."""
+        """Final sequence lengths (last prompt + completion) summed across branches."""
         return sum(branch.num_total_tokens for branch in self.branches)
 
     @property


### PR DESCRIPTION
## Summary

- Derive `Trace`/`Branch` `num_input_tokens` / `num_output_tokens` / `num_total_tokens` from provider **usage** instead of token-id sums, with one consistent definition:
  - `num_total_tokens` = the last call's prompt + completion (the final sequence length the model saw)
  - `num_output_tokens` = every completion token generated across all turns
  - `num_input_tokens` = `num_total_tokens − num_output_tokens` (fed-in tokens counted once: system + user + tool)
- This makes the three counts reconcile: `input + output == total` by construction.
- Update the dashboard `_tokens` docstring, which documented the old "not derived by subtraction" behavior.

## Motivation

`Trace.num_total_tokens` summed branch token-id lengths. On relay/eval clients there are no token IDs, so it always returned `0`, making `max_total_tokens` a dead cap. `num_input_tokens` / `num_output_tokens` already fell back to provider usage, but with mismatched semantics (final-turn prompt vs. all sampled tokens), so the three counts did not reconcile with each other. Going usage-based throughout gives one coherent contract and fixes the dead cap without a separate fallback branch.

## Verification

Recomputed the three counts on recorded `terminal-bench-2 / fix-git` rollouts (relay/eval → no token IDs, usage present), before (current `main`) vs. after:

| turns | input (old→new) | output | total (old→new) |
|---|---|---|---|
| 12 | 5576 → 3685 | 2142 | 0 → 5827 |
| 13 | 5747 → 3144 | 2834 | 0 → 5978 |
| 14 | 5783 → 3039 | 3047 | 0 → 6086 |

- `total` goes from `0` (dead cap) to the real final sequence length.
- `input` drops from the full re-fed last prompt to fed-in-once tokens; `input + output == total`.
- Checked across all usage-bearing `fix-git` traces: no negative inputs; `tests/v1/test_trace.py` passes.

## Notes

- **Now purely usage-based.** The token-id counting path is removed. This assumes assistant nodes carry `usage` during training too (set from `response.usage` in `graph.commit`); if a training inference path returns no usage, all three counts go to `0`.
- **Reasoning tokens.** `completion_tokens` includes reasoning (a subset). When a provider generates reasoning it does not re-feed, `num_input = total − output` slightly undercounts the literal system+user+tool count. It stayed positive across all observed traces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core token accounting used for caps, dashboards, and training batching; missing `usage` on any inference path now yields zeros instead of ID-based fallbacks.
> 
> **Overview**
> **`Branch` and `Trace` token metrics now come entirely from provider-reported usage**, with one shared definition so `num_input_tokens + num_output_tokens == num_total_tokens`.
> 
> On each branch, **`num_total_tokens`** is the final model call’s sequence length (`last_usage.total_tokens`), not a sum of token IDs — fixing **`0` totals on relay/eval paths** where IDs are missing and **`max_total_tokens`** never applied. **`num_output_tokens`** is aggregated **`completion_tokens`** across all turns; **`num_input_tokens`** is **`total − output`** (fed-in context counted once, not the full re-sent last prompt). Token-ID / mask fallbacks are removed. **`Branch.last_usage`** exposes the last call’s usage for that total.
> 
> **`Trace`** rolls the same semantics up by summing branches; docstrings on trace-level properties match. The eval dashboard **`_tokens`** docstring is updated to describe the new reconciliation instead of the old “not derived by subtraction” behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b804b917107caaad02d70ad39e300c09406f9380. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix token count properties on `Branch` to use provider-reported usage
> - `Branch.num_total_tokens` now returns the last provider call's `total_tokens` instead of summing node `token_ids`, avoiding double-counting of re-sent context.
> - `Branch.num_output_tokens` now sums provider-reported `completion_tokens` across all turns, dropping the previous mask/token-id-based computation.
> - `Branch.num_input_tokens` is derived as `num_total_tokens - num_output_tokens`, matching fed-in tokens counted once (system + user + tool).
> - A new `Branch.last_usage` property exposes the `Usage` from the final model call by scanning nodes in reverse.
> - Behavioral Change: all three token count properties now return provider-reported values; results will differ from previous token-id-based counts, especially for multi-turn branches.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b804b91.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->