### PR TITLE
chore: make stable release manual-dispatch only

### DIFF
--- a/.github/workflows/publish-verifiers.yml
+++ b/.github/workflows/publish-verifiers.yml
@@ -4,7 +4,7 @@ name: Publish verifiers
 # - Every push to `main` publishes a pre-release for the next release: the last
 #   `vX.Y.Z` tag with its final segment bumped, plus `.dev<N>` where N = commits
 #   since that tag (e.g. `v0.1.14` -> `0.1.15.dev<N>`). No per-commit tags created.
-# - Pushing a `vX.Y.Z` tag (or dispatching with one) publishes that exact stable
+# - Dispatching with an existing `vX.Y.Z` tag publishes that exact stable
 #   release to PyPI and creates a GitHub release.
 
 on:
@@ -17,9 +17,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v[0-9]*.[0-9]*.[0-9]*'
-      - '!v[0-9]*dev*'  # `.dev` tags are auto-versioning artifacts, not releases
 
 concurrency:
   group: publish-verifiers-${{ github.ref }}
@@ -73,40 +70,27 @@ jobs:
         with:
           skip-existing: true
 
-  # Stable release: a pushed `vX.Y.Z` tag or a manual dispatch with an existing tag.
+  # Stable release: a manual dispatch with an existing tag.
   build-tag:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
       tag: ${{ steps.release.outputs.tag }}
     steps:
-      - name: Checkout tagged release (dispatch)
-        if: github.event_name == 'workflow_dispatch'
+      - name: Checkout tagged release
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: refs/tags/${{ inputs.tag }}
 
-      - name: Checkout tagged release (push)
-        if: github.event_name != 'workflow_dispatch'
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
       - name: Resolve release tag
         id: release
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          PUSHED_REF: ${{ github.ref_name }}
-          INPUT_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || '' }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            TAG="$INPUT_TAG"
-          else
-            TAG="$PUSHED_REF"
-          fi
+          TAG="$INPUT_TAG"
 
           if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Release tags must look like 'vX.Y.Z' (received '$TAG')" >&2


### PR DESCRIPTION
## Summary
- Remove the `vX.Y.Z` tag push trigger from the Publish verifiers workflow — pushing release tags is not permitted, so stable releases are now cut only via `workflow_dispatch` with an existing tag.
- Simplify the `build-tag` job accordingly: single dispatch-only checkout, and the tag resolution step reads `inputs.tag` directly (dropping the now-dead push-ref branch).
- The main-branch dev pre-release path (`build-dev` / `publish-dev`) is unchanged.

## Breaking
- Pushing a `vX.Y.Z` tag no longer triggers a PyPI publish or GitHub release. To cut a stable release, run the **Publish verifiers** workflow via `workflow_dispatch` with the existing tag as input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how production PyPI/GitHub releases are triggered; teams that relied on pushing `vX.Y.Z` tags must switch to manual workflow dispatch or releases will not ship.
> 
> **Overview**
> **Stable `verifiers` releases no longer run on tag push** — only **Publish verifiers** via `workflow_dispatch` with an existing `vX.Y.Z` tag publishes to PyPI and creates the GitHub release (aligned with tag pushes not being allowed).
> 
> The `on.push.tags` trigger is removed from `publish-verifiers.yml`. The **`build-tag`** job is gated to dispatch only, uses a single checkout of `refs/tags/${{ inputs.tag }}`, and resolves the release tag from **`inputs.tag`** instead of branching on push vs dispatch.
> 
> **Unchanged:** pushes to **`main`** still drive dev pre-releases (`build-dev` / `publish-dev`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 049c3961c8ba5b2b57b858362a4fbc27b18a6331. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restrict stable release workflow to manual dispatch only
> - Removes the `vX.Y.Z` tag-push trigger from [publish-verifiers.yml](.github/workflows/publish-verifiers.yml); stable releases now require an explicit `workflow_dispatch` with a tag input.
> - Simplifies the `build-tag` job by removing tag-push event logic and always checking out `refs/tags/${{ inputs.tag }}`.
> - Behavioral Change: pushing a `vX.Y.Z` tag no longer triggers a stable release; the workflow will fail if `inputs.tag` is absent or does not match `vX.Y.Z`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 049c396.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->