### PR TITLE
fix: rename Agent.run shared_tools kwarg to tools

### DIFF
--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -221,17 +221,17 @@ class Agent:
         task: Task,
         *,
         runtime: Runtime | None = None,
-        shared_tools: Mapping[str, SharedToolServer] | None = None,
+        tools: Mapping[str, SharedToolServer] | None = None,
     ) -> Trace:
         """Run this agent on `task` once and return the trace: `runtime` places it
-        into a live borrowed box instead of provisioning one; `shared_tools` are
-        live servers borrowed from their owner, counted in the pairing check.
+        into a live borrowed box instead of provisioning one; `tools` are live
+        servers borrowed from their owner, counted in the pairing check.
         Retries whole while the trace ends with a retryable error (`config.retries`)
         — never into a borrowed box; the final trace keeps earlier attempts' errors."""
         retry = self.config.retries
         history: list = []
         for attempt in range(retry.max_retries + 1):
-            trace = await self._run_once(task, runtime, shared_tools)
+            trace = await self._run_once(task, runtime, tools)
             if attempt == retry.max_retries or not trace_should_retry(trace, retry):
                 break
             if runtime is not None:
@@ -363,7 +363,7 @@ class _EpisodeAgent(Agent):
     they're created, finished ones land in `completed` (the episode's traces),
     each run takes the eval's gate. The taskset's shared tool servers ride only
     its own tasks — on an env-minted task they'd wrongly put MCP in play
-    (`shared_tools=` overrides)."""
+    (`tools=` overrides)."""
 
     def __init__(
         self,
@@ -414,15 +414,13 @@ class _EpisodeAgent(Agent):
         task: Task,
         *,
         runtime: Runtime | None = None,
-        shared_tools: Mapping[str, SharedToolServer] | None = None,
+        tools: Mapping[str, SharedToolServer] | None = None,
     ) -> Trace:
         async with self._gate or nullcontext():
             trace = await super().run(
                 task,
                 runtime=runtime,
-                shared_tools=shared_tools
-                if shared_tools is not None
-                else self._shared_for(task),
+                tools=tools if tools is not None else self._shared_for(task),
             )
         self._completed.append(trace)
         return trace


### PR DESCRIPTION
## Summary

- Rename the public keyword on `Agent.run` / `_EpisodeAgent.run` from `shared_tools` to `tools`. At the run boundary "shared" is implied — the caller just hands over the tool servers this run may use.
- The internal *shared tool servers* infrastructure keeps its name (`Env.shared_tools()`, `RolloutRun`, `validate_pairing`, `mcp/launch`): those servers are genuinely shared/borrowed across a whole eval, and calling them `tools` there would collide with `Task.tools` (the declared toolset classes). So the rename is scoped to the `.run` surface, with the seam kept at `RolloutRun`.

## Breaking

- `Agent.run(..., shared_tools=...)` → `Agent.run(..., tools=...)`. No in-repo callers passed it (the only consumer routed through the internal seat plumbing, which is unchanged), so this is a rename of an undocumented kwarg.

> [!NOTE]
> Stacked on #2091 (base is `fix/agent-run-drop-on-trace`); will retarget to `main` once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Surface-only API rename on an optional kwarg with no in-repo callers passing it; behavior and internal wiring stay the same.
> 
> **Overview**
> Renames the public keyword on **`Agent.run`** and **`_EpisodeAgent.run`** from `shared_tools` to **`tools`**, so callers pass borrowed MCP tool servers at the run boundary without the redundant "shared" prefix.
> 
> Internal rollout plumbing is unchanged: **`_run_once`**, **`_rollout_params`**, **`RolloutRun`**, **`validate_pairing`**, and env **`_shared_tools`** still use `shared_tools`, avoiding collision with **`Task.tools`** (declared toolset classes). **`_EpisodeAgent`** still defaults runs via **`_shared_for`** when `tools` is omitted.
> 
> **Breaking:** `Agent.run(..., shared_tools=...)` must become `Agent.run(..., tools=...)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6844eaf6a0e3c13997acc3b7efff182cbb607133. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename `shared_tools` kwarg to `tools` in `Agent.run` and `_EpisodeAgent.run`
> Renames the `shared_tools` keyword argument to `tools` in [agent.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2093/files#diff-f719e773e216506045964fdfb9fad948b7b504ea092359ced06c928ab5148ea2) for both `Agent.run` and `_EpisodeAgent.run`, and updates docstrings and internal call sites to match. Risk: any caller passing `shared_tools=` as a keyword argument will get a `TypeError` at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6844eaf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->