### PR TITLE
fix(v1): derive num_input_tokens from the final call so it can't go negative

### DIFF
--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -238,9 +238,7 @@ class Branch(StrictBaseModel):
 
     @property
     def num_total_tokens(self) -> int:
-        """Final sequence length: the last call's prompt + completion. Earlier turns' context
-        is already contained in that prompt, so re-sent tokens are counted once rather than
-        summed per turn."""
+        """Total tokens reported for the final model call."""
         last = self.last_usage
         return last.total_tokens if last is not None else 0
 

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -252,10 +252,9 @@ class Branch(StrictBaseModel):
 
     @property
     def num_input_tokens(self) -> int:
-        """Tokens fed to the model, counted once: the final sequence minus everything the model
-        generated (i.e. system + user + tool inputs). Not the last prompt — re-sent context is
-        not double-counted."""
-        return self.num_total_tokens - self.num_output_tokens
+        """Tokens fed in the final model call, including its full re-sent context."""
+        last = self.last_usage
+        return last.input_tokens if last is not None else 0
 
 
 _NODE_DUMP_EXCLUDE: dict = {


### PR DESCRIPTION
## Description

`Branch.num_input_tokens` can go negative on any multi-turn trace, which silently disables the `max_input_tokens` cap. It is defined as `num_total_tokens - num_output_tokens`. `num_total_tokens` is the final call's total, but `num_output_tokens` sums completions from every call. Once a rollout has more than one turn, the summed output exceeds the final total and the difference is negative. A cap check of `num_input_tokens >= max_input_tokens` then never fires.

This has been latent since #2040 made the counts usage-based; that change kept the subtraction. It follows up on #2021, which fixed the zero fallback but was closed in favour of #2040.

The fix: `num_input_tokens` returns `last_usage.input_tokens` (zero when no call has usage). That is the tokens fed to the final call, its full re-sent context counted once — the measure `max_input_tokens` is meant to bound.

One thing worth a maintainer's eye. #2040 aimed for `input + output == total`. That equality cannot hold while `num_total_tokens` is the final sequence length and `num_output_tokens` sums generation across turns — the two use different frames, which is why input went negative. The three caps measure different things: `max_input_tokens` bounds the prompt, `max_output_tokens` bounds all generated tokens, `max_total_tokens` bounds the final footprint. This change keeps each cap meaningful and drops the reconciliation identity. The alternative is to derive all three from aggregated usage, but that double-counts re-sent context in input and total — the overcount both review bots flagged on #2021. I went with the final-sequence frame the docstrings already describe. Happy to switch if you prefer strict reconciliation.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

Validation performed:
- focused repro proof: `total 5 output 21 input -16` became `total 5 output 21 input 4`
- `uv run ruff check --fix .` — passed
- `uv run pytest tests/v1/` — 63 passed, 144 skipped because they require `PRIME_API_KEY`

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

`verifiers/v1/push.py` continues to use raw branch usage for pushed token counts. This change affects the derived trace/session accounting properties.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `Branch.num_input_tokens` to read directly from the final model call instead of deriving it
> Previously, `num_input_tokens` was computed as `num_total_tokens - num_output_tokens`, which could produce negative values. It now reads `input_tokens` directly from the final model call's usage data, returning 0 if absent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b3c20f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout limit enforcement and dashboard/push accounting derived from `num_input_tokens`, though behavior aligns with how `max_input_tokens` is documented to work.
> 
> **Overview**
> **Fixes `Branch.num_input_tokens` going negative on multi-turn traces**, which could prevent the framework `max_input_tokens` cap from firing.
> 
> Instead of `num_total_tokens - num_output_tokens` (final-call total minus completions summed across every turn), **`num_input_tokens` now reads `last_usage.input_tokens`** — the provider-reported prompt size for the last model call, including re-sent context counted once. Docstrings on `num_total_tokens` and `num_input_tokens` are tightened to match that framing; **`input + output == total` is no longer implied** because output still aggregates all turns while total/input stay on the final call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3c20f433820ba80fe12f8a0951bda32a9cc41d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->