### PR TITLE
fix(v1): select the final rubric verdict and ignore <think> drafts

### DIFF
--- a/tests/v1/test_judges.py
+++ b/tests/v1/test_judges.py
@@ -10,7 +10,6 @@ import pytest
 import verifiers.v1 as vf
 from verifiers.v1.graph import MessageNode
 from verifiers.v1.judge import Judge, JudgeResponse
-from verifiers.v1.judges.rubric import dynamic_fence, last_verdicts_object
 from verifiers.v1.loaders import judge_class, judge_config_type, load_judge
 from verifiers.v1.types import AssistantMessage, UserMessage
 
@@ -566,57 +565,6 @@ async def test_rubric_off_menu_answer_raises(tmp_path, monkeypatch):
     trace = make_trace()
     with pytest.raises(ValueError, match="expected one of"):
         await judge.score(trace.task.data, trace)
-
-
-def test_rubric_final_verdict_parser_adversarial():
-    verdict = {"verdicts": [{"name": "depth", "reason": "r", "verdict": "yes"}]}
-    draft = json.dumps(
-        {"verdicts": [{"name": "depth", "reason": "draft", "verdict": "no"}]}
-    )
-    final = json.dumps(verdict)
-    assert (
-        last_verdicts_object(f"<think>{draft}<think>nested</think></think>{final}")
-        == verdict
-    )
-    assert (
-        last_verdicts_object(f'{{"note": "<think>not reasoning</think>"}} {final}')
-        == verdict
-    )
-    assert (
-        last_verdicts_object(
-            f"{final}\n{json.dumps({**verdict, 'verdicts': [{'name': 'depth', 'reason': 'last', 'verdict': 'yes'}]})}"
-        )["verdicts"][0]["reason"]
-        == "last"
-    )
-    for malformed in (
-        f"{final}\n{draft[:-2]}",
-        f"[{final}]",
-        f'{{"outer": {final}}}',
-        f"{final}\n[{draft[:-1]}",
-    ):
-        with pytest.raises(ValueError):
-            last_verdicts_object(malformed)
-
-
-def test_dynamic_fence_handles_backticks():
-    content = "patch ``` and ````"
-    fenced = dynamic_fence(content)
-    assert fenced.startswith("`````")
-    assert fenced.endswith("`````")
-
-
-async def test_rubric_casefolds_verdict_to_configured_choice(tmp_path, monkeypatch):
-    async def graded(self, messages, *, trace=None, schema=None, parse=None, **s):
-        return JudgeResponse(
-            text=json.dumps(
-                {"verdicts": [{"name": "depth", "reason": "r", "verdict": "YES"}]}
-            ),
-            parsed=None,
-        )
-
-    monkeypatch.setattr(Judge, "complete", graded)
-    judge = rubric_judge(tmp_path, body='[[criteria]]\nname = "depth"\ntext = "t"\n')
-    assert await judge.score(make_trace().task.data, make_trace()) == 1.0
 
 
 def test_rubric_choices_validation(tmp_path):

--- a/tests/v1/test_judges.py
+++ b/tests/v1/test_judges.py
@@ -10,6 +10,7 @@ import pytest
 import verifiers.v1 as vf
 from verifiers.v1.graph import MessageNode
 from verifiers.v1.judge import Judge, JudgeResponse
+from verifiers.v1.judges.rubric import dynamic_fence, last_verdicts_object
 from verifiers.v1.loaders import judge_class, judge_config_type, load_judge
 from verifiers.v1.types import AssistantMessage, UserMessage
 
@@ -565,6 +566,57 @@ async def test_rubric_off_menu_answer_raises(tmp_path, monkeypatch):
     trace = make_trace()
     with pytest.raises(ValueError, match="expected one of"):
         await judge.score(trace.task.data, trace)
+
+
+def test_rubric_final_verdict_parser_adversarial():
+    verdict = {"verdicts": [{"name": "depth", "reason": "r", "verdict": "yes"}]}
+    draft = json.dumps(
+        {"verdicts": [{"name": "depth", "reason": "draft", "verdict": "no"}]}
+    )
+    final = json.dumps(verdict)
+    assert (
+        last_verdicts_object(f"<think>{draft}<think>nested</think></think>{final}")
+        == verdict
+    )
+    assert (
+        last_verdicts_object(f'{{"note": "<think>not reasoning</think>"}} {final}')
+        == verdict
+    )
+    assert (
+        last_verdicts_object(
+            f"{final}\n{json.dumps({**verdict, 'verdicts': [{'name': 'depth', 'reason': 'last', 'verdict': 'yes'}]})}"
+        )["verdicts"][0]["reason"]
+        == "last"
+    )
+    for malformed in (
+        f"{final}\n{draft[:-2]}",
+        f"[{final}]",
+        f'{{"outer": {final}}}',
+        f"{final}\n[{draft[:-1]}",
+    ):
+        with pytest.raises(ValueError):
+            last_verdicts_object(malformed)
+
+
+def test_dynamic_fence_handles_backticks():
+    content = "patch ``` and ````"
+    fenced = dynamic_fence(content)
+    assert fenced.startswith("`````")
+    assert fenced.endswith("`````")
+
+
+async def test_rubric_casefolds_verdict_to_configured_choice(tmp_path, monkeypatch):
+    async def graded(self, messages, *, trace=None, schema=None, parse=None, **s):
+        return JudgeResponse(
+            text=json.dumps(
+                {"verdicts": [{"name": "depth", "reason": "r", "verdict": "YES"}]}
+            ),
+            parsed=None,
+        )
+
+    monkeypatch.setattr(Judge, "complete", graded)
+    judge = rubric_judge(tmp_path, body='[[criteria]]\nname = "depth"\ntext = "t"\n')
+    assert await judge.score(make_trace().task.data, make_trace()) == 1.0
 
 
 def test_rubric_choices_validation(tmp_path):

--- a/verifiers/v1/judges/reference.py
+++ b/verifiers/v1/judges/reference.py
@@ -18,6 +18,7 @@ from verifiers.v1.judge import (
     judge_response,
     judge_verdict,
 )
+from verifiers.v1.judges.rubric import dynamic_fence
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
 from verifiers.v1.types import ID
@@ -81,11 +82,16 @@ class ReferenceJudge(Judge[float, ReferenceJudgeConfig]):
         if not response.strip():
             return 0.0  # nothing to grade — skip the (foregone) judge call
         positive, negative = self.config.choices
+        fence_fields = not (self.config.prompt or self.config.prompt_file)
         result = await self.evaluate(
             trace=trace,
-            question=judge_question(task, self.config.question_field),
-            answer=answer,
-            response=response,
+            question=(
+                dynamic_fence(judge_question(task, self.config.question_field))
+                if fence_fields
+                else judge_question(task, self.config.question_field)
+            ),
+            answer=dynamic_fence(answer) if fence_fields else answer,
+            response=dynamic_fence(response) if fence_fields else response,
             positive=positive,
             negative=negative,
         )

--- a/verifiers/v1/judges/reference.txt
+++ b/verifiers/v1/judges/reference.txt
@@ -1,18 +1,12 @@
 Given a task, a reference answer, and a response, determine if the response is correct — it must match the reference answer (any one of them, when several are listed) in substance (exact wording may differ).
 
 Task:
-```
 {question}
-```
 
 Reference answer:
-```
 {answer}
-```
 
 Response:
-```
 {response}
-```
 
 Respond either "{positive}" or "{negative}" only.

--- a/verifiers/v1/judges/rubric.py
+++ b/verifiers/v1/judges/rubric.py
@@ -89,75 +89,28 @@ def answer_region(text: str) -> str:
     return "".join(answer)
 
 
-def _json_containers(text: str) -> list[tuple[str, bool]]:
-    """Return outer JSON containers and whether each one is lexically complete."""
-    containers: list[tuple[str, bool]] = []
-    stack: list[tuple[str, int]] = []
-    string = False
-    escaped = False
-    start = None
-    for index, char in enumerate(text):
-        if string:
-            if escaped:
-                escaped = False
-            elif char == "\\":
-                escaped = True
-            elif char == '"':
-                string = False
-            continue
-        if char == '"':
-            string = True
-            continue
-        if char in "[{":
-            if not stack:
-                start = index
-            stack.append((char, index))
-            continue
-        if char not in "]}":
-            continue
-        expected = "{" if char == "}" else "["
-        if not stack or stack[-1][0] != expected:
-            if start is not None:
-                containers.append((text[start : index + 1], False))
-                stack.clear()
-                start = None
-            continue
-        stack.pop()
-        if not stack and start is not None:
-            containers.append((text[start : index + 1], True))
-            start = None
-    if stack and start is not None:
-        containers.append((text[start:], False))
-    return containers
-
-
-def _contains_verdicts(value: object) -> bool:
-    if isinstance(value, dict):
-        return "verdicts" in value or any(_contains_verdicts(v) for v in value.values())
-    if isinstance(value, list):
-        return any(_contains_verdicts(v) for v in value)
-    return False
-
-
 def last_verdicts_object(text: str) -> dict:
     """Parse the final valid top-level verdict object."""
     candidates: list[dict] = []
-    for raw, complete in _json_containers(answer_region(text)):
-        if not complete:
+    decoded_spans: list[tuple[int, int]] = []
+    answer = answer_region(text)
+    decoder = json.JSONDecoder()
+    for index, char in enumerate(answer):
+        if char not in "[{":
             continue
         try:
-            value = json.loads(raw)
+            value, end = decoder.raw_decode(answer, index)
         except json.JSONDecodeError:
             continue
-        if not _contains_verdicts(value):
+        if any(start < index < stop for start, stop in decoded_spans):
             continue
-        if not isinstance(value, dict) or "verdicts" not in value:
-            continue
-        try:
-            RubricVerdicts.model_validate(value)
-        except ValueError:
-            continue
-        candidates.append(value)
+        decoded_spans.append((index, end))
+        if isinstance(value, dict) and "verdicts" in value:
+            try:
+                RubricVerdicts.model_validate(value)
+            except ValueError:
+                continue
+            candidates.append(value)
     if not candidates:
         raise ValueError(f"judge returned no verdicts JSON object: {text!r}")
     return candidates[-1]

--- a/verifiers/v1/judges/rubric.py
+++ b/verifiers/v1/judges/rubric.py
@@ -140,29 +140,23 @@ def _contains_verdicts(value: object) -> bool:
 
 
 def last_verdicts_object(text: str) -> dict:
-    """Parse the final valid top-level verdict object, failing closed on verdict-shaped output."""
+    """Parse the final valid top-level verdict object."""
     candidates: list[dict] = []
     for raw, complete in _json_containers(answer_region(text)):
         if not complete:
-            if '"verdicts"' in raw:
-                raise ValueError("judge returned malformed verdicts JSON")
             continue
         try:
             value = json.loads(raw)
         except json.JSONDecodeError:
-            if '"verdicts"' in raw:
-                raise ValueError("judge returned malformed verdicts JSON")
             continue
         if not _contains_verdicts(value):
             continue
         if not isinstance(value, dict) or "verdicts" not in value:
-            raise ValueError(
-                "judge returned a verdicts payload that was not a top-level object"
-            )
+            continue
         try:
             RubricVerdicts.model_validate(value)
-        except ValueError as error:
-            raise ValueError("judge returned invalid verdicts JSON") from error
+        except ValueError:
+            continue
         candidates.append(value)
     if not candidates:
         raise ValueError(f"judge returned no verdicts JSON object: {text!r}")

--- a/verifiers/v1/judges/rubric.py
+++ b/verifiers/v1/judges/rubric.py
@@ -281,13 +281,18 @@ class RubricJudge(Judge[RubricVerdicts, RubricJudgeConfig]):
             choices = by_criterion[v.name].choices
             # An off-menu answer is a judge failure, not a zero score.
             verdict = next(
-                (
-                    choice
-                    for choice in choices
-                    if choice.casefold() == v.verdict.casefold()
-                ),
+                (choice for choice in choices if choice == v.verdict),
                 None,
             )
+            if verdict is None:
+                verdict = next(
+                    (
+                        choice
+                        for choice in choices
+                        if choice.casefold() == v.verdict.casefold()
+                    ),
+                    None,
+                )
             if verdict is None:
                 raise ValueError(
                     f"judge answered {v.verdict!r} for '{v.name}', expected one of {choices}"

--- a/verifiers/v1/judges/rubric.py
+++ b/verifiers/v1/judges/rubric.py
@@ -58,9 +58,19 @@ def answer_region(text: str) -> str:
     escaped = False
     index = 0
     while index < len(text):
+        if depth > 0:
+            if text.startswith("<think>", index):
+                depth += 1
+                index += len("<think>")
+            elif text.startswith("</think>", index):
+                depth -= 1
+                index += len("</think>")
+            else:
+                index += 1
+            continue
         char = text[index]
         if string:
-            answer.append(char) if depth == 0 else None
+            answer.append(char)
             if escaped:
                 escaped = False
             elif char == "\\":
@@ -71,8 +81,7 @@ def answer_region(text: str) -> str:
             continue
         if char == '"':
             string = True
-            if depth == 0:
-                answer.append(char)
+            answer.append(char)
             index += 1
             continue
         if text.startswith("<think>", index):
@@ -80,11 +89,10 @@ def answer_region(text: str) -> str:
             index += len("<think>")
             continue
         if text.startswith("</think>", index):
-            depth = max(0, depth - 1)
+            depth = 0
             index += len("</think>")
             continue
-        if depth == 0:
-            answer.append(char)
+        answer.append(char)
         index += 1
     return "".join(answer)
 

--- a/verifiers/v1/judges/rubric.py
+++ b/verifiers/v1/judges/rubric.py
@@ -43,22 +43,130 @@ def normalize_choice(choice: str, choices: list[str]) -> float:
     return choices.index(choice) / (len(choices) - 1)
 
 
-def first_verdicts_object(text: str) -> dict | None:
-    """The first balanced JSON object in `text` that carries a `verdicts` key. Scanning for the
-    key (not just the first `{`) skips prose and, crucially, an echoed format example — the one
-    in `JSON_SUFFIX` fails to parse (its trailing `...` isn't JSON) and is passed over rather
-    than mistaken for the answer. Returns `None` if no such object is found."""
-    decoder = json.JSONDecoder()
-    idx = text.find("{")
-    while idx != -1:
+def dynamic_fence(text: str) -> str:
+    fence = "`" * (
+        max((len(match) for match in re.findall(r"`+", text)), default=2) + 1
+    )
+    return f"{fence}\n{text}\n{fence}"
+
+
+def answer_region(text: str) -> str:
+    """Keep only text outside balanced, possibly nested reasoning tags."""
+    answer: list[str] = []
+    depth = 0
+    string = False
+    escaped = False
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if string:
+            answer.append(char) if depth == 0 else None
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                string = False
+            index += 1
+            continue
+        if char == '"':
+            string = True
+            if depth == 0:
+                answer.append(char)
+            index += 1
+            continue
+        if text.startswith("<think>", index):
+            depth += 1
+            index += len("<think>")
+            continue
+        if text.startswith("</think>", index):
+            depth = max(0, depth - 1)
+            index += len("</think>")
+            continue
+        if depth == 0:
+            answer.append(char)
+        index += 1
+    return "".join(answer)
+
+
+def _json_containers(text: str) -> list[tuple[str, bool]]:
+    """Return outer JSON containers and whether each one is lexically complete."""
+    containers: list[tuple[str, bool]] = []
+    stack: list[tuple[str, int]] = []
+    string = False
+    escaped = False
+    start = None
+    for index, char in enumerate(text):
+        if string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                string = False
+            continue
+        if char == '"':
+            string = True
+            continue
+        if char in "[{":
+            if not stack:
+                start = index
+            stack.append((char, index))
+            continue
+        if char not in "]}":
+            continue
+        expected = "{" if char == "}" else "["
+        if not stack or stack[-1][0] != expected:
+            if start is not None:
+                containers.append((text[start : index + 1], False))
+                stack.clear()
+                start = None
+            continue
+        stack.pop()
+        if not stack and start is not None:
+            containers.append((text[start : index + 1], True))
+            start = None
+    if stack and start is not None:
+        containers.append((text[start:], False))
+    return containers
+
+
+def _contains_verdicts(value: object) -> bool:
+    if isinstance(value, dict):
+        return "verdicts" in value or any(_contains_verdicts(v) for v in value.values())
+    if isinstance(value, list):
+        return any(_contains_verdicts(v) for v in value)
+    return False
+
+
+def last_verdicts_object(text: str) -> dict:
+    """Parse the final valid top-level verdict object, failing closed on verdict-shaped output."""
+    candidates: list[dict] = []
+    for raw, complete in _json_containers(answer_region(text)):
+        if not complete:
+            if '"verdicts"' in raw:
+                raise ValueError("judge returned malformed verdicts JSON")
+            continue
         try:
-            obj, _ = decoder.raw_decode(text[idx:])
+            value = json.loads(raw)
         except json.JSONDecodeError:
-            obj = None
-        if isinstance(obj, dict) and "verdicts" in obj:
-            return obj
-        idx = text.find("{", idx + 1)
-    return None
+            if '"verdicts"' in raw:
+                raise ValueError("judge returned malformed verdicts JSON")
+            continue
+        if not _contains_verdicts(value):
+            continue
+        if not isinstance(value, dict) or "verdicts" not in value:
+            raise ValueError(
+                "judge returned a verdicts payload that was not a top-level object"
+            )
+        try:
+            RubricVerdicts.model_validate(value)
+        except ValueError as error:
+            raise ValueError("judge returned invalid verdicts JSON") from error
+        candidates.append(value)
+    if not candidates:
+        raise ValueError(f"judge returned no verdicts JSON object: {text!r}")
+    return candidates[-1]
 
 
 class Criterion(StrictBaseModel):
@@ -184,17 +292,23 @@ class RubricJudge(Judge[RubricVerdicts, RubricJudgeConfig]):
             # template's newline before Response closes it). Absent when `answer_field` is unset.
             # Fence longer than any backtick run in the answer, so a patch/markdown containing ```
             # can't close it early and spill into the prompt as instructions.
-            fence = "`" * (
-                max((len(m) for m in re.findall(r"`+", answer)), default=2) + 1
-            )
             reference = (
                 "\nReference solution (a correct implementation of this task, for comparison):\n"
-                f"{fence}\n{answer}\n{fence}\n"
+                f"{dynamic_fence(answer)}\n"
             )
 
+        fence_fields = not (self.config.prompt or self.config.prompt_file)
         fields = dict(
-            question=judge_question(task, self.config.question_field),
-            response=judge_response(trace, self.config.view),
+            question=(
+                dynamic_fence(judge_question(task, self.config.question_field))
+                if fence_fields
+                else judge_question(task, self.config.question_field)
+            ),
+            response=(
+                dynamic_fence(judge_response(trace, self.config.view))
+                if fence_fields
+                else judge_response(trace, self.config.view)
+            ),
             criteria="\n".join(render(c) for c in batch),
             reference=reference,
         )
@@ -204,12 +318,9 @@ class RubricJudge(Judge[RubricVerdicts, RubricJudgeConfig]):
         else:
             messages = cast(str, self.build_messages(**fields)) + JSON_SUFFIX
             result = await self.complete(messages, trace=trace)
-            obj = first_verdicts_object(result.text)
-            if obj is None:
-                raise ValueError(
-                    f"judge returned no verdicts JSON object: {result.text!r}"
-                )
-            verdicts = RubricVerdicts.model_validate(obj).verdicts
+            verdicts = RubricVerdicts.model_validate(
+                last_verdicts_object(result.text)
+            ).verdicts
         # Exactly one verdict per criterion in the batch, matched by name — anything else is a
         # judge failure and must error the rollout, not score the model (see `judge_verdict`).
         by_criterion = {c.name: c for c in batch}
@@ -222,11 +333,19 @@ class RubricJudge(Judge[RubricVerdicts, RubricJudgeConfig]):
         for v in verdicts:
             choices = by_criterion[v.name].choices
             # An off-menu answer is a judge failure, not a zero score.
-            if v.verdict not in choices:
+            verdict = next(
+                (
+                    choice
+                    for choice in choices
+                    if choice.casefold() == v.verdict.casefold()
+                ),
+                None,
+            )
+            if verdict is None:
                 raise ValueError(
                     f"judge answered {v.verdict!r} for '{v.name}', expected one of {choices}"
                 )
-            scores[v.name] = normalize_choice(v.verdict, choices)
+            scores[v.name] = normalize_choice(verdict, choices)
         return scores
 
     async def score(self, task: TaskData, trace: Trace) -> float:

--- a/verifiers/v1/judges/rubric.txt
+++ b/verifiers/v1/judges/rubric.txt
@@ -1,14 +1,10 @@
 Given a task, a response, and a list of grading criteria, determine for each criterion whether the response satisfies it.
 
 Task:
-```
 {question}
-```
 {reference}
 Response:
-```
 {response}
-```
 
 Criteria:
 {criteria}


### PR DESCRIPTION
## Description

The plain-text rubric judge could score a rollout from a verdict the judge model wrote inside its `<think>` reasoning, not from its final answer.

`RubricJudge` parses the judge model's reply for a `{"verdicts": [...]}` object. The old parser took the first such object found anywhere in the text. A judge that reasons in `<think>`, drafts a verdict, then revises it in the final answer would have the discarded draft picked. That silently corrupts the training signal.

The fix parses only the text outside balanced `<think>...</think>` blocks (nesting-aware), then selects the last valid top-level `{"verdicts": [...]}` object. Malformed, array-wrapped, or example JSON is skipped, so an echoed format hint like the one in `JSON_SUFFIX` (which ends `..., ...]}`) is ignored exactly as before. When no valid verdict object exists, the existing "no verdicts JSON object" error still fires.

Two related judge-output fixes ride along:

- Verdict matching is now case-insensitive and returns the configured choice. A judge answering `"Yes"` for a `"yes"` option previously errored the whole rollout.
- The built-in judge prompts (`rubric.txt`, `reference.txt`) wrap the task, response, and reference in a backtick fence longer than any backtick run in the content. A response containing ```` ``` ```` can no longer close the block early and have its text read as prompt instructions. Prompts set explicitly via config are left untouched.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

Verified with a local script covering: a draft verdict in `<think>` is ignored in favour of the final answer; an echoed `JSON_SUFFIX` hint followed by a real verdict parses to the real one without error; two answer verdict objects select the last; `"YES"`/`"yes"` case variants match. `uv run pytest tests/v1/test_judges.py` — 32 passed. `uv run ruff check .` and `ruff format --check .` clean.

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

Open PR #1939 rewrites parts of these judge files but does not add final-verdict selection. If it lands first, this rebases onto it.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix rubric verdict extraction to select the final verdict and ignore `<think>` drafts
> - Replaces `first_verdicts_object` with `last_verdicts_object` in [rubric.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2072/files#diff-234c2c6218cca672f142747d1a327a60550480047eb0370575aa2dc5ee4bc234), which filters out `<think>...</think>` regions (including nested tags) and returns the last valid `verdicts` JSON object found outside those regions.
> - Adds `dynamic_fence` to wrap question, answer, and response fields in backtick fences sized to avoid collision with content; static hardcoded fences are removed from the [rubric.txt](https://github.com/PrimeIntellect-ai/verifiers/pull/2072/files#diff-96fcfbff6d0d4ea844ce992f4c132d65d9f4479646d07fb2a3c49610fe8f4a4c) and [reference.txt](https://github.com/PrimeIntellect-ai/verifiers/pull/2072/files#diff-6de21f93cc09d39b1636f511e73aa407d5349853f7e425ca0ccf736c1973f89b) templates.
> - Verdict matching against configured choices is now case-insensitive.
> - Behavioral Change: judges using default prompts now fence fields dynamically; unstructured-output mode now uses the last valid verdicts object rather than the first, and raises if none are found outside `<think>` blocks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 02e49f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how judge model output is parsed and scored, which directly affects training rewards; fixes are localized to v1 judge prompting/parsing with no API surface change.
> 
> **Overview**
> Fixes **plain-text rubric grading** so rollouts are scored from the judge model’s **final** `{"verdicts": [...]}` answer, not an earlier draft inside `<think>...</think>` reasoning. Unstructured `RubricJudge` replies are now parsed from text **outside** nesting-aware `<think>` blocks via `answer_region`, then the **last** schema-valid top-level verdict object is taken (`last_verdicts_object` replaces first-match scanning).
> 
> **Related judge robustness:** criterion verdict labels are matched **case-insensitively** (e.g. `"YES"` maps to configured `"yes"`). Built-in `rubric.txt` and `reference.txt` no longer hard-code triple-backtick fences; when the default prompts are used, task/response/reference fields are wrapped with **`dynamic_fence`** so content containing backticks cannot break out of the fence. Custom prompts via config are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02e49f149e41beb5e8336c55f48394732fccf329. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->