### PR TITLE
fix(v1): derive num_input_tokens from the final call so it can't go negative

### DIFF
--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -238,9 +238,7 @@ class Branch(StrictBaseModel):
 
     @property
     def num_total_tokens(self) -> int:
-        """Final sequence length: the last call's prompt + completion. Earlier turns' context
-        is already contained in that prompt, so re-sent tokens are counted once rather than
-        summed per turn."""
+        """Total tokens reported for the final model call."""
         last = self.last_usage
         return last.total_tokens if last is not None else 0
 

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -252,10 +252,9 @@ class Branch(StrictBaseModel):
 
     @property
     def num_input_tokens(self) -> int:
-        """Tokens fed to the model, counted once: the final sequence minus everything the model
-        generated (i.e. system + user + tool inputs). Not the last prompt — re-sent context is
-        not double-counted."""
-        return self.num_total_tokens - self.num_output_tokens
+        """Tokens fed in the final model call, including its full re-sent context."""
+        last = self.last_usage
+        return last.input_tokens if last is not None else 0
 
 
 _NODE_DUMP_EXCLUDE: dict = {


### PR DESCRIPTION
**TL;DR** — `Branch.num_input_tokens` goes negative on any multi-turn trace where generated tokens outpace the final call's total, which silently disables the `max_input_tokens` cap for the rest of the rollout. Fix reads the final call's input directly.

### Repro
`num_input_tokens` was `num_total_tokens - num_output_tokens`, but the two sides count different frames:
- `num_total_tokens` = the *final* call's `total_tokens` (`trace.py:243`)
- `num_output_tokens` = `completion_tokens` aggregated across *every* call (`trace.py:246`)

Two calls on one branch, reasoning model — reasoning tokens count as completion but aren't re-sent into the next prompt:

| call | input | completion | total |
|------|-------|------------|-------|
| 1    | 100   | 500        | 600   |
| 2    | 200   | 50         | 250   |

`num_total_tokens` = 250 (call 2). `num_output_tokens` = 500 + 50 = 550. So `num_input_tokens = 250 - 550 = -300`.

### Impact
The cap check is `trace.num_input_tokens >= max_input_tokens` (`session.py:48`). At -300 it never fires, so `max_input_tokens` stops bounding anything for the rest of that rollout. Any multi-turn run where earlier output isn't re-sent — reasoning models, context trimming — hits the same sign flip. Latent since #2040 made the counts usage-based but kept the subtraction.

### Fix
```python
# before
def num_input_tokens(self) -> int:
    return self.num_total_tokens - self.num_output_tokens

# after
def num_input_tokens(self) -> int:
    last = self.last_usage
    return last.input_tokens if last is not None else 0
```
`last_usage.input_tokens` is the tokens fed to the final call — its full re-sent context, counted once. That is the number `max_input_tokens` is documented to bound, and it can't go negative.

Reopens #2069. Trace requested by @xeophon is in that thread.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout limit semantics for multi-turn traces (reasoning, trimming); behavior is a bugfix but directly affects when rollouts stop for `max_input_tokens`.
> 
> **Overview**
> Fixes **`Branch.num_input_tokens`** so it matches what **`max_input_tokens`** is meant to bound: the prompt size of the **final** model call, not `num_total_tokens - num_output_tokens`.
> 
> Previously **`num_total_tokens`** came from the last call while **`num_output_tokens`** summed completions across every turn (e.g. reasoning tokens that are not re-sent). On multi-turn branches that mismatch could make **`num_input_tokens`** negative, so **`trace.num_input_tokens >= max_input_tokens`** in **`RolloutLimits.reached`** never fired.
> 
> The property now returns **`last_usage.input_tokens`** (or 0), aligned with **`num_total_tokens`** / **`last_usage`**. Docstrings for **`num_total_tokens`** and **`num_input_tokens`** were tightened to describe this semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3c20f433820ba80fe12f8a0951bda32a9cc41d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `Branch.num_input_tokens` to read directly from the final model call instead of deriving it
> Previously, `num_input_tokens` was computed as `num_total_tokens - num_output_tokens`, which could produce negative values. It now reads `input_tokens` directly from the final model call's usage data, returning 0 if absent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b3c20f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->