### PR TITLE
feat(v1): expose pool env-server stats on an optional Prometheus /metrics endpoint

### DIFF
--- a/verifiers/v1/cli/serve.py
+++ b/verifiers/v1/cli/serve.py
@@ -63,6 +63,8 @@ def main(argv: list[str] | None = None) -> None:
         **pool_serve_kwargs(config.pool),
         legacy=config.is_legacy,
         address=config.address,
+        metrics_address=config.metrics_address,
+        metrics_port=config.metrics_port,
         log_setup=partial(setup_logging, level),
         **server_kwargs,
     )

--- a/verifiers/v1/configs/serve.py
+++ b/verifiers/v1/configs/serve.py
@@ -14,3 +14,7 @@ class ServeConfig(EnvServerConfig):
     """Log at debug level instead of info."""
     dry_run: bool = False
     """Resolve + validate the config and dump it, then exit."""
+    metrics_address: str = "127.0.0.1"
+    """Address for the optional Prometheus HTTP endpoint."""
+    metrics_port: int | None = Field(None, ge=1, le=65535)
+    """Port for the optional Prometheus HTTP endpoint; unset disables metrics."""

--- a/verifiers/v1/serve/__init__.py
+++ b/verifiers/v1/serve/__init__.py
@@ -1,6 +1,7 @@
 """Serve V1 environments over ZMQ."""
 
 from verifiers.v1.serve.client import EnvClient
+from verifiers.v1.serve.metrics import MetricsServer, PoolMetrics
 from verifiers.v1.serve.pool import EnvServerPool, env_config_data, serve_env
 from verifiers.v1.serve.server import EnvServer
 from verifiers.v1.serve.types import (
@@ -20,6 +21,8 @@ __all__ = [
     "serve_env",
     "env_config_data",
     "EnvClient",
+    "MetricsServer",
+    "PoolMetrics",
     "HealthRequest",
     "HealthResponse",
     "InfoRequest",

--- a/verifiers/v1/serve/metrics.py
+++ b/verifiers/v1/serve/metrics.py
@@ -4,6 +4,8 @@ import asyncio
 import contextlib
 from collections.abc import Callable
 
+_REQUEST_TIMEOUT_SECONDS = 5
+
 
 def _metric_line(
     name: str, value: int | float, labels: dict[str, str] | None = None
@@ -107,7 +109,9 @@ class MetricsServer:
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
     ) -> None:
         try:
-            request_line = await reader.readline()
+            request_line = await asyncio.wait_for(
+                reader.readline(), timeout=_REQUEST_TIMEOUT_SECONDS
+            )
             method, path, *_ = request_line.decode("ascii", "replace").split()
             if method != "GET":
                 status = "405 Method Not Allowed"
@@ -127,6 +131,8 @@ class MetricsServer:
             ).encode()
             writer.write(headers + body)
             await writer.drain()
+        except asyncio.TimeoutError:
+            return
         except (ValueError, UnicodeError):
             writer.write(b"HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n")
             with contextlib.suppress(Exception):

--- a/verifiers/v1/serve/metrics.py
+++ b/verifiers/v1/serve/metrics.py
@@ -1,0 +1,144 @@
+"""Dependency-free Prometheus metrics for the v1 env-server pool."""
+
+import asyncio
+import contextlib
+from collections.abc import Callable
+
+
+def _metric_line(
+    name: str, value: int | float, labels: dict[str, str] | None = None
+) -> str:
+    if labels:
+        escaped = {
+            key: value.replace("\\", "\\\\").replace('"', '\\"')
+            for key, value in labels.items()
+        }
+        label_text = ",".join(f'{key}="{value}"' for key, value in escaped.items())
+        return f"{name}{{{label_text}}} {value}"
+    return f"{name} {value}"
+
+
+class PoolMetrics:
+    """Mutable broker-side metrics state rendered on the broker event loop."""
+
+    def __init__(self, configured_workers: int | None) -> None:
+        self.configured_workers = configured_workers
+        self.request_total = 0
+        self.request_latency_seconds_count = 0
+        self.request_latency_seconds_sum = 0.0
+        self.pending_depth = 0
+        self.active_rollouts = 0
+        self.workers: list[dict] = []
+
+    def render(self) -> str:
+        lines = [
+            "# HELP verifiers_v1_env_active_rollouts Active rollout slots in the pool.",
+            "# TYPE verifiers_v1_env_active_rollouts gauge",
+            _metric_line("verifiers_v1_env_active_rollouts", self.active_rollouts),
+            "# HELP verifiers_v1_env_worker_active_rollouts Active rollout slots per worker.",
+            "# TYPE verifiers_v1_env_worker_active_rollouts gauge",
+        ]
+        lines.extend(
+            _metric_line(
+                "verifiers_v1_env_worker_active_rollouts",
+                worker["active"],
+                {"worker_index": str(worker["index"])},
+            )
+            for worker in self.workers
+        )
+        lines.extend(
+            [
+                "# HELP verifiers_v1_env_workers Current worker processes.",
+                "# TYPE verifiers_v1_env_workers gauge",
+                _metric_line("verifiers_v1_env_workers", len(self.workers)),
+                "# HELP verifiers_v1_env_configured_workers Configured worker limit; zero means unbounded.",
+                "# TYPE verifiers_v1_env_configured_workers gauge",
+                _metric_line(
+                    "verifiers_v1_env_configured_workers",
+                    self.configured_workers or 0,
+                ),
+                "# HELP verifiers_v1_env_pending_requests Requests currently awaiting a worker reply.",
+                "# TYPE verifiers_v1_env_pending_requests gauge",
+                _metric_line("verifiers_v1_env_pending_requests", self.pending_depth),
+                "# HELP verifiers_v1_env_requests_total Requests dispatched to workers.",
+                "# TYPE verifiers_v1_env_requests_total counter",
+                _metric_line("verifiers_v1_env_requests_total", self.request_total),
+                "# HELP verifiers_v1_env_request_latency_seconds Request latency from dispatch to worker reply.",
+                "# TYPE verifiers_v1_env_request_latency_seconds summary",
+                _metric_line(
+                    "verifiers_v1_env_request_latency_seconds_count",
+                    self.request_latency_seconds_count,
+                ),
+                _metric_line(
+                    "verifiers_v1_env_request_latency_seconds_sum",
+                    self.request_latency_seconds_sum,
+                ),
+                "",
+            ]
+        )
+        return "\n".join(lines)
+
+
+class MetricsServer:
+    """Minimal HTTP server exposing one Prometheus text endpoint."""
+
+    def __init__(
+        self,
+        address: str,
+        port: int,
+        render: Callable[[], str],
+    ) -> None:
+        self.address = address
+        self.port = port
+        self.render = render
+        self._server: asyncio.Server | None = None
+
+    async def start(self) -> None:
+        self._server = await asyncio.start_server(
+            self._handle_connection, self.address, self.port
+        )
+        sockets = self._server.sockets or []
+        if sockets:
+            host, port, *_ = sockets[0].getsockname()
+            self.address = str(host)
+            self.port = int(port)
+
+    async def _handle_connection(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        try:
+            request_line = await reader.readline()
+            method, path, *_ = request_line.decode("ascii", "replace").split()
+            if method != "GET":
+                status = "405 Method Not Allowed"
+                body = b"method not allowed\n"
+            elif path.split("?", 1)[0] != "/metrics":
+                status = "404 Not Found"
+                body = b"not found\n"
+            else:
+                status = "200 OK"
+                body = self.render().encode()
+            headers = (
+                f"HTTP/1.1 {status}\r\n"
+                "Content-Type: text/plain; version=0.0.4; charset=utf-8\r\n"
+                f"Content-Length: {len(body)}\r\n"
+                "Connection: close\r\n"
+                "\r\n"
+            ).encode()
+            writer.write(headers + body)
+            await writer.drain()
+        except (ValueError, UnicodeError):
+            writer.write(b"HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n")
+            with contextlib.suppress(Exception):
+                await writer.drain()
+        finally:
+            writer.close()
+            with contextlib.suppress(Exception):
+                await writer.wait_closed()
+
+    async def close(self) -> None:
+        if self._server is None:
+            return
+        self._server.close()
+        await self._server.wait_closed()
+        self._server = None

--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -28,6 +28,7 @@ import multiprocessing as mp
 import os
 import signal
 import threading
+import time
 import uuid
 from collections.abc import Callable
 
@@ -37,6 +38,7 @@ import zmq.asyncio
 
 from verifiers.v1.env import EnvConfig
 from verifiers.v1.serve.server import EnvServer
+from verifiers.v1.serve.metrics import MetricsServer, PoolMetrics
 from verifiers.v1.serve.types import HealthResponse, RunGroupRequest
 
 logger = logging.getLogger(__name__)
@@ -88,6 +90,8 @@ class EnvServerPool:
         log_setup: Callable[[], None] | None = None,
         multiplex: int = 128,
         elastic: bool = True,
+        metrics_address: str = "127.0.0.1",
+        metrics_port: int | None = None,
     ) -> None:
         self.server_kwargs = server_kwargs
         self.max_workers = max_workers
@@ -99,6 +103,10 @@ class EnvServerPool:
         self.workers: list[dict] = []
         self._mpctx = mp.get_context("spawn")
         self._poller: zmq.asyncio.Poller | None = None
+        self.metrics_address = metrics_address
+        self.metrics_port = metrics_port
+        self.metrics = PoolMetrics(max_workers)
+        self._metrics_server: MetricsServer | None = None
 
         self.ctx = zmq.asyncio.Context()
         self.frontend = self.ctx.socket(zmq.ROUTER)
@@ -173,7 +181,7 @@ class EnvServerPool:
         # (`max_workers` is a concrete count when elastic is off).
         for _ in range(1 if self.elastic else (self.max_workers or 1)):
             self._spawn_worker()
-        # request_id -> {client_id, worker, rollout_slots}
+        # request_id -> {client_id, worker, rollout_slots, dispatched_at}
         pending: dict[bytes, dict] = {}
         logger.info(
             "EnvServerPool up: address=%s workers=%d/%s multiplex=%d elastic=%s",
@@ -185,6 +193,17 @@ class EnvServerPool:
         )
         try:
             in_flight = 0
+            self.metrics.workers = self.workers
+            if self.metrics_port is not None:
+                self._metrics_server = MetricsServer(
+                    self.metrics_address, self.metrics_port, self.metrics.render
+                )
+                await self._metrics_server.start()
+                logger.info(
+                    "EnvServerPool metrics: address=%s:%d",
+                    self._metrics_server.address,
+                    self._metrics_server.port,
+                )
             while True:
                 events = dict(await self._poller.poll())
                 if self.frontend in events:
@@ -213,8 +232,13 @@ class EnvServerPool:
                             "client_id": client_id,
                             "worker": worker,
                             "rollout_slots": rollout_slots,
+                            "dispatched_at": time.monotonic(),
                         }
                         in_flight += rollout_slots
+                        self.metrics.request_total += 1
+                        self.metrics.pending_depth = len(pending)
+                        self.metrics.active_rollouts = in_flight
+                        self.metrics.workers = self.workers
                         # forward without client_id — the DEALER identity is the worker's
                         # `client_id`; we hold the real one in `pending`.
                         await worker["dealer"].send_multipart(
@@ -229,8 +253,15 @@ class EnvServerPool:
                         entry = pending.pop(request_id.bytes, None)
                         if entry is None:
                             continue
+                        self.metrics.request_latency_seconds_count += 1
+                        self.metrics.request_latency_seconds_sum += (
+                            time.monotonic() - entry["dispatched_at"]
+                        )
                         entry["worker"]["active"] -= entry["rollout_slots"]
                         in_flight -= entry["rollout_slots"]
+                        self.metrics.pending_depth = len(pending)
+                        self.metrics.active_rollouts = in_flight
+                        self.metrics.workers = self.workers
                         with contextlib.suppress(zmq.ZMQError):
                             await self.frontend.send_multipart(
                                 [entry["client_id"], request_id, data], copy=False
@@ -238,6 +269,9 @@ class EnvServerPool:
         except (asyncio.CancelledError, KeyboardInterrupt):
             pass
         finally:
+            if self._metrics_server is not None:
+                await self._metrics_server.close()
+                self._metrics_server = None
             self._shutdown()
 
     def _shutdown(self) -> None:
@@ -279,6 +313,8 @@ def serve_env(
     log_setup: Callable[[], None] | None = None,
     multiplex: int = 128,
     elastic: bool = True,
+    metrics_address: str = "127.0.0.1",
+    metrics_port: int | None = None,
     **server_kwargs,
 ) -> None:
     """Serve one env over ZMQ: a single in-process `EnvServer` when `max_workers <= 1`,
@@ -324,11 +360,18 @@ def serve_env(
                 log_setup,
                 multiplex,
                 elastic,
+                metrics_address,
+                metrics_port,
             )
             if address_queue is not None:
                 address_queue.put(pool.address)
             asyncio.run(pool.run())
         else:
+            if metrics_port is not None:
+                logger.warning(
+                    "metrics endpoint is only available for EnvServerPool; "
+                    "single-server mode is unchanged"
+                )
             from verifiers.v1.legacy import LegacyEnvServer
 
             if (


### PR DESCRIPTION
## Description

The v1 env-server pool (`verifiers/v1/serve/pool.py`) — the process that actually serves rollouts during training — has no observability surface today: no stats snapshot, no `/metrics`, no way to see how many rollouts are in flight or whether a worker is saturated. The only existing metrics work (#1415) targets the legacy v0 `verifiers/serve/server/` architecture, so v1 runs blind.

This adds a small, **dependency-free** Prometheus endpoint for the v1 pool, addressing #1188.

**What it does**
- New `verifiers/v1/serve/metrics.py`: a hand-rendered Prometheus text renderer (`PoolMetrics`) plus a minimal `asyncio.start_server`-based `MetricsServer` exposing `GET /metrics`. No new dependencies.
- The broker loop in `EnvServerPool.run()` updates cheap, O(1) counters/gauges as it dispatches and reaps requests; the metrics server is started/stopped inside the existing `try/finally` so its lifecycle is coupled to the broker.
- **Opt-in**: `metrics_port` is unset by default (no port → no server). `metrics_address` defaults to `127.0.0.1` (loopback) rather than binding all interfaces. Both are threaded through `ServeConfig` and the `serve` CLI.
- Pool-only: single-server (non-pool) mode is unchanged and logs a warning if metrics are configured.

**Metrics exposed**
```
verifiers_v1_env_active_rollouts                      # aggregate in-flight slots
verifiers_v1_env_worker_active_rollouts{worker_index} # per-worker in-flight slots
verifiers_v1_env_workers                              # current worker processes
verifiers_v1_env_configured_workers                   # configured limit (0 = unbounded)
verifiers_v1_env_pending_requests                     # requests awaiting a worker reply
verifiers_v1_env_requests_total                       # dispatched requests (counter)
verifiers_v1_env_request_latency_seconds_{count,sum}  # dispatch->reply latency (summary)
```

Deliberately scoped to observability: no worker-restart or event-loop-lag gauges, since the pool has no restart controller or lag monitor yet (exposing those would be misleading, and lifecycle work is being handled separately in #1993/#1995). The reply path does **no** payload decoding, so the broker's zero-copy `copy=False` forward is preserved.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Testing
- [x] All existing tests pass when running `uv run pytest` locally (targeted: `tests/v1/test_configs.py`, `tests/test_env_server.py` — 26 passed).
- [ ] New tests have been added to cover the changes

Per AGENTS.md ("Do not add unit tests to your PRs"), no unit tests are added. Verified with a throwaway script that starts a real one-worker `EnvServerPool`, issues a request, and curls the endpoint:
```
HTTP/1.1 200 OK
Content-Type: text/plain; version=0.0.4; charset=utf-8
verifiers_v1_env_active_rollouts 0
verifiers_v1_env_worker_active_rollouts{worker_index="0"} 0
verifiers_v1_env_workers 1
verifiers_v1_env_configured_workers 1
verifiers_v1_env_pending_requests 0
verifiers_v1_env_requests_total 1
verifiers_v1_env_request_latency_seconds_count 1
verifiers_v1_env_request_latency_seconds_sum 1.157...
```

## Checklist
- [x] My code follows the style guidelines of this project as outlined in AGENTS.md
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Additional Notes
No new dependencies. Endpoint is disabled unless `metrics_port` is set, and binds to loopback by default. Related: #1188 (request), #1415 (v0 equivalent).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in metrics on loopback by default; broker hot path only adds O(1) counter updates and does not change rollout protocol or single-server behavior.
> 
> **Overview**
> Adds **opt-in observability** for the v1 `EnvServerPool` broker via a dependency-free `GET /metrics` HTTP endpoint.
> 
> New `metrics.py` defines `PoolMetrics` (Prometheus text) and a minimal `MetricsServer` on `asyncio.start_server`. The pool broker updates gauges/counters on dispatch and reply (active rollouts, per-worker load, pending depth, request totals, dispatch→reply latency) without decoding response payloads, so zero-copy forwarding is unchanged. The metrics server starts only when `metrics_port` is set and shuts down in the existing `finally` block.
> 
> `ServeConfig` and the `serve` CLI gain `metrics_address` (default `127.0.0.1`) and `metrics_port` (unset = disabled), threaded through `serve_env` → `EnvServerPool`. **Pool-only**: single in-process server mode ignores metrics and logs a warning if configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9427736344ae2e5e15a11d9740127dfee2de1d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose pool env-server stats on an optional Prometheus `/metrics` endpoint
> - Adds `MetricsServer`, a minimal asyncio HTTP server serving Prometheus text format at `/metrics`, and `PoolMetrics`, a model tracking active rollouts, workers, pending depth, request counts, and latency summaries in [verifiers/v1/serve/metrics.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2077/files#diff-9d4b23dc27df60bac139a516a74d9fb50b58bfa834ff5095e6a0527cb9638783).
> - `EnvServerPool` optionally starts `MetricsServer` when `metrics_port` is configured, updating metrics on every dispatch and reply, and shuts it down cleanly on exit.
> - `ServeConfig` gains two new fields: `metrics_address` (default `"0.0.0.0"`) and `metrics_port` (default `None`; unset disables metrics entirely).
> - Metrics are only available in multi-worker pool mode; single-server mode is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 65836a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->