### PR TITLE
feat(v1): dtype-aware routed-experts payload decode

### DIFF
--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -203,8 +203,7 @@ class RoutedExpertsPayload(TypedDict):
     data: Any
     shape: list[int]
     start: int
-    dtype: NotRequired[str]
-    """Numpy dtype of the packed expert indices ("uint8" when absent; "uint16" for models with >256 experts)."""
+    dtype: str
 
 
 class ResponseTokens(CustomBaseModel):

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -203,6 +203,8 @@ class RoutedExpertsPayload(TypedDict):
     data: Any
     shape: list[int]
     start: int
+    dtype: NotRequired[str]
+    """Numpy dtype of the packed expert indices ("uint8" when absent; "uint16" for models with >256 experts)."""
 
 
 class ResponseTokens(CustomBaseModel):

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -448,7 +448,9 @@ def _attribute_routed_experts(
     if payload is None:
         return
     raw = binascii.a2b_base64(payload["data"])
-    arr = np.frombuffer(raw, dtype=np.uint8).reshape(payload["shape"])
+    # Expert indices are uint8 unless the model has >256 experts; the payload
+    # self-describes via "dtype" (absent = uint8 for backward compatibility).
+    arr = np.frombuffer(raw, dtype=np.dtype(payload.get("dtype", "uint8"))).reshape(payload["shape"])
     off = path_len - int(payload.get("start", 0) or 0)
     needed = off + sum(len(trace.nodes[nid].token_ids) for nid in new_node_ids)
     for nid in new_node_ids:

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -448,7 +448,9 @@ def _attribute_routed_experts(
     if payload is None:
         return
     raw = binascii.a2b_base64(payload["data"])
-    arr = np.frombuffer(raw, dtype=np.dtype(payload.get("dtype", "uint8"))).reshape(payload["shape"])
+    arr = np.frombuffer(raw, dtype=np.dtype(payload.get("dtype", "uint8"))).reshape(
+        payload["shape"]
+    )
     off = path_len - int(payload.get("start", 0) or 0)
     needed = off + sum(len(trace.nodes[nid].token_ids) for nid in new_node_ids)
     for nid in new_node_ids:

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -448,8 +448,6 @@ def _attribute_routed_experts(
     if payload is None:
         return
     raw = binascii.a2b_base64(payload["data"])
-    # Expert indices are uint8 unless the model has >256 experts; the payload
-    # self-describes via "dtype" (absent = uint8 for backward compatibility).
     arr = np.frombuffer(raw, dtype=np.dtype(payload.get("dtype", "uint8"))).reshape(payload["shape"])
     off = path_len - int(payload.get("start", 0) or 0)
     needed = off + sum(len(trace.nodes[nid].token_ids) for nid in new_node_ids)


### PR DESCRIPTION
Decoder half of the >256-expert router-replay fix — encoder: PrimeIntellect-ai/prime-rl#3051 (design per Slack w/ @S1ro1: self-describing payload, uint8 when indices fit, uint16 otherwise).

The `/generate` routed-experts payload packs expert indices as **uint8**, which overflows for models with >256 experts — NemotronH Super/Ultra route over **512**, so every train rollout 500s server-side.

- `graph.py`: decode with `np.dtype(payload.get("dtype", "uint8"))` — old payloads (no field) unchanged
- `types.py`: `RoutedExpertsPayload.dtype: NotRequired[str]`

**Deploy order**: this lands first (accepts both payload forms), then prime-rl#3051 starts emitting `dtype`.

E2E validation on the Nemotron Super RL config (512 experts, router replay on) is running — results will be posted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Decode routed-experts payload buffers using dtype from payload
> Previously, `_attribute_routed_experts` in [graph.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2043/files#diff-64c9d635eb215902a512c9e8ab316fd9b9967c36db03d4049aacc812cdfbd740) always decoded base64 buffers as `np.uint8`. It now reads the `dtype` field from the payload and uses `np.dtype(payload.get("dtype", "uint8"))` when constructing the array, with `uint8` as a fallback.
>
> The `dtype` key is also added as a required field to the `RoutedExpertsPayload` TypedDict in [types.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2043/files#diff-8bc45ba080ed8ff01ee6adbafb54c0346181c6f292928e53c2a94dd9ed5156c3).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 44692fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow decode-path change with backward-compatible default; no auth or data-model changes beyond expert-routing attribution.
> 
> **Overview**
> Fixes MoE **router replay** for models with **>256 experts** by decoding `/generate` routed-expert indices with a **self-describing dtype** instead of always **`uint8`** (which overflowed for 512-expert NemotronH and caused server-side 500s).
> 
> **`RoutedExpertsPayload`** now includes a **`dtype`** field so the wire format can be **`uint8`** or **`uint16`**. **`_attribute_routed_experts`** in **`graph.py`** builds the NumPy buffer with `np.dtype(payload.get("dtype", "uint8"))`, so payloads **without** `dtype` behave exactly as before. Encoder changes land separately in prime-rl; this decoder is meant to deploy first and accept both forms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44692fe1908bdf9247ca9c88e809fcd6785b0ceb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->