### PR TITLE
fix(v1): reject misaligned training logprobs instead of silently zero-filling

### DIFF
--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -116,6 +116,13 @@ def response_from_generate(
     ] or None
     prompt_ids = result.get("prompt_ids") or []
     completion_ids = result.get("completion_ids") or []
+    completion_logprobs = result.get("completion_logprobs") or []
+    if len(completion_logprobs) != len(completion_ids):
+        raise ValueError(
+            "renderer returned misaligned sampled-token logprobs: "
+            f"{len(completion_ids)} completion ids but "
+            f"{len(completion_logprobs)} logprobs"
+        )
     # Per-message token spans (the renderer's attribution) let the trace graph store each
     # message's tokens once; carried transiently on TurnTokens and consumed by turn.commit().
     attribution = result.get("prompt_attribution")
@@ -145,7 +152,7 @@ def response_from_generate(
         tokens=TurnTokens.model_construct(
             prompt_ids=prompt_ids,
             completion_ids=completion_ids,
-            completion_logprobs=result.get("completion_logprobs") or [],
+            completion_logprobs=completion_logprobs,
             message_spans=message_spans,
             is_content=attribution.is_content if attribution is not None else None,
             multi_modal_data=result.get("multi_modal_data"),

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -158,16 +158,20 @@ class Branch(StrictBaseModel):
         out: list[float] = []
         for node in self.nodes:
             mask = node.mask
-            sampled = sum(mask) if node.logprobs else 0
+            sampled = sum(mask)
+            if len(node.logprobs) != sampled:
+                raise ValueError(
+                    "sampled-token logprobs are misaligned in trace node: "
+                    f"{sampled} sampled tokens but {len(node.logprobs)} logprobs"
+                )
             # Bulk-fill the canonical unsampled-prefix/sampled-suffix layout.
             if not sampled or all(mask[-sampled:]):
                 out += [0.0] * (len(mask) - sampled) + node.logprobs[:sampled]
-                out += [0.0] * max(0, sampled - len(node.logprobs))
                 continue
             li = 0
             for sampled in mask:
                 if sampled:
-                    out.append(node.logprobs[li] if li < len(node.logprobs) else 0.0)
+                    out.append(node.logprobs[li])
                     li += 1
                 else:
                     out.append(0.0)


### PR DESCRIPTION
## Description

In the v1 training path, a completion's sampling logprobs can silently go missing and get replaced with `0.0` — i.e. **log-probability 0.0 = probability 1.0** — on tokens that are used as the behavior policy for the GRPO / importance-sampling ratio. That is silent training-data corruption: the affected tokens get an importance weight computed against a fabricated certainty.

**How it happens (today, on `main`):**
- `response_from_generate` (`verifiers/v1/clients/train.py`) keeps `completion_ids` and `completion_logprobs` independently, with no length check — `completion_logprobs = result.get("completion_logprobs") or []`.
- Graph commit marks every completion id as a sampled token.
- `Branch.logprobs` (`verifiers/v1/trace.py`) then pads any missing sampled positions with `0.0`.

So if a provider/engine ever returns completion token ids with a shorter or empty logprobs vector (logprobs disabled/unsupported, an engine hiccup, a legacy path), the training sample is silently poisoned instead of failing.

This is **latent**, not a claim that stock vLLM does this today: the renderer requests `logprobs=1`, so a healthy vLLM path returns one logprob per completion token. The point is that the *contract is unvalidated* and the failure mode is silent corruption of the training signal rather than a loud, debuggable error.

**Fix:** enforce the contract instead of inventing data.
- At the training boundary (`response_from_generate`), reject a response whose `completion_logprobs` length doesn't match `completion_ids` with a clear error.
- In `Branch.logprobs`, raise on a sampled/logprob mismatch instead of zero-filling, as a defensive backstop for any trace reaching export. Genuine non-sampled tokens still contribute `0.0`, unchanged.

No short/padded array is emitted (prime-rl's packer requires `len(logprobs) == len(tokens)`), and no `NaN` sentinel is introduced. Non-training / eval flows that legitimately carry no sampled-token logprobs are unaffected — validation is scoped to the training renderer boundary.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] All existing tests pass when running `uv run pytest` locally (`tests/v1/test_graph.py test_trace.py test_legacy.py test_configs.py`, `tests/test_env_server.py` — 35 passed, 2 skipped for missing `PRIME_API_KEY`).
- [ ] New tests have been added to cover the changes

Per AGENTS.md ("Do not add unit tests to your PRs"), no unit tests are added. Verified with a throwaway script exercising four cases:
```
aligned:          accepted (3 logprobs)
empty:            rejected (3 completion ids but 0 logprobs)
short:            rejected (3 completion ids but 1 logprobs)
eval/no-logprob:  accepted
```

## Checklist
- [x] My code follows the style guidelines of this project as outlined in AGENTS.md
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Additional Notes
Training-correctness fix: converts a silent `prob=1.0` corruption of the behavior-policy logprobs into a loud, debuggable failure at the boundary. No new dependencies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes training-data correctness on the v1 path: misaligned logprobs now abort rollouts that previously continued with fabricated certainty, which is desirable but may surface latent provider/renderer bugs as hard failures.
> 
> **Overview**
> **Training logprobs are now validated** so misaligned renderer output cannot silently corrupt GRPO / importance-sampling behavior-policy weights.
> 
> At the v1 training boundary (`response_from_generate`), responses where `completion_logprobs` length does not match `completion_ids` raise a clear `ValueError` instead of defaulting to an empty list and flowing into training. In `Branch.logprobs`, a sampled-token count vs. node logprob length mismatch raises instead of padding missing positions with `0.0` (which implied probability 1.0). Non-sampled tokens still get `0.0` in the exported per-token vector; only invented logprobs for sampled tokens are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43f0ed59a276ffe4009bdcc72d67283d820e68d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject misaligned training logprobs with `ValueError` instead of zero-filling
> - [`response_from_generate`](https://github.com/PrimeIntellect-ai/verifiers/pull/2078/files#diff-c9bcd6c691890b1de6942fe012d2e74678460b22bf335721a8bba5e939d139c3) now raises `ValueError` when the number of `completion_logprobs` returned by the renderer does not match the number of `completion_ids`.
> - [`Branch.logprobs`](https://github.com/PrimeIntellect-ai/verifiers/pull/2078/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e) now raises `ValueError` when a node's logprob count does not match its sampled token count, removing the previous zero-padding fallback.
> - Risk: code that previously relied on silent zero-filling for misaligned logprobs will now raise an exception instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 43f0ed5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->