### PR TITLE
feat: ignore harbor task timeouts by default

### DIFF
--- a/docs/v1/harbor.md
+++ b/docs/v1/harbor.md
@@ -56,11 +56,14 @@ On the `prime` runtime any pullable image reference just works: the first sandbo
 
 ## Additional features
 
-Every Harbor taskset can also be modified with a `timeout_multiplier` and a `resource_multiplier`:
+By default, each task's declared agent and verifier timeouts are ignored (`ignore_timeouts = true`): Harbor task timeouts are authored against Harbor's own runtime, so enforcing them confounds model capability with the speed of your inference stack. Set `ignore_timeouts = false` (or pass `--no-taskset.ignore-timeouts`) to apply them, e.g. for a faithful comparison against the Harbor implementation.
+
+With `ignore_timeouts = false`, every Harbor taskset can also be modified with a `timeout_multiplier`, and any Harbor taskset with a `resource_multiplier`:
 
 ```toml
 [taskset]
 id = "MY_TASKSET"
+ignore_timeouts = false
 timeout_multiplier = 2.0
 resource_multiplier = 2.0
 ```

--- a/verifiers/v1/tasksets/harbor/taskset.py
+++ b/verifiers/v1/tasksets/harbor/taskset.py
@@ -48,8 +48,14 @@ class HarborConfig(TasksetConfig):
     """Optional Harbor `--registry-url` selector for a raw registry.json URL."""
     tasks: list[str] | None = None
     """Optional subset of task names to load (None = all)."""
+    ignore_timeouts: bool = True
+    """Drop each task's declared agent and verifier timeouts so rollouts run
+    unbounded (unless run-level `--timeout.*` limits are set). Task timeouts are
+    authored against Harbor's runtime and confound model capability with inference
+    speed; set False to apply them anyway."""
     timeout_multiplier: float = Field(1.0, gt=0)
-    """Scale each task's agent and verifier timeouts."""
+    """Scale each task's agent and verifier timeouts. Only applies with
+    `ignore_timeouts=False`."""
     resource_multiplier: float = Field(1.0, gt=0)
     """Scale each task's CPU, memory, and disk requests. GPU requests are unchanged."""
     require_image: bool = False
@@ -273,8 +279,11 @@ def parse_task(task_dir: Path, idx: int, harbor_config: HarborConfig) -> HarborD
     # Older registry entries stored one author in [metadata].
     if not authors and meta.get("author_name"):
         authors = [Author(name=meta["author_name"], email=meta.get("author_email"))]
-    harness_timeout = config.get("agent", {}).get("timeout_sec")
-    scoring_timeout = config.get("verifier", {}).get("timeout_sec")
+    if harbor_config.ignore_timeouts:
+        harness_timeout = scoring_timeout = None
+    else:
+        harness_timeout = config.get("agent", {}).get("timeout_sec")
+        scoring_timeout = config.get("verifier", {}).get("timeout_sec")
     return HarborData(
         idx=idx,
         name=task.get("name") or task_dir.name,


### PR DESCRIPTION
## Summary
- Add `ignore_timeouts: bool = True` to `HarborConfig`: by default, Harbor tasksets no longer apply each task's declared `[agent]`/`[verifier]` `timeout_sec`, so rollouts run unbounded unless run-level `--timeout.*` limits are set.
- Rationale: Harbor task timeouts are authored against Harbor's own runtime — enforcing them confounds model capability with inference-stack speed (e.g. tokens/sec). Pass `--no-taskset.ignore-timeouts` for a faithful comparison against the Harbor implementation.
- `timeout_multiplier` now only applies with `ignore_timeouts = false`; docs updated accordingly.

## Breaking
- Harbor tasksets ignore task-declared timeouts by default. Restore the previous behavior with `ignore_timeouts = false` in the taskset config or `--no-taskset.ignore-timeouts` on the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ignore Harbor task timeouts by default in `HarborConfig`
> - Adds `ignore_timeouts` field to `HarborConfig` (default `True`), which causes `harness_timeout` and `scoring_timeout` to be set to `None` in `parse_task` instead of reading values from the task config.
> - When `ignore_timeouts = False`, the previous behavior is preserved: timeouts are read from `agent.timeout_sec` and `verifier.timeout_sec` and scaled by `timeout_multiplier`.
> - Behavioral Change: existing Harbor tasksets will now skip per-task timeouts by default; opt out by setting `ignore_timeouts = false` or passing `--no-taskset.ignore-timeouts`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7b61bf4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default behavior change can make rollouts run much longer and alter scores vs prior runs; opt-out is documented but easy to miss.
> 
> **Overview**
> Harbor tasksets now **drop per-task agent and verifier timeouts by default** via new `HarborConfig.ignore_timeouts` (`True`). `parse_task` sets harness/scoring timeouts to `None` instead of reading `[agent]` / `[verifier]` `timeout_sec` from each `task.toml`, so rollouts are only bounded by run-level `--timeout.*` unless you opt in.
> 
> **`timeout_multiplier` only applies when `ignore_timeouts = false`** (config or `--no-taskset.ignore-timeouts`). Docs explain the rationale (Harbor-authored limits vs inference speed) and show the updated TOML example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b61bf4d18df1f4741eed71e16c7eed621af77f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->