### PR TITLE
fix(v1): close agent-owned clients

### DIFF
--- a/docs/v1/agent.md
+++ b/docs/v1/agent.md
@@ -7,13 +7,13 @@ An `Agent` is a configured **harness** (the program that drives the model), a
 ```python
 import verifiers.v1 as vf
 
-solver = vf.make_agent(vf.AgentConfig(model="z-ai/glm-5.2"))
-trace = await solver.run(vf.Task(vf.TaskData(prompt="What is 2+2?")))
+async with vf.make_agent(vf.AgentConfig(model="z-ai/glm-5.2")) as solver:
+    trace = await solver.run(vf.Task(vf.TaskData(prompt="What is 2+2?")))
 ```
 
 Every run is a standard rollout producing a `vf.Trace`. By default, the agent
-is self-contained: each run brings up the machinery it needs — interception
-server, network tunnel — and tears it down afterwards.
+is self-contained: its context owns the model client and shared interception
+server, while each run owns its runtime and any per-run interception machinery.
 
 ## Borrowed Resources
 
@@ -91,15 +91,16 @@ places a run into it instead of provisioning a fresh one. Chained agents then
 share one file system — here, the judge inspects what the solver left behind:
 
 ```python
-solver = vf.make_agent(vf.AgentConfig(model="z-ai/glm-5.2"))
-judge = vf.make_agent(vf.AgentConfig(model="openai/gpt-5.4-mini"))
-
 task = vf.Task(vf.TaskData(prompt="Sum the first 100 primes into answer.txt"))
 audit = vf.Task(vf.TaskData(prompt="Recompute the sum and verify answer.txt"))
 
-async with solver.provision(task) as box:
-    solution = await solver.run(task, runtime=box)
-    verdict = await judge.run(audit, runtime=box)
+async with (
+    vf.make_agent(vf.AgentConfig(model="z-ai/glm-5.2")) as solver,
+    vf.make_agent(vf.AgentConfig(model="openai/gpt-5.4-mini")) as judge,
+):
+    async with solver.provision(task) as box:
+        solution = await solver.run(task, runtime=box)
+        verdict = await judge.run(audit, runtime=box)
 ```
 
 The box lives exactly as long as the `async with`: borrowed runs never

--- a/docs/v1/agent.md
+++ b/docs/v1/agent.md
@@ -15,6 +15,9 @@ Every run is a standard rollout producing a `vf.Trace`. By default, the agent
 is self-contained: its context owns the model client and shared interception
 server, while each run owns its runtime and any per-run interception machinery.
 
+Exiting the context closes an agent-owned client, so create a new agent for
+later runs; injected clients remain caller-owned.
+
 ## Borrowed Resources
 
 At scale (large evals, training), per-run machinery adds up. `make_agent`

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -7,6 +7,9 @@ are local-only (their marks are excluded in CI)."""
 
 import pytest
 
+import verifiers.v1 as vf
+from verifiers.v1.clients import EvalClient
+
 _m = pytest.mark
 
 
@@ -82,6 +85,31 @@ SHARED_TOOL_PLACEMENTS = [
     _pair("subprocess", "docker", "harness-in-subprocess-with-tool-in-docker"),
     _pair("modal", "modal", "harness-in-modal-with-tool-in-modal"),
 ]
+
+
+async def test_agent_client_lifecycle():
+    config = vf.AgentConfig(model="unused", harness=vf.HarnessConfig(id="null"))
+    agent = vf.make_agent(config)
+    first = agent.ctx.client
+    assert isinstance(first, EvalClient)
+
+    async with agent:
+        assert not first.http.is_closed
+    assert first.http.is_closed
+
+    async with agent:
+        second = agent.ctx.client
+        assert isinstance(second, EvalClient)
+        assert second is not first
+        assert not second.http.is_closed
+    assert second.http.is_closed
+
+    borrowed = vf.resolve_client(vf.EvalClientConfig())
+    assert isinstance(borrowed, EvalClient)
+    async with vf.make_agent(config, client=borrowed):
+        pass
+    assert not borrowed.http.is_closed
+    await borrowed.close()
 
 
 @pytest.mark.e2e

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -7,9 +7,6 @@ are local-only (their marks are excluded in CI)."""
 
 import pytest
 
-import verifiers.v1 as vf
-from verifiers.v1.clients import EvalClient
-
 _m = pytest.mark
 
 
@@ -85,31 +82,6 @@ SHARED_TOOL_PLACEMENTS = [
     _pair("subprocess", "docker", "harness-in-subprocess-with-tool-in-docker"),
     _pair("modal", "modal", "harness-in-modal-with-tool-in-modal"),
 ]
-
-
-async def test_agent_client_lifecycle():
-    config = vf.AgentConfig(model="unused", harness=vf.HarnessConfig(id="null"))
-    agent = vf.make_agent(config)
-    first = agent.ctx.client
-    assert isinstance(first, EvalClient)
-
-    async with agent:
-        assert not first.http.is_closed
-    assert first.http.is_closed
-
-    async with agent:
-        second = agent.ctx.client
-        assert isinstance(second, EvalClient)
-        assert second is not first
-        assert not second.http.is_closed
-    assert second.http.is_closed
-
-    borrowed = vf.resolve_client(vf.EvalClientConfig())
-    assert isinstance(borrowed, EvalClient)
-    async with vf.make_agent(config, client=borrowed):
-        pass
-    assert not borrowed.http.is_closed
-    await borrowed.close()
 
 
 @pytest.mark.e2e

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -148,15 +148,14 @@ class Agent:
         self.config = config
         self.harness = load_harness(harness_config)
         self._owns_client = client is None
-        self._client_config = config.client or EvalClientConfig()
         if self._owns_client:
-            client = resolve_client(self._client_config)
+            client = resolve_client(config.client or EvalClientConfig())
         self.ctx = ModelContext(
             model=config.model,
             client=client,
             sampling=config.sampling if config.sampling is not None else Sampling(),
         )
-        self._client_closed = False
+        self._closed = False
         self.runtime_config: RuntimeConfig = self.harness.config.runtime
         self.interception = interception
         self.limits = RolloutLimits(
@@ -176,13 +175,8 @@ class Agent:
     async def __aenter__(self) -> "Agent":
         if self._entered:
             raise RuntimeError("Agent is already entered; enter it once and share it")
-        if self._client_closed:
-            self.ctx = ModelContext(
-                model=self.ctx.model,
-                client=resolve_client(self._client_config),
-                sampling=self.ctx.sampling,
-            )
-            self._client_closed = False
+        if self._closed:
+            raise RuntimeError("Agent is closed; create a new agent")
         self._entered = True
         if self.interception is None:
             # Sized to the runtime policy (remote needs the tunnel); runs the
@@ -197,8 +191,8 @@ class Agent:
                 # here, or the agent stays "already entered" forever.
                 self._entered, self._server = False, None
                 if self._owns_client:
+                    self._closed = True
                     await self.ctx.client.close()
-                    self._client_closed = True
                 raise
         return self
 
@@ -210,8 +204,8 @@ class Agent:
                 await server.__aexit__(*exc)
         finally:
             if self._owns_client:
+                self._closed = True
                 await self.ctx.client.close()
-                self._client_closed = True
 
     def _interception_for(
         self, run_is_local: bool, task: Task, shared_tools: Mapping
@@ -248,6 +242,8 @@ class Agent:
         `on_trace` observes the trace the moment it's minted, before any I/O.
         Retries whole while the trace ends with a retryable error (`config.retries`)
         — never into a borrowed box; the final trace keeps earlier attempts' errors."""
+        if self._closed:
+            raise RuntimeError("Agent is closed; create a new agent")
         retry = self.config.retries
         history: list = []
         for attempt in range(retry.max_retries + 1):

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -148,13 +148,15 @@ class Agent:
         self.config = config
         self.harness = load_harness(harness_config)
         self._owns_client = client is None
+        self._client_config = config.client or EvalClientConfig()
         if self._owns_client:
-            client = resolve_client(config.client or EvalClientConfig())
+            client = resolve_client(self._client_config)
         self.ctx = ModelContext(
             model=config.model,
             client=client,
             sampling=config.sampling if config.sampling is not None else Sampling(),
         )
+        self._client_closed = False
         self.runtime_config: RuntimeConfig = self.harness.config.runtime
         self.interception = interception
         self.limits = RolloutLimits(
@@ -174,6 +176,13 @@ class Agent:
     async def __aenter__(self) -> "Agent":
         if self._entered:
             raise RuntimeError("Agent is already entered; enter it once and share it")
+        if self._client_closed:
+            self.ctx = ModelContext(
+                model=self.ctx.model,
+                client=resolve_client(self._client_config),
+                sampling=self.ctx.sampling,
+            )
+            self._client_closed = False
         self._entered = True
         if self.interception is None:
             # Sized to the runtime policy (remote needs the tunnel); runs the
@@ -189,6 +198,7 @@ class Agent:
                 self._entered, self._server = False, None
                 if self._owns_client:
                     await self.ctx.client.close()
+                    self._client_closed = True
                 raise
         return self
 
@@ -201,6 +211,7 @@ class Agent:
         finally:
             if self._owns_client:
                 await self.ctx.client.close()
+                self._client_closed = True
 
     def _interception_for(
         self, run_is_local: bool, task: Task, shared_tools: Mapping

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -147,7 +147,8 @@ class Agent:
             harness_config = harness_config_type("bash")(id="bash")
         self.config = config
         self.harness = load_harness(harness_config)
-        if client is None:
+        self._owns_client = client is None
+        if self._owns_client:
             client = resolve_client(config.client or EvalClientConfig())
         self.ctx = ModelContext(
             model=config.model,
@@ -186,14 +187,20 @@ class Agent:
                 # A failed __aenter__ gets no __aexit__ from `async with`: unwind
                 # here, or the agent stays "already entered" forever.
                 self._entered, self._server = False, None
+                if self._owns_client:
+                    await self.ctx.client.close()
                 raise
         return self
 
     async def __aexit__(self, *exc) -> None:
         self._entered = False
         server, self._server = self._server, None
-        if server is not None:
-            await server.__aexit__(*exc)
+        try:
+            if server is not None:
+                await server.__aexit__(*exc)
+        finally:
+            if self._owns_client:
+                await self.ctx.client.close()
 
     def _interception_for(
         self, run_is_local: bool, task: Task, shared_tools: Mapping


### PR DESCRIPTION
## What

- track whether a standalone V1 agent created its own model client
- close owned clients during agent teardown, including failed context entry
- leave injected clients under caller ownership
- update standalone examples to use the agent context manager

## Why

`make_agent(...)` creates an `EvalClient` when no client is injected, but `Agent.__aexit__` previously stopped only the interception server. The owned HTTP connection pool therefore remained open after the agent context exited.

## Impact

Standalone agents now release internally created client resources with their context. Agents borrowing an injected `client=` keep the existing ownership contract and do not close it.

## Checks

- focused owned/borrowed client lifecycle probe
- `UV_FROZEN=1 uv run ruff format`
- `UV_FROZEN=1 uv run ruff check --fix`
- `UV_FROZEN=1 uv run pytest tests/ -q`
- `UV_FROZEN=1 uv run pre-commit run --all-files`
- frozen pre-push hooks: ruff check, ruff format, ty

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Close agent-owned model clients on `Agent` context exit
> - [agent.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2098/files#diff-f719e773e216506045964fdfb9fad948b7b504ea092359ced06c928ab5148ea2) tracks whether the `Agent` constructed its own client (`_owns_client`) and closes it when the async context exits, preventing resource leaks. Injected (caller-provided) clients are left open.
> - Adds a `_closed` flag so that calling `run()` or re-entering the context after close raises `RuntimeError`.
> - If the `InterceptionServer` fails to start during `__aenter__`, an agent-owned client is now closed and the agent is marked closed before re-raising.
> - Behavioral Change: code that uses `Agent` without an async context manager and constructs its own client will no longer have that client closed automatically — the context manager is now required for proper cleanup.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e8f2a72.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes resource lifecycle for standalone agents—callers who kept using an agent or its client after exiting the context will now see closed clients and must create a new agent.
> 
> **Overview**
> Standalone V1 `Agent` instances that create their own model client (no `client=` injection) now **close that client** when the async context exits, fixing leaked HTTP connection pools after `__aexit__` only tore down the interception server.
> 
> Teardown runs in a `finally` after the owned interception server stops; if **`__aenter__` fails** after partial setup, the owned client is closed and the agent is marked closed so it cannot stay half-entered. **`run()`** and re-entry after close raise **"Agent is closed; create a new agent"**; injected **`client=`** resources are unchanged and never closed by the agent.
> 
> Docs now show **`async with make_agent(...)`** and spell out that the context owns the client and shared interception server, while each run still owns its runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8f2a727f3ec3f4d3a5d013807907d5485417172. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->