### PR TITLE
fix(v1): transport unbounded harness input safely

### DIFF
--- a/environments/compact/compact/harness.py
+++ b/environments/compact/compact/harness.py
@@ -51,4 +51,7 @@ class CompactingHarness(Harness[CompactingHarnessConfig]):
                 {"mcpServers": {name: {"url": url} for name, url in mcp_urls.items()}}
             )
         program = await runtime.prepare_uv_script(PROGRAM_SOURCE, self.config.env)
-        return await runtime.run_program([*program, trace.task.data.prompt], env)
+        prompt = trace.task.data.prompt
+        if not isinstance(prompt, str):
+            raise ValueError("compact harness requires a string task prompt")
+        return await runtime.run_program(program, env, stdin=prompt.encode("utf-8"))

--- a/environments/compact/compact/program.py
+++ b/environments/compact/compact/program.py
@@ -99,7 +99,7 @@ async def call_mcp(dispatch: dict, name: str, arguments: dict) -> str:
 
 
 async def main() -> None:
-    task = sys.argv[1]
+    task = sys.stdin.read()
     config = json.loads(os.environ.get("MCP_CONFIG", "{}"))
     notes: str | None = None  # the durable memory carried across turns
     tool_output: str | None = None  # the last tool result, kept for exactly one turn

--- a/verifiers/v1/harnesses/bash/harness.py
+++ b/verifiers/v1/harnesses/bash/harness.py
@@ -68,19 +68,13 @@ class BashHarness(Harness[BashHarnessConfig]):
             f"--base-url={endpoint}",
             f"--api-key={secret}",
             f"--model={ctx.model}",
-            f"--system-prompt={system_prompt}",
+            "--payload-stdin",
         ]
         if self.config.edit:
             args.append("--edit")
         if self.config.search:
-            # Resolve the key and keep it OUT of the program env: it's handed to the program over
-            # argv (--serper-key), so popping it here stops the agent's `bash` subprocesses from
-            # inheriting it via $SERPER_API_KEY / /proc/self/environ. Prefer a key set in the harness
-            # env (--harness.env / forward_env); fall back to the host env only when the key is
-            # *absent* (None), not present-but-empty — a rollout setting SERPER_API_KEY="" is
-            # deliberately masking the host secret, so honor that (the check below then fails loudly
-            # rather than leaking the host key). The pop is scoped to search=true, so an unrelated
-            # key forwarded for the agent's own bash-side use is left untouched.
+            # Keep the search key out of the program environment so agent-spawned Bash commands
+            # cannot inherit it. It is bounded secret/config data rather than task payload.
             serper_key = env.pop("SERPER_API_KEY", None)
             if serper_key is None:
                 serper_key = os.environ.get("SERPER_API_KEY")
@@ -90,34 +84,23 @@ class BashHarness(Harness[BashHarnessConfig]):
                     "(the host env or --harness.env)"
                 )
             args += ["--search", f"--serper-key={serper_key}"]
-        if mcp_urls:
-            # The program connects to the tool servers over HTTP; hand it a standard
-            # `mcpServers` URL config (the `mcp` client itself comes from the uv deps).
-            args.append(
-                "--mcp-config="
-                + json.dumps(
-                    {
-                        "mcpServers": {
-                            name: {"url": url} for name, url in mcp_urls.items()
-                        }
-                    }
-                )
-            )
-        if isinstance(prompt, str):
-            # Prompts can exceed the OS per-argument limit (typically 128 KiB on Linux),
-            # so pass them through the runtime filesystem instead of argv.
-            path = f".vf-prompt-{trace.id}.txt"
-            await runtime.write(path, prompt.encode("utf-8"))
-            args.append(f"--prompt-file={path}")
-        elif prompt is not None:
-            # Base64 images can exceed exec limits, so hand Messages off through a file.
-            path = f".vf-initial-messages-{trace.id}.json"
-            await runtime.write(
-                path,
-                json.dumps([message_to_wire(m) for m in prompt]).encode(),
-            )
-            args.append(f"--initial-messages-file={path}")
+        payload = {
+            "system_prompt": system_prompt,
+            "prompt": prompt if isinstance(prompt, str) else None,
+            "initial_messages": (
+                [message_to_wire(message) for message in prompt]
+                if prompt is not None and not isinstance(prompt, str)
+                else []
+            ),
+            "mcp_config": {
+                "mcpServers": {name: {"url": url} for name, url in mcp_urls.items()}
+            },
+        }
         program = await runtime.prepare_uv_script(
             PROGRAM_SOURCE, self.config.resolved_env
         )
-        return await runtime.run_program([*program, *args], env)
+        return await runtime.run_program(
+            [*program, *args],
+            env,
+            stdin=json.dumps(payload).encode("utf-8"),
+        )

--- a/verifiers/v1/harnesses/bash/harness.py
+++ b/verifiers/v1/harnesses/bash/harness.py
@@ -104,7 +104,11 @@ class BashHarness(Harness[BashHarnessConfig]):
                 )
             )
         if isinstance(prompt, str):
-            args.append(f"--prompt={prompt}")
+            # Prompts can exceed the OS per-argument limit (typically 128 KiB on Linux),
+            # so pass them through the runtime filesystem instead of argv.
+            path = f".vf-prompt-{trace.id}.txt"
+            await runtime.write(path, prompt.encode("utf-8"))
+            args.append(f"--prompt-file={path}")
         elif prompt is not None:
             # Base64 images can exceed exec limits, so hand Messages off through a file.
             path = f".vf-initial-messages-{trace.id}.json"

--- a/verifiers/v1/harnesses/bash/program.py
+++ b/verifiers/v1/harnesses/bash/program.py
@@ -301,6 +301,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--model", required=True)
     parser.add_argument("--system-prompt", default="")
     parser.add_argument("--prompt", default="")
+    parser.add_argument("--prompt-file", default="")
     parser.add_argument("--initial-messages-file", default="")
     parser.add_argument("--mcp-config", default="")
     parser.add_argument("--edit", action="store_true")
@@ -312,6 +313,11 @@ def parse_args() -> argparse.Namespace:
 async def main() -> None:
     args = parse_args()
     initial = []
+    prompt = args.prompt
+    if args.prompt_file:
+        path = Path(args.prompt_file)
+        prompt = path.read_text(encoding="utf-8")
+        path.unlink()
     if args.initial_messages_file:
         path = Path(args.initial_messages_file)
         payload = path.read_bytes()
@@ -340,8 +346,8 @@ async def main() -> None:
     )
     if initial:
         messages.extend(initial)
-    elif args.prompt:
-        messages.append({"role": "user", "content": args.prompt})
+    elif prompt:
+        messages.append({"role": "user", "content": prompt})
     while True:
         message = await chat(client, args.model, messages, tools)
         messages.append(message.model_dump(exclude_none=True))

--- a/verifiers/v1/harnesses/bash/program.py
+++ b/verifiers/v1/harnesses/bash/program.py
@@ -8,6 +8,7 @@ import argparse
 import asyncio
 import json
 import subprocess
+import sys
 from contextlib import AsyncExitStack, asynccontextmanager, suppress
 from pathlib import Path
 
@@ -136,7 +137,11 @@ def run_search(query: str, api_key: str, num_results: int = 5) -> str:
 def run_bash(command: str) -> str:
     try:
         result = subprocess.run(
-            ["bash", "-c", command], capture_output=True, text=True, timeout=3600
+            ["bash"],
+            input=command,
+            capture_output=True,
+            text=True,
+            timeout=3600,
         )
         return result.stdout + result.stderr
     except Exception as e:
@@ -300,6 +305,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--api-key", required=True)
     parser.add_argument("--model", required=True)
     parser.add_argument("--system-prompt", default="")
+    parser.add_argument("--payload-stdin", action="store_true")
     parser.add_argument("--prompt", default="")
     parser.add_argument("--prompt-file", default="")
     parser.add_argument("--initial-messages-file", default="")
@@ -314,6 +320,14 @@ async def main() -> None:
     args = parse_args()
     initial = []
     prompt = args.prompt
+    system_prompt = args.system_prompt
+    mcp_config = args.mcp_config
+    if args.payload_stdin:
+        payload = json.load(sys.stdin)
+        system_prompt = payload.get("system_prompt") or ""
+        prompt = payload.get("prompt") or ""
+        initial = payload.get("initial_messages") or []
+        mcp_config = json.dumps(payload.get("mcp_config") or {})
     if args.prompt_file:
         path = Path(args.prompt_file)
         prompt = path.read_text(encoding="utf-8")
@@ -324,7 +338,7 @@ async def main() -> None:
         path.unlink()
         initial = json.loads(payload)
     client = AsyncOpenAI(base_url=args.base_url, api_key=args.api_key)
-    config = json.loads(args.mcp_config or "{}")
+    config = json.loads(mcp_config or "{}")
     tools = [BASH_TOOL]
     reserved = {"bash"}
     if args.edit:
@@ -339,11 +353,7 @@ async def main() -> None:
         else ([], {}, {})
     )
     tools += mcp_tools
-    messages = (
-        [{"role": "system", "content": args.system_prompt}]
-        if args.system_prompt
-        else []
-    )
+    messages = [{"role": "system", "content": system_prompt}] if system_prompt else []
     if initial:
         messages.extend(initial)
     elif prompt:

--- a/verifiers/v1/harnesses/claude_code/harness.py
+++ b/verifiers/v1/harnesses/claude_code/harness.py
@@ -79,7 +79,9 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
             ctx.model,
         ]
         if system_prompt:
-            argv += ["--append-system-prompt", system_prompt]
+            system_prompt_path = f".vf-claude-system-{trace.id}.txt"
+            await runtime.write(system_prompt_path, system_prompt.encode("utf-8"))
+            argv += ["--append-system-prompt-file", system_prompt_path]
         argv += [
             arg
             for tool in self.config.disabled_tools or []
@@ -97,6 +99,7 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
             mcp_path,
             "--strict-mcp-config",
             "--",
-            instruction or "",
         ]
-        return await runtime.run_program(argv, env)
+        return await runtime.run_program(
+            argv, env, stdin=(instruction or "").encode("utf-8")
+        )

--- a/verifiers/v1/harnesses/codex/harness.py
+++ b/verifiers/v1/harnesses/codex/harness.py
@@ -119,6 +119,8 @@ class CodexHarness(Harness[CodexHarnessConfig]):
                     image_args += ["-i", path]
                     image_index += 1
             prompt = "\n\n".join(texts)
+        if prompt is None:
+            raise ValueError("Codex requires a task prompt (it has no user simulator)")
         # codex authenticates to the interception server with the session secret (its provider
         # api key) and posts Responses calls to `{endpoint}/responses`.
         env = {**self.config.resolved_env, KEY_VAR: secret}
@@ -163,10 +165,10 @@ class CodexHarness(Harness[CodexHarnessConfig]):
             *tool_config,
             *image_args,
             "--",
-            prompt,
+            "-",
         ]
         try:
-            return await runtime.run_program(argv, env)
+            return await runtime.run_program(argv, env, stdin=prompt.encode("utf-8"))
         finally:
             if image_args:
                 try:

--- a/verifiers/v1/harnesses/null/harness.py
+++ b/verifiers/v1/harnesses/null/harness.py
@@ -38,33 +38,23 @@ class NullHarness(Harness[NullHarnessConfig]):
             f"--base-url={endpoint}",
             f"--api-key={secret}",
             f"--model={ctx.model}",
+            "--payload-stdin",
         ]
-        if system_prompt:
-            args.append(f"--system-prompt={system_prompt}")
-        if mcp_urls:
-            # The program connects to the tool servers over HTTP; hand it a standard
-            # `mcpServers` URL config (the `mcp` client itself comes from the uv deps).
-            args.append(
-                "--mcp-config="
-                + json.dumps(
-                    {
-                        "mcpServers": {
-                            name: {"url": url} for name, url in mcp_urls.items()
-                        }
-                    }
-                )
-            )
-        if isinstance(prompt, str):
-            args.append(f"--prompt={prompt}")
-        elif prompt is not None:
-            # Base64 images can exceed exec limits, so hand Messages off through a file.
-            path = f".vf-initial-messages-{trace.id}.json"
-            await runtime.write(
-                path,
-                json.dumps([message_to_wire(m) for m in prompt]).encode(),
-            )
-            args.append(f"--initial-messages-file={path}")
+        payload = {
+            "system_prompt": system_prompt,
+            "prompt": prompt if isinstance(prompt, str) else None,
+            "initial_messages": (
+                [message_to_wire(message) for message in prompt]
+                if prompt is not None and not isinstance(prompt, str)
+                else []
+            ),
+            "mcp_config": {
+                "mcpServers": {name: {"url": url} for name, url in mcp_urls.items()}
+            },
+        }
         program = await runtime.prepare_uv_script(
             PROGRAM_SOURCE, self.config.resolved_env
         )
-        return await runtime.run_program([*program, *args], env)
+        return await runtime.run_program(
+            [*program, *args], env, stdin=json.dumps(payload).encode("utf-8")
+        )

--- a/verifiers/v1/harnesses/null/program.py
+++ b/verifiers/v1/harnesses/null/program.py
@@ -7,6 +7,7 @@
 import argparse
 import asyncio
 import json
+import sys
 from contextlib import AsyncExitStack, asynccontextmanager, suppress
 from pathlib import Path
 
@@ -144,6 +145,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--api-key", required=True)
     parser.add_argument("--model", required=True)
     parser.add_argument("--system-prompt", default="")
+    parser.add_argument("--payload-stdin", action="store_true")
     parser.add_argument("--prompt", default="")
     parser.add_argument("--initial-messages-file", default="")
     parser.add_argument("--mcp-config", default="")
@@ -153,28 +155,33 @@ def parse_args() -> argparse.Namespace:
 async def main() -> None:
     args = parse_args()
     initial = []
+    prompt = args.prompt
+    system_prompt = args.system_prompt
+    mcp_config = args.mcp_config
+    if args.payload_stdin:
+        payload = json.load(sys.stdin)
+        system_prompt = payload.get("system_prompt") or ""
+        prompt = payload.get("prompt") or ""
+        initial = payload.get("initial_messages") or []
+        mcp_config = json.dumps(payload.get("mcp_config") or {})
     if args.initial_messages_file:
         path = Path(args.initial_messages_file)
         payload = path.read_bytes()
         path.unlink()
         initial = json.loads(payload)
     client = AsyncOpenAI(base_url=args.base_url, api_key=args.api_key)
-    config = json.loads(args.mcp_config or "{}")
+    config = json.loads(mcp_config or "{}")
     if config.get("mcpServers"):
         # Bound only tool enumeration; each session is opened and closed within this task.
         async with asyncio.timeout(60):
             tools, dispatch, servers = await connect_mcp(config)
     else:
         tools, dispatch, servers = [], {}, {}
-    messages = (
-        [{"role": "system", "content": args.system_prompt}]
-        if args.system_prompt
-        else []
-    )
+    messages = [{"role": "system", "content": system_prompt}] if system_prompt else []
     if initial:
         messages.extend(initial)
-    elif args.prompt:
-        messages.append({"role": "user", "content": args.prompt})
+    elif prompt:
+        messages.append({"role": "user", "content": prompt})
     while True:
         message = await chat(client, args.model, messages, tools)
         messages.append(message.model_dump(exclude_none=True))

--- a/verifiers/v1/harnesses/pi/harness.py
+++ b/verifiers/v1/harnesses/pi/harness.py
@@ -234,7 +234,12 @@ class PiHarness(Harness[PiHarnessConfig]):
             if self.config.disabled_tools
             else []
         )
-        system_args = ["--append-system-prompt", system_prompt] if system_prompt else []
+        system_args: list[str] = []
+        if system_prompt:
+            system_prompt_path = f"{agent_dir}/system-prompt.txt"
+            await runtime.write(system_prompt_path, system_prompt.encode("utf-8"))
+            # Pi interprets an existing path as the system-prompt file contents.
+            system_args = ["--append-system-prompt", system_prompt_path]
         argv = [
             "sh",
             "-c",

--- a/verifiers/v1/harnesses/terminus_2/harness.py
+++ b/verifiers/v1/harnesses/terminus_2/harness.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from pathlib import Path
 
@@ -58,13 +59,15 @@ class Terminus2Harness(Harness[Terminus2HarnessConfig]):
             f"--base-url={endpoint}",
             f"--api-key={secret}",
             f"--model={ctx.model}",
-            f"--system-prompt={system_prompt or ''}",
-            f"--task={prompt}",
+            "--payload-stdin",
         ]
+        payload = json.dumps(
+            {"system_prompt": system_prompt or "", "task": prompt}
+        ).encode("utf-8")
         try:
             source = PROGRAM_SOURCE.replace("{version}", self.config.version)
             program = await runtime.prepare_uv_script(source, self.config.resolved_env)
-            return await runtime.run_program([*program, *args], env)
+            return await runtime.run_program([*program, *args], env, stdin=payload)
         finally:
             # Harbor normally destroys its whole sandbox; this adapter borrows the
             # Verifiers runtime, so clean up Terminus's detached tmux server ourselves.

--- a/verifiers/v1/harnesses/terminus_2/program.py
+++ b/verifiers/v1/harnesses/terminus_2/program.py
@@ -5,8 +5,10 @@
 
 import argparse
 import asyncio
+import json
 import os
 import subprocess
+import sys
 from pathlib import Path, PurePosixPath
 
 from harbor.agents.terminus_2 import Terminus2
@@ -29,8 +31,8 @@ class LocalEnvironment:
     ) -> ExecResult:
         _ = user
         result = subprocess.run(
-            command,
-            shell=True,
+            ["sh"],
+            input=command,
             cwd=cwd,
             env={**os.environ, **(env or {})},
             capture_output=True,
@@ -50,13 +52,18 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--api-key", required=True)
     parser.add_argument("--model", required=True)
     parser.add_argument("--system-prompt", default="")
-    parser.add_argument("--task", required=True)
+    parser.add_argument("--task", default="")
+    parser.add_argument("--payload-stdin", action="store_true")
     return parser.parse_args()
 
 
 async def main() -> None:
     args = parse_args()
     model, system_prompt, task = args.model, args.system_prompt, args.task
+    if args.payload_stdin:
+        payload = json.load(sys.stdin)
+        system_prompt = payload.get("system_prompt") or ""
+        task = payload.get("task") or ""
     logs_dir = Path(os.environ["TMUX_TMPDIR"])
     logs_dir.mkdir(mode=0o700, exist_ok=True)
     EnvironmentPaths.agent_dir = PurePosixPath(logs_dir)

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -145,13 +145,56 @@ class Runtime(ABC):
     async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
         pass
 
-    async def run_program(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
-        """Run the harness's MAIN program — the rollout itself (a possibly long-lived, stateful,
-        agentic run) — as opposed to the short idempotent infra ops (write / mv / install /
-        provisioning) that go through `run`. No framework layer may replay this argv: doing so
-        against the rollout's persistent trace would fork a duplicate branch. Provider SDKs may
-        still retry individual safe transport operations underneath `run`."""
-        return await self.run(argv, env)
+    async def run_program(
+        self,
+        argv: list[str],
+        env: dict[str, str],
+        *,
+        stdin: bytes | None = None,
+    ) -> ProgramResult:
+        """Run the harness's MAIN program once, optionally feeding binary stdin.
+
+        Runtimes with a native stdin channel override ``_run_program_stdin``; the portable
+        fallback stages the bytes in the runtime workspace and redirects them through a bounded
+        shell wrapper. Either path keeps unbounded payloads out of argv and the environment. No
+        framework layer may replay the program: doing so against the rollout's persistent trace
+        would fork a duplicate branch.
+        """
+        self._validate_exec_payload(argv, env)
+        if stdin is None:
+            return await self.run(argv, env)
+        return await self._run_program_stdin(argv, env, stdin)
+
+    async def _run_program_stdin(
+        self, argv: list[str], env: dict[str, str], stdin: bytes
+    ) -> ProgramResult:
+        """File-backed stdin fallback for runtimes whose execution API has no stdin channel."""
+        path = f".vf-stdin-{uuid.uuid4().hex}.bin"
+        await self.write(path, stdin)
+        command = (
+            'chmod 600 "$0"; status=0; "$@" < "$0" || status=$?; '
+            'rm -f -- "$0"; exit "$status"'
+        )
+        return await self.run(["sh", "-c", command, path, *argv], env)
+
+    @staticmethod
+    def _validate_exec_payload(argv: list[str], env: dict[str, str]) -> None:
+        """Fail clearly before exec when one argv/env entry exceeds Linux MAX_ARG_STRLEN."""
+        limit = 128 * 1024
+        entries = [(f"argv[{i}]", value) for i, value in enumerate(argv)]
+        entries += [(f"env[{key!r}]", f"{key}={value}") for key, value in env.items()]
+        for name, value in entries:
+            if "\0" in value:
+                raise ValueError(
+                    f"{name} contains a NUL byte and cannot be passed to exec"
+                )
+            size = len(value.encode("utf-8")) + 1
+            if size > limit:
+                raise ValueError(
+                    f"{name} is {size:,} bytes, exceeding the portable 128 KiB exec "
+                    "argument limit; pass unbounded content through run_program(stdin=...) "
+                    "or a runtime file"
+                )
 
     async def run_background(
         self, argv: list[str], env: dict[str, str], log: str

--- a/verifiers/v1/runtimes/docker.py
+++ b/verifiers/v1/runtimes/docker.py
@@ -135,6 +135,32 @@ class DockerRuntime(Runtime):
             "exec", *env_args, "--workdir", self.config.workdir, self._container, *argv
         )
 
+    async def _run_program_stdin(
+        self, argv: list[str], env: dict[str, str], stdin: bytes
+    ) -> ProgramResult:
+        env_args = [
+            arg for key, value in env.items() for arg in ("--env", f"{key}={value}")
+        ]
+        proc = await asyncio.create_subprocess_exec(
+            "docker",
+            "exec",
+            "-i",
+            *env_args,
+            "--workdir",
+            self.config.workdir,
+            self._container,
+            *argv,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate(input=stdin)
+        return ProgramResult(
+            exit_code=proc.returncode or 0,
+            stdout=stdout.decode(errors="replace"),
+            stderr=stderr.decode(errors="replace"),
+        )
+
     async def run_background(
         self, argv: list[str], env: dict[str, str], log: str
     ) -> None:

--- a/verifiers/v1/runtimes/subprocess.py
+++ b/verifiers/v1/runtimes/subprocess.py
@@ -73,6 +73,32 @@ class SubprocessRuntime(Runtime):
             stderr=stderr.decode(errors="replace"),
         )
 
+    async def _run_program_stdin(
+        self, argv: list[str], env: dict[str, str], stdin: bytes
+    ) -> ProgramResult:
+        full_env = {k: v for k, v in os.environ.items() if "API_KEY" not in k.upper()}
+        full_env.update(env)
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            env=full_env,
+            cwd=self.workdir,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,
+        )
+        try:
+            stdout, stderr = await proc.communicate(input=stdin)
+        finally:
+            if proc.returncode is None:
+                with contextlib.suppress(ProcessLookupError, PermissionError):
+                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        return ProgramResult(
+            exit_code=proc.returncode or 0,
+            stdout=stdout.decode(errors="replace"),
+            stderr=stderr.decode(errors="replace"),
+        )
+
     async def run_background(
         self, argv: list[str], env: dict[str, str], log: str
     ) -> None:


### PR DESCRIPTION
## Summary

- add binary stdin support to `Runtime.run_program`, using native pipes for subprocess and Docker and a runtime-file fallback for remote runtimes
- reject oversized or NUL-containing argv/environment entries before `exec` with an actionable error
- move unbounded task/system/message payloads off argv for Bash, Null, Claude Code, Codex, Pi, Terminus 2, and the Compact example
- move model-generated Bash and Terminus shell scripts from `sh -c <script>` to shell stdin
- keep existing program flags as compatibility inputs for Verifiers-owned harness programs

## Motivation

Linux commonly limits each individual exec argument to about 128 KiB, independently of aggregate `ARG_MAX`. Large task prompts can therefore fail before a harness starts with `OSError: [Errno 7] Argument list too long`. The same unsafe argv pattern can fail under subprocess, Docker, Modal, or Prime because every backend eventually starts a process.

The general transport policy is:

1. stdin where the target CLI supports it;
2. runtime files where stdin is unavailable or a separate payload is required;
3. argv/environment only for bounded control values, guarded before launch.

Harnesses whose pinned external CLIs do not have verified stdin/file support (Kimi Code, mini-swe-agent, RLM) retain their current launch semantics but now fail early with a clear size error rather than an OS-level `E2BIG`.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest tests/v1/test_configs.py tests/v1/test_taskset.py -q`
- existing Bash and Null subprocess E2E cases
- manual 200 KB binary/text stdin validation for `SubprocessRuntime`
- manual 200 KB Bash and Null payload validation with bounded launch argv
- `ty` diagnostics match the current-main baseline

The full local non-Prime/non-Modal matrix could not exercise Docker because Docker Desktop is unavailable on this machine; its Docker-selected failures were infrastructure errors. No tests were added.
