### PR TITLE
fix(v1): guard the pool health reply so a departed client can't crash the pool

### DIFF
--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -195,9 +195,10 @@ class EnvServerPool:
                         payload,
                     ) = await self.frontend.recv_multipart()
                     if method == b"health":
-                        await self.frontend.send_multipart(
-                            [client_id, request_id, _HEALTH]
-                        )
+                        with contextlib.suppress(zmq.ZMQError):
+                            await self.frontend.send_multipart(
+                                [client_id, request_id, _HEALTH]
+                            )
                     else:
                         # Pool capacity is measured in rollouts; one group request carries n.
                         rollout_slots = 1


### PR DESCRIPTION
**TL;DR** — under `ROUTER_MANDATORY=1`, one client abandoning a health poll crashes the entire env-server pool (all workers, all in-flight rollouts). Three-line fix.

### Repro
Client calls `.health()` on a short timeout, times out, and closes its DEALER socket in the gap between the broker reading the request (`pool.py:196`) and sending the reply (`pool.py:199`). The ROUTER has already dropped that identity, so the send raises `zmq.ZMQError`.

### Impact
`run()`'s only handler is `except (asyncio.CancelledError, KeyboardInterrupt)` (`pool.py:239`), so the `ZMQError` escapes the loop. It unwinds into `finally: self._shutdown()` (`pool.py:242`), which calls `w["process"].terminate()` on every worker (`pool.py:249`). The whole pool goes down, killing every concurrent rollout, not just the health request that triggered it.

### Fix
```python
# before
if method == b"health":
    await self.frontend.send_multipart([client_id, request_id, _HEALTH])

# after
if method == b"health":
    with contextlib.suppress(zmq.ZMQError):
        await self.frontend.send_multipart([client_id, request_id, _HEALTH])
```
The worker-reply send two branches down already uses this exact guard (`pool.py:235`); the health send was the one path missing it. Live clients are unaffected, since the suppress only swallows a send to a peer that's already gone. Happy to add a regression test that drops a client mid-health poll.

Reopens #2071.
