### PR TITLE
chore: update pinned harness versions

### DIFF
--- a/skills/evaluate-environments/references/REFERENCE.md
+++ b/skills/evaluate-environments/references/REFERENCE.md
@@ -301,7 +301,7 @@ Runs Harbor's tmux agent through LiteLLM.
 
 | Field | Type | Default | Notes |
 |---|---|---|---|
-| `version` | `str` | `"0.19.0"` | Harbor release to install, pinned. |
+| `version` | `str` | `"0.14.0"` | Harbor release to install, pinned. |
 
 #### `KimiCodeHarnessConfig` — `id: "kimi-code"`
 Installs the Kimi Code CLI and runs it headlessly.

--- a/skills/evaluate-environments/references/REFERENCE.md
+++ b/skills/evaluate-environments/references/REFERENCE.md
@@ -308,7 +308,7 @@ Installs the Kimi Code CLI and runs it headlessly.
 
 | Field | Type | Default | Notes |
 |---|---|---|---|
-| `version` | `str` | `"0.14.3"` | Kimi Code release to install, pinned. |
+| `version` | `str` | `"0.27.0"` | Kimi Code release to install, pinned. |
 
 ---
 

--- a/skills/evaluate-environments/references/REFERENCE.md
+++ b/skills/evaluate-environments/references/REFERENCE.md
@@ -277,7 +277,7 @@ Installs the Codex CLI into the runtime and runs `codex exec`.
 
 | Field | Type | Default | Notes |
 |---|---|---|---|
-| `version` | `str` | `"0.137.0"` | Codex release to install (the `rust-v<version>` GitHub release); pinned. |
+| `version` | `str` | `"0.144.5"` | Codex release to install (the `rust-v<version>` GitHub release); pinned. |
 
 #### `RLMHarnessConfig` — `id: "rlm"`
 Installs the rlm CLI and runs it. Knobs map onto `RLM_*` env vars; base `HarnessConfig.env` passes any other `RLM_*` var through verbatim.
@@ -294,14 +294,14 @@ Runs the native bash-tool agent through LiteLLM.
 
 | Field | Type | Default | Notes |
 |---|---|---|---|
-| `version` | `str` | `"2.2.8"` | mini-swe-agent release to install, pinned. |
+| `version` | `str` | `"2.4.5"` | mini-swe-agent release to install, pinned. |
 
 #### `Terminus2HarnessConfig` — `id: "terminus-2"`
 Runs Harbor's tmux agent through LiteLLM.
 
 | Field | Type | Default | Notes |
 |---|---|---|---|
-| `version` | `str` | `"0.14.0"` | Harbor release to install, pinned. |
+| `version` | `str` | `"0.19.0"` | Harbor release to install, pinned. |
 
 #### `KimiCodeHarnessConfig` — `id: "kimi-code"`
 Installs the Kimi Code CLI and runs it headlessly.

--- a/verifiers/v1/harnesses/claude_code/harness.py
+++ b/verifiers/v1/harnesses/claude_code/harness.py
@@ -21,7 +21,7 @@ curl -fsSL https://claude.ai/install.sh | HOME={home} bash -s {version}
 
 
 class ClaudeCodeHarnessConfig(HarnessConfig):
-    version: str = Field(default="2.1.207", pattern=r"^[A-Za-z0-9._+-]+$")
+    version: str = Field(default="2.1.214", pattern=r"^[A-Za-z0-9._+-]+$")
     """Claude Code release to install; pinned for reproducibility."""
 
 

--- a/verifiers/v1/harnesses/codex/harness.py
+++ b/verifiers/v1/harnesses/codex/harness.py
@@ -36,7 +36,7 @@ chmod +x {bin}
 
 
 class CodexHarnessConfig(HarnessConfig):
-    version: str = "0.137.0"
+    version: str = "0.144.5"
     """Codex release to install (the `rust-v<version>` GitHub release); pinned for reproducibility."""
     multi_agent: bool = False
     """Enable Codex's native multi-agent v2 tools."""

--- a/verifiers/v1/harnesses/kimi_code/harness.py
+++ b/verifiers/v1/harnesses/kimi_code/harness.py
@@ -32,7 +32,7 @@ env \
 
 
 class KimiCodeHarnessConfig(HarnessConfig):
-    version: str = "0.14.3"
+    version: str = "0.27.0"
     """Kimi Code release to install, pinned for reproducibility."""
 
 

--- a/verifiers/v1/harnesses/mini_swe_agent/harness.py
+++ b/verifiers/v1/harnesses/mini_swe_agent/harness.py
@@ -9,7 +9,7 @@ PROGRAM_SOURCE = (Path(__file__).resolve().parent / "program.py").read_text()
 
 
 class MiniSWEAgentHarnessConfig(HarnessConfig):
-    version: str = "2.2.8"
+    version: str = "2.4.5"
     """mini-swe-agent release to install, pinned for reproducibility."""
 
 

--- a/verifiers/v1/harnesses/mini_swe_agent/program.py
+++ b/verifiers/v1/harnesses/mini_swe_agent/program.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["mini-swe-agent=={version}"]
+# dependencies = ["mini-swe-agent=={version}", "litellm[proxy]"]
 # ///
 
 from minisweagent.run.mini import app

--- a/verifiers/v1/harnesses/pi/harness.py
+++ b/verifiers/v1/harnesses/pi/harness.py
@@ -87,7 +87,7 @@ export default async function isolatedMcp(pi) {{
 
 
 class PiHarnessConfig(HarnessConfig):
-    version: str = "0.80.6"
+    version: str = "0.80.10"
     """Pi release to install, pinned for reproducibility."""
 
 

--- a/verifiers/v1/harnesses/terminus_2/harness.py
+++ b/verifiers/v1/harnesses/terminus_2/harness.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 class Terminus2HarnessConfig(HarnessConfig):
-    version: str = "0.19.0"
+    version: str = "0.14.0"
     """Harbor release to install, pinned for reproducibility."""
 
 

--- a/verifiers/v1/harnesses/terminus_2/harness.py
+++ b/verifiers/v1/harnesses/terminus_2/harness.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 class Terminus2HarnessConfig(HarnessConfig):
-    version: str = "0.14.0"
+    version: str = "0.19.0"
     """Harbor release to install, pinned for reproducibility."""
 
 


### PR DESCRIPTION
## Summary

- Update the pinned v1 harness releases: Codex 0.144.5, Claude Code 2.1.214, Pi 0.80.10, mini-swe-agent 2.4.5, Harbor 0.19.0, and Kimi Code 0.27.0.
- Keep the existing evaluate-environments reference table defaults aligned with the harness implementations.
- Include LiteLLM's `proxy` extra in the mini-swe-agent PEP 723 script so its Responses API path has the runtime dependencies it imports.

This keeps newly provisioned agent harnesses on current upstream releases and gives mini-swe-agent the dependency set required by LiteLLM's proxy-backed request path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-pin and dependency-only changes with no auth or scoring logic touched; main risk is rollout behavior shifting with newer external agent CLIs when defaults are used.
> 
> **Overview**
> Bumps **default pinned releases** for several v1 agent harnesses so evals that rely on config defaults install newer upstream CLIs: **Codex** `0.144.5`, **Claude Code** `2.1.214`, **Pi** `0.80.10`, **mini-swe-agent** `2.4.5`, and **Kimi Code** `0.27.0`. Matching defaults in `skills/evaluate-environments/references/REFERENCE.md` are updated for Codex, mini-swe-agent, and Kimi.
> 
> For **mini-swe-agent**, the PEP 723 uv script now declares **`litellm[proxy]`** alongside `mini-swe-agent` so the LiteLLM-backed Responses/proxy import path has the extra runtime packages it needs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ea901d102eb8c1253ca243fa499c6be562aa5ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update default versions for Kimi Code, Codex, MiniSWEAgent, ClaudeCode, and Pi harnesses
> - Updates default versions across multiple harness configs: Kimi Code `0.14.3` → `0.27.0`, Codex `0.137.0` → `0.144.5`, MiniSWEAgent `2.2.8` → `2.4.5`, ClaudeCode `2.1.207` → `2.1.214`, Pi `0.80.6` → `0.80.10`.
> - Adds `litellm[proxy]` as a runtime dependency in [mini_swe_agent/program.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2064/files#diff-ed829d9d3aa931d8ed409e1e7a59bd3b04a9fa7c65836ad7285a9e0a0fdd4845) alongside the existing `mini-swe-agent` install.
> - Updates [REFERENCE.md](https://github.com/PrimeIntellect-ai/verifiers/pull/2064/files#diff-575f12fd01439aa9c1657a1d188a485753f75ba00d62a0006c7014b0ba7e5fad) to reflect the new default versions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ea901d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->