### PR TITLE
fix(v1): execute same-turn tool calls concurrently

### DIFF
--- a/verifiers/v1/harnesses/default/program.py
+++ b/verifiers/v1/harnesses/default/program.py
@@ -179,7 +179,7 @@ async def chat(
 
 async def connect_mcp(stack: AsyncExitStack, config: dict) -> tuple[list[dict], dict]:
     """Connect to each configured MCP server (a streamable-HTTP `url`); return
-    (tool schemas, dispatch mapping `<server>_<tool>` -> (session, raw tool name))."""
+    (tool schemas, dispatch mapping `<server>_<tool>` -> (session, raw name, read-only))."""
     from mcp import ClientSession
     from mcp.client.streamable_http import (
         create_mcp_http_client,
@@ -210,7 +210,8 @@ async def connect_mcp(stack: AsyncExitStack, config: dict) -> tuple[list[dict], 
                     },
                 }
             )
-            dispatch[full] = (session, tool.name)
+            read_only = getattr(tool.annotations, "readOnlyHint", False) is True
+            dispatch[full] = (session, tool.name, read_only)
     return tool_schemas, dispatch
 
 
@@ -232,7 +233,7 @@ def mcp_content_to_chat_content(blocks) -> str | list[dict]:
 
 
 async def call_mcp(dispatch: dict, name: str, arguments: dict) -> str | list[dict]:
-    session, raw = dispatch[name]
+    session, raw, _ = dispatch[name]
     result = await session.call_tool(raw, arguments)
     return mcp_content_to_chat_content(result.content)
 
@@ -282,6 +283,34 @@ async def execute_tool_call(
         else:
             content = f"error: unknown tool {name!r}"
     return {"role": "tool", "tool_call_id": call.id, "content": content}
+
+
+async def execute_tool_calls(
+    calls,
+    dispatch: dict,
+    *,
+    edit: bool,
+    search: bool,
+    serper_key: str,
+) -> list[dict]:
+    """Run read-only calls concurrently; treat mutating calls as ordered barriers."""
+    results = []
+    pending = []
+    options = {"edit": edit, "search": search, "serper_key": serper_key}
+
+    for call in calls:
+        name = call.function.name
+        entry = dispatch.get(name)
+        if (name == "search" and search) or (entry is not None and entry[2]):
+            pending.append(execute_tool_call(call, dispatch, **options))
+            continue
+        if pending:
+            results.extend(await asyncio.gather(*pending))
+            pending.clear()
+        results.append(await execute_tool_call(call, dispatch, **options))
+    if pending:
+        results.extend(await asyncio.gather(*pending))
+    return results
 
 
 def parse_args() -> argparse.Namespace:
@@ -334,17 +363,12 @@ async def main() -> None:
             if not message.tool_calls:
                 break
             messages.extend(
-                await asyncio.gather(
-                    *(
-                        execute_tool_call(
-                            call,
-                            dispatch,
-                            edit=args.edit,
-                            search=args.search,
-                            serper_key=args.serper_key,
-                        )
-                        for call in message.tool_calls
-                    )
+                await execute_tool_calls(
+                    message.tool_calls,
+                    dispatch,
+                    edit=args.edit,
+                    search=args.search,
+                    serper_key=args.serper_key,
                 )
             )
 

--- a/verifiers/v1/harnesses/default/program.py
+++ b/verifiers/v1/harnesses/default/program.py
@@ -237,6 +237,53 @@ async def call_mcp(dispatch: dict, name: str, arguments: dict) -> str | list[dic
     return mcp_content_to_chat_content(result.content)
 
 
+async def execute_tool_call(
+    call,
+    dispatch: dict,
+    *,
+    edit: bool,
+    search: bool,
+    serper_key: str,
+) -> dict:
+    name = call.function.name
+    try:
+        tool_args = json.loads(call.function.arguments or "{}")
+    except json.JSONDecodeError as e:
+        content = (
+            f"error: invalid JSON in tool arguments ({e}); "
+            "resend the call with valid JSON"
+        )
+    else:
+        # Valid JSON can still be a non-object (`[]`, `42`, `null`); the tool handlers
+        # assume a dict, so reject anything else as a tool error rather than crashing.
+        if not isinstance(tool_args, dict):
+            content = (
+                "error: tool arguments must be a JSON object, "
+                f"got {type(tool_args).__name__}; resend as an object"
+            )
+        elif name in dispatch:
+            content = await call_mcp(dispatch, name, tool_args)
+        elif name == "bash":
+            content = await asyncio.to_thread(run_bash, tool_args.get("command", ""))
+        elif name == "edit" and edit:
+            content = await asyncio.to_thread(
+                run_edit,
+                tool_args.get("path"),
+                tool_args.get("old_str"),
+                tool_args.get("new_str"),
+            )
+        elif name == "search" and search:
+            content = await asyncio.to_thread(
+                run_search,
+                tool_args.get("query", ""),
+                serper_key,
+                tool_args.get("num_results", 5),
+            )
+        else:
+            content = f"error: unknown tool {name!r}"
+    return {"role": "tool", "tool_call_id": call.id, "content": content}
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--base-url", required=True)
@@ -286,55 +333,20 @@ async def main() -> None:
             messages.append(message.model_dump(exclude_none=True))
             if not message.tool_calls:
                 break
-            for call in message.tool_calls:
-                name = call.function.name
-                try:
-                    tool_args = json.loads(call.function.arguments or "{}")
-                except json.JSONDecodeError as e:
-                    messages.append(
-                        {
-                            "role": "tool",
-                            "tool_call_id": call.id,
-                            "content": f"error: invalid JSON in tool arguments ({e}); resend the call with valid JSON",
-                        }
+            messages.extend(
+                await asyncio.gather(
+                    *(
+                        execute_tool_call(
+                            call,
+                            dispatch,
+                            edit=args.edit,
+                            search=args.search,
+                            serper_key=args.serper_key,
+                        )
+                        for call in message.tool_calls
                     )
-                    continue
-                # Valid JSON can still be a non-object (`[]`, `42`, `null`); the `.get(...)` calls
-                # below assume a dict, so reject anything else as a tool error rather than crashing.
-                if not isinstance(tool_args, dict):
-                    messages.append(
-                        {
-                            "role": "tool",
-                            "tool_call_id": call.id,
-                            "content": f"error: tool arguments must be a JSON object, got {type(tool_args).__name__}; resend as an object",
-                        }
-                    )
-                    continue
-                if name in dispatch:
-                    content = await call_mcp(dispatch, name, tool_args)
-                elif name == "bash":
-                    content = await asyncio.to_thread(
-                        run_bash, tool_args.get("command", "")
-                    )
-                elif name == "edit" and args.edit:
-                    content = await asyncio.to_thread(
-                        run_edit,
-                        tool_args.get("path"),
-                        tool_args.get("old_str"),
-                        tool_args.get("new_str"),
-                    )
-                elif name == "search" and args.search:
-                    content = await asyncio.to_thread(
-                        run_search,
-                        tool_args.get("query", ""),
-                        args.serper_key,
-                        tool_args.get("num_results", 5),
-                    )
-                else:
-                    content = f"error: unknown tool {name!r}"
-                messages.append(
-                    {"role": "tool", "tool_call_id": call.id, "content": content}
                 )
+            )
 
 
 if __name__ == "__main__":

--- a/verifiers/v1/harnesses/null/program.py
+++ b/verifiers/v1/harnesses/null/program.py
@@ -87,6 +87,30 @@ async def call_mcp(dispatch: dict, name: str, arguments: dict) -> str | list[dic
     return mcp_content_to_chat_content(result.content)
 
 
+async def execute_tool_call(call, dispatch: dict) -> dict:
+    name = call.function.name
+    try:
+        tool_args = json.loads(call.function.arguments or "{}")
+    except json.JSONDecodeError as e:
+        content = (
+            f"error: invalid JSON in tool arguments ({e}); "
+            "resend the call with valid JSON"
+        )
+    else:
+        # Valid JSON can still be a non-object (`[]`, `42`, `null`); the MCP dispatch
+        # assumes a dict, so reject anything else as a tool error rather than crashing.
+        if not isinstance(tool_args, dict):
+            content = (
+                "error: tool arguments must be a JSON object, "
+                f"got {type(tool_args).__name__}; resend as an object"
+            )
+        elif name in dispatch:
+            content = await call_mcp(dispatch, name, tool_args)
+        else:
+            content = f"error: unknown tool {name!r}"
+    return {"role": "tool", "tool_call_id": call.id, "content": content}
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--base-url", required=True)
@@ -131,37 +155,11 @@ async def main() -> None:
             messages.append(message.model_dump(exclude_none=True))
             if not message.tool_calls:
                 break
-            for call in message.tool_calls:
-                name = call.function.name
-                try:
-                    tool_args = json.loads(call.function.arguments or "{}")
-                except json.JSONDecodeError as e:
-                    messages.append(
-                        {
-                            "role": "tool",
-                            "tool_call_id": call.id,
-                            "content": f"error: invalid JSON in tool arguments ({e}); resend the call with valid JSON",
-                        }
-                    )
-                    continue
-                # Valid JSON can still be a non-object (`[]`, `42`, `null`); the MCP dispatch
-                # assumes a dict, so reject anything else as a tool error rather than crashing.
-                if not isinstance(tool_args, dict):
-                    messages.append(
-                        {
-                            "role": "tool",
-                            "tool_call_id": call.id,
-                            "content": f"error: tool arguments must be a JSON object, got {type(tool_args).__name__}; resend as an object",
-                        }
-                    )
-                    continue
-                if name in dispatch:
-                    content = await call_mcp(dispatch, name, tool_args)
-                else:
-                    content = f"error: unknown tool {name!r}"
-                messages.append(
-                    {"role": "tool", "tool_call_id": call.id, "content": content}
+            messages.extend(
+                await asyncio.gather(
+                    *(execute_tool_call(call, dispatch) for call in message.tool_calls)
                 )
+            )
 
 
 if __name__ == "__main__":

--- a/verifiers/v1/harnesses/null/program.py
+++ b/verifiers/v1/harnesses/null/program.py
@@ -24,9 +24,9 @@ async def chat(
 
 async def connect_mcp(stack: AsyncExitStack, config: dict) -> tuple[list[dict], dict]:
     """Connect to each configured MCP server (a streamable-HTTP `url`); return
-    (tool schemas, dispatch mapping advertised name -> (session, raw tool name)). Tools are
-    advertised as `<server>_<tool>`; a server named `""` (TOOL_PREFIX = None) advertises its
-    tools bare, so names must be unique across the rollout's servers."""
+    (tool schemas, dispatch mapping advertised name -> (session, raw name, read-only)).
+    Tools are advertised as `<server>_<tool>`; a server named `""` (TOOL_PREFIX = None)
+    advertises its tools bare, so names must be unique across the rollout's servers."""
     from mcp import ClientSession
     from mcp.client.streamable_http import (
         create_mcp_http_client,
@@ -60,7 +60,8 @@ async def connect_mcp(stack: AsyncExitStack, config: dict) -> tuple[list[dict], 
                     },
                 }
             )
-            dispatch[full] = (session, tool.name)
+            read_only = getattr(tool.annotations, "readOnlyHint", False) is True
+            dispatch[full] = (session, tool.name, read_only)
     return tool_schemas, dispatch
 
 
@@ -82,7 +83,7 @@ def mcp_content_to_chat_content(blocks) -> str | list[dict]:
 
 
 async def call_mcp(dispatch: dict, name: str, arguments: dict) -> str | list[dict]:
-    session, raw = dispatch[name]
+    session, raw, _ = dispatch[name]
     result = await session.call_tool(raw, arguments)
     return mcp_content_to_chat_content(result.content)
 
@@ -109,6 +110,25 @@ async def execute_tool_call(call, dispatch: dict) -> dict:
         else:
             content = f"error: unknown tool {name!r}"
     return {"role": "tool", "tool_call_id": call.id, "content": content}
+
+
+async def execute_tool_calls(calls, dispatch: dict) -> list[dict]:
+    """Run explicitly read-only MCP calls concurrently; serialize all others."""
+    results = []
+    pending = []
+
+    for call in calls:
+        entry = dispatch.get(call.function.name)
+        if entry is not None and entry[2]:
+            pending.append(execute_tool_call(call, dispatch))
+            continue
+        if pending:
+            results.extend(await asyncio.gather(*pending))
+            pending.clear()
+        results.append(await execute_tool_call(call, dispatch))
+    if pending:
+        results.extend(await asyncio.gather(*pending))
+    return results
 
 
 def parse_args() -> argparse.Namespace:
@@ -155,11 +175,7 @@ async def main() -> None:
             messages.append(message.model_dump(exclude_none=True))
             if not message.tool_calls:
                 break
-            messages.extend(
-                await asyncio.gather(
-                    *(execute_tool_call(call, dispatch) for call in message.tool_calls)
-                )
-            )
+            messages.extend(await execute_tool_calls(message.tool_calls, dispatch))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The `null` and `default` harness programs currently await same-turn tool calls one at a time. This change runs adjacent read-only calls concurrently while keeping calls that may mutate state sequential.

- MCP tools run concurrently only when they explicitly advertise `readOnlyHint: true`.
- The built-in `search` tool runs concurrently.
- `bash`, `edit`, and mutating or unannotated MCP tools act as ordered barriers.

Tool-result messages remain aligned with the model's original call order. No configuration or dependency changes are introduced.

## Motivation

Sequential execution makes the latency of a read-only tool batch approximately the sum of its call latencies. This is especially noticeable when a model issues several independent searches or MCP reads in one turn.

The earlier v1 harness used an async-helper-plus-`gather()` pattern for same-turn tool calls in [`4f198764`](https://github.com/PrimeIntellect-ai/verifiers/commit/4f1987647a869f8ddc76223a127c75995b0036a3). Its MCP client also queued calls and executed them one at a time within each MCP session, so unconditional `gather()` in the current programs would not reproduce the earlier effective behavior.

During the nano-as-v1 transition, [`68737166`](https://github.com/PrimeIntellect-ai/verifiers/commit/687371665ca23f3ad326cf532e13a86168bf5b45) introduced the standalone chat program with per-call execution. That loop later moved into the built-in harnesses in [#1826](https://github.com/PrimeIntellect-ai/verifiers/pull/1826) and into the current `null` and `default` programs in [#1904](https://github.com/PrimeIntellect-ai/verifiers/pull/1904).

This brings back concurrency for calls that explicitly identify themselves as read-only without allowing filesystem or rollout-state mutations to overlap.

## Execution behavior

Read-only calls are collected into consecutive batches and executed with `asyncio.gather()`. Before any potentially mutating call runs, the current read-only batch completes; the mutating call then runs by itself. This preserves the model's call order around state changes.

MCP annotations are handled conservatively: a missing or false `readOnlyHint` remains sequential.

## Verification

- `uv run pytest tests/v1/` — 63 passed, 136 skipped because `PRIME_API_KEY` is unavailable
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pre-commit run --all-files`
- push-time `ty` CI-parity check
- temporary timing check covering concurrent read batches, sequential mutation barriers, and stable result ordering

Happy to adjust this if there are MCP annotation or tool-ordering cases I've missed.
