### PR TITLE
fix: Avoid init failures

### DIFF
--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -29,11 +29,13 @@ import os
 import signal
 import threading
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import fields, is_dataclass
 
 import msgpack
 import zmq
 import zmq.asyncio
+from pydantic import BaseModel
 
 from verifiers.v1.env import EnvConfig
 from verifiers.v1.serve.server import EnvServer
@@ -261,11 +263,41 @@ class EnvServerPool:
         logger.info("EnvServerPool down")
 
 
+def _constructor_excludes(value: object) -> dict:
+    """Build a Pydantic exclusion tree for fields that cannot be constructor inputs."""
+    if is_dataclass(value) and not isinstance(value, type):
+        excluded = {}
+        for config_field in fields(value):
+            if not config_field.init:
+                excluded[config_field.name] = True
+                continue
+            nested = _constructor_excludes(getattr(value, config_field.name))
+            if nested:
+                excluded[config_field.name] = nested
+        return excluded
+
+    if isinstance(value, BaseModel):
+        items = ((name, getattr(value, name)) for name in type(value).model_fields)
+    elif isinstance(value, Mapping):
+        items = value.items()
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        items = enumerate(value)
+    else:
+        return {}
+
+    excluded = {}
+    for key, item in items:
+        nested = _constructor_excludes(item)
+        if nested:
+            excluded[key] = nested
+    return excluded
+
+
 def env_config_data(config) -> dict:
     """The picklable `EnvConfig` fields of a (possibly dynamically-narrowed, unpicklable)
     config object — ship this across a process boundary, then rebuild via
     `EnvConfig.model_validate` (its validator re-resolves the concrete taskset/harness)."""
-    data = config.model_dump(mode="json")
+    data = config.model_dump(mode="json", exclude=_constructor_excludes(config))
     return {k: v for k, v in data.items() if k in EnvConfig.model_fields}
 
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix init failures by excluding non-constructor fields in `env_config_data` serialization
- Adds a `_constructor_excludes` helper in [pool.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2088/files#diff-0c9c59578214be2580d340bc524321e352f48038207a68945637d00fc399600c) that recursively builds a Pydantic exclude tree, skipping dataclass fields with `init=False` and recursing into nested dataclasses, `BaseModel` instances, mappings, and sequences.
- `env_config_data` now passes this exclude tree to `model_dump` before filtering to `EnvConfig.model_fields`, preventing fields that cannot be passed to constructors from appearing in the serialized output.
- Behavioral Change: `model_dump` output for nested config objects will now omit `init=False` fields that were previously included.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized c14c5fa.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->