### PR TITLE
fix: rename Agent.run shared_tools kwarg to tools

### DIFF
--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -221,19 +221,19 @@ class Agent:
         task: Task,
         *,
         runtime: Runtime | None = None,
-        shared_tools: Mapping[str, SharedToolServer] | None = None,
+        tools: Mapping[str, SharedToolServer] | None = None,
         on_trace: Callable[[Trace], None] | None = None,
     ) -> Trace:
         """Run this agent on `task` once and return the trace: `runtime` places it
-        into a live borrowed box instead of provisioning one; `shared_tools` are
-        live servers borrowed from their owner, counted in the pairing check;
+        into a live borrowed box instead of provisioning one; `tools` are live
+        servers borrowed from their owner, counted in the pairing check;
         `on_trace` observes the trace the moment it's minted, before any I/O.
         Retries whole while the trace ends with a retryable error (`config.retries`)
         — never into a borrowed box; the final trace keeps earlier attempts' errors."""
         retry = self.config.retries
         history: list = []
         for attempt in range(retry.max_retries + 1):
-            trace = await self._run_once(task, runtime, shared_tools, on_trace)
+            trace = await self._run_once(task, runtime, tools, on_trace)
             if attempt == retry.max_retries or not trace_should_retry(trace, retry):
                 break
             if runtime is not None:
@@ -356,7 +356,7 @@ class _EpisodeAgent(Agent):
     they're created, finished ones land in `completed` (the episode's traces),
     each run takes the eval's gate. The taskset's shared tool servers ride only
     its own tasks — on an env-minted task they'd wrongly put MCP in play
-    (`shared_tools=` overrides)."""
+    (`tools=` overrides)."""
 
     def __init__(
         self,
@@ -392,7 +392,7 @@ class _EpisodeAgent(Agent):
         task: Task,
         *,
         runtime: Runtime | None = None,
-        shared_tools: Mapping[str, SharedToolServer] | None = None,
+        tools: Mapping[str, SharedToolServer] | None = None,
         on_trace: Callable[[Trace], None] | None = None,
     ) -> Trace:
         last: Trace | None = None
@@ -416,9 +416,7 @@ class _EpisodeAgent(Agent):
             trace = await super().run(
                 task,
                 runtime=runtime,
-                shared_tools=shared_tools
-                if shared_tools is not None
-                else self._shared_for(task),
+                tools=tools if tools is not None else self._shared_for(task),
                 on_trace=watch,
             )
         self._completed.append(trace)


### PR DESCRIPTION
## Summary

- Rename the public keyword on `Agent.run` / `_EpisodeAgent.run` from `shared_tools` to `tools`. At the run boundary "shared" is implied — the caller just hands over the tool servers this run may use.
- The internal *shared tool servers* infrastructure keeps its name (`Env.shared_tools()`, `RolloutRun`, `validate_pairing`, `mcp/launch`): those servers are genuinely shared/borrowed across a whole eval, and calling them `tools` there would collide with `Task.tools` (the declared toolset classes). So the rename is scoped to the `.run` surface, with the seam kept at `RolloutRun`.

## Breaking

- `Agent.run(..., shared_tools=...)` → `Agent.run(..., tools=...)`. No in-repo callers passed it (the only consumer routes through internal seat plumbing, which is unchanged), so this is a rename of an undocumented kwarg.

> [!NOTE]
> This re-targets the change from #2093 (which merged into a stacked branch, not `main`) directly at `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Keyword-only API rename with no in-repo callers; behavior and internal `shared_tools` plumbing are unchanged.
> 
> **Overview**
> Renames the public **`tools`** keyword on **`Agent.run`** and **`_EpisodeAgent.run`** (formerly **`shared_tools`**), so callers pass borrowed MCP tool servers at the run boundary without the redundant “shared” prefix.
> 
> **`_EpisodeAgent`** still defaults from env-owned **`shared_tools`** when **`tools`** is omitted; internal rollout plumbing (**`_run_once`**, **`RolloutRun`**, **`validate_pairing`**, **`Env.shared_tools()`**) keeps the **`shared_tools`** name to avoid clashing with **`Task.tools`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0fbf04793b0f89eb3780155d050f46b03fba9e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename `shared_tools` parameter to `tools` in `Agent.run` and `_EpisodeAgent.run`
> Renames the `shared_tools` keyword argument to `tools` in [agent.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2094/files#diff-f719e773e216506045964fdfb9fad948b7b504ea092359ced06c928ab5148ea2) for both `Agent.run` and `_EpisodeAgent.run`. Risk: callers passing `shared_tools=` as a keyword argument will receive a `TypeError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b0fbf04.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->