### PR TITLE
fix(v1): guard the pool health reply so a departed client can't crash the pool

### DIFF
--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -195,9 +195,10 @@ class EnvServerPool:
                         payload,
                     ) = await self.frontend.recv_multipart()
                     if method == b"health":
-                        await self.frontend.send_multipart(
-                            [client_id, request_id, _HEALTH]
-                        )
+                        with contextlib.suppress(zmq.ZMQError):
+                            await self.frontend.send_multipart(
+                                [client_id, request_id, _HEALTH]
+                            )
                     else:
                         # Pool capacity is measured in rollouts; one group request carries n.
                         rollout_slots = 1


### PR DESCRIPTION
## Description

Under `ROUTER_MANDATORY=1`, the pool's inline health reply can race with a client disconnect. The unguarded `send_multipart` then raises `zmq.ZMQError` while handling a health request.

The health send now uses the same `contextlib.suppress(zmq.ZMQError)` protection as the worker reply path. PR #1993 rewrites `run()`, but it does not guard this specific inline health send, so this change remains needed alongside that coordination work.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

Validation performed:
- focused repro proof: source inspection confirms the health send is now inside `contextlib.suppress(zmq.ZMQError)`; the in-process ZMQ repro continues to accept the send because it does not reproduce a departed client
- `uv run ruff check --fix .` — passed
- `uv run pytest tests/test_env_server.py` — 15 passed

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

This change only guards the inline health reply. The broader pool lifecycle rewrite is tracked separately in #1993.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard pool health reply against crashed clients in `EnvServerPool` broker loop
> Wraps the health response send path in `contextlib.suppress(zmq.ZMQError)` in [pool.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2071/files#diff-0c9c59578214be2580d340bc524321e352f48038207a68945637d00fc399600c) so that a departed or crashed client can no longer raise an unhandled `ZMQError` and crash the broker loop. The broker now silently drops the response and continues running.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7632f2d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line defensive error handling on an existing ZMQ send path; no protocol or capacity behavior changes.
> 
> **Overview**
> With **`ROUTER_MANDATORY=1`**, replying to a **health** check on the pool frontend can raise **`zmq.ZMQError`** if the client disconnects before the send completes, which previously could take down the broker loop.
> 
> The inline health **`send_multipart`** in `EnvServerPool.run()` is now wrapped in **`contextlib.suppress(zmq.ZMQError)`**, matching the existing worker reply path so a gone client drops the response and the pool keeps polling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7632f2da5bf88481462727a6c1c26ed4a8b24398. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->