### PR TITLE
chore: use 'uv run init' in create-environments skill

### DIFF
--- a/skills/create-environments/SKILL.md
+++ b/skills/create-environments/SKILL.md
@@ -12,15 +12,15 @@ Create native v1 tasksets that are installable and runnable with verifiers.
 To start, ALWAYS use the CLI to create a package with the correct files:
 
 ```bash
-prime env init my-task-v1
+uv run init my-task-v1
 ```
 
 Add only the components the contract needs:
 
 ```bash
-prime env init my-task-v1 -T      # task toolset
-prime env init my-task-v1 -U      # user simulator
-prime env init my-agent-v1 -H     # custom reusable harness
+uv run init my-task-v1 -T      # task toolset
+uv run init my-task-v1 -U      # user simulator
+uv run init my-agent-v1 -H     # custom reusable harness
 ```
 
 Often, the user does not want nor need a custom reusable harness, as verifiers offer a lot of built-in ones.
@@ -50,7 +50,7 @@ Ask the user about unresolved semantic choices instead of inventing them. Presen
 
 ## Native package contract
 
-A package exports one `vf.Taskset` subclass and optionally one `vf.Harness` subclass through `__all__`. This happens automatically when you bootstrap a new taskset using `prime env init`.
+A package exports one `vf.Taskset` subclass and optionally one `vf.Harness` subclass through `__all__`. This happens automatically when you bootstrap a new taskset using `uv run init`.
 
 Do not add `load_environment()`, `load_taskset()`, or `load_harness()` functions. The v1 loader
 resolves classes and their config types from `__all__` and generic bases.


### PR DESCRIPTION
Updates `skills/create-environments/SKILL.md` to use the repo-local scaffold command `uv run init` (defined in `verifiers/v1/cli/init.py`) instead of `prime env init` in all 4 mentions (3 CLI examples + 1 prose reference).

The remaining `prime env init` references in `docs/v0/` are untouched since they describe the legacy v0 flow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an agent skill file; no runtime or API behavior is affected.
> 
> **Overview**
> Updates the **create-environments** skill so all bootstrap instructions point at the repo-local scaffold command **`uv run init`** instead of **`prime env init`**.
> 
> That covers the main “create a package” example, the `-T` / `-U` / `-H` flag examples, and the prose note that bootstrapping via the CLI sets up the native package contract automatically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86bb73a64a6266a979773afc2782ce5b912ae2d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update `create-environments` skill docs to use `uv run init` instead of `prime env init`
> Updates CLI examples and explanatory text in [SKILL.md](https://github.com/PrimeIntellect-ai/verifiers/pull/2057/files#diff-1697fb73db30ed7c1e5a0c48ad0e1205e3502967ba1d51da63a4292ae4c4fa3e) to replace `prime env init` with `uv run init` across all command blocks and the bootstrapping description.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 86bb73a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->