### PR TITLE
chore: bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/publish-envs.yml
+++ b/.github/workflows/publish-envs.yml
@@ -16,7 +16,7 @@ jobs:
       has_envs: ${{ steps.set-matrix.outputs.has_envs }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set matrix
         id: set-matrix
@@ -47,7 +47,7 @@ jobs:
       PRIME_TEAM_ID: ${{ secrets.PRIME_TEAM_ID }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: true
 

--- a/.github/workflows/publish-verifiers.yml
+++ b/.github/workflows/publish-verifiers.yml
@@ -34,7 +34,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -48,7 +48,7 @@ jobs:
         run: ls -1 dist/
 
       - name: Upload dist artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: verifiers-dev-dist
           path: dist/
@@ -63,7 +63,7 @@ jobs:
       id-token: write
     steps:
       - name: Download dist artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: verifiers-dev-dist
           path: dist/
@@ -84,14 +84,14 @@ jobs:
     steps:
       - name: Checkout tagged release (dispatch)
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: refs/tags/${{ inputs.tag }}
 
       - name: Checkout tagged release (push)
         if: github.event_name != 'workflow_dispatch'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -122,7 +122,7 @@ jobs:
         run: uv build
 
       - name: Upload dist artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: verifiers-dist
           path: dist/
@@ -137,7 +137,7 @@ jobs:
       id-token: write
     steps:
       - name: Download dist artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: verifiers-dist
           path: dist/
@@ -152,12 +152,12 @@ jobs:
       contents: write
     steps:
       - name: Checkout tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: refs/tags/${{ needs.build-tag.outputs.tag }}
 
       - name: Download dist artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: verifiers-dist
           path: dist/

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: true
       - name: Lint
-        uses: astral-sh/ruff-action@v3
+        uses: astral-sh/ruff-action@v4
       - name: Format
-        uses: astral-sh/ruff-action@v3
+        uses: astral-sh/ruff-action@v4
         with:
           args: "format --check"
   ty:
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Set up Python

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -19,9 +19,9 @@ jobs:
         with:
           submodules: true
       - name: Lint
-        uses: astral-sh/ruff-action@v4
+        uses: astral-sh/ruff-action@v4.1.0
       - name: Format
-        uses: astral-sh/ruff-action@v4
+        uses: astral-sh/ruff-action@v4.1.0
         with:
           args: "format --check"
   ty:

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger public-docs workflow
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.DOCS_SYNC_PAT }}
           repository: PrimeIntellect-ai/public-docs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
- Bump GitHub Actions pinned to versions running on deprecated Node runtimes, matching the versions used in prime-rl:
  - `actions/checkout` v4 → v5
  - `actions/upload-artifact` v4 → v5
  - `actions/download-artifact` v4 → v6
  - `peter-evans/repository-dispatch` v3 → v4
  - `astral-sh/ruff-action` v3 → v4
- Already on latest, left unchanged: `astral-sh/setup-uv@v7`, `actions/setup-python@v6`, `actions/cache@v4`, `softprops/action-gh-release@v2`, and the SHA-pinned `pypa/gh-action-pypi-publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only dependency bumps with no application or runtime code changes; residual risk is limited to possible CI breakage from action major-version behavior changes.
> 
> **Overview**
> Updates pinned **GitHub Actions** across CI workflows so jobs run on supported Node runtimes, aligned with **prime-rl**.
> 
> **Checkout** moves from `actions/checkout@v4` to **v5** in publish-envs, publish-verifiers, style, sync-docs, and test. **Artifact** steps in publish-verifiers use **upload-artifact v5** and **download-artifact v6** (replacing v4). **Style** pins **astral-sh/ruff-action** to **v4.1.0** (from v3). **Docs sync** uses **peter-evans/repository-dispatch v4** (from v3).
> 
> Other actions (e.g. `setup-uv@v7`, `setup-python@v6`, SHA-pinned PyPI publish) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f372accb848d7602c19728f8053e03e81c2fbc18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump GitHub Actions to latest major versions across CI workflows
> Updates action versions across all CI workflow files: `actions/checkout` to v5, `actions/upload-artifact` to v5, `actions/download-artifact` to v6, `astral-sh/ruff-action` to v4.1.0, and `peter-evans/repository-dispatch` to v4.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f372acc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->