### PR TITLE
fix: point mint.json at renamed v1 env page

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -12,7 +12,7 @@
             "v1/getting_started",
             "v1/architecture",
             "v1/tasksets",
-            "v1/environments",
+            "v1/env",
             "v1/evaluation",
             "v1/harnesses",
             "v1/agent",

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -12,10 +12,10 @@
             "v1/getting_started",
             "v1/architecture",
             "v1/tasksets",
-            "v1/env",
             "v1/evaluation",
             "v1/harnesses",
             "v1/agent",
+            "v1/env",
             "v1/harbor",
             "v1/gepa"
           ]


### PR DESCRIPTION
## Summary
- Update `docs/mint.json` navigation to reference `v1/env` instead of the removed `v1/environments` page. The rename of `docs/v1/environments.md` to `docs/v1/env.md` missed the nav entry, so https://docs.primeintellect.ai/verifiers/v1/environments 404'd and the new Env page never appeared in the sidebar.
- Place the Env page after Agent in the sidebar order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix broken docs navigation link for renamed v1 env page
> Updates [mint.json](https://github.com/PrimeIntellect-ai/verifiers/pull/2097/files#diff-c91a604899dfef4b2494c317f4fd39a7f22b79986095f580399347293d534deb) to reference `v1/env` instead of the old `v1/environments` path, correcting a broken navigation entry after the page was renamed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa0a621.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->