### PR TITLE
fix: drop redundant on_trace kwarg from Agent.run

### DIFF
--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -222,18 +222,16 @@ class Agent:
         *,
         runtime: Runtime | None = None,
         tools: Mapping[str, SharedToolServer] | None = None,
-        on_trace: Callable[[Trace], None] | None = None,
     ) -> Trace:
         """Run this agent on `task` once and return the trace: `runtime` places it
         into a live borrowed box instead of provisioning one; `tools` are live
-        servers borrowed from their owner, counted in the pairing check;
-        `on_trace` observes the trace the moment it's minted, before any I/O.
+        servers borrowed from their owner, counted in the pairing check.
         Retries whole while the trace ends with a retryable error (`config.retries`)
         — never into a borrowed box; the final trace keeps earlier attempts' errors."""
         retry = self.config.retries
         history: list = []
         for attempt in range(retry.max_retries + 1):
-            trace = await self._run_once(task, runtime, tools, on_trace)
+            trace = await self._run_once(task, runtime, tools)
             if attempt == retry.max_retries or not trace_should_retry(trace, retry):
                 break
             if runtime is not None:
@@ -243,6 +241,8 @@ class Agent:
                 )
                 break
             history.extend(trace.errors)
+            # This attempt is abandoned; drop it from any live view before backoff.
+            self._discard(trace)
             delay = backoff(attempt)
             logger.warning(
                 "retrying agent rollout (retry %d/%d) in %.1fs after error: %s",
@@ -258,15 +258,22 @@ class Agent:
             trace.errors = history + trace.errors
         return trace
 
+    def _observe(self, trace: Trace) -> None:
+        """The moment a trace is minted, before any I/O. Base: no-op; an episode
+        seat stamps its standing onto the trace and feeds the episode's live view."""
+
+    def _discard(self, trace: Trace) -> None:
+        """A retry is abandoning this attempt's trace. Base: no-op; an episode seat
+        drops it from live views (only the final attempt joins the episode)."""
+
     async def _run_once(
         self,
         task: Task,
         runtime: Runtime | None,
         shared_tools: Mapping[str, SharedToolServer] | None,
-        on_trace: Callable[[Trace], None] | None,
     ) -> Trace:
         params = self._rollout_params(task, runtime, dict(shared_tools or {}))
-        run = RolloutRun(task=task, on_trace=on_trace, **params)
+        run = RolloutRun(task=task, on_trace=self._observe, **params)
         try:
             if await run.open():
                 await run.step()
@@ -387,37 +394,33 @@ class _EpisodeAgent(Agent):
     def _shared_for(self, task: Task) -> Mapping[str, SharedToolServer]:
         return self._shared_tools if isinstance(task, self._task_cls) else {}
 
+    def _observe(self, trace: Trace) -> None:
+        # The seat's standing lands on the trace the moment it's minted, then the
+        # trace joins the episode's live view (before any I/O, retries included).
+        if trace.agent is not None:
+            trace.agent.name = self._name
+            trace.agent.trainable = self.trainable
+        if self._on_trace is not None:
+            self._on_trace(trace)
+
+    def _discard(self, trace: Trace) -> None:
+        # A per-agent retry abandons this attempt's trace; drop it from live views
+        # (only the final attempt joins the episode).
+        if self._on_discard is not None:
+            self._on_discard(trace)
+
     async def run(
         self,
         task: Task,
         *,
         runtime: Runtime | None = None,
         tools: Mapping[str, SharedToolServer] | None = None,
-        on_trace: Callable[[Trace], None] | None = None,
     ) -> Trace:
-        last: Trace | None = None
-
-        def watch(trace: Trace) -> None:
-            nonlocal last
-            if trace.agent is not None:
-                trace.agent.name = self._name
-                trace.agent.trainable = self.trainable
-            # A per-agent retry mints a replacement: the abandoned attempt's trace
-            # must leave live views (only the final one joins the episode).
-            if last is not None and self._on_discard is not None:
-                self._on_discard(last)
-            last = trace
-            if self._on_trace is not None:
-                self._on_trace(trace)
-            if on_trace is not None:
-                on_trace(trace)
-
         async with self._gate or nullcontext():
             trace = await super().run(
                 task,
                 runtime=runtime,
                 tools=tools if tools is not None else self._shared_for(task),
-                on_trace=watch,
             )
         self._completed.append(trace)
         return trace


### PR DESCRIPTION
## Summary

- `Agent.run` returns the `Trace`, so a public `on_trace(trace)` callback on it is redundant for the standalone agent — and no external caller ever passed it.
- Its only consumer was `_EpisodeAgent`, which injected a per-call `watch` closure to observe each trace *at mint* (stamp the seat's `agent.name`/`trainable`, feed the episode's live view, discard abandoned retry attempts). The base retry loop already knows each attempt, so it can drive this directly.
- Make mint-observation an internal protected mechanism: base `Agent` grows no-op `_observe`/`_discard` hooks; `_run_once` fires `_observe` at mint (via `RolloutRun`'s `on_trace`); the retry loop calls `_discard` when it abandons an attempt for backoff. `_EpisodeAgent` overrides both — no per-call closure, no public kwarg.
- Live-dashboard streaming (`slot.traces` fed at mint) and per-agent retry discard are behaviorally unchanged.

## Breaking

- `Agent.run` / `_EpisodeAgent.run` no longer accept the `on_trace` keyword. It was never part of the advertised API (`solver.run(task)`), had no callers outside the internal `watch` plumbing, and callers already get the trace as the return value. For mint-time/live observation inside an env, keep going through `Env.run_episode(on_trace=...)` (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking removal of Agent.run's on_trace and a behavior-sensitive change to when abandoned retry traces leave live views (now via base retry loop + _discard); episode streaming should be unchanged but callers relying on the old kwarg must migrate.
> 
> **Overview**
> Removes the public **`on_trace`** kwarg from **`Agent.run`** and **`_EpisodeAgent.run`**. Mint-time trace handling is now internal: base **`Agent`** defines no-op **`_observe`** / **`_discard`** hooks, **`_run_once`** wires **`RolloutRun`** to **`self._observe`**, and the retry loop calls **`_discard`** on abandoned attempts before backoff.
> 
> **`_EpisodeAgent`** overrides those hooks to stamp seat **`name`** / **`trainable`**, forward to the episode’s **`on_trace`** / **`on_discard`**, and drop superseded traces from live views—replacing the previous per-**`run`** **`watch`** closure (including discard-on-retry logic inlined there).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 408b45a26536034e9e87a98bbe487555fe8f9cbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop `on_trace` parameter from `Agent.run` and replace with `_observe`/`_discard` hooks
> - Removes the `on_trace` callback parameter from `Agent.run` and `Agent._run_once`; callers passing it will now get a `TypeError`.
> - Adds protected `_observe` and `_discard` hook methods to `Agent` that subclasses can override; `_observe` fires when a trace is minted, `_discard` fires when a retried attempt is abandoned before backoff.
> - `_EpisodeAgent` overrides both hooks to stamp traces with seat metadata and forward events to episode-level callbacks, replacing the previous per-run `watch()` closure.
> - Risk: any caller currently passing `on_trace` to `Agent.run` or `_EpisodeAgent.run` will break with a `TypeError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 408b45a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->