### PR TITLE
fix(v1): unblock env client waiters on close and receive death

### DIFF
--- a/verifiers/v1/serve/client.py
+++ b/verifiers/v1/serve/client.py
@@ -58,15 +58,42 @@ class EnvClient:
         if self._receiver is None:
             self._receiver = asyncio.create_task(self._receive_loop())
 
+    def _fail_pending(self, exc: BaseException | None = None) -> int:
+        """Unblock every in-flight waiter. `exc is None` cancels (close path);
+        otherwise each future gets a fresh copy of `exc` (receive-loop death).
+        Returns how many were still waiting."""
+        pending = list(self._pending.values())
+        self._pending.clear()
+        n = 0
+        for future in pending:
+            if future.done():
+                continue
+            n += 1
+            if exc is None:
+                future.cancel()
+            else:
+                # Fresh instance per future — asyncio mutates the exception object.
+                future.set_exception(type(exc)(str(exc)))
+        return n
+
     async def _receive_loop(self) -> None:
-        while True:
-            try:
-                request_id_bytes, data = await self.socket.recv_multipart()
-            except asyncio.CancelledError:
-                break
-            future = self._pending.pop(request_id_bytes.decode(), None)
-            if future is not None and not future.done():
-                future.set_result(data)
+        try:
+            while True:
+                try:
+                    request_id_bytes, data = await self.socket.recv_multipart()
+                except asyncio.CancelledError:
+                    break
+                except zmq.ZMQError as e:
+                    logger.error("ZMQ error in env client receive loop (%s)", e)
+                    self._fail_pending(RuntimeError(f"env client ZMQ error: {e}"))
+                    break
+                future = self._pending.pop(request_id_bytes.decode(), None)
+                if future is not None and not future.done():
+                    future.set_result(data)
+        finally:
+            # Anything still waiting after the loop exits has no path to a reply.
+            if self._pending:
+                self._fail_pending(RuntimeError("env client receive loop stopped"))
 
     async def _request(
         self,
@@ -169,6 +196,11 @@ class EnvClient:
         return response.traces
 
     async def close(self) -> None:
+        # Cancel waiters before stopping the receiver so they see CancelledError
+        # (not the receive-loop RuntimeError). Matches legacy ZMQEnvClient.close.
+        n = self._fail_pending()
+        if n:
+            logger.info("cancelled %d pending env client request(s) on close", n)
         if self._receiver is not None:
             self._receiver.cancel()
             with contextlib.suppress(asyncio.CancelledError):


### PR DESCRIPTION
## Description

v1 `EnvClient` only resolved a pending future when a reply arrived. `close()` stopped the receive loop and tore down the socket without touching `_pending`, and a ZMQ error in the receive loop just broke out of the loop. Any in-flight `run_rollout` / `run_group` / `info` waiter then hung until an outer timeout (rollouts have none).

Legacy `ZMQEnvClient` already cancels pending requests on close and on socket death. This brings the v1 client in line:

- `close()` cancels outstanding waiters before stopping the receiver (so they see `CancelledError`, not a late receive-loop error)
- a ZMQ error in the receive loop fails remaining waiters with an explicit error
- if the receive loop exits for any other reason, leftover waiters are failed so nothing is stranded

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing

- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

Focused checks (no permanent unit tests, per AGENTS.md):

- close with multiple pending futures -> all cancelled
- receive-loop ZMQ error with multiple pending futures -> each gets its own RuntimeError
- in-flight `_request` cancelled promptly when `close()` runs mid-wait
- `uv run ruff check verifiers/v1/serve/client.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized asyncio/ZMQ client lifecycle fix with no auth, data, or API contract changes; behavior matches the existing legacy client.
> 
> **Overview**
> Fixes a hang in v1 **`EnvClient`** where in-flight `run_rollout` / `run_group` / `info` calls could wait forever because **`_pending` futures were only completed on a matching reply**, not when the socket or receive loop died.
> 
> Adds **`_fail_pending`** to clear waiters: **`close()`** cancels them first (so callers get **`CancelledError`**, aligned with legacy **`ZMQEnvClient`**), **`zmq.ZMQError`** in the receive loop fails each with its own **`RuntimeError`**, and a **`finally`** block fails any stragglers if the loop exits for any other reason.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2fec35774efde8d7d1cc0bb7bdd7466e4d34fa7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fail pending `EnvClient` waiters on `close` and receive-loop death
> - Adds `_fail_pending` helper to [client.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2066/files#diff-ef98a21052536967b8f8723e36022f69e539f4e8b13794791e8254434ac4696e) that cancels or assigns a supplied exception to every pending response future, skipping already-complete ones
> - Receive loop now fails all pending requests with `RuntimeError` when a ZMQ receive error occurs or the loop exits without replies
> - `close` fails pending waiters before cancelling the receiver task so shutdown-initiated waiters observe `CancelledError` rather than the receiver-loop failure exception
> - Behavioral Change: in-flight `EnvClient` request waiters now complete with `CancelledError` on `close` and `RuntimeError` on receive-loop failure instead of remaining pending indefinitely
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8c038e2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->