### PR TITLE
fix(v1): serialize env-server replies inside the request error boundary

### DIFF
--- a/verifiers/v1/serve/server.py
+++ b/verifiers/v1/serve/server.py
@@ -163,16 +163,21 @@ class EnvServer:
                 response = BaseResponse(
                     success=False, error=f"unknown method {route!r}"
                 )
+            data = msgpack.packb(
+                response.model_dump(mode="python"),
+                default=msgpack_encoder,
+                use_bin_type=True,
+            )
         except (
             Exception
         ) as e:  # a failed request is data, not a crash — report and keep serving
             logger.warning("request failed: %s", e, exc_info=True)
             response = BaseResponse(success=False, error=f"{type(e).__name__}: {e}")
-        data = msgpack.packb(
-            response.model_dump(mode="python"),
-            default=msgpack_encoder,
-            use_bin_type=True,
-        )
+            data = msgpack.packb(
+                response.model_dump(mode="python"),
+                default=msgpack_encoder,
+                use_bin_type=True,
+            )
         try:
             # Let ZMQ retain the packed response instead of copying large traces.
             await self.frontend.send_multipart(


### PR DESCRIPTION
## Description

The env-server request handler encoded its response after the request error boundary. If `msgpack.packb` failed on a response payload, the `TypeError` escaped instead of becoming a reply, which could terminate request handling.

Response encoding now runs inside the request `try` block. If encoding fails, the handler sends a minimal `BaseResponse(success=False, error=...)` response without including the offending payload.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

Validation performed:
- focused repro proof: a serialization `TypeError` produces an encoded `success=False` reply instead of escaping `_handle`
- `uv run ruff check --fix .` — passed
- `uv run pytest tests/test_env_server.py` — 15 passed

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

The fallback error response is intentionally minimal and does not attempt to serialize the failed response object again.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix serialization errors in `EnvServer` reply handler to return error responses instead of bubbling
> Moves `msgpack.packb` serialization inside the try/except block in [server.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2070/files#diff-64422f6a8749fcc024415b2756129bc98000e830e74b3b5245de50a555480a22) so that exceptions during serialization on the success path are caught and converted into a serialized error `BaseResponse`, rather than propagating out of the handler.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0e7f756.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small control-flow change in the env-server reply path; improves robustness without altering rollout or auth behavior.
> 
> **Overview**
> **EnvServer** request handling now runs successful-path `msgpack.packb` encoding inside the same `try`/`except` that already wraps routing and rollout logic.
> 
> Previously, a serialization failure (e.g. `TypeError` from an unencodable trace) happened after that boundary and could escape `_handle` instead of returning a wire reply. Failures on either the success or error path are now packed into a minimal `BaseResponse(success=False, …)` and still sent over ZMQ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e7f756409ebd455dd27f56ba0a1f1b721439b1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->