### PR TITLE
fix(v1): reject duplicate default harness tools

### DIFF
--- a/verifiers/v1/harnesses/default/program.py
+++ b/verifiers/v1/harnesses/default/program.py
@@ -200,6 +200,10 @@ async def connect_mcp(stack: AsyncExitStack, config: dict) -> tuple[list[dict], 
         for tool in (await session.list_tools()).tools:
             # A server named "" (TOOL_PREFIX = None) advertises its tools bare.
             full = f"{name}_{tool.name}" if name else tool.name
+            if full in dispatch:
+                raise ValueError(
+                    f"duplicate tool name {full!r} across servers; keep qualified names"
+                )
             tool_schemas.append(
                 {
                     "type": "function",

--- a/verifiers/v1/harnesses/default/program.py
+++ b/verifiers/v1/harnesses/default/program.py
@@ -177,7 +177,9 @@ async def chat(
     return completion.choices[0].message
 
 
-async def connect_mcp(stack: AsyncExitStack, config: dict) -> tuple[list[dict], dict]:
+async def connect_mcp(
+    stack: AsyncExitStack, config: dict, reserved: set[str]
+) -> tuple[list[dict], dict]:
     """Connect to each configured MCP server (a streamable-HTTP `url`); return
     (tool schemas, dispatch mapping `<server>_<tool>` -> (session, raw tool name))."""
     from mcp import ClientSession
@@ -200,9 +202,9 @@ async def connect_mcp(stack: AsyncExitStack, config: dict) -> tuple[list[dict], 
         for tool in (await session.list_tools()).tools:
             # A server named "" (TOOL_PREFIX = None) advertises its tools bare.
             full = f"{name}_{tool.name}" if name else tool.name
-            if full in dispatch:
+            if full in reserved or full in dispatch:
                 raise ValueError(
-                    f"duplicate tool name {full!r} across servers; keep qualified names"
+                    f"duplicate tool name {full!r}; keep MCP tool names qualified"
                 )
             tool_schemas.append(
                 {
@@ -267,14 +269,19 @@ async def main() -> None:
     client = AsyncOpenAI(base_url=args.base_url, api_key=args.api_key)
     config = json.loads(args.mcp_config or "{}")
     async with AsyncExitStack() as stack:
-        mcp_tools, dispatch = (
-            await connect_mcp(stack, config) if config.get("mcpServers") else ([], {})
-        )
         tools = [BASH_TOOL]
+        reserved = {"bash"}
         if args.edit:
             tools.append(EDIT_TOOL)
+            reserved.add("edit")
         if args.search:
             tools.append(SEARCH_TOOL)
+            reserved.add("search")
+        mcp_tools, dispatch = (
+            await connect_mcp(stack, config, reserved)
+            if config.get("mcpServers")
+            else ([], {})
+        )
         tools += mcp_tools
         messages = (
             [{"role": "system", "content": args.system_prompt}]


### PR DESCRIPTION
## Summary

- reject MCP tool names that conflict with enabled default harness built-ins
- reject duplicate names across MCP servers
- fail during setup instead of exposing ambiguous schemas or routing the wrong tool

## Details

The default harness checks MCP dispatch entries before its built-in tool branches. A server with `TOOL_PREFIX = None` can advertise a bare `bash`, `edit`, or `search` tool, which previously allowed the MCP tool to shadow the corresponding built-in. Separately, a bare MCP name can collide with another server qualified as `<server>_<tool>`.

The harness now reserves `bash` and the enabled optional built-ins before connecting MCP servers. `connect_mcp` rejects both reserved-name conflicts and duplicate MCP names with a clear error asking the configuration to keep MCP names qualified.

## Impact

Invalid tool configurations now fail at startup. Valid qualified MCP tools and the built-in execution paths are unchanged.