### PR TITLE
Add native ACP harness continuation

### DIFF
--- a/environments/compact/compact/harness.py
+++ b/environments/compact/compact/harness.py
@@ -29,9 +29,7 @@ class CompactingHarness(Harness[CompactingHarnessConfig]):
     SUPPORTS_MCP = True
 
     async def setup(self, runtime: Runtime) -> None:
-        await runtime.prepare_uv_script(
-            PROGRAM_SOURCE, {**self.config.resolved_env, "UV_FROZEN": "false"}
-        )
+        await runtime.prepare_uv_script(PROGRAM_SOURCE, self.config.env)
 
     async def launch(
         self,
@@ -45,7 +43,6 @@ class CompactingHarness(Harness[CompactingHarnessConfig]):
     ) -> ProgramResult:
         _, prompt = self.resolve_prompt(data)
         env = {
-            **self.config.resolved_env,
             "OPENAI_BASE_URL": endpoint,
             "OPENAI_API_KEY": secret,
             "OPENAI_MODEL": ctx.model,
@@ -56,7 +53,5 @@ class CompactingHarness(Harness[CompactingHarnessConfig]):
             env["MCP_CONFIG"] = json.dumps(
                 {"mcpServers": {name: {"url": url} for name, url in mcp_urls.items()}}
             )
-        program = await runtime.prepare_uv_script(
-            PROGRAM_SOURCE, {**self.config.resolved_env, "UV_FROZEN": "false"}
-        )
+        program = await runtime.prepare_uv_script(PROGRAM_SOURCE, self.config.env)
         return await runtime.run_program([*program, prompt], env)

--- a/environments/compact/compact/harness.py
+++ b/environments/compact/compact/harness.py
@@ -11,9 +11,10 @@ the harness program.
 import json
 from pathlib import Path
 
-from verifiers.v1.harness import Harness, HarnessConfig
 from verifiers.v1.clients import ModelContext
+from verifiers.v1.harness import Harness, HarnessConfig
 from verifiers.v1.runtimes import ProgramResult, Runtime
+from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
 
 PROGRAM_SOURCE = (Path(__file__).resolve().parent / "program.py").read_text()
@@ -28,7 +29,9 @@ class CompactingHarness(Harness[CompactingHarnessConfig]):
     SUPPORTS_MCP = True
 
     async def setup(self, runtime: Runtime) -> None:
-        await runtime.prepare_uv_script(PROGRAM_SOURCE, self.config.env)
+        await runtime.prepare_uv_script(
+            PROGRAM_SOURCE, {**self.config.resolved_env, "UV_FROZEN": "false"}
+        )
 
     async def launch(
         self,
@@ -38,8 +41,11 @@ class CompactingHarness(Harness[CompactingHarnessConfig]):
         endpoint: str,
         secret: str,
         mcp_urls: dict[str, str],
+        data: TaskData,
     ) -> ProgramResult:
+        _, prompt = self.resolve_prompt(data)
         env = {
+            **self.config.resolved_env,
             "OPENAI_BASE_URL": endpoint,
             "OPENAI_API_KEY": secret,
             "OPENAI_MODEL": ctx.model,
@@ -50,5 +56,7 @@ class CompactingHarness(Harness[CompactingHarnessConfig]):
             env["MCP_CONFIG"] = json.dumps(
                 {"mcpServers": {name: {"url": url} for name, url in mcp_urls.items()}}
             )
-        program = await runtime.prepare_uv_script(PROGRAM_SOURCE, self.config.env)
-        return await runtime.run_program([*program, trace.task.data.prompt], env)
+        program = await runtime.prepare_uv_script(
+            PROGRAM_SOURCE, {**self.config.resolved_env, "UV_FROZEN": "false"}
+        )
+        return await runtime.run_program([*program, prompt], env)

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -2,6 +2,7 @@ import logging as _logging
 
 from pydantic_config import BaseConfig
 
+from verifiers.v1.acp import ACP
 from verifiers.v1.clients import (
     BaseClientConfig,
     Client,
@@ -238,6 +239,7 @@ __all__ = [
     "BaseConfig",
     "Harness",
     "HarnessConfig",
+    "ACP",
     "ModelContext",
     "Runtime",
     "RuntimeConfig",

--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -1,0 +1,65 @@
+"""Public Agent Client Protocol support for harness programs."""
+
+import json
+import secrets
+from dataclasses import replace
+from pathlib import Path
+
+from verifiers.v1.dialects.chat import message_to_wire
+from verifiers.v1.harness import Harness
+from verifiers.v1.runtimes import ProgramResult, Runtime
+from verifiers.v1.types import Messages
+from verifiers.v1.utils.aio import run_shielded
+
+ACP_SOURCE = (Path(__file__).resolve().parent / "_runner.py").read_text()
+
+__all__ = ["ACP"]
+
+
+class ACP:
+    """Run an ACP agent."""
+
+    async def setup(self, harness: Harness, runtime: Runtime) -> None:
+        await runtime.prepare_uv_script(
+            ACP_SOURCE, {**harness.config.resolved_env, "UV_FROZEN": "false"}
+        )
+
+    async def run(
+        self,
+        runtime: Runtime,
+        env: dict[str, str],
+        command: list[str],
+        prompt: str | Messages | None,
+        *,
+        mcp_urls: dict[str, str] | None = None,
+        system_prompt: str | None = None,
+        session_path: str | None = None,
+    ) -> ProgramResult:
+        if prompt is None:
+            raise ValueError("ACP requires a prompt")
+        messages = (
+            [{"role": "user", "content": prompt}]
+            if isinstance(prompt, str)
+            else [message_to_wire(message) for message in prompt]
+        )
+        config = {
+            "command": command,
+            "messages": messages,
+            "mcp_urls": mcp_urls or {},
+            "system_prompt": system_prompt or "",
+            "session_path": session_path,
+        }
+        program = await runtime.prepare_uv_script(
+            ACP_SOURCE, {**env, "UV_FROZEN": "false"}
+        )
+        directory = f".vf-acp-{secrets.token_hex(8)}"
+        created = await runtime.run(["mkdir", "-m", "700", directory], {})
+        if created.exit_code != 0:
+            raise RuntimeError(f"ACP config directory failed: {created.stderr.strip()}")
+        path = f"{directory}/config.json"
+        try:
+            await runtime.write(path, json.dumps(config).encode())
+            result = await runtime.run_program([*program, path], env)
+            return replace(result, visible_reply=result.stdout.strip())
+        finally:
+            await run_shielded(runtime.run(["rm", "-rf", directory], {}))

--- a/verifiers/v1/acp/_runner.py
+++ b/verifiers/v1/acp/_runner.py
@@ -41,9 +41,10 @@ class VerifiersClient(Client):
             update.content, TextContentBlock
         ):
             return
-        if update.message_id is not None and update.message_id != self.message_id:
+        message_id = getattr(update, "message_id", None)
+        if message_id is not None and message_id != self.message_id:
             self.visible_reply = ""
-            self.message_id = update.message_id
+            self.message_id = message_id
         self.visible_reply += update.content.text
 
     async def request_permission(

--- a/verifiers/v1/acp/_runner.py
+++ b/verifiers/v1/acp/_runner.py
@@ -1,0 +1,213 @@
+# /// script
+# requires-python = ">=3.10,<3.15"
+# dependencies = ["agent-client-protocol==0.11.0"]
+# ///
+"""Run one harness segment through an ACP agent."""
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from acp import (
+    PROTOCOL_VERSION,
+    Client,
+    RequestError,
+    image_block,
+    spawn_agent_process,
+    text_block,
+)
+from acp.schema import (
+    AgentMessageChunk,
+    AllowedOutcome,
+    ClientCapabilities,
+    DeniedOutcome,
+    FileSystemCapabilities,
+    HttpMcpServer,
+    PermissionOption,
+    ReadTextFileResponse,
+    RequestPermissionResponse,
+    TextContentBlock,
+    WriteTextFileResponse,
+)
+
+
+class VerifiersClient(Client):
+    def __init__(self) -> None:
+        self.visible_reply = ""
+        self.message_id: str | None = None
+
+    async def session_update(self, session_id: str, update: Any, **kwargs: Any) -> None:
+        if not isinstance(update, AgentMessageChunk) or not isinstance(
+            update.content, TextContentBlock
+        ):
+            return
+        if update.message_id is not None and update.message_id != self.message_id:
+            self.visible_reply = ""
+            self.message_id = update.message_id
+        self.visible_reply += update.content.text
+
+    async def read_text_file(
+        self,
+        session_id: str,
+        path: str,
+        line: int | None = None,
+        limit: int | None = None,
+        **kwargs: Any,
+    ) -> ReadTextFileResponse:
+        lines = Path(path).read_text().splitlines(keepends=True)
+        start = (line or 1) - 1
+        return ReadTextFileResponse(
+            content="".join(lines[start : start + limit if limit is not None else None])
+        )
+
+    async def write_text_file(
+        self,
+        session_id: str,
+        path: str,
+        content: str,
+        **kwargs: Any,
+    ) -> WriteTextFileResponse:
+        Path(path).write_text(content)
+        return WriteTextFileResponse()
+
+    async def request_permission(
+        self,
+        session_id: str,
+        tool_call: Any,
+        options: list[PermissionOption],
+        **kwargs: Any,
+    ) -> RequestPermissionResponse:
+        option = next(
+            (item for item in options if item.kind in ("allow_once", "allow_always")),
+            None,
+        )
+        outcome = (
+            AllowedOutcome(outcome="selected", option_id=option.option_id)
+            if option
+            else DeniedOutcome(outcome="cancelled")
+        )
+        return RequestPermissionResponse(outcome=outcome)
+
+
+def content_blocks(messages: list[dict], supports_images: bool) -> list:
+    blocks = []
+    transcript = len(messages) != 1 or messages[0].get("role") != "user"
+    for message in messages:
+        if blocks:
+            blocks.append(text_block("\n\n"))
+        if transcript:
+            blocks.append(text_block(f"[{message.get('role', 'message')}]\n"))
+        content = message.get("content") or ""
+        parts = (
+            [{"type": "text", "text": content}] if isinstance(content, str) else content
+        )
+        for part in parts:
+            if part["type"] == "text":
+                blocks.append(text_block(part["text"]))
+                continue
+            if not supports_images:
+                raise ValueError("ACP agent does not support image prompts")
+            url = part["image_url"]["url"]
+            metadata, separator, data = url.partition(",")
+            media_type, *parameters = metadata.removeprefix("data:").split(";")
+            if (
+                not separator
+                or not metadata.startswith("data:image/")
+                or not any(value.lower() == "base64" for value in parameters)
+            ):
+                raise ValueError("ACP image prompts require base64 data:image URLs")
+            blocks.append(image_block(data, media_type))
+        metadata = {
+            key: value
+            for key, value in message.items()
+            if key not in ("role", "content") and value
+        }
+        if metadata:
+            blocks.append(text_block("\n" + json.dumps(metadata, ensure_ascii=False)))
+    return blocks
+
+
+async def run_client(config: dict) -> None:
+    client = VerifiersClient()
+    command = config["command"]
+    async with spawn_agent_process(
+        client,
+        command[0],
+        *command[1:],
+        env=os.environ.copy(),
+        transport_kwargs={"stderr": None},
+    ) as (connection, _process):
+        initialized = await connection.initialize(
+            protocol_version=PROTOCOL_VERSION,
+            client_capabilities=ClientCapabilities(
+                fs=FileSystemCapabilities(read_text_file=True, write_text_file=True)
+            ),
+        )
+        capabilities = initialized.agent_capabilities
+        prompt_capabilities = capabilities and capabilities.prompt_capabilities
+        supports_images = bool(prompt_capabilities and prompt_capabilities.image)
+        mcp_servers = [
+            HttpMcpServer(type="http", name=name, url=url, headers=[])
+            for name, url in config["mcp_urls"].items()
+        ]
+        session_path = Path(config["session_path"]) if config["session_path"] else None
+        is_new = session_path is None or not session_path.exists()
+        if is_new:
+            session = await connection.new_session(
+                cwd=os.getcwd(), mcp_servers=mcp_servers
+            )
+            session_id = session.session_id
+        else:
+            if not capabilities or not capabilities.load_session:
+                raise RuntimeError("ACP agent does not support loading sessions")
+            session_id = session_path.read_text().strip()
+            await connection.load_session(
+                cwd=os.getcwd(), session_id=session_id, mcp_servers=mcp_servers
+            )
+
+        messages = config["messages"]
+        if not is_new:
+            last_assistant = max(
+                (
+                    index
+                    for index, message in enumerate(messages)
+                    if message.get("role") == "assistant"
+                ),
+                default=-1,
+            )
+            messages = messages[last_assistant + 1 :]
+        if is_new and config["system_prompt"]:
+            messages = [
+                {"role": "system", "content": config["system_prompt"]},
+                *messages,
+            ]
+        prompt = content_blocks(messages, supports_images)
+        if not prompt:
+            raise ValueError("ACP prompt has no content")
+        client.visible_reply = ""
+        client.message_id = None
+        try:
+            await connection.prompt(session_id=session_id, prompt=prompt)
+        except RequestError as error:
+            detail = error.data.get("details") if isinstance(error.data, dict) else None
+            raise RuntimeError(detail or str(error)) from error
+        if not client.visible_reply.strip():
+            raise RuntimeError("ACP agent produced no visible reply")
+        sys.stdout.write(client.visible_reply)
+        if session_path and is_new:
+            session_path.parent.mkdir(parents=True, exist_ok=True)
+            session_path.write_text(session_id)
+
+
+async def main() -> None:
+    path = Path(sys.argv[1])
+    config = json.loads(path.read_text())
+    path.unlink()
+    await run_client(config)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/verifiers/v1/acp/_runner.py
+++ b/verifiers/v1/acp/_runner.py
@@ -24,13 +24,10 @@ from acp.schema import (
     AllowedOutcome,
     ClientCapabilities,
     DeniedOutcome,
-    FileSystemCapabilities,
     HttpMcpServer,
     PermissionOption,
-    ReadTextFileResponse,
     RequestPermissionResponse,
     TextContentBlock,
-    WriteTextFileResponse,
 )
 
 
@@ -48,30 +45,6 @@ class VerifiersClient(Client):
             self.visible_reply = ""
             self.message_id = update.message_id
         self.visible_reply += update.content.text
-
-    async def read_text_file(
-        self,
-        session_id: str,
-        path: str,
-        line: int | None = None,
-        limit: int | None = None,
-        **kwargs: Any,
-    ) -> ReadTextFileResponse:
-        lines = Path(path).read_text().splitlines(keepends=True)
-        start = (line or 1) - 1
-        return ReadTextFileResponse(
-            content="".join(lines[start : start + limit if limit is not None else None])
-        )
-
-    async def write_text_file(
-        self,
-        session_id: str,
-        path: str,
-        content: str,
-        **kwargs: Any,
-    ) -> WriteTextFileResponse:
-        Path(path).write_text(content)
-        return WriteTextFileResponse()
 
     async def request_permission(
         self,
@@ -96,10 +69,11 @@ def content_blocks(messages: list[dict], supports_images: bool) -> list:
     blocks = []
     transcript = len(messages) != 1 or messages[0].get("role") != "user"
     for message in messages:
-        if blocks:
-            blocks.append(text_block("\n\n"))
         if transcript:
-            blocks.append(text_block(f"[{message.get('role', 'message')}]\n"))
+            separator = "\n\n" if blocks else ""
+            blocks.append(
+                text_block(f"{separator}[{message.get('role', 'message')}]\n")
+            )
         content = message.get("content") or ""
         parts = (
             [{"type": "text", "text": content}] if isinstance(content, str) else content
@@ -142,9 +116,7 @@ async def run_client(config: dict) -> None:
     ) as (connection, _process):
         initialized = await connection.initialize(
             protocol_version=PROTOCOL_VERSION,
-            client_capabilities=ClientCapabilities(
-                fs=FileSystemCapabilities(read_text_file=True, write_text_file=True)
-            ),
+            client_capabilities=ClientCapabilities(),
         )
         capabilities = initialized.agent_capabilities
         prompt_capabilities = capabilities and capabilities.prompt_capabilities
@@ -161,12 +133,18 @@ async def run_client(config: dict) -> None:
             )
             session_id = session.session_id
         else:
-            if not capabilities or not capabilities.load_session:
-                raise RuntimeError("ACP agent does not support loading sessions")
             session_id = session_path.read_text().strip()
-            await connection.load_session(
-                cwd=os.getcwd(), session_id=session_id, mcp_servers=mcp_servers
-            )
+            session_capabilities = capabilities and capabilities.session_capabilities
+            if session_capabilities and session_capabilities.resume is not None:
+                await connection.resume_session(
+                    cwd=os.getcwd(), session_id=session_id, mcp_servers=mcp_servers
+                )
+            elif capabilities and capabilities.load_session:
+                await connection.load_session(
+                    cwd=os.getcwd(), session_id=session_id, mcp_servers=mcp_servers
+                )
+            else:
+                raise RuntimeError("ACP agent does not support resuming sessions")
 
         messages = config["messages"]
         if not is_new:

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -193,12 +193,17 @@ class ChatSession:
         elif message is not None:
             messages = _as_messages(message)
         self._started = True
-        turns_before = self.trace.num_turns
-        await self._run.step(messages)
-        if self.trace.num_turns > turns_before:
+        result = await self._run.step(messages)
+        if result is not None:
             # The segment answered — even if a limit or @stop then ended the
             # exchange, that surfaces as the NEXT turn's stopped reply.
-            return Reply(text=self.trace.last_reply)
+            return Reply(
+                text=(
+                    result.visible_reply
+                    if result.visible_reply is not None
+                    else self.trace.last_reply
+                )
+            )
         self._over = True
         return Reply(text="", stopped=True)
 

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -197,13 +197,7 @@ class ChatSession:
         if result is not None:
             # The segment answered — even if a limit or @stop then ended the
             # exchange, that surfaces as the NEXT turn's stopped reply.
-            return Reply(
-                text=(
-                    result.visible_reply
-                    if result.visible_reply is not None
-                    else self.trace.last_reply
-                )
-            )
+            return Reply(text=result.visible_reply or self.trace.last_reply)
         self._over = True
         return Reply(text="", stopped=True)
 

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -111,7 +111,7 @@ class Harness(ABC, Generic[ConfigT]):
         mcp_urls: dict[str, str],
         data: TaskData,
         messages: Messages | None = None,
-    ) -> None:
+    ) -> ProgramResult:
         """Run ONE segment of the exchange: the program from launch (or, with
         `messages`, the user's next turn(s) via `resume`) until it yields — a segment
         ends when the program exits. The rollout loop owns the exchange across
@@ -125,14 +125,13 @@ class Harness(ABC, Generic[ConfigT]):
                 result = await self.resume(
                     ctx, trace, runtime, endpoint, secret, mcp_urls, data, messages
                 )
-        if trace.stop_condition is not None:
-            return  # a @stop refused a turn mid-rollout; the harness's exit is expected
-        if result.exit_code != 0:
+        if trace.stop_condition is None and result.exit_code != 0:
             # The real cause is at the END of a traceback, so keep the tail.
             detail = (result.stderr or result.stdout).strip()[-2000:] or "<no output>"
             raise HarnessError(
                 f"harness {self.config.id!r} exited {result.exit_code}: {detail}"
             )
+        return result
 
     async def score(self, trace: Trace, runtime: Runtime) -> None:
         """Run this harness's `@metric` methods over the finished trace, recording

--- a/verifiers/v1/harnesses/claude_code/harness.py
+++ b/verifiers/v1/harnesses/claude_code/harness.py
@@ -8,6 +8,7 @@ from pydantic import Field
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.harness import Harness, HarnessConfig
 from verifiers.v1.runtimes import ProgramResult, Runtime
+from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
 
 CLAUDE_HOME = "/tmp/vf-claude-code-{version}"
@@ -55,8 +56,9 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
         endpoint: str,
         secret: str,
         mcp_urls: dict[str, str],
+        data: TaskData,
     ) -> ProgramResult:
-        system_prompt, instruction = self.resolve_prompt(trace.task.data)
+        system_prompt, instruction = self.resolve_prompt(data)
         if ctx.client.base_url == "https://api.pinference.ai/api/v1":
             # remove the /v1 from pinference
             ctx.client.base_url = ctx.client.base_url.removesuffix("/v1")

--- a/verifiers/v1/harnesses/kimi_code/harness.py
+++ b/verifiers/v1/harnesses/kimi_code/harness.py
@@ -5,6 +5,7 @@ import logging
 import shlex
 
 from verifiers.v1.clients import ModelContext
+from verifiers.v1.dialects.chat import message_to_wire
 from verifiers.v1.harness import Harness, HarnessConfig
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.trace import Trace
@@ -38,8 +39,9 @@ class KimiCodeHarnessConfig(HarnessConfig):
 
 
 class KimiCodeHarness(Harness[KimiCodeHarnessConfig]):
-    APPENDS_SYSTEM_PROMPT = False
+    APPENDS_SYSTEM_PROMPT = True
     SUPPORTS_MCP = True
+    SUPPORTS_MESSAGE_PROMPT = True
 
     async def setup(self, runtime: Runtime) -> None:
         logger.info(
@@ -66,10 +68,22 @@ class KimiCodeHarness(Harness[KimiCodeHarnessConfig]):
         mcp_urls: dict[str, str],
         data: TaskData,
     ) -> ProgramResult:
-        _, prompt = self.resolve_prompt(data)
+        system_prompt, prompt = self.resolve_prompt(data)
+        if prompt is None:
+            raise ValueError("Kimi Code requires a prompt")
+        messages = [
+            *([{"role": "system", "content": system_prompt}] if system_prompt else []),
+            *(
+                [{"role": "user", "content": prompt}]
+                if isinstance(prompt, str)
+                else [message_to_wire(message) for message in prompt]
+            ),
+        ]
+        prompt = json.dumps(messages, ensure_ascii=False)
+        kimi_home = f"{KIMI_HOME}/{trace.id}"
         env = {
             **self.config.resolved_env,
-            "KIMI_CODE_HOME": KIMI_HOME,
+            "KIMI_CODE_HOME": kimi_home,
             "KIMI_MODEL_NAME": ctx.model,
             "KIMI_MODEL_API_KEY": secret,
             "KIMI_MODEL_PROVIDER_TYPE": "openai",
@@ -78,7 +92,6 @@ class KimiCodeHarness(Harness[KimiCodeHarnessConfig]):
             "KIMI_DISABLE_TELEMETRY": "1",
             "KIMI_CODE_NO_AUTO_UPDATE": "1",
         }
-
         mcp = {"mcpServers": {name: {"url": url} for name, url in mcp_urls.items()}}
         # Values are Kimi permission patterns such as `Bash` or `Bash(rm -rf*)`.
         # https://moonshotai.github.io/kimi-code/en/configuration/config-files#permission
@@ -95,7 +108,8 @@ class KimiCodeHarness(Harness[KimiCodeHarnessConfig]):
             for tool in self.config.disabled_tools or []
         )
         if permission_rules:
-            await runtime.write(f"{KIMI_HOME}/config.toml", permission_rules.encode())
-        await runtime.write(f"{KIMI_HOME}/mcp.json", json.dumps(mcp).encode())
-        # `--prompt` is Kimi Code's non-interactive print mode.
+            await runtime.write(f"{kimi_home}/config.toml", permission_rules.encode())
+        await runtime.write(f"{kimi_home}/mcp.json", json.dumps(mcp).encode())
+        # Kimi ACP currently requires an interactive account login. Until it can
+        # use the intercepted provider, replay the transcript explicitly.
         return await runtime.run_program([BINARY, "--prompt", prompt], env)

--- a/verifiers/v1/harnesses/kimi_code/harness.py
+++ b/verifiers/v1/harnesses/kimi_code/harness.py
@@ -1,20 +1,25 @@
-"""Kimi receives interception through `KIMI_MODEL_*`; task MCP config uses an isolated home."""
+"""Kimi receives interception through `KIMI_MODEL_*` and runs through native ACP."""
 
 import json
 import logging
 import shlex
 
+from verifiers.v1.acp import ACP
 from verifiers.v1.clients import ModelContext
-from verifiers.v1.dialects.chat import message_to_wire
 from verifiers.v1.harness import Harness, HarnessConfig
 from verifiers.v1.runtimes import ProgramResult, Runtime
-from verifiers.v1.trace import Trace
 from verifiers.v1.task import TaskData
+from verifiers.v1.trace import Trace
 
 logger = logging.getLogger(__name__)
 
 BINARY = "/tmp/vf-kimi-code/bin/kimi"
 KIMI_HOME = ".vf-kimi-code"
+ACP_COMMAND = [
+    "sh",
+    "-c",
+    f'KIMI_CODE_HOME="$PWD/$KIMI_CODE_HOME" exec {BINARY} acp',
+]
 
 INSTALL = r"""
 set -e
@@ -32,9 +37,11 @@ env \
     bash "$installer"
 """
 
+KIMI_ACP = ACP()
+
 
 class KimiCodeHarnessConfig(HarnessConfig):
-    version: str = "0.27.0"
+    version: str = "0.29.0"
     """Kimi Code release to install, pinned for reproducibility."""
 
 
@@ -57,6 +64,7 @@ class KimiCodeHarness(Harness[KimiCodeHarnessConfig]):
             raise RuntimeError(
                 f"Kimi Code install failed: {install.stderr.strip()[-500:]}"
             )
+        await KIMI_ACP.setup(self, runtime)
 
     async def launch(
         self,
@@ -69,17 +77,6 @@ class KimiCodeHarness(Harness[KimiCodeHarnessConfig]):
         data: TaskData,
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(data)
-        if prompt is None:
-            raise ValueError("Kimi Code requires a prompt")
-        messages = [
-            *([{"role": "system", "content": system_prompt}] if system_prompt else []),
-            *(
-                [{"role": "user", "content": prompt}]
-                if isinstance(prompt, str)
-                else [message_to_wire(message) for message in prompt]
-            ),
-        ]
-        prompt = json.dumps(messages, ensure_ascii=False)
         kimi_home = f"{KIMI_HOME}/{trace.id}"
         env = {
             **self.config.resolved_env,
@@ -92,7 +89,6 @@ class KimiCodeHarness(Harness[KimiCodeHarnessConfig]):
             "KIMI_DISABLE_TELEMETRY": "1",
             "KIMI_CODE_NO_AUTO_UPDATE": "1",
         }
-        mcp = {"mcpServers": {name: {"url": url} for name, url in mcp_urls.items()}}
         # Values are Kimi permission patterns such as `Bash` or `Bash(rm -rf*)`.
         # https://moonshotai.github.io/kimi-code/en/configuration/config-files#permission
         permission_rules = "\n".join(
@@ -109,7 +105,12 @@ class KimiCodeHarness(Harness[KimiCodeHarnessConfig]):
         )
         if permission_rules:
             await runtime.write(f"{kimi_home}/config.toml", permission_rules.encode())
-        await runtime.write(f"{kimi_home}/mcp.json", json.dumps(mcp).encode())
-        # Kimi ACP currently requires an interactive account login. Until it can
-        # use the intercepted provider, replay the transcript explicitly.
-        return await runtime.run_program([BINARY, "--prompt", prompt], env)
+        return await KIMI_ACP.run(
+            runtime,
+            env,
+            ACP_COMMAND,
+            prompt,
+            mcp_urls=mcp_urls,
+            system_prompt=system_prompt,
+            session_path=f"{kimi_home}/acp-session",
+        )

--- a/verifiers/v1/harnesses/pi/harness.py
+++ b/verifiers/v1/harnesses/pi/harness.py
@@ -1,66 +1,84 @@
-"""Pi reaches interception through a custom OpenAI-compatible provider.
+"""Pi harness using the upstream pi-acp adapter."""
 
-Pi intentionally leaves MCP to extensions, so the harness always installs and loads the
-pi-mcp-adapter package.
-"""
-
-import base64
 import json
 import logging
-import re
 import shlex
 
+from verifiers.v1.acp import ACP
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.harness import Harness, HarnessConfig
 from verifiers.v1.runtimes import ProgramResult, Runtime
-from verifiers.v1.trace import Trace
-from verifiers.v1.types import SystemMessage, TextContentPart, UserMessage
 from verifiers.v1.task import TaskData
+from verifiers.v1.trace import Trace
 
 logger = logging.getLogger(__name__)
 
 PROVIDER = "intercept"
 KEY_VAR = "PI_INTERCEPT_KEY"
-VERSION_VAR = "VF_PI_VERSION"
-MCP_VERSION_VAR = "VF_PI_MCP_VERSION"
 HOME_VAR = "VF_PI_ORIGINAL_HOME"
 
 PI_DIR = "/tmp/vf-pi"
-PI_BIN = f"{PI_DIR}/pi"
+PACKAGES_DIR = f"{PI_DIR}/mcp"
+PI_BIN = f"{PACKAGES_DIR}/node_modules/.bin/pi"
 MCP_VERSION = "2.11.0"
-MCP_ADAPTER = f"{PI_DIR}/mcp/node_modules/pi-mcp-adapter/index.ts"
+ACP_VERSION = "0.0.31"
+NODE_VERSION = "22.19.0"
+MCP_ADAPTER = f"{PACKAGES_DIR}/node_modules/pi-mcp-adapter/index.ts"
+ACP_BIN = f"{PACKAGES_DIR}/node_modules/.bin/pi-acp"
+ACP_COMMAND = [
+    "sh",
+    "-c",
+    f'export {HOME_VAR}="$HOME"; '
+    'PI_CODING_AGENT_DIR="$PWD/$PI_CODING_AGENT_DIR"; '
+    'export PI_CODING_AGENT_DIR HOME="$PI_CODING_AGENT_DIR"; '
+    f'export PATH="{PI_DIR}/node/bin:$PATH"; exec {ACP_BIN}',
+]
 
 INSTALL = r"""
 set -e
-dir=/tmp/vf-pi
-bin="$dir/pi"
-mcp="$dir/mcp"
+packages=/tmp/vf-pi/mcp
+node=/tmp/vf-pi/node
 
-if ! command -v curl >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
-    { apt-get update -qq && apt-get install -y -qq curl ca-certificates nodejs npm >/dev/null; } \
-        || apk add --no-cache curl ca-certificates nodejs npm >/dev/null
+if [ -f /etc/alpine-release ]; then
+    apk add --no-cache curl ca-certificates nodejs-current npm >/dev/null
+    if ! node -e 'const [a,b]=process.versions.node.split(".").map(Number); process.exit(a>22 || a===22 && b>=19 ? 0 : 1)'; then
+        sed -E -i 's/v[0-9]+\.[0-9]+/v3.22/g' /etc/apk/repositories
+        apk upgrade --available --no-cache >/dev/null
+        apk add --no-cache nodejs-current npm >/dev/null
+    fi
+    node_bin="$(dirname "$(command -v node)")"
+else
+    command -v curl >/dev/null 2>&1 \
+        || { apt-get update -qq && apt-get install -y -qq curl ca-certificates >/dev/null; }
+    if [ ! -x "$node/bin/node" ] || [ "$("$node/bin/node" --version 2>/dev/null)" != "v$VF_PI_NODE_VERSION" ]; then
+        case "$(uname -m)" in aarch64|arm64) node_arch=arm64 ;; *) node_arch=x64 ;; esac
+        rm -rf "$node"
+        mkdir -p "$node"
+        curl -fsSL "https://nodejs.org/dist/v$VF_PI_NODE_VERSION/node-v$VF_PI_NODE_VERSION-linux-${node_arch}.tar.gz" \
+            | tar -xz -C "$node" --strip-components=1
+    fi
+    node_bin="$node/bin"
 fi
+export PATH="$node_bin:$PATH"
+node -e 'const [a,b]=process.versions.node.split(".").map(Number); process.exit(a>22 || a===22 && b>=19 ? 0 : 1)' \
+    || { echo "pi-acp requires Node.js 22.19 or newer" >&2; exit 1; }
 
-if [ ! -x "$bin" ] || [ "$("$bin" --version 2>/dev/null)" != "$VF_PI_VERSION" ]; then
-    case "$(uname -m)" in aarch64|arm64) arch=arm64 ;; *) arch=x64 ;; esac
-    curl -fsSL "https://github.com/earendil-works/pi/releases/download/v$VF_PI_VERSION/pi-linux-${arch}.tar.gz" \
-        | tar -xz -C "$dir" --strip-components=1
+pi_version="$(node -p "require('$packages/node_modules/@earendil-works/pi-coding-agent/package.json').version" 2>/dev/null || true)"
+mcp_version="$(node -p "require('$packages/node_modules/pi-mcp-adapter/package.json').version" 2>/dev/null || true)"
+acp_version="$(node -p "require('$packages/node_modules/pi-acp/package.json').version" 2>/dev/null || true)"
+if [ "$pi_version" != "$VF_PI_VERSION" ] || [ "$mcp_version" != "$VF_PI_MCP_VERSION" ] || [ "$acp_version" != "$VF_PI_ACP_VERSION" ]; then
+    npm install --prefix "$packages" --ignore-scripts --no-audit --no-fund --omit=dev \
+        "@earendil-works/pi-coding-agent@$VF_PI_VERSION" \
+        "pi-mcp-adapter@$VF_PI_MCP_VERSION" \
+        "pi-acp@$VF_PI_ACP_VERSION" >/dev/null
 fi
-
-[ "$(node -p "require('$mcp/node_modules/pi-mcp-adapter/package.json').version" 2>/dev/null)" = "$VF_PI_MCP_VERSION" ] \
-    || npm install --prefix "$mcp" --ignore-scripts --no-audit --no-fund --omit=dev \
-        "pi-mcp-adapter@$VF_PI_MCP_VERSION" >/dev/null
 """
 
-# pi-mcp-adapter treats --mcp-config as additive, so isolate its automatic discovery
-# roots, then restore Pi's task environment before agent tools run.
+# Isolate pi-mcp-adapter discovery while it registers, then restore the task home.
 MCP_WRAPPER = f"""
 export default async function isolatedMcp(pi) {{
   const agentDir = process.env.PI_CODING_AGENT_DIR;
-  if (!agentDir) throw new Error("PI_CODING_AGENT_DIR is required");
-
   const cwd = process.cwd();
-  const home = process.env.{HOME_VAR};
   process.chdir(agentDir);
   process.env.HOME = agentDir;
   try {{
@@ -79,12 +97,13 @@ export default async function isolatedMcp(pi) {{
     mcpAdapter(isolatedPi);
   }} finally {{
     process.chdir(cwd);
-    if (home === undefined) delete process.env.HOME;
-    else process.env.HOME = home;
+    process.env.HOME = process.env.{HOME_VAR};
     delete process.env.{HOME_VAR};
   }}
 }}
 """.strip()
+
+PI_ACP = ACP()
 
 
 class PiHarnessConfig(HarnessConfig):
@@ -99,9 +118,9 @@ class PiHarness(Harness[PiHarnessConfig]):
 
     async def setup(self, runtime: Runtime) -> None:
         logger.info(
-            "pi: ensuring Pi %s and pi-mcp-adapter %s are installed",
+            "pi: ensuring Pi %s and pi-acp %s are installed",
             self.config.version,
-            MCP_VERSION,
+            ACP_VERSION,
         )
         lock = f"{PI_DIR}/install.lock"
         guarded = (
@@ -116,10 +135,16 @@ class PiHarness(Harness[PiHarnessConfig]):
         )
         install = await runtime.run(
             ["sh", "-c", guarded],
-            {VERSION_VAR: self.config.version, MCP_VERSION_VAR: MCP_VERSION},
+            {
+                "VF_PI_VERSION": self.config.version,
+                "VF_PI_MCP_VERSION": MCP_VERSION,
+                "VF_PI_ACP_VERSION": ACP_VERSION,
+                "VF_PI_NODE_VERSION": NODE_VERSION,
+            },
         )
         if install.exit_code != 0:
             raise RuntimeError(f"pi install failed: {install.stderr.strip()[-500:]}")
+        await PI_ACP.setup(self, runtime)
 
     async def launch(
         self,
@@ -132,53 +157,7 @@ class PiHarness(Harness[PiHarnessConfig]):
         data: TaskData,
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(data)
-
-        agent_dir = f"{PI_DIR}/agent-{trace.id}"
-        image_args: list[str] = []
-        if prompt is not None and not isinstance(prompt, str):
-            system_texts = [system_prompt] if system_prompt else []
-            texts: list[str] = []
-            image_index = 0
-            for message in prompt:
-                if not isinstance(message, (SystemMessage, UserMessage)):
-                    raise ValueError(
-                        "Pi print mode only supports system and user initial messages"
-                    )
-                parts = (
-                    [TextContentPart(text=message.content)]
-                    if isinstance(message.content, str)
-                    else message.content
-                )
-                for part in parts:
-                    if isinstance(part, TextContentPart):
-                        (system_texts if message.role == "system" else texts).append(
-                            part.text
-                        )
-                        continue
-                    metadata, separator, encoded = part.image_url.url.partition(",")
-                    media_type, *parameters = metadata.removeprefix("data:").split(";")
-                    if (
-                        not separator
-                        or not metadata.startswith("data:image/")
-                        or not any(p.lower() == "base64" for p in parameters)
-                    ):
-                        raise ValueError(
-                            "Pi image prompts require base64 data:image URLs"
-                        )
-                    extension = re.sub(
-                        r"[^a-zA-Z0-9]+", "_", media_type.removeprefix("image/")
-                    ).strip("_")
-                    path = (
-                        f"{agent_dir}/images/image_{image_index}.{extension or 'image'}"
-                    )
-                    await runtime.write(path, base64.b64decode(encoded))
-                    image_args.append(f"@{path}")
-                    image_index += 1
-            system_prompt = "\n\n".join(system_texts) or None
-            prompt = "\n\n".join(texts)
-        if prompt is None:
-            raise ValueError("Pi requires a task prompt")
-
+        agent_dir = f".vf-pi-agent-{trace.id}"
         reasoning = ctx.sampling.reasoning_effort not in (
             None,
             "none",
@@ -199,12 +178,10 @@ class PiHarness(Harness[PiHarnessConfig]):
                 }
             }
         }
-        prompt_path = f"{agent_dir}/prompt.txt"
-        await runtime.write(prompt_path, prompt.encode())
         await runtime.write(f"{agent_dir}/models.json", json.dumps(models).encode())
 
-        launch = 'exec "$@" < "$0"'
         mcp_args: list[str] = []
+        restore_home = f'export HOME="${HOME_VAR}"; unset {HOME_VAR}; '
         if mcp_urls:
             extension_path = f"{agent_dir}/mcp.js"
             mcp = {
@@ -221,8 +198,7 @@ class PiHarness(Harness[PiHarnessConfig]):
                 "--mcp-config",
                 f"{agent_dir}/mcp.json",
             ]
-            # Isolate adapter global discovery before Bun caches HOME.
-            launch = f'export {HOME_VAR}="$HOME"; export HOME="$PI_CODING_AGENT_DIR"; {launch}'
+            restore_home = ""
 
         env = {
             **self.config.resolved_env,
@@ -231,36 +207,34 @@ class PiHarness(Harness[PiHarnessConfig]):
             "PI_OFFLINE": "1",
             "PI_TELEMETRY": "0",
         }
-        tool_args = (
-            ["--exclude-tools", ",".join(self.config.disabled_tools)]
-            if self.config.disabled_tools
-            else []
-        )
-        system_args = ["--append-system-prompt", system_prompt] if system_prompt else []
-        argv = [
-            "sh",
-            "-c",
-            # Pi has no `--` terminator, so the prompt must not be parsed as argv.
-            launch,
-            prompt_path,
+        pi_args = [
             PI_BIN,
-            "--print",
-            "--no-session",
             "--no-approve",
-            "--offline",
             "--provider",
             PROVIDER,
             "--model",
             ctx.model,
             *mcp_args,
-            *tool_args,
-            *system_args,
-            *image_args,
+            *(
+                ["--exclude-tools", ",".join(self.config.disabled_tools)]
+                if self.config.disabled_tools
+                else []
+            ),
+            *(["--append-system-prompt", system_prompt] if system_prompt else []),
         ]
-        try:
-            return await runtime.run_program(argv, env)
-        finally:
-            try:
-                await runtime.run(["rm", "-rf", agent_dir], {})
-            except Exception:
-                logger.warning("failed to clean up Pi agent directory", exc_info=True)
+        pi_wrapper = f"{agent_dir}/pi"
+        await runtime.write(
+            pi_wrapper,
+            f'#!/bin/sh\n{restore_home}exec {shlex.join(pi_args)} "$@"\n'.encode(),
+        )
+        chmod = await runtime.run(["chmod", "+x", pi_wrapper], {})
+        if chmod.exit_code != 0:
+            raise RuntimeError(f"Pi wrapper setup failed: {chmod.stderr}")
+        env["PI_ACP_PI_COMMAND"] = pi_wrapper
+        return await PI_ACP.run(
+            runtime,
+            env,
+            ACP_COMMAND,
+            prompt,
+            session_path=f"{agent_dir}/acp-session",
+        )

--- a/verifiers/v1/harnesses/pi/harness.py
+++ b/verifiers/v1/harnesses/pi/harness.py
@@ -38,10 +38,11 @@ INSTALL = r"""
 set -e
 packages=/tmp/vf-pi/mcp
 node=/tmp/vf-pi/node
+node_ok() { node -e 'const [a,b]=process.versions.node.split(".").map(Number); process.exit(a>22 || a===22 && b>=19 ? 0 : 1)'; }
 
 if [ -f /etc/alpine-release ]; then
     apk add --no-cache curl ca-certificates nodejs-current npm >/dev/null
-    if ! node -e 'const [a,b]=process.versions.node.split(".").map(Number); process.exit(a>22 || a===22 && b>=19 ? 0 : 1)'; then
+    if ! node_ok; then
         sed -E -i 's/v[0-9]+\.[0-9]+/v3.22/g' /etc/apk/repositories
         apk upgrade --available --no-cache >/dev/null
         apk add --no-cache nodejs-current npm >/dev/null
@@ -60,17 +61,15 @@ else
     node_bin="$node/bin"
 fi
 export PATH="$node_bin:$PATH"
-node -e 'const [a,b]=process.versions.node.split(".").map(Number); process.exit(a>22 || a===22 && b>=19 ? 0 : 1)' \
-    || { echo "pi-acp requires Node.js 22.19 or newer" >&2; exit 1; }
+node_ok || { echo "pi-acp requires Node.js 22.19 or newer" >&2; exit 1; }
 
-pi_version="$(node -p "require('$packages/node_modules/@earendil-works/pi-coding-agent/package.json').version" 2>/dev/null || true)"
-mcp_version="$(node -p "require('$packages/node_modules/pi-mcp-adapter/package.json').version" 2>/dev/null || true)"
-acp_version="$(node -p "require('$packages/node_modules/pi-acp/package.json').version" 2>/dev/null || true)"
-if [ "$pi_version" != "$VF_PI_VERSION" ] || [ "$mcp_version" != "$VF_PI_MCP_VERSION" ] || [ "$acp_version" != "$VF_PI_ACP_VERSION" ]; then
+versions="$VF_PI_VERSION:$VF_PI_MCP_VERSION:$VF_PI_ACP_VERSION"
+if [ "$(cat "$packages/.versions" 2>/dev/null)" != "$versions" ]; then
     npm install --prefix "$packages" --ignore-scripts --no-audit --no-fund --omit=dev \
         "@earendil-works/pi-coding-agent@$VF_PI_VERSION" \
         "pi-mcp-adapter@$VF_PI_MCP_VERSION" \
         "pi-acp@$VF_PI_ACP_VERSION" >/dev/null
+    printf %s "$versions" > "$packages/.versions"
 fi
 """
 
@@ -215,21 +214,17 @@ class PiHarness(Harness[PiHarnessConfig]):
             "--model",
             ctx.model,
             *mcp_args,
-            *(
-                ["--exclude-tools", ",".join(self.config.disabled_tools)]
-                if self.config.disabled_tools
-                else []
-            ),
-            *(["--append-system-prompt", system_prompt] if system_prompt else []),
         ]
+        if self.config.disabled_tools:
+            pi_args += ["--exclude-tools", ",".join(self.config.disabled_tools)]
+        if system_prompt:
+            pi_args += ["--append-system-prompt", system_prompt]
         pi_wrapper = f"{agent_dir}/pi"
         await runtime.write(
             pi_wrapper,
             f'#!/bin/sh\n{restore_home}exec {shlex.join(pi_args)} "$@"\n'.encode(),
         )
-        chmod = await runtime.run(["chmod", "+x", pi_wrapper], {})
-        if chmod.exit_code != 0:
-            raise RuntimeError(f"Pi wrapper setup failed: {chmod.stderr}")
+        await runtime.run(["chmod", "+x", pi_wrapper], {})
         env["PI_ACP_PI_COMMAND"] = pi_wrapper
         return await PI_ACP.run(
             runtime,

--- a/verifiers/v1/harnesses/pool/harness.py
+++ b/verifiers/v1/harnesses/pool/harness.py
@@ -1,19 +1,18 @@
-"""Run Poolside's `pool exec` against interception as an OpenAI-compatible provider."""
+"""Run Poolside's native ACP server against interception."""
 
 import json
 import shlex
 
 from pydantic import Field
 
+from verifiers.v1.acp import ACP
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.harness import Harness, HarnessConfig
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
-from verifiers.v1.types import SystemMessage, TextContentPart, UserMessage
 
 POOL_DIR = "/tmp/vf-pool-{version}"
-SETTINGS_PATH = ".poolside/settings.local.yaml"
 INSTALL = r"""
 set -e
 command -v curl >/dev/null || (apt-get update -qq && apt-get install -y -qq curl ca-certificates >/dev/null)
@@ -25,6 +24,8 @@ curl -fsSL "https://github.com/poolsideai/pool/releases/download/v{version}/pool
 mv "{dir}/pool-$os-$arch" "{dir}/pool"
 chmod +x "{dir}/pool"
 """
+
+POOL_ACP = ACP()
 
 
 class PoolHarnessConfig(HarnessConfig):
@@ -54,6 +55,7 @@ class PoolHarness(Harness[PoolHarnessConfig]):
         if result.exit_code != 0:
             detail = (result.stderr or result.stdout).strip()[-500:]
             raise RuntimeError(f"Pool install failed: {detail}")
+        await POOL_ACP.setup(self, runtime)
 
     async def launch(
         self,
@@ -66,42 +68,6 @@ class PoolHarness(Harness[PoolHarnessConfig]):
         data: TaskData,
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(data)
-        if prompt is None:
-            raise ValueError("Pool requires a task prompt (it has no user simulator)")
-        texts = [system_prompt] if system_prompt else []
-        if isinstance(prompt, str):
-            texts.append(prompt)
-        else:
-            for message in prompt:
-                if not isinstance(message, (SystemMessage, UserMessage)):
-                    raise ValueError(
-                        "pool exec only supports system and user initial messages"
-                    )
-                parts = (
-                    [TextContentPart(text=message.content)]
-                    if isinstance(message.content, str)
-                    else message.content
-                )
-                for part in parts:
-                    if not isinstance(part, TextContentPart):
-                        raise ValueError("pool exec does not support image prompts")
-                    texts.append(part.text)
-        text = "\n\n".join(text for text in texts if text)
-
-        settings = {
-            "mcp_servers": {
-                name: {"transport": {"type": "http", "url": url}}
-                for name, url in mcp_urls.items()
-            },
-            # Values are Pool tool names such as `shell`, `read`, or `edit`.
-            "tools": {
-                name: {"disabled": True} for name in self.config.disabled_tools or []
-            },
-        }
-        await runtime.write(SETTINGS_PATH, json.dumps(settings).encode())
-
-        prompt_path = f".vf-pool/prompt-{trace.id}.txt"
-        await runtime.write(prompt_path, text.encode())
         env = {
             **self.config.resolved_env,
             # Standalone provider mode sends this bearer and model to interception.
@@ -109,24 +75,25 @@ class PoolHarness(Harness[PoolHarnessConfig]):
             "POOLSIDE_STANDALONE_BASE_URL": endpoint,
             "POOLSIDE_STANDALONE_MODEL": ctx.model,
         }
-        directory = POOL_DIR.format(version=self.config.version)
-        argv = [
-            f"{directory}/pool",
-            "exec",
-            "--unsafe-auto-allow",
-            "--sandbox",
-            "disabled",
-            "--prompt-file",
-            prompt_path,
+        pool_home = f".vf-pool/{trace.id}"
+        # Values are Pool tool names such as `shell`, `read`, or `edit`.
+        tools = {name: {"disabled": True} for name in self.config.disabled_tools or []}
+        settings = shlex.quote(json.dumps({"tools": tools}))
+        command = [
+            "sh",
+            "-c",
+            f'export HOME="$PWD/{pool_home}/home" '
+            f'XDG_CONFIG_HOME="$PWD/{pool_home}/config" '
+            f'XDG_STATE_HOME="$PWD/{pool_home}/state"; '
+            f"exec {POOL_DIR.format(version=self.config.version)}/pool acp "
+            f"--sandbox disabled --settings {settings}",
         ]
-        # Keep Pool's home, config, logs, and trajectories inside the rollout workspace.
-        isolate = (
-            'export HOME="$PWD/.vf-pool/home" '
-            'XDG_CONFIG_HOME="$PWD/.vf-pool/config" '
-            'XDG_STATE_HOME="$PWD/.vf-pool/state"; exec "$@"'
+        return await POOL_ACP.run(
+            runtime,
+            env,
+            command,
+            prompt,
+            mcp_urls=mcp_urls,
+            system_prompt=system_prompt,
+            session_path=f"{pool_home}/acp-session",
         )
-        result = await runtime.run_program(["sh", "-c", isolate, "pool", *argv], env)
-        # Exit 4 means the agent declined the task, not that the harness failed.
-        if result.exit_code == 4:
-            return ProgramResult(0, result.stdout, result.stderr)
-        return result

--- a/verifiers/v1/harnesses/pool/harness.py
+++ b/verifiers/v1/harnesses/pool/harness.py
@@ -8,6 +8,7 @@ from pydantic import Field
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.harness import Harness, HarnessConfig
 from verifiers.v1.runtimes import ProgramResult, Runtime
+from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
 from verifiers.v1.types import SystemMessage, TextContentPart, UserMessage
 
@@ -62,8 +63,9 @@ class PoolHarness(Harness[PoolHarnessConfig]):
         endpoint: str,
         secret: str,
         mcp_urls: dict[str, str],
+        data: TaskData,
     ) -> ProgramResult:
-        system_prompt, prompt = self.resolve_prompt(trace.task.data)
+        system_prompt, prompt = self.resolve_prompt(data)
         if prompt is None:
             raise ValueError("Pool requires a task prompt (it has no user simulator)")
         texts = [system_prompt] if system_prompt else []

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -145,13 +145,12 @@ class RLMHarness(Harness[RLMHarnessConfig]):
     @metric
     async def rlm(self, runtime: Runtime) -> dict[str, float]:
         # Stateless continuation creates one session per segment; report the latest.
-        result = await runtime.run(
-            ["sh", "-c", f"ls -t {RLM_HOME}/sessions/*/meta.json | head -1"], {}
-        )
+        latest = f'cat "$(ls -t {RLM_HOME}/sessions/*/meta.json | head -1)"'
+        result = await runtime.run(["sh", "-c", latest], {})
         if result.exit_code != 0 or not result.stdout.strip():
             return {}
         try:
-            meta = json.loads(await runtime.read(result.stdout.strip()))
+            meta = json.loads(result.stdout)
         except json.JSONDecodeError:
             return {}
         return {

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -11,6 +11,7 @@ from pydantic import model_validator
 from verifiers.v1.harness import Harness, HarnessConfig
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.decorators import metric
+from verifiers.v1.dialects.chat import message_to_wire
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.trace import Trace
 from verifiers.v1.task import TaskData
@@ -72,6 +73,7 @@ class RLMHarnessConfig(HarnessConfig):
 class RLMHarness(Harness[RLMHarnessConfig]):
     APPENDS_SYSTEM_PROMPT = True
     SUPPORTS_MCP = True
+    SUPPORTS_MESSAGE_PROMPT = True
 
     async def setup(self, runtime: Runtime) -> None:
         # install.sh fetches curl/uv itself; add git only when the image lacks it.
@@ -114,6 +116,12 @@ class RLMHarness(Harness[RLMHarnessConfig]):
         data: TaskData,
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(data)
+        if prompt is None:
+            raise ValueError("RLM requires a prompt")
+        if not isinstance(prompt, str):
+            prompt = json.dumps(
+                [message_to_wire(message) for message in prompt], ensure_ascii=False
+            )
         env = {
             **self.config.resolved_env,
             "RLM_BASE_URL": endpoint,
@@ -131,22 +139,19 @@ class RLMHarness(Harness[RLMHarnessConfig]):
             env["RLM_MCP_CONFIG"] = json.dumps(
                 {"mcpServers": {name: {"url": url} for name, url in mcp_urls.items()}}
             )
+        # RLM has no interactive mode; resumed segments explicitly replay the transcript.
         return await runtime.run_program([RLM_BIN, "--", prompt], env)
 
     @metric
-    async def rlm(self, trace: Trace, runtime: Runtime) -> dict[str, float]:
-        # rlm writes a session meta.json with a rich `metrics` block (compactions,
-        # ipython input size, programmatic tool-call counts). There's one top-level
-        # session dir (sub-harnesses nest as sub-*/), so the glob matches a single
-        # file. Surface its numeric metrics as-is; non-numeric fields (e.g.
-        # stop_reason) don't fit the float-only trace metrics, so they're skipped.
+    async def rlm(self, runtime: Runtime) -> dict[str, float]:
+        # Stateless continuation creates one session per segment; report the latest.
         result = await runtime.run(
-            ["sh", "-c", f"cat {RLM_HOME}/sessions/*/meta.json"], {}
+            ["sh", "-c", f"ls -t {RLM_HOME}/sessions/*/meta.json | head -1"], {}
         )
         if result.exit_code != 0 or not result.stdout.strip():
             return {}
         try:
-            meta = json.loads(result.stdout)
+            meta = json.loads(await runtime.read(result.stdout.strip()))
         except json.JSONDecodeError:
             return {}
         return {

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -23,6 +23,7 @@ import logging
 import time
 from collections.abc import AsyncIterator, Callable
 from contextlib import AsyncExitStack, asynccontextmanager
+from dataclasses import dataclass
 
 from verifiers import __version__
 from verifiers.v1.harness import Harness
@@ -56,6 +57,13 @@ from verifiers.v1.types import Messages
 from verifiers.v1.utils.version import verifiers_commit
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SegmentResult:
+    """The harness output addressed to the exchange's user."""
+
+    visible_reply: str | None = None
 
 
 def _as_messages(raw: Messages) -> Messages:
@@ -293,22 +301,22 @@ class RolloutRun:
             self.deadline_at = asyncio.get_running_loop().time() + self._harness_timeout
         return True
 
-    async def step(self, messages: Messages | None = None) -> bool:
+    async def step(self, messages: Messages | None = None) -> SegmentResult | None:
         """Run ONE segment: the harness program to its exit. With `messages`, the
         segment resumes the exchange with the user's turn(s) (`Harness.resume` —
         for an exchange the user opens, this is also the first segment, on an
         empty conversation); without, it launches on the task's own prompt.
-        Returns whether the exchange can continue — a refused turn (limit, @stop),
-        a timeout, a failure, or a segment that made no progress all end it."""
+        Returns the segment result when it produced an assistant turn; a refused
+        turn (limit, @stop), timeout, failure, or no progress returns None."""
         if not self._opened or self._closed or not self.ok:
-            return False
+            return None
         trace = self.trace
         turns_before = trace.num_turns
         # Prefer an intercepted model/tool error to the harness exit it caused.
         # A timeout still scores the partial trajectory.
         try:
             async with asyncio.timeout_at(self.deadline_at):
-                await self.harness.run(
+                result = await self.harness.run(
                     self.ctx,
                     trace,
                     self.runtime,
@@ -328,7 +336,7 @@ class RolloutRun:
                 trace.stop("harness_timeout")
             else:
                 self.fail(e)
-            return False
+            return None
         except Exception as e:
             real = self._session.error
             if real is not None and isinstance(e, RolloutError):
@@ -336,14 +344,16 @@ class RolloutRun:
                 self.fail(real)
             else:
                 self.fail(e)
-            return False
+            return None
         if self._session.error is not None:
             self.fail(self._session.error)
-            return False
+            return None
         # A segment that committed nothing can't be waiting on the user; treating
         # it as continuable would consult the user against a conversation that
         # never moved, forever.
-        return self.ok and trace.num_turns > turns_before
+        if trace.num_turns > turns_before:
+            return SegmentResult(visible_reply=result.visible_reply)
+        return None
 
     async def abort(self) -> None:
         """Free everything this run holds — the entered servers and an owned

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -23,7 +23,6 @@ import logging
 import time
 from collections.abc import AsyncIterator, Callable
 from contextlib import AsyncExitStack, asynccontextmanager
-from dataclasses import dataclass
 
 from verifiers import __version__
 from verifiers.v1.harness import Harness
@@ -45,6 +44,7 @@ from verifiers.v1.interception import (
 )
 from verifiers.v1.session import RolloutLimits, RolloutSession
 from verifiers.v1.runtimes import (
+    ProgramResult,
     Runtime,
     RuntimeConfig,
     make_runtime,
@@ -57,13 +57,6 @@ from verifiers.v1.types import Messages
 from verifiers.v1.utils.version import verifiers_commit
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass(frozen=True)
-class SegmentResult:
-    """The harness output addressed to the exchange's user."""
-
-    visible_reply: str | None = None
 
 
 def _as_messages(raw: Messages) -> Messages:
@@ -301,7 +294,7 @@ class RolloutRun:
             self.deadline_at = asyncio.get_running_loop().time() + self._harness_timeout
         return True
 
-    async def step(self, messages: Messages | None = None) -> SegmentResult | None:
+    async def step(self, messages: Messages | None = None) -> ProgramResult | None:
         """Run ONE segment: the harness program to its exit. With `messages`, the
         segment resumes the exchange with the user's turn(s) (`Harness.resume` —
         for an exchange the user opens, this is also the first segment, on an
@@ -352,7 +345,7 @@ class RolloutRun:
         # it as continuable would consult the user against a conversation that
         # never moved, forever.
         if trace.num_turns > turns_before:
-            return SegmentResult(visible_reply=result.visible_reply)
+            return result
         return None
 
     async def abort(self) -> None:

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -49,6 +49,7 @@ class ProgramResult:
     exit_code: int
     stdout: str
     stderr: str
+    visible_reply: str | None = None
 
 
 def parse_gpu(gpu: str | None) -> tuple[str | None, int]:


### PR DESCRIPTION
## Overview

Adds user-simulation continuation across v1 harnesses on top of the unified agent chat exchange in #2049, using native ACP only where the underlying agent supports it.

## Details

- Exposes `vf.ACP` as the public native ACP transport and surfaces the ACP-visible agent response through `ChatSession`.
- Uses the upstream `pi-acp` adapter for persistent Pi sessions, with full-transcript recovery when the session marker is missing.
- Keeps Kimi Code and RLM as explicit stateless transcript replays, while Compact remains direct so its process-local state is preserved.
- Installs Pi and its adapters from npm with a compatible Node.js runtime on Debian and Alpine.
- Keeps existing harness launch overrides compatible with the parent exchange API.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add native ACP harness continuation for Kimi, Pi, Pool, and RLM agents
> - Introduces a new [`ACP` class](https://github.com/PrimeIntellect-ai/verifiers/pull/2046/files#diff-4a98e09e3584605f8da12349ce8fa454922c607127e29c836edfae5094b41ccf) and [runner script](https://github.com/PrimeIntellect-ai/verifiers/pull/2046/files#diff-d382c5bf34763d245280e299f2edacb56db3f010e8c820587d752f9139cafa51) that executes ACP agents, captures streaming assistant text as `visible_reply`, handles session resume, and auto-approves permissions.
> - Migrates Kimi, Pi, and Pool harnesses to run via the ACP adapter instead of direct `--print` mode, enabling session handling and structured reply capture.
> - Adds `visible_reply: str | None` to [`ProgramResult`](https://github.com/PrimeIntellect-ai/verifiers/pull/2046/files#diff-0811c040a163eb5a3212208f1e3a6c6388d7690fcc4780c081cc7754036232b9) so ACP-based harnesses can surface assistant output to callers.
> - `Harness.run` now returns `ProgramResult` and only raises `HarnessError` on non-zero exit when no stop condition is set; `RolloutRun.step` now returns `ProgramResult | None` instead of `bool`.
> - All `launch` handlers now accept `data: TaskData` and resolve prompts via `self.resolve_prompt(data)` rather than reading directly from `trace.task.data`.
> - Behavioral Change: Pi and Pool harnesses no longer invoke agents in direct print mode; existing rollouts relying on `step()` returning `bool` will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2280387.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switches several agent harnesses from print-mode CLIs to ACP/session semantics and changes `step()`'s return type—multi-turn rollouts and callers of `step()` may behave differently; install paths now pull npm/Node and external agent binaries.
> 
> **Overview**
> Introduces **`vf.ACP`** as the shared Agent Client Protocol runner (uv script + session resume, MCP wiring, streamed assistant text as **`visible_reply`** on **`ProgramResult`**). **Kimi Code**, **Pi**, and **Pool** no longer use one-shot print/exec modes—they launch native **`acp`** subprocesses with per-rollout session files so **`Agent.chat()`** can continue exchanges via the default **`Harness.resume`** relaunch (Pi via **`pi-acp`**, npm/Node 22.19+ install).
> 
> **RLM** opts into **`SUPPORTS_MESSAGE_PROMPT`** and JSON-serializes **`Messages`** prompts for stateless transcript replay; compact/claude launch paths take **`TaskData`** and **`resolve_prompt(data)`**. **`Harness.run`** returns **`ProgramResult`**; **`RolloutRun.step`** returns **`ProgramResult | None`** (replacing **`bool`**), and **`ChatSession.turn`** prefers **`visible_reply`** over trace text when present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2280387cdb130cc196f3599aba008fa2f97ee9d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->