### PR TITLE
chore: apply automatic markdownlint fixes

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -5,25 +5,31 @@ This directory contains automated workflows for the verifiers project.
 ## Workflows
 
 ### 1. Style (`style.yml`)
+
 **Purpose**: Code style checking using ruff and ty.
 
 **Triggers**:
+
 - Pull requests (opened, synchronized, reopened)
 - Pushes to `main` branch
 
 **What it does**:
+
 - Runs ruff for linting and formatting checks
 - Runs ty type checks with `uv run ty check verifiers`
 - Uses configuration from `pyproject.toml` and `.pre-commit-config.yaml`
 
 ### 2. Test (`test.yml`)
+
 **Purpose**: Comprehensive testing with coverage reports.
 
 **Triggers**:
+
 - Pull requests affecting Python files, dependencies, or workflow files
 - Pushes to `main`, `master`, or `develop` branches with the same file changes
 
 **What it does**:
+
 - Runs tests on multiple Python versions (3.12, 3.13)
 - Generates coverage reports (XML, HTML, and terminal output)
 - Uploads coverage to Codecov (requires `CODECOV_TOKEN` secret)
@@ -31,15 +37,19 @@ This directory contains automated workflows for the verifiers project.
 - Comments on PRs with test results
 
 ### 3. Package Publishing
+
 **Purpose**: Build and publish PyPI packages.
 
 **Workflows**:
+
 - `publish-verifiers.yml` publishes `verifiers` with trusted publishing. On every push to `main` it builds and publishes a pre-release (`skip-existing`), and on a pushed `vX.Y.Z` tag (or manual dispatch) it publishes that stable release and creates a GitHub release.
 
 ## Setting Up
 
 ### Branch Protection
+
 It's recommended to set up branch protection rules for your main branch:
+
 1. Go to Settings → Branches
 2. Add a rule for your main branch
 3. Enable "Require status checks to pass before merging"
@@ -58,6 +68,7 @@ uv sync
 uv run pytest tests/ -v
 uv run pytest tests/ -v --cov=verifiers --cov-report=html
 ```
+
 Tip: install pre-push hooks to block pushes when Ty fails:
 
 ```bash
@@ -67,13 +78,17 @@ uv run pre-commit install --hook-type pre-commit --hook-type pre-push
 ## Customization
 
 ### Adding New Python Versions
+
 Edit the `matrix.python-version` in the workflow files to test on additional Python versions.
 
 ### Changing Trigger Conditions
+
 Modify the `on:` section in the workflow files to change when workflows run.
 
 ### Adding More Checks
+
 You can extend the workflows to include:
+
 - Type checking with mypy
 - Security scanning
 - Documentation building

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ uv tool install prime
 - The [docs](docs/) contain short, human-written guides and overviews about the architecture.
 - The [AGENTS.md](AGENTS.md) and [skills](skills/) are for coding agents and go into more details.
 
-
 ## Citation
 
 Originally created by Will Brown ([@willccbb](https://github.com/willccbb)).

--- a/assets/lab/README.md
+++ b/assets/lab/README.md
@@ -2,7 +2,6 @@
 
 This is a workspace for training and evaluating LLMs in environments created with the `verifiers` [library](https://docs.primeintellect.ai/verifiers/overview), which can be used with the [Prime Intellect](https://app.primeintellect.ai/dashboard/environments) Lab platform or other supported frameworks. It is automatically prepared by running `prime lab setup` with the `prime` [CLI](https://docs.primeintellect.ai/cli-reference/introduction).
 
-
 ## Contents
 
 - `configs/`: Configuration files for training and evaluation

--- a/assets/templates/browserbase/cua/README.md
+++ b/assets/templates/browserbase/cua/README.md
@@ -7,6 +7,7 @@ A Fastify server that exposes Stagehand's Computer Use Agent (CUA) browser primi
 ## Automatic Sandbox Deployment
 
 When using `BrowserEnv(mode="cua")`, the server is automatically:
+
 1. Uploaded to a sandbox container
 2. Started via `setup.sh`
 3. Accessed via curl commands inside the sandbox
@@ -101,6 +102,7 @@ Content-Type: application/json
 ```
 
 Returns:
+
 ```json
 {
   "sessionId": "session_1234567890_abc123",
@@ -142,6 +144,7 @@ Content-Type: application/json
 ```
 
 Returns:
+
 ```json
 {
   "success": true,
@@ -158,7 +161,7 @@ Returns:
 ### Mouse Actions
 
 | Action | Parameters | Description |
-|--------|------------|-------------|
+| -------- | ------------ | ------------- |
 | `click` | `x`, `y`, `button?`, `clickCount?` | Click at coordinates |
 | `double_click` | `x`, `y` | Double-click at coordinates |
 | `tripleClick` | `x`, `y` | Triple-click at coordinates |
@@ -175,7 +178,7 @@ Returns:
 ### Navigation Actions
 
 | Action | Parameters | Description |
-|--------|------------|-------------|
+| -------- | ------------ | ------------- |
 | `goto` | `url` | Navigate to URL |
 | `back` | - | Go back in history |
 | `forward` | - | Go forward in history |
@@ -271,4 +274,3 @@ cua-server/
 ├── tsconfig.json      # TypeScript configuration
 └── README.md          # This file
 ```
-

--- a/docs/v0/development.md
+++ b/docs/v0/development.md
@@ -20,6 +20,7 @@ This guide covers setup, testing, and contributing to the verifiers package.
 ## Setup
 
 ### Prerequisites
+
 - Python 3.13 recommended for CI parity with Ty checks
 - [uv](https://docs.astral.sh/uv/) package manager
 
@@ -228,12 +229,14 @@ safe.
 ## Common Issues
 
 ### Import Errors
+
 ```bash
 # Ensure package is installed in development mode
 uv sync
 ```
 
 ### Integration Tests
+
 ```bash
 # Install optional dependencies for specific integrations
 uv sync --extra ta   # for TextArenaEnv
@@ -244,6 +247,7 @@ uv sync --python 3.12 --extra harbor  # for the Harbor Python package and CLI
 ```
 
 ### Test Failures
+
 ```bash
 # Debug specific test
 uv run pytest tests/test_file.py::test_name -vvs --pdb
@@ -322,7 +326,7 @@ prime eval view                              # Browse evals in the tree browser
 ### CLI Tools
 
  | Command | Description |
-|---------|-------------|
+| --------- | ------------- |
 | `prime eval run` | Run evaluations on environments |
 | `prime env init` | Initialize new environment from template |
 | `prime env install` | Install environment module |

--- a/docs/v0/development.md
+++ b/docs/v0/development.md
@@ -201,13 +201,9 @@ def test_with_mock(mock_client):
 
 ### Public Surface
 
-Treat public config, docs, starter examples, skills, and generated agent
-guidance as one surface. If a behavior changes for users, update all matching
-surfaces in the same patch.
+Treat public config, docs, starter examples, skills, and generated agent guidance as one surface. If a behavior changes for users, update all matching surfaces in the same patch.
 
-For TOML config, keep one shape across eval, GEPA, RL, and Hosted Training.
-Normalize old or alternate inputs at the loader boundary, then keep examples on
-the current golden path.
+For TOML config, keep one shape across eval, GEPA, RL, and Hosted Training. Normalize old or alternate inputs at the loader boundary, then keep examples on the current golden path.
 
 ### Validation By Change Type
 
@@ -220,11 +216,7 @@ the current golden path.
 
 ### Downstream Checks
 
-Before changing dependencies, optional extras, lockfiles, exported config fields,
-or upload/eval metadata, trace the consumers in `prime-cli`, `prime-rl`, Hosted
-Training, and public docs when they are in scope. Update the consumer or document
-the compatibility boundary rather than assuming transitive behavior remains
-safe.
+Before changing dependencies, optional extras, lockfiles, exported config fields, or upload/eval metadata, trace the consumers in `prime-cli`, `prime-rl`, Hosted Training, and public docs when they are in scope. Update the consumer or document the compatibility boundary rather than assuming transitive behavior remains safe.
 
 ## Common Issues
 

--- a/docs/v0/environments.md
+++ b/docs/v0/environments.md
@@ -275,9 +275,7 @@ rubric = vf.Rubric(funcs=[correct_answer, diversity_bonus])
 
 ### Shared Objects
 
-In rubric environments, reward functions can request static helper objects that
-live within the Rubric class. These are stored in the Rubric's `class_objects`
-dictionary, and can be added after initialization via `add_class_object()`:
+In rubric environments, reward functions can request static helper objects that live within the Rubric class. These are stored in the Rubric's `class_objects` dictionary, and can be added after initialization via `add_class_object()`:
 
 ```python
 rubric = vf.Rubric(funcs=[my_reward_func])
@@ -288,18 +286,9 @@ async def my_reward_func(completion, my_helper) -> float:
     return await my_helper.score(completion)
 ```
 
-For taskset/harness environments, keep shared dependencies behind the taskset or
-harness that owns them. Bindings are the canonical way to inject shared
-resources into rewards, updates, tools, and programs. Configured binding
-objects should use serializable loader paths when they cross a TOML or CLI
-boundary; Python-only construction may use factory callables directly when a
-resource cannot be serialized. Required Taskset and Toolset factory parameters
-must be supplied through bindings.
+For taskset/harness environments, keep shared dependencies behind the taskset or harness that owns them. Bindings are the canonical way to inject shared resources into rewards, updates, tools, and programs. Configured binding objects should use serializable loader paths when they cross a TOML or CLI boundary; Python-only construction may use factory callables directly when a resource cannot be serialized. Required Taskset and Toolset factory parameters must be supplied through bindings.
 
-Judges are used for tasks where deterministic evaluation is impractical, and an
-LLM is used to score responses. **JudgeRubric** stores an LLM client inside the
-rubric, and provides a `judge` callable to reward
-functions for scoring responses:
+Judges are used for tasks where deterministic evaluation is impractical, and an LLM is used to score responses. **JudgeRubric** stores an LLM client inside the rubric, and provides a `judge` callable to reward functions for scoring responses:
 
 ```python
 judge_rubric = vf.JudgeRubric(
@@ -558,11 +547,7 @@ def load_environment():
     return MyGameEnv(dataset=dataset, rubric=rubric, extract_action=extract_action)
 ```
 
-`env_response` receives the full conversation history thus far (and `state`) and
-returns a list of _new_ messages to append. For tool environments,
-`env_response` typically executes tool calls and returns results. For games or
-other custom protocols, this might involve extracting structured output and
-returning state updates or feedback.
+`env_response` receives the full conversation history thus far (and `state`) and returns a list of _new_ messages to append. For tool environments, `env_response` typically executes tool calls and returns results. For games or other custom protocols, this might involve extracting structured output and returning state updates or feedback.
 
 Several other methods can optionally be overridden for more control in complex custom environments:
 
@@ -787,9 +772,7 @@ combined = vf.EnvGroup(
 )
 ```
 
-The group concatenates all sub-environment datasets and injects
-`info["env_id"]` as internal routing metadata. It is not a top-level input,
-state, or output field. Metrics from all environments are tracked together.
+The group concatenates all sub-environment datasets and injects `info["env_id"]` as internal routing metadata. It is not a top-level input, state, or output field. Metrics from all environments are tracked together.
 
 ## Performance
 

--- a/docs/v0/environments.md
+++ b/docs/v0/environments.md
@@ -906,6 +906,7 @@ Newer and more experimental environment classes include:
         timeouts=SandboxTimeouts(read_file=30.0, extract=180.0, poll=120.0),
     )
     ```
+
 - **`vf.Env` / `vf.Taskset` / `vf.Harness`** — preferred taskset/harness pattern for composing task data and program execution without subclassing. Use this for environments that need reusable tasksets, reusable harnesses, config-driven metrics, rewards, toolsets, users, endpoint interception, or sandboxed Python/command programs. `vf.Taskset` owns train/eval tasks, prompt shaping, setup/update/reward hooks, and toolsets. `vf.Harness` owns the framework program, endpoint proxy, model controls, sandbox options, and runtime hooks. `vf.Env` wires them into the standard evaluation and training surface.
 - **`SandboxDebugEnv`** — no-agent debugger for sandbox-backed `SandboxTaskSet` instances. It creates the task sandbox, optionally runs `taskset.setup(state)`, performs one debug step (`none`, `gold_patch`, `command`, or `script`), and optionally runs the task tests and scorer. It records setup, sandbox creation, gold patch, debug command, and test timings in state for validation and timing investigations. `SWEDebugEnv` is a deprecated compatibility wrapper.
 - **`HarborEnv`** — loads Harbor-format agent benchmark tasks

--- a/docs/v0/evaluation.md
+++ b/docs/v0/evaluation.md
@@ -5,6 +5,7 @@
 This section explains how to run evaluations with Verifiers environments. See [Environments](environments.md) for information on building your own environments.
 
 ## Table of Contents
+
 - [Basic Usage](#basic-usage)
 - [Hosted Evaluations](#hosted-evaluations)
 - [Command Reference](#command-reference)
@@ -56,7 +57,7 @@ For the full hosted workflow and hosted-only flags such as `--follow`, `--timeou
 ### Environment Selection
 
 | Flag | Short | Default | Description |
-|------|-------|---------|-------------|
+| ------ | ------- | --------- | ------------- |
 | `env_id_or_path` | (positional) | — | Environment ID(s) or path to TOML config |
 | `--env-args` | `-a` | `{}` | JSON object passed to `load_environment()` |
 | `--extra-env-kwargs` | `-x` | `{}` | JSON object passed to environment constructor |
@@ -64,6 +65,7 @@ For the full hosted workflow and hosted-only flags such as `--follow`, `--timeou
 | `--env-dir-path` | `-p` | `./environments` | Base path for saving output files |
 
 The positional argument accepts two formats:
+
 - **Single environment**: `gsm8k` — evaluates one environment
 - **TOML config path**: `configs/eval/benchmark.toml` — evaluates multiple environments defined in the config file
 
@@ -117,7 +119,7 @@ env.set_concurrency(256)
 ### Model Configuration
 
 | Flag | Short | Default | Description |
-|------|-------|---------|-------------|
+| ------ | ------- | --------- | ------------- |
 | `--model` | `-m` | `openai/gpt-4.1-mini` | Model name or endpoint alias |
 | `--api-base-url` | `-b` | `https://api.pinference.ai/api/v1` | API base URL |
 | `--api-key-var` | `-k` | `PRIME_API_KEY` | Environment variable containing API key |
@@ -183,7 +185,7 @@ When using eval TOML configs, you can set `endpoint_id` in `[[eval]]` sections t
 ### Sampling Parameters
 
 | Flag | Short | Default | Description |
-|------|-------|---------|-------------|
+| ------ | ------- | --------- | ------------- |
 | `--max-tokens` | `-t` | model default | Maximum tokens to generate |
 | `--temperature` | `-T` | model default | Sampling temperature |
 | `--sampling-args` | `-S` | — | JSON object for additional sampling parameters |
@@ -215,7 +217,7 @@ client translate them for the selected provider.
 ### Evaluation Scope
 
 | Flag | Short | Default | Description |
-|------|-------|---------|-------------|
+| ------ | ------- | --------- | ------------- |
 | `--num-examples` | `-n` | 5 | Number of dataset examples to evaluate |
 | `--rollouts-per-example` | `-r` | 3 | Rollouts per example (for pass@k, variance) |
 | `--shuffle` | — | false | Shuffle the evaluation dataset before selecting examples |
@@ -228,7 +230,7 @@ When `--shuffle` is enabled, Verifiers shuffles the full evaluation dataset firs
 ### Concurrency
 
 | Flag | Short | Default | Description |
-|------|-------|---------|-------------|
+| ------ | ------- | --------- | ------------- |
 | `--max-concurrent` | `-c` | 32 | Maximum concurrent requests |
 | `--max-concurrent-generation` | — | same as `-c` | Concurrent generation requests |
 | `--max-concurrent-scoring` | — | same as `-c` | Concurrent scoring requests |
@@ -252,7 +254,7 @@ When an eval runs against a Prime Inference endpoint and the model id has pricin
 ### Output and Saving
 
 | Flag | Short | Default | Description |
-|------|-------|---------|-------------|
+| ------ | ------- | --------- | ------------- |
 | `--verbose` | `-v` | false | Enable debug logging |
 | `--fullscreen` | `-f` | false | Use alternate screen buffer (fullscreen) for the Rich display |
 | `--disable-tui` | `-d` | false | Disable Rich display; use normal logging and tqdm progress |
@@ -391,7 +393,7 @@ a legacy alias and normalizes to the same internal field. All other fields are
 optional:
 
 | Field | Type | Description |
-|-------|------|-------------|
+| ------- | ------ | ------------- |
 | `id` | string | Environment module name |
 | `name` | string | Optional eval label for display and saved result paths |
 | `args` | table | Arguments passed to `load_environment()` |

--- a/docs/v0/evaluation.md
+++ b/docs/v0/evaluation.md
@@ -71,8 +71,7 @@ The positional argument accepts two formats:
 
 Environment IDs are converted to Python module names (`my-env` → `my_env`) and imported after `prime eval run` resolves the environment package.
 
-For legacy or direct-constructor environments, the `--env-args` flag passes
-arguments to your `load_environment()` function:
+For legacy or direct-constructor environments, the `--env-args` flag passes arguments to your `load_environment()` function:
 
 ```bash
 prime eval run my-env -a '{"difficulty": "hard", "num_examples": 100}'
@@ -209,10 +208,7 @@ enable_thinking = true
 id = "my-env"
 ```
 
-`reasoning_effort` and `enable_thinking` stay in `sampling_args` and are also
-mirrored into `extra_body.chat_template_kwargs` for OpenAI-compatible servers
-that read chat template options there. Keeping the top-level values lets the
-client translate them for the selected provider.
+`reasoning_effort` and `enable_thinking` stay in `sampling_args` and are also mirrored into `extra_body.chat_template_kwargs` for OpenAI-compatible servers that read chat template options there. Keeping the top-level values lets the client translate them for the selected provider.
 
 ### Evaluation Scope
 
@@ -388,9 +384,7 @@ A minimal config requires only a single `[[eval]]` section:
 id = "gsm8k"
 ```
 
-Each `[[eval]]` section usually contains an `id` field. `env_id` is accepted as
-a legacy alias and normalizes to the same internal field. All other fields are
-optional:
+Each `[[eval]]` section usually contains an `id` field. `env_id` is accepted as a legacy alias and normalizes to the same internal field. All other fields are optional:
 
 | Field | Type | Description |
 | ------- | ------ | ------------- |
@@ -436,8 +430,7 @@ difficulty = "hard"
 split = "test"
 ```
 
-The legacy inline `sampling_args = { ... }` spelling is still accepted and
-normalizes the same way as `[sampling]` / `[eval.sampling]`.
+The legacy inline `sampling_args = { ... }` spelling is still accepted and normalizes the same way as `[sampling]` / `[eval.sampling]`.
 
 ### Ablation Sweeps
 

--- a/docs/v0/faqs.md
+++ b/docs/v0/faqs.md
@@ -21,6 +21,7 @@ The `-s` flag prints sample outputs so you can see what's happening.
 ```bash
 prime eval view
 ```
+
 The TUI opens a single run browser (`environment -> model -> run`). Press `Enter` on a run to open rollout details, `b` to go back, `tab` to cycle panes, `e` and `x` to expand or collapse history, `pageup` and `pagedown` to scroll history, and `c` for Copy Mode.
 
 **If using the Python API** (`env.generate()` / `env.evaluate()`):

--- a/docs/v0/overview.md
+++ b/docs/v0/overview.md
@@ -5,17 +5,19 @@
 Verifiers is our library for creating environments to train and evaluate LLMs.
 
 Environments contain everything required to run and evaluate a model on a particular task:
+
 - A *dataset* of task inputs
 - A *harness* for the model (tools, sandboxes, context management, etc.)
 - A reward function or *rubric* to score the model's performance
 
-Environments can be used for training models with reinforcement learning (RL), evaluating capabilities, generating synthetic data, experimenting with agent harnesses, and more. 
+Environments can be used for training models with reinforcement learning (RL), evaluating capabilities, generating synthetic data, experimenting with agent harnesses, and more.
 
 Verifiers is tightly integrated with the [Environments Hub](https://app.primeintellect.ai/dashboard/environments?ex_sort=most_stars), as well as our training framework [prime-rl](https://github.com/PrimeIntellect-ai/prime-rl) and our [Hosted Training](https://app.primeintellect.ai/dashboard/training) platform.
 
 ## Getting Started
 
 Ensure you have `uv` installed, as well as the `prime` [CLI](https://docs.primeintellect.ai/cli-reference/introduction) tool:
+
 ```bash
 # install uv
 curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -24,13 +26,16 @@ uv tool install prime
 # log in to the Prime Intellect platform
 prime login
 ```
+
 To set up a new workspace for developing environments, do:
+
 ```bash
 # ~/dev/my-lab
 prime lab setup 
 ```
 
 This sets up a Python project if needed (with `uv init`), installs `verifiers` (with `uv add verifiers`), creates the recommended workspace structure, and downloads useful starter files:
+
 ```
 configs/
 ├── endpoints.toml      # OpenAI-compatible API endpoint configuration
@@ -46,6 +51,7 @@ CLAUDE.md               # Claude-specific pointer to AGENTS.md
 ```
 
 Alternatively, add `verifiers` to an existing project:
+
 ```bash
 uv add verifiers && prime lab setup --skip-install
 ```
@@ -58,12 +64,14 @@ Optional features are installed with extras:
 | `notebook` | `uv add "verifiers[notebook]"` | `Environment.generate_sync()` inside Jupyter or another active event loop |
 
 Environments built with Verifiers are self-contained Python modules. To initialize a fresh environment template, do:
+
 ```bash
 prime env init my-env # creates a v0 stub in ./environments/my_env
 ```
 
 This will create a new module called `my_env` with a runnable environment
 template.
+
 ```
 environments/my_env/
 ├── my_env.py           # Main implementation
@@ -74,6 +82,7 @@ environments/my_env/
 Environment modules should expose a `load_environment` function which returns an
 environment object. For simple legacy environments, this can still be a direct
 constructor:
+
 ```python
 # my_env.py
 import verifiers as vf
@@ -89,23 +98,29 @@ def load_environment(dataset_name: str = 'gsm8k') -> vf.Environment:
 ```
 
 To run a local evaluation with any OpenAI-compatible model, do:
+
 ```bash
 prime eval run my-env -m openai/gpt-5-nano # run and save eval results locally
 ```
+
 Evaluations use [Prime Inference](https://docs.primeintellect.ai/inference/overview) by default; configure your own API endpoints in `./configs/endpoints.toml`.
 
 View local evaluation results in the terminal UI:
+
 ```bash
 prime eval view
 ```
+
 The TUI opens a single run browser (`environment -> model -> run`). Press `Enter` on a run to open rollout details, `b` to go back, `tab` to cycle panes, `e` and `x` to expand or collapse history, `pageup` and `pagedown` to scroll history, and `c` for Copy Mode.
 
 To publish the environment to the [Environments Hub](https://app.primeintellect.ai/dashboard/environments?ex_sort=most_stars), do:
+
 ```bash
 prime env push my-env # equivalent to --path ./environments/my_env
 ```
 
 To run an evaluation directly from the Environments Hub, do:
+
 ```bash
 prime eval run primeintellect/math-python
 ```

--- a/docs/v0/overview.md
+++ b/docs/v0/overview.md
@@ -69,8 +69,7 @@ Environments built with Verifiers are self-contained Python modules. To initiali
 prime env init my-env # creates a v0 stub in ./environments/my_env
 ```
 
-This will create a new module called `my_env` with a runnable environment
-template.
+This will create a new module called `my_env` with a runnable environment template.
 
 ```
 environments/my_env/
@@ -79,9 +78,7 @@ environments/my_env/
 └── README.md           # Documentation
 ```
 
-Environment modules should expose a `load_environment` function which returns an
-environment object. For simple legacy environments, this can still be a direct
-constructor:
+Environment modules should expose a `load_environment` function which returns an environment object. For simple legacy environments, this can still be a direct constructor:
 
 ```python
 # my_env.py

--- a/docs/v0/reference.md
+++ b/docs/v0/reference.md
@@ -76,12 +76,7 @@ class SystemPromptConfig:
     messages: list[JsonData] = []
 ```
 
-v1 system prompt type. Plain strings are prompt text. Use
-`vf.SystemPromptConfig(path="system_prompt.txt")` for file-backed prompts, or
-override `load_system_prompt(config)` when prompt construction belongs to the
-class. System prompt resolution is per task: task prompt overrides taskset
-prompt for the taskset side, then the harness applies
-`system_prompt_strategy`. The default strategy is `HT`.
+v1 system prompt type. Plain strings are prompt text. Use `vf.SystemPromptConfig(path="system_prompt.txt")` for file-backed prompts, or override `load_system_prompt(config)` when prompt construction belongs to the class. System prompt resolution is per task: task prompt overrides taskset prompt for the taskset side, then the harness applies `system_prompt_strategy`. The default strategy is `HT`.
 
 ### RewardFunc
 
@@ -409,8 +404,7 @@ Abstract base class for all environments.
 | `run_rollout(sem, input, client, model, sampling_args)` | `State` | Run rollout with semaphore |
 | `run_group(group_inputs, client, model, ...)` | `list[State]` | Generate and score one group |
 
-Calling `generate_sync()` from Jupyter or another active event loop requires
-`uv add "verifiers[notebook]"`.
+Calling `generate_sync()` from Jupyter or another active event loop requires `uv add "verifiers[notebook]"`.
 
 **Configuration methods:**
 
@@ -590,9 +584,7 @@ env_group = vf.EnvGroup(
 )
 ```
 
-Combines multiple environments for mixed-task training. Combined datasets use
-`info["env_id"]` as internal routing metadata; it is not a top-level input,
-state, or output field.
+Combines multiple environments for mixed-task training. Combined datasets use `info["env_id"]` as internal routing metadata; it is not a top-level input, state, or output field.
 
 ---
 
@@ -906,8 +898,7 @@ class EndpointConfig(BaseModel):
 Endpoints = dict[str, list[EndpointConfig]]
 ```
 
-`api_key_var` is a credential reference. Endpoint configs never serialize the
-materialized API key.
+`api_key_var` is a credential reference. Endpoint configs never serialize the materialized API key.
 
 `Endpoints` maps an endpoint id to one or more endpoint variants. A single variant is represented as a one-item list.
 

--- a/docs/v0/reference.md
+++ b/docs/v0/reference.md
@@ -125,7 +125,7 @@ A `dict` subclass that tracks rollout information. Accessing keys in `INPUT_FIEL
 **Fields set during initialization:**
 
 | Field | Type | Description |
-|-------|------|-------------|
+| ------- | ------ | ------------- |
 | `input` | `RolloutInput` | Nested input data |
 | `client` | `Client` | Client instance |
 | `model` | `str` | Model name |
@@ -140,7 +140,7 @@ A `dict` subclass that tracks rollout information. Accessing keys in `INPUT_FIEL
 **Fields set after scoring:**
 
 | Field | Type | Description |
-|-------|------|-------------|
+| ------- | ------ | ------------- |
 | `completion` | `Messages \| None` | Final completion |
 | `reward` | `float \| None` | Final reward |
 | `advantage` | `float \| None` | Advantage over group mean |
@@ -276,7 +276,7 @@ class TokenUsage(TypedDict, total=False):
 ```
 
 | Field | Description |
-|-------|-------------|
+| ------- | ------------- |
 | `input_tokens` | Sum of prompt tokens across all turns. Shared context is counted each time it appears in a prompt. |
 | `output_tokens` | Sum of completion tokens across all turns. |
 | `final_input_tokens` | Non-completion tokens in the final turn's context (system prompts, user messages, tool results, etc.). |
@@ -384,7 +384,7 @@ Abstract base class for all environments.
 **Generation methods:**
 
 | Method | Returns | Description |
-|--------|---------|-------------|
+| -------- | --------- | ------------- |
 | `generate(inputs, client, model, ...)` | `GenerateOutputs` | Run rollouts asynchronously. `client` accepts `Client \| ClientConfig`. |
 | `generate_sync(inputs, client, ...)` | `GenerateOutputs` | Synchronous wrapper; inside an active event loop, install `verifiers[notebook]` |
 | `evaluate(client, model, ...)` | `GenerateOutputs` | Evaluate on eval_dataset |
@@ -393,7 +393,7 @@ Abstract base class for all environments.
 **Dataset methods:**
 
 | Method | Returns | Description |
-|--------|---------|-------------|
+| -------- | --------- | ------------- |
 | `get_dataset(n=-1, seed=None)` | `Dataset` | Get training dataset (optionally first n, shuffled) |
 | `get_eval_dataset(n=-1, seed=None)` | `Dataset` | Get evaluation dataset |
 | `make_dataset(...)` | `Dataset` | Static method to create dataset from inputs |
@@ -401,7 +401,7 @@ Abstract base class for all environments.
 **Rollout methods (used internally or by subclasses):**
 
 | Method | Returns | Description |
-|--------|---------|-------------|
+| -------- | --------- | ------------- |
 | `rollout(input, client, model, sampling_args)` | `State` | Abstract: run single rollout |
 | `init_state(input, client, model, sampling_args)` | `State` | Create initial state from input |
 | `get_model_response(state, prompt, ...)` | `Response` | Get model response for prompt |
@@ -415,7 +415,7 @@ Calling `generate_sync()` from Jupyter or another active event loop requires
 **Configuration methods:**
 
 | Method | Description |
-|--------|-------------|
+| -------- | ------------- |
 | `set_kwargs(**kwargs)` | Set attributes using setter methods when available |
 | `set_concurrency(concurrency)` | Set `concurrency` and scale all registered thread-pool executors to match |
 | `add_rubric(rubric)` | Add or merge rubric |
@@ -452,7 +452,7 @@ async def env_response(self, messages: Messages, state: State, **kwargs) -> Mess
 **Hooks:**
 
 | Method | Description |
-|--------|-------------|
+| -------- | ------------- |
 | `setup_state(state)` | Initialize per-rollout state |
 | `get_prompt_messages(state)` | Customize prompt construction |
 | `render_completion(state)` | Customize completion rendering |
@@ -480,7 +480,7 @@ Tool calling with stateless Python functions. Automatically converts functions t
 **Methods:**
 
 | Method | Description |
-|--------|-------------|
+| -------- | ------------- |
 | `add_tool(tool)` | Add a tool at runtime |
 | `remove_tool(tool)` | Remove a tool at runtime |
 | `call_tool(name, args, id)` | Override to customize tool execution |
@@ -517,7 +517,7 @@ Sandboxed container execution using `prime` sandboxes.
 **Key parameters:**
 
 | Parameter | Type | Description |
-|-----------|------|-------------|
+| ----------- | ------ | ------------- |
 | `sandbox_name` | `str` | Name prefix for sandbox instances |
 | `docker_image` | `str` | Docker image to use for the sandbox |
 | `cpu_cores` | `int` | Number of CPU cores |
@@ -637,7 +637,7 @@ parser = vf.XMLParser(fields=["reasoning", ("code", "answer")])
 **Methods:**
 
 | Method | Returns | Description |
-|--------|---------|-------------|
+| -------- | --------- | ------------- |
 | `parse(text)` | `SimpleNamespace` | Parse XML into object with field attributes |
 | `parse_answer(completion)` | `str \| None` | Extract answer field from completion |
 | `get_format_str()` | `str` | Get format description string |
@@ -678,7 +678,7 @@ Combines multiple reward functions with weights. Default weight is `1.0`. Functi
 **Methods:**
 
 | Method | Description |
-|--------|-------------|
+| -------- | ------------- |
 | `add_reward_func(func, weight=1.0)` | Add a reward function |
 | `add_metric(func, weight=0.0)` | Add a metric (no reward contribution) |
 | `add_class_object(name, obj)` | Add object accessible in reward functions |
@@ -755,7 +755,7 @@ Abstract base class for all model clients. Wraps a provider-specific SDK client 
 **Abstract methods (for subclass implementors):**
 
 | Method | Description |
-|--------|-------------|
+| -------- | ------------- |
 | `setup_client(config)` | Create the native SDK client from `ClientConfig` |
 | `to_native_prompt(messages)` | Convert `Messages` → native prompt format + extra kwargs |
 | `to_native_tool(tool)` | Convert `Tool` → native tool format |
@@ -767,7 +767,7 @@ Abstract base class for all model clients. Wraps a provider-specific SDK client 
 ### Built-in Client Implementations
 
 | Class | `client_type` | SDK Client | Description |
-|-------|---------------|------------|-------------|
+| ------- | --------------- | ------------ | ------------- |
 | `OpenAIChatCompletionsClient` | `"openai_chat_completions"` | `AsyncOpenAI` | Chat Completions API (default) |
 | `OpenAICompletionsClient` | `"openai_completions"` | `AsyncOpenAI` | Legacy Completions API |
 | `OpenAIChatCompletionsTokenClient` | `"openai_chat_completions_token"` | `AsyncOpenAI` | Custom vLLM token route (`/v1/chat/completions/tokens`) — server-side templating + token IDs returned alongside content |
@@ -842,6 +842,7 @@ class ClientConfig(BaseModel):
 `preserve_all_thinking` and `preserve_thinking_between_tool_calls` are forwarded to the underlying renderer when `client_type == "renderer"`. They control whether past-assistant `reasoning_content` is re-emitted on subsequent renders — `preserve_all_thinking` keeps every past-assistant turn's thinking, and `preserve_thinking_between_tool_calls` keeps thinking only inside the in-flight assistant→tool→…→assistant block after the most recent user turn (when that block contains at least one tool response). Both default to `False` (template default applies).
 
 When `api_key_var` is `"PRIME_API_KEY"` (the default), credentials are loaded with the following precedence:
+
 - **API key**: `PRIME_API_KEY` env var > `~/.prime/config.json` > `"EMPTY"`
 - **Team ID**: `PRIME_TEAM_ID` env var > `~/.prime/config.json` > not set
 

--- a/docs/v0/training.md
+++ b/docs/v0/training.md
@@ -7,25 +7,25 @@ This section covers how to use Verifiers environments for RL training with our H
 ## Table of Contents
 
 - [Hosted Training](#hosted-training)
-    - [Configuration](#configuration)
+  - [Configuration](#configuration)
 - [Training with `prime-rl`](#training-with-prime-rl)
-    - [Setup and Configuration](#setup-and-configuration)
+  - [Setup and Configuration](#setup-and-configuration)
 - [Prompt Optimization with `prime gepa run`](#prompt-optimization-with-prime-gepa-run)
-    - [Usage](#usage)
-    - [Output](#output)
+  - [Usage](#usage)
+  - [Output](#output)
 - [RL Rules of Thumb](#rl-rules-of-thumb)
-    - [Before Training](#before-training)
-    - [Performance Trade-offs](#performance-trade-offs)
-    - [Common Issues](#common-issues)
+  - [Before Training](#before-training)
+  - [Performance Trade-offs](#performance-trade-offs)
+  - [Common Issues](#common-issues)
 - [Other Trainers](#other-trainers)
-    - [Tinker](#tinker)
-    - [SkyRL](#skyrl)
-    - [rLLM](#rllm)
-    - [Integrating with Other Trainers](#integrating-with-other-trainers)
+  - [Tinker](#tinker)
+  - [SkyRL](#skyrl)
+  - [rLLM](#rllm)
+  - [Integrating with Other Trainers](#integrating-with-other-trainers)
 
 ## Hosted Training
 
-Hosted Training, available within our Lab platform, enables you to automatically train models via `prime-rl` without needing to manage your own infrastructure. Hosted Training supports LoRA for RL training, and can be used with any environment built with Verifiers. 
+Hosted Training, available within our Lab platform, enables you to automatically train models via `prime-rl` without needing to manage your own infrastructure. Hosted Training supports LoRA for RL training, and can be used with any environment built with Verifiers.
 
 ### Configuration
 
@@ -81,6 +81,7 @@ id = "primeintellect/reverse-text"
 ```
 
 We currently support the following models for Hosted Training:
+
 - `Qwen/Qwen3-30B-A3B-Instruct-2507`
 - `Qwen/Qwen3-30B-A3B-Thinking-2507`
 - `Qwen/Qwen3-4B-Instruct-2507`
@@ -105,11 +106,12 @@ Hosted Training is currently in Private Beta. For access, please fill out [this 
 
 ## Training with `prime-rl`
 
-Our [`prime-rl`](https://github.com/PrimeIntellect-ai/prime-rl) trainer is a production-ready async RL training framework that supports large-scale multi-node training, agentic rollouts with Verifiers environments, Mixture-of-Experts (MoE) models, LoRA adapters, and other training algorithms such as SFT and online distillation. We recommend using `prime-rl` for training with Verifiers environments on self-managed GPU infrastructure. The default configuration distills the best practices from our research team's experience and the broader community into a stable, easy-to-use recipe, including advanced features such as online difficulty filtering, continuous batching, in-flight weight updates, importance sampling and logprob clipping for stability, and more. 
+Our [`prime-rl`](https://github.com/PrimeIntellect-ai/prime-rl) trainer is a production-ready async RL training framework that supports large-scale multi-node training, agentic rollouts with Verifiers environments, Mixture-of-Experts (MoE) models, LoRA adapters, and other training algorithms such as SFT and online distillation. We recommend using `prime-rl` for training with Verifiers environments on self-managed GPU infrastructure. The default configuration distills the best practices from our research team's experience and the broader community into a stable, easy-to-use recipe, including advanced features such as online difficulty filtering, continuous batching, in-flight weight updates, importance sampling and logprob clipping for stability, and more.
 
 ### Setup and Configuration
 
 To set up your workspace for training with `prime-rl`, run:
+
 ```bash
 prime lab setup --prime-rl
 ```
@@ -123,6 +125,7 @@ This will clone and install the `prime-rl` trainer and its dependencies. For con
 ### Usage
 
 Basic usage mirrors `prime eval run`:
+
 ```bash
 prime gepa run wiki-search --model google/gemini-3-flash-preview
 ```
@@ -130,6 +133,7 @@ prime gepa run wiki-search --model google/gemini-3-flash-preview
 This will optimize the system prompt for the `wiki-search` environment using the specified model for both evaluation rollouts and reflection. Results are saved to `environments/wiki-search/outputs/gepa/`.
 
 Key options:
+
 - `--model` / `-m`: Model for evaluation rollouts
 - `--reflection-model` / `-M`: Teacher model for prompt reflection (defaults to `--model`)
 - `--max-calls` / `-B`: Evaluation budget (default: 500)
@@ -144,6 +148,7 @@ In TOML configs, set GEPA parameters such as `max_calls`, `num_train`, `num_val`
 ### Output
 
 After optimization, you'll find:
+
 - `system_prompt.txt` - The optimized system prompt.
 - `results.jsonl` - Candidate prompt rows for evaluation upload; GEPA-specific fields live under `info`.
 - `pareto_frontier.jsonl` - Best candidate references per validation example
@@ -164,10 +169,12 @@ RL training can be sensitive to implementation details and hyperparameters. Some
 ### Performance Trade-offs
 
 **For more aggressive training** (higher risk of collapse):
+
 - Increase learning rate (1e-5 to 1e-4 for LoRA, 1e-6 to 1e-5 for full finetuning)
 - Decrease `rollouts_per_example` and `batch_size` for faster generation
 
 **For more stable training** (slower progress):
+
 - Increase `rollouts_per_example` (16-32)
 - Increase `batch_size` (512-1024)
 - Use larger models (14B+)
@@ -189,16 +196,19 @@ For production RL training, use `openai_chat_completions_token` — it's the tri
 **Non-Increasing Chat Templates:** The Qwen3 and DeepSeek-R1 model series both remove `<think>` sections from messages when processing inputs, which violates the increasing context requirement for multi-turn training. We provide versions of many of these models with modified chat templates [here](https://huggingface.co/collections/willcb/qwen3-68434f4883925bfdb4570ee5).
 
 **OOM during generation:**
+
 - Reduce `rollouts_per_example` or `micro_batch_size`
 - Use LoRA instead of full finetuning
 - Check vLLM server has sufficient memory
 
 **Training instability:**
+
 - Decrease learning rate
 - Increase `rollouts_per_example`
 - Increase `batch_size`
 
 **Slow training:**
+
 - Increase learning rate
 - Leverage continuous rewards
 - Use online difficulty filtering

--- a/docs/v1/agent.md
+++ b/docs/v1/agent.md
@@ -1,8 +1,6 @@
 # The Agent
 
-An `Agent` is a configured **harness** (the program that drives the model), a
-**model**, and a **runtime** (where the harness executes), built from an
-`AgentConfig` alone. An agent is given a `Task` and produces a `Trace`.
+An `Agent` is a configured **harness** (the program that drives the model), a **model**, and a **runtime** (where the harness executes), built from an `AgentConfig` alone. An agent is given a `Task` and produces a `Trace`.
 
 ```python
 import verifiers.v1 as vf
@@ -11,14 +9,11 @@ solver = vf.make_agent(vf.AgentConfig(model="z-ai/glm-5.2"))
 trace = await solver.run(vf.Task(vf.TaskData(prompt="What is 2+2?")))
 ```
 
-Every run is a standard rollout producing a `vf.Trace`. By default, the agent
-is self-contained: each run brings up the machinery it needs — interception
-server, network tunnel — and tears it down afterwards.
+Every run is a standard rollout producing a `vf.Trace`. By default, the agent is self-contained: each run brings up the machinery it needs — interception server, network tunnel — and tears it down afterwards.
 
 ## Borrowed Resources
 
-At scale (large evals, training), per-run machinery adds up. `make_agent`
-accepts live resources to borrow instead of creating its own.
+At scale (large evals, training), per-run machinery adds up. `make_agent` accepts live resources to borrow instead of creating its own.
 
 ### Interception Server
 
@@ -35,8 +30,7 @@ async with InterceptionServer() as server:
 
 ### Client
 
-Pass `client=` to reuse an existing client — agents on the same endpoint should
-share a single `Client` (one connection pool).
+Pass `client=` to reuse an existing client — agents on the same endpoint should share a single `Client` (one connection pool).
 
 ```python
 client = vf.resolve_client(vf.EvalClientConfig())
@@ -45,23 +39,17 @@ solver = vf.make_agent(vf.AgentConfig(model="z-ai/glm-5.2"), client=client)
 judge = vf.make_agent(vf.AgentConfig(model="openai/gpt-5.4-mini"), client=client)
 ```
 
-The caller is responsible for correctly handling the lifecycle of such
-borrowed resources: they must be live for every run placed on them, and the
-agent never tears them down.
+The caller is responsible for correctly handling the lifecycle of such borrowed resources: they must be live for every run placed on them, and the agent never tears them down.
 
 ## Trace
 
-A `Trace` holds all information on a single agent's rollout: the message graph,
-model calls, usage, timing, the rewards, metrics, and errors it recorded.
-Whatever a run did, the trace is the artifact you store, chain, and train on.
+A `Trace` holds all information on a single agent's rollout: the message graph, model calls, usage, timing, the rewards, metrics, and errors it recorded. Whatever a run did, the trace is the artifact you store, chain, and train on.
 
 ## Examples
 
 ### Chaining agents
 
-Agents are chained via `vf.Task`. For example, a common pattern is one agent's
-task depending on another agent's task. Use the `Task.from_trace` API, to
-construct such "glue" tasks.
+Agents are chained via `vf.Task`. For example, a common pattern is one agent's task depending on another agent's task. Use the `Task.from_trace` API, to construct such "glue" tasks.
 
 ```python
 class ProposedData(vf.TaskData):
@@ -85,10 +73,7 @@ async with asyncio.TaskGroup() as tg:
 
 ### Shared Runtimes
 
-Runtimes can be borrowed too: `agent.provision(task)` provisions a box from
-the agent's runtime policy as a context manager, and `run(..., runtime=box)`
-places a run into it instead of provisioning a fresh one. Chained agents then
-share one file system — here, the judge inspects what the solver left behind:
+Runtimes can be borrowed too: `agent.provision(task)` provisions a box from the agent's runtime policy as a context manager, and `run(..., runtime=box)` places a run into it instead of provisioning a fresh one. Chained agents then share one file system — here, the judge inspects what the solver left behind:
 
 ```python
 solver = vf.make_agent(vf.AgentConfig(model="z-ai/glm-5.2"))
@@ -102,5 +87,4 @@ async with solver.provision(task) as box:
     verdict = await judge.run(audit, runtime=box)
 ```
 
-The box lives exactly as long as the `async with`: borrowed runs never
-provision or tear it down.
+The box lives exactly as long as the `async with`: borrowed runs never provision or tear it down.

--- a/docs/v1/agent.md
+++ b/docs/v1/agent.md
@@ -22,7 +22,7 @@ accepts live resources to borrow instead of creating its own.
 
 ### Interception Server
 
-Pass `interception=` to reuse interception servers. 
+Pass `interception=` to reuse interception servers.
 
 ```python
 from verifiers.v1.interception import InterceptionServer

--- a/docs/v1/architecture.md
+++ b/docs/v1/architecture.md
@@ -1,12 +1,13 @@
 # Architecture
 
-verifiers is built out of the following parts: 
+verifiers is built out of the following parts:
 
 A server-backed evaluation or prime-rl **orchestrator** creates worker processes and distributes rollout requests among them. Each worker loads its taskset and harness, owns an **interception pool**, and creates the runtime used by each rollout it handles.
 
 The orchestrator and workers are managed by verifiers and prime-rl themselves and thus offer few configurable knobs.
 
 The **rollout** is the executable combination of one loaded task, the harness, and any tools. Each rollout has an independent trace and runtime state. verifiers has three different runtimes which you can use for most tasksets:
+
 - The `subprocess` runtime runs the rollouts in Python subprocesses locally. Thus, it is meant for debugging purposes, as there might be side effects during runtime, such as one subprocess altering the config files of the harness, which then affects the other subprocesses.
 - The `docker` runtime runs the rollouts in docker containers on your local machine.
 - Sandbox runtimes, such as `prime` or `modal`, are meant for production, especially for training or higher concurrency evaluation. These runtimes run remotely.
@@ -15,7 +16,8 @@ The harness runs inside the rollout runtime to interact with the taskset. The ha
 
 The interception server receives all these requests and then sends them over to the actual API, e.g. the OpenAI responses endpoint. It uses the endpoint that the harness expects, so Codex will use OpenAI Responses, while Claude Code will use the Anthropic Messages API.
 
-The interception server, however, allows several things beyond just replaying the correct API response: 
+The interception server, however, allows several things beyond just replaying the correct API response:
+
 - Traces are built live, thus allowing the collection of the trajectories as they happen
 - Setting sampling parameters in harnesses that don't necessarily expose those settings
 - Intercepting and rewriting tool responses or server-side web search results to block reward hacks

--- a/docs/v1/env.md
+++ b/docs/v1/env.md
@@ -1,17 +1,10 @@
 # The Env
 
-An `Env` defines the control flow between agents. In the simplest case, it is just
-a `SingleAgentEnv` where a single agent solves a task from a taskset. In more
-advanced settings, it can define grader-solver (agentic judges) or
-proposer-solver episodes which chains multiple agents.
+An `Env` defines the control flow between agents. In the simplest case, it is just a `SingleAgentEnv` where a single agent solves a task from a taskset. In more advanced settings, it can define grader-solver (agentic judges) or proposer-solver episodes which chains multiple agents.
 
-The core method is `Env.run`, which builds up an `Episode` artifact implicitly:
-it returns nothing, and every finished agent run joins the episode automatically
-— one `Trace` per agent run. The `setup` and `finalize` hooks let you configure
-which agents should be trained in prime-rl or set cross-agent rewards.
+The core method is `Env.run`, which builds up an `Episode` artifact implicitly: it returns nothing, and every finished agent run joins the episode automatically — one `Trace` per agent run. The `setup` and `finalize` hooks let you configure which agents should be trained in prime-rl or set cross-agent rewards.
 
-This example illustrates two agents, `pro` and `con`, arguing for opposing
-positions on a question from a taskset, judged by a `judge` agent.
+This example illustrates two agents, `pro` and `con`, arguing for opposing positions on a question from a taskset, judged by a `judge` agent.
 
 ```python
 class DebateConfig(vf.EnvConfig):
@@ -48,15 +41,11 @@ class DebateEnv(vf.Env[DebateConfig]):
 
 ## Episode
 
-An `Episode` holds all agents' traces from a single invocation of `Env.run`. A
-good mental model is: the `Trace` is an agent's local view of a rollout, while
-the `Episode` is the global view.
+An `Episode` holds all agents' traces from a single invocation of `Env.run`. A good mental model is: the `Trace` is an agent's local view of a rollout, while the `Episode` is the global view.
 
 ## Pluggability
 
-Just like tasksets and harnesses, an `Env` can be user-defined for full
-expressiveness over multi-agent interaction patterns — export an `Env` subclass
-via `__all__`. Otherwise, verifiers ships with a handful of built-ins.
+Just like tasksets and harnesses, an `Env` can be user-defined for full expressiveness over multi-agent interaction patterns — export an `Env` subclass via `__all__`. Otherwise, verifiers ships with a handful of built-ins.
 
 | id | agents | what it does |
 | --- | --- | --- |

--- a/docs/v1/getting_started.md
+++ b/docs/v1/getting_started.md
@@ -1,4 +1,5 @@
 ### Installation
+
 verifiers runs locally with `uv`. Install it, clone the repo, and sync dependencies:
 
 ```bash
@@ -11,4 +12,5 @@ uv sync
 You can now run tasksets directly, e.g. `uv run eval <taskset-id>`, and scaffold new ones with `uv run init <name>`.
 
 ### Skills
+
 To equip your agent with the necessary knowledge, we highly recommend the skills in this repository's [`skills/`](../../skills/) directory (alongside [`AGENTS.md`](../../AGENTS.md)). They are more comprehensive than these docs, which are meant for human consumption.

--- a/docs/v1/harbor.md
+++ b/docs/v1/harbor.md
@@ -2,7 +2,6 @@
 
 verifiers offers built-in support for Harbor via the `HarborTaskset` class. Creating a Harbor-based taskset is straightforward in most cases:
 
-
 ```python
 import verifiers.v1 as vf
 from verifiers.v1.tasksets.harbor import HarborConfig, HarborTask, HarborTaskset
@@ -72,7 +71,8 @@ The `timeout_multiplier` multiplies both the agent and verifier timeout, while t
 
 ## Shortcomings
 
-verifiers does not have parity with Harbor yet, so some features are missing and currently being worked on. The most notable missing features right now are: 
+verifiers does not have parity with Harbor yet, so some features are missing and currently being worked on. The most notable missing features right now are:
+
 - `no-network` support for sandbox runtimes ([Harbor Docs](https://www.harborframework.com/docs/tasks/network-policy))
 - Shared & separate verifiers ([Harbor Docs](https://www.harborframework.com/docs/tasks#verifier-environment-shared-vs-separate))
 - Multi-step tasks ([Harbor Docs](https://www.harborframework.com/docs/tasks/multi-step))

--- a/docs/v1/harnesses.md
+++ b/docs/v1/harnesses.md
@@ -4,7 +4,6 @@ verifiers supports a range of harnesses out of the box, including Claude Code, C
 
 ## A minimal harness implementation
 
-
 ```python
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.harness import Harness, HarnessConfig

--- a/docs/v1/tasksets.md
+++ b/docs/v1/tasksets.md
@@ -33,6 +33,7 @@ Most tasksets do not need specific tools, user simulations or custom harnesses.
 ## An example taskset
 
 Tasksets are made of the following components:
+
 - The **Taskset** loads the actual **Tasks** from a dataset using the `load()` function. It can be configured with the **TasksetConfig**, to e.g. load a certain split. Configs are exposed to the user and thus should only contain configurable values.
 - A **Task** defines the scoring, stop conditions, setup, judging etc. of the task to solve. It also gets the tools or user config. It gets configured by a **TaskConfig**, e.g., to set a specific judge model.
 - The **TaskData** is the immutable object that holds the actual data, i.e., the prompts, images, expected outputs etc., as well as other information such as timeouts (if set).
@@ -152,6 +153,7 @@ Some tasksets require custom tools, which are bundled as a `vf.Toolset` (similar
 Tools are exposed as MCP servers to the given harness and thus need a harness which exposes MCP support (via `SUPPORTS_MCP`).
 
 You can create them like this (remember the bootstrapping with `uv run init MY_ENV -T`):
+
 ```python
 DATABASE = None
 

--- a/docs/v1/tasksets.md
+++ b/docs/v1/tasksets.md
@@ -114,14 +114,9 @@ These values can be overridden with `--env.taskset.num-tasks` and `--env.taskset
 
 ## Lazy and infinite tasksets
 
-`load()` may be a generator instead of returning a list: yield each task as it's built.
-Consumers materialize tasks through `Taskset.select`, which pulls only what a run needs —
-`eval -n 5` builds 5 tasks, not the whole set — so a generator pays off whenever building
-a task is expensive.
+`load()` may be a generator instead of returning a list: yield each task as it's built. Consumers materialize tasks through `Taskset.select`, which pulls only what a run needs — `eval -n 5` builds 5 tasks, not the whole set — so a generator pays off whenever building a task is expensive.
 
-A procedural taskset can keep yielding forever. Declare `INFINITE = True` so consumers know
-the stream never ends — infinity is inherent to the taskset, not a config knob; how many
-tasks a run takes is the run's choice (`-n`), not the taskset's:
+A procedural taskset can keep yielding forever. Declare `INFINITE = True` so consumers know the stream never ends — infinity is inherent to the taskset, not a config knob; how many tasks a run takes is the run's choice (`-n`), not the taskset's:
 
 ```python
 import itertools
@@ -139,18 +134,11 @@ class AdditionTaskset(vf.Taskset[AdditionTask, vf.TasksetConfig]):
             )
 ```
 
-Two rules follow from infinity: a run over an infinite taskset must be bounded with
-`num_tasks` (`-n` on the CLI — omitting it is an error), and `shuffle` is a no-op (warned):
-there is no whole set to sample from, and the first `n` generated tasks are already an
-arbitrary sample. Generation must be deterministic — env-server pool workers each run
-their own `load()` and rely on every worker producing the same sequence, so seed any
-randomness with a constant (see `alphabet_sort_v1`, `color_codeword_v1`, or the built-in
-`textarena` taskset).
+Two rules follow from infinity: a run over an infinite taskset must be bounded with `num_tasks` (`-n` on the CLI — omitting it is an error), and `shuffle` is a no-op (warned): there is no whole set to sample from, and the first `n` generated tasks are already an arbitrary sample. Generation must be deterministic — env-server pool workers each run their own `load()` and rely on every worker producing the same sequence, so seed any randomness with a constant (see `alphabet_sort_v1`, `color_codeword_v1`, or the built-in `textarena` taskset).
 
 ## Adding Tools
 
-Some tasksets require custom tools, which are bundled as a `vf.Toolset` (similar to how a `vf.Taskset` bundles `vf.Task`).
-Tools are exposed as MCP servers to the given harness and thus need a harness which exposes MCP support (via `SUPPORTS_MCP`).
+Some tasksets require custom tools, which are bundled as a `vf.Toolset` (similar to how a `vf.Taskset` bundles `vf.Task`). Tools are exposed as MCP servers to the given harness and thus need a harness which exposes MCP support (via `SUPPORTS_MCP`).
 
 You can create them like this (remember the bootstrapping with `uv run init MY_ENV -T`):
 
@@ -240,6 +228,4 @@ To override the judge model, set `env.taskset.task.judge.model` in your config (
 
 ## Beyond one agent
 
-One episode doesn't have to be one agent run: agents, the control flow between
-agents, and cross-agent rewards are the environment's job — see
-[The Env](env.md).
+One episode doesn't have to be one agent run: agents, the control flow between agents, and cross-agent rewards are the environment's job — see [The Env](env.md).

--- a/skills/brainstorm/SKILL.md
+++ b/skills/brainstorm/SKILL.md
@@ -19,7 +19,9 @@ Run an interactive idea session with the user to turn their idea into a concrete
 ## Discovery workflow
 
 1. Find out what the user wants:
+
   - Is it running existing evaluations or training with common tasksets? If so, use the Environment Hub to see whether those tasksets already exist.
   - Is it optimizing an existing workflow? In this case, prompt optimization with GEPA is the right tool.
   - Else: For training and evaluations, building a taskset together is the right call.
+
 2. After you have found this out, look at the other skills and choose the appropriate one to proceed on the technical level, while still keeping the interactive session with the user alive.

--- a/skills/create-environments/SKILL.md
+++ b/skills/create-environments/SKILL.md
@@ -38,6 +38,7 @@ Use the naming convention `<env>.x86.<task>:latest` for the image name (e.g. `ab
 ## Define the needed values first
 
 Before starting with the implementation, think about the following things:
+
 - What is the dataset about, which fields does it have?
 - Does it come with custom tools that are strictly necessary and not added by common harnesses? For example, a lot of harnesses come with bash or web search tools, which makes custom tools obsolete. Always prefer harnesses over custom tools
 - Does the taskset need a user simulator?
@@ -184,7 +185,6 @@ Choose placement from the tool's lifetime and filesystem needs:
 - **Task-scoped, colocated:** set `colocated = true` on its `ToolsetConfig` when the tool must see the harness's filesystem or processes. It still launches once per rollout.
 - **Taskset-scoped, shared:** parameterize the toolset with `vf.SharedToolsetConfig`, put the matching config field directly on `TasksetConfig`, and declare the class on `Taskset.tools`.
 - **Existing remote service:** set `url` on the matching toolset config. Verifiers connects to the streamable-HTTP MCP endpoint instead of launching the class locally.
-
 
 ## User simulation
 

--- a/skills/create-environments/SKILL.md
+++ b/skills/create-environments/SKILL.md
@@ -54,8 +54,7 @@ Ask the user about unresolved semantic choices instead of inventing them. Presen
 
 A package exports one `vf.Taskset` subclass — and optionally one `vf.Environment` subclass (multi-agent control flow) and/or one `vf.Harness` subclass — through `__all__`. The taskset export happens automatically when you bootstrap a new taskset using `uv run init`.
 
-Do not add `load_environment()`, `load_taskset()`, or `load_harness()` functions. The v1 loader
-resolves classes and their config types from `__all__` and generic bases.
+Do not add `load_environment()`, `load_taskset()`, or `load_harness()` functions. The v1 loader resolves classes and their config types from `__all__` and generic bases.
 
 Use:
 

--- a/skills/evaluate-environments/SKILL.md
+++ b/skills/evaluate-environments/SKILL.md
@@ -48,17 +48,13 @@ When the user requests a full run, do not restrict the number of tasks. Ask for 
 - `owner/name` installs a Hub package on demand.
 - `owner/name@version` pins a Hub version.
 
-The leading ID is shorthand for `--env.taskset.id`. A harness belongs to an agent —
-`--env.agent.harness.*` on the single-agent env, `--env.<agent>.harness.*` on a
-multi-agent one (there is no run-level `--harness.*`):
+The leading ID is shorthand for `--env.taskset.id`. A harness belongs to an agent — `--env.agent.harness.*` on the single-agent env, `--env.<agent>.harness.*` on a multi-agent one (there is no run-level `--harness.*`):
 
 ```bash
 prime eval run owner/name --env.agent.harness.id codex --env.agent.harness.runtime.type prime
 ```
 
-The env — the control flow between agents — owns the whole `[env]` block. Empty `--env.id`
-keeps the taskset's own story (its exported `Environment` subclass, else the single-agent
-env); `--env.id` pairs a reusable env with any taskset, its knobs typed under `--env.*`:
+The env — the control flow between agents — owns the whole `[env]` block. Empty `--env.id` keeps the taskset's own story (its exported `Environment` subclass, else the single-agent env); `--env.id` pairs a reusable env with any taskset, its knobs typed under `--env.*`:
 
 ```bash
 prime eval run my-task-v1 --env.id best-of-n --env.n 8      # pass@k / rejection sampling

--- a/skills/evaluate-environments/SKILL.md
+++ b/skills/evaluate-environments/SKILL.md
@@ -115,7 +115,7 @@ For all parameters, look up the [reference](references/REFERENCE.md). Leaving th
 
 ## Reproducible TOML
 
-You can also use a TOML: 
+You can also use a TOML:
 
 ```toml
 model = "openai/gpt-5-mini"

--- a/skills/evaluate-environments/references/REFERENCE.md
+++ b/skills/evaluate-environments/references/REFERENCE.md
@@ -24,11 +24,7 @@ EvalConfig                          (the run)
 └─ pool: PoolConfig                 (static | elastic) — env-server only
 ```
 
-There is no run-level harness: each agent pins its own (`--env.agent.harness.*` on the
-single-agent env), an unpinned agent runs the taskset's default harness (its bundled
-one, else `bash`), and a declared pin is the env author's default. The
-retired flat axes error with a pointer: `--taskset.*` → `--env.taskset.*`,
-`--harness.*` → `--env.<agent>.harness.*`.
+There is no run-level harness: each agent pins its own (`--env.agent.harness.*` on the single-agent env), an unpinned agent runs the taskset's default harness (its bundled one, else `bash`), and a declared pin is the env author's default. The retired flat axes error with a pointer: `--taskset.*` → `--env.taskset.*`, `--harness.*` → `--env.<agent>.harness.*`.
 
 Sibling entrypoints reuse the same tree: [`ServeConfig`](#serveconfig--the-env-server-cli) (env server) and [`ValidateConfig`](#validateconfig--the-validate-cli) (per-task validation). All three live in `verifiers/v1/configs/`.
 
@@ -106,14 +102,7 @@ A vLLM `/inference/v1/generate` endpoint with client-side tokenization (response
 
 ## EnvConfig — the environment
 
-`verifiers/v1/env.py` — `EnvConfig(BaseConfig)`, the run's whole `[env]` block. One subclass
-per `Environment` class (bound via `Environment[YourConfig]`): the base carries which env
-(`id`), the seed taskset, and the env-agnostic run limits; the subclass declares each agent as
-an `AgentConfig` field plus the env's own knobs (`--env.n`, `--env.weight`, ...). The run's
-`env` field is narrowed to the selected env's config class by `--env.id` (else the taskset id,
-else `SingleAgentEnvConfig`), so everything renders typed in `-h`. Each loaded `Task` supplies
-the row's behavior, tools, user simulator, and scoring; only its `TaskData` is stored on the
-trace.
+`verifiers/v1/env.py` — `EnvConfig(BaseConfig)`, the run's whole `[env]` block. One subclass per `Environment` class (bound via `Environment[YourConfig]`): the base carries which env (`id`), the seed taskset, and the env-agnostic run limits; the subclass declares each agent as an `AgentConfig` field plus the env's own knobs (`--env.n`, `--env.weight`, ...). The run's `env` field is narrowed to the selected env's config class by `--env.id` (else the taskset id, else `SingleAgentEnvConfig`), so everything renders typed in `-h`. Each loaded `Task` supplies the row's behavior, tools, user simulator, and scoring; only its `TaskData` is stored on the trace.
 
 | Field | Type | Default | Notes |
 | --- | --- | --- | --- |
@@ -128,11 +117,7 @@ Per-run caps (turns, tokens, stage timeouts, retries) are agent fields, not env 
 
 ### Agent config
 
-`verifiers/v1/agent.py` — `AgentConfig(BaseConfig)`. One per declared agent, addressed
-`--env.<agent>.*`. The **model context** defaults to the run's own (the serve protocol carries
-model/client/sampling per rollout request — what makes self-play trainable). The **harness**
-does not: an unpinned agent runs the taskset's default harness; a declared pin is the env
-author's per-agent default; partial overrides deep-merge onto it (an `id` switch replaces it).
+`verifiers/v1/agent.py` — `AgentConfig(BaseConfig)`. One per declared agent, addressed `--env.<agent>.*`. The **model context** defaults to the run's own (the serve protocol carries model/client/sampling per rollout request — what makes self-play trainable). The **harness** does not: an unpinned agent runs the taskset's default harness; a declared pin is the env author's per-agent default; partial overrides deep-merge onto it (an `id` switch replaces it).
 
 | Field | Type | Default | Notes |
 | --- | --- | --- | --- |
@@ -143,15 +128,11 @@ author's per-agent default; partial overrides deep-merge onto it (an `id` switch
 | `timeout` | `TimeoutConfig` | `TimeoutConfig()` | Per-stage wall-clock timeouts for this agent's runs (`setup`/`rollout`/`finalize`/`scoring`; each stage falls back to the task's own). |
 | `max_turns` / `max_input_tokens` / `max_output_tokens` / `max_total_tokens` | `int \| None` | `None` | Per-agent caps (None = no limit); map onto [`RolloutLimits`](#rollout-limits), each checked between turns (soft by one turn). |
 
-Trainability is not a config field: it is env truth, set in place by the env's
-`setup(agents)` hook (default: every agent trains) and stamped on each trace. An env
-that wants the flip run-configurable exposes its own switch (e.g. proposer-solver's
-`--env.train_solver false`).
+Trainability is not a config field: it is env truth, set in place by the env's `setup(agents)` hook (default: every agent trains) and stamped on each trace. An env that wants the flip run-configurable exposes its own switch (e.g. proposer-solver's `--env.train_solver false`).
 
 ### Legacy (v0) backwards-compat fields
 
-On `EnvServerConfig` (below): set `id` (leave `env.taskset` unset) to run a classic
-`verifiers.load_environment` env through the legacy bridge.
+On `EnvServerConfig` (below): set `id` (leave `env.taskset` unset) to run a classic `verifiers.load_environment` env through the legacy bridge.
 
 | Field | Type | Default | Notes |
 | --- | --- | --- | --- |
@@ -163,8 +144,7 @@ On `EnvServerConfig` (below): set `id` (leave `env.taskset` unset) to run a clas
 
 ### EnvServerConfig — the pool
 
-`EnvServerConfig(BaseConfig)`. The `env` block plus the worker pool sizing and the legacy v0
-fields. Shared by the `serve` CLI, server-backed eval, and prime-rl's orchestrator.
+`EnvServerConfig(BaseConfig)`. The `env` block plus the worker pool sizing and the legacy v0 fields. Shared by the `serve` CLI, server-backed eval, and prime-rl's orchestrator.
 
 | Field | Type | Default | Notes |
 | --- | --- | --- | --- |
@@ -231,10 +211,7 @@ Elastic pool: start at one worker and scale up on demand.
 
 ## Taskset config
 
-`verifiers/v1/taskset.py` — `TasksetConfig(BaseConfig)`. Subclass it for values used while
-`Taskset.load()` builds the task list: dataset id, split, seed, sample count, difficulty filters,
-and similar load-time choices. The concrete subclass is selected through `env.taskset.id`, so
-its fields become typed dotted flags such as `--env.taskset.split test`.
+`verifiers/v1/taskset.py` — `TasksetConfig(BaseConfig)`. Subclass it for values used while `Taskset.load()` builds the task list: dataset id, split, seed, sample count, difficulty filters, and similar load-time choices. The concrete subclass is selected through `env.taskset.id`, so its fields become typed dotted flags such as `--env.taskset.split test`.
 
 | Field | Type | Default | Notes |
 | --- | --- | --- | --- |
@@ -243,15 +220,11 @@ its fields become typed dotted flags such as `--env.taskset.split test`.
 
 `.name` → the package name (id with org / version stripped).
 
-A taskset implements `load()` and declares exactly one task type through its generic base. It may
-also declare task-agnostic tool classes on `Taskset.tools`; those servers are shared by the
-rollouts handled by one environment worker.
+A taskset implements `load()` and declares exactly one task type through its generic base. It may also declare task-agnostic tool classes on `Taskset.tools`; those servers are shared by the rollouts handled by one environment worker.
 
 ### Task config
 
-`TaskConfig` contains knobs read by task behavior. Subclass it for scoring parameters and
-task-scoped `ToolsetConfig` or `UserConfig` fields, then narrow the taskset config's `task` field to
-that subclass. These are run-wide knobs, not per-row data; the row itself belongs on `TaskData`.
+`TaskConfig` contains knobs read by task behavior. Subclass it for scoring parameters and task-scoped `ToolsetConfig` or `UserConfig` fields, then narrow the taskset config's `task` field to that subclass. These are run-wide knobs, not per-row data; the row itself belongs on `TaskData`.
 
 | Field | Type | Default | Notes |
 |---|---|---|---|
@@ -275,8 +248,7 @@ that subclass. These are run-wide knobs, not per-row data; the row itself belong
 
 `.name` → the package name; `.resolved_env` → `env` merged with forwarded `forward_env` vars.
 
-A harness class also declares capability flags (ClassVars, not user-settable):
-`APPENDS_SYSTEM_PROMPT`, `SUPPORTS_MCP`, `SUPPORTS_USER_SIM`, `SUPPORTS_MESSAGE_PROMPT`.
+A harness class also declares capability flags (ClassVars, not user-settable): `APPENDS_SYSTEM_PROMPT`, `SUPPORTS_MCP`, `SUPPORTS_USER_SIM`, `SUPPORTS_MESSAGE_PROMPT`.
 
 ### Built-in harness configs
 
@@ -293,11 +265,7 @@ A growing-message-list chat loop with a local `bash` tool, plus optional `edit`/
 
 #### `NullHarnessConfig` — `id: "null"`
 
-A growing-message-list chat loop with the task- and taskset-scoped MCP tools, and **no built-in
-tools of its own**. It runs as a uv script whose dependencies are `openai` and `mcp`, so setup
-bootstraps everything it needs in the selected runtime. `NullHarnessConfig` adds no fields beyond
-the base `HarnessConfig` fields. Use it for pure chat or tasksets whose entire tool surface is
-provided through MCP; use an agentic harness for shell/edit capabilities.
+A growing-message-list chat loop with the task- and taskset-scoped MCP tools, and **no built-in tools of its own**. It runs as a uv script whose dependencies are `openai` and `mcp`, so setup bootstraps everything it needs in the selected runtime. `NullHarnessConfig` adds no fields beyond the base `HarnessConfig` fields. Use it for pure chat or tasksets whose entire tool surface is provided through MCP; use an agentic harness for shell/edit capabilities.
 
 #### `CodexHarnessConfig` — `id: "codex"`
 
@@ -350,9 +318,7 @@ Installs the Kimi Code CLI and runs it headlessly.
 
 ### `SubprocessConfig` — `type: "subprocess"` (default)
 
-Run on the host in a fresh `/tmp/<name>` workspace per rollout. **No extra fields.** Implicit
-host inheritance removes names containing `API_KEY`; explicit values passed in the runtime `env`
-mapping are merged afterward and inherited by child processes.
+Run on the host in a fresh `/tmp/<name>` workspace per rollout. **No extra fields.** Implicit host inheritance removes names containing `API_KEY`; explicit values passed in the runtime `env` mapping are merged afterward and inherited by child processes.
 
 ### `DockerConfig` — `type: "docker"`
 
@@ -403,8 +369,7 @@ Remote Modal sandbox; reached via Modal's own port forwarding (`encrypted_ports`
 | `disk` | `float` | `5.0` | Disk in GB. Modal sandboxes have no disk knob, so **accepted but not enforced**. |
 | `creates_per_sec` | `float \| None` | `40.0` | Pace sandbox creation to this many per second, host-wide across every env-server worker (None/≤0 disables). |
 
-Before each rollout or validation check, `resolve_runtime_config` combines the selected runtime
-config with the row's `TaskData`:
+Before each rollout or validation check, `resolve_runtime_config` combines the selected runtime config with the row's `TaskData`:
 
 - `TaskData.image` is the row's required execution image and replaces the runtime's base image. A
   row with an image cannot use the subprocess runtime.
@@ -413,32 +378,21 @@ config with the row's `TaskData`:
 - Non-`None` `TaskData.resources` values similarly fill supported runtime fields only while those
   fields remain at their defaults. Any non-default runtime-config resource value wins.
 - A resource field unsupported by the chosen runtime is ignored; evaluation warns once per
-  runtime/field combination. Docker and Modal accept `disk` so portable task data validates, but
-  neither enforces a disk limit.
+  runtime/field combination. Docker and Modal accept `disk` so portable task data validates, but neither enforces a disk limit.
 
-This resolution produces a copied runtime config; it does not mutate the frozen row or the shared
-base config.
+This resolution produces a copied runtime config; it does not mutate the frozen row or the shared base config.
 
 ---
 
 ## Task resources & timeouts
 
-`verifiers/v1/task.py`. `TaskData` is the frozen, serializable row stored on `trace.task` and sent
-across worker/runtime boundaries. Taskset packages subclass it for typed row-specific fields
-such as reference answers, repository metadata, or judge inputs. Those fields are not CLI flags;
-they are produced by `Taskset.load()`.
+`verifiers/v1/task.py`. `TaskData` is the frozen, serializable row stored on `trace.task` and sent across worker/runtime boundaries. Taskset packages subclass it for typed row-specific fields such as reference answers, repository metadata, or judge inputs. Those fields are not CLI flags; they are produced by `Taskset.load()`.
 
-`Task` is the behavior wrapper around that row. It owns hooks and scoring and reads uniform,
-run-configurable knobs from `TaskConfig`, but the `Task` object itself is not serialized onto the
-trace. Replay validates each recorded row as the taskset's declared `TaskData`, reattaches the
-declared task class, and propagates validation failures instead of changing task types.
+`Task` is the behavior wrapper around that row. It owns hooks and scoring and reads uniform, run-configurable knobs from `TaskConfig`, but the `Task` object itself is not serialized onto the trace. Replay validates each recorded row as the taskset's declared `TaskData`, reattaches the declared task class, and propagates validation failures instead of changing task types.
 
 ### `TaskResources` (frozen)
 
-Portable runtime resources requested by one row. CPU is measured in cores; memory and disk are in
-gigabytes. `None` means “do not override the chosen runtime/provider default.” Values are applied
-only to runtime fields that remain at their defaults; any non-default runtime-config value wins.
-Unsupported fields are ignored; evaluation warns once per runtime/field combination.
+Portable runtime resources requested by one row. CPU is measured in cores; memory and disk are in gigabytes. `None` means “do not override the chosen runtime/provider default.” Values are applied only to runtime fields that remain at their defaults; any non-default runtime-config value wins. Unsupported fields are ignored; evaluation warns once per runtime/field combination.
 
 | Field | Type | Default | Notes |
 | --- | --- | --- | --- |
@@ -449,10 +403,7 @@ Unsupported fields are ignored; evaluation warns once per runtime/field combinat
 
 ### `TaskTimeout` (frozen)
 
-Per-row wall-clock timeout requests, in seconds, one for each rollout stage. For eval, a non-`None`
-value in the agent's `TimeoutConfig` (`--env.<agent>.timeout.*`) wins; otherwise the corresponding
-row value is used. If both are `None`, that stage has no framework timeout. Remote harness execution
-is capped at the provider's 24-hour sandbox lifetime.
+Per-row wall-clock timeout requests, in seconds, one for each rollout stage. For eval, a non-`None` value in the agent's `TimeoutConfig` (`--env.<agent>.timeout.*`) wins; otherwise the corresponding row value is used. If both are `None`, that stage has no framework timeout. Remote harness execution is capped at the provider's 24-hour sandbox lifetime.
 
 | Field | Type | Default | Notes |
 | --- | --- | --- | --- |
@@ -475,29 +426,19 @@ is capped at the provider's 24-hour sandbox lifetime.
 | `timeout` | `TaskTimeout` | `TaskTimeout()` | Per-stage timeout requests described above. |
 | `resources` | `TaskResources` | `TaskResources()` | Portable runtime resource requests described above. |
 
-`TaskData.prompt_text` renders a string prompt directly or joins the textual content of a
-`Messages` prompt. Judges use it as the default question text when no dedicated question field is
-configured.
+`TaskData.prompt_text` renders a string prompt directly or joins the textual content of a `Messages` prompt. Judges use it as the default question text when no dedicated question field is configured.
 
 ---
 
 ## Toolset config
 
-`verifiers/v1/mcp/toolset.py`. Tool scope is structural: a class declared on `Task.tools` is
-task-scoped, while a class declared on `Taskset.tools` is shared by one environment worker. The
-framework finds the matching config field by the toolset's generic config type. Subclass either
-config to add knobs consumed by the tool's `@vf.tool` methods.
+`verifiers/v1/mcp/toolset.py`. Tool scope is structural: a class declared on `Task.tools` is task-scoped, while a class declared on `Taskset.tools` is shared by one environment worker. The framework finds the matching config field by the toolset's generic config type. Subclass either config to add knobs consumed by the tool's `@vf.tool` methods.
 
 ### `ToolsetConfig` — `Task.tools`
 
-A task-scoped server is launched per rollout. Its matching config field normally lives on
-`TaskConfig`, under `--env.taskset.task.*`.
+A task-scoped server is launched per rollout. Its matching config field normally lives on `TaskConfig`, under `--env.taskset.task.*`.
 
-The default placement is the toolset's own subprocess runtime on the host, where verifiers and the
-taskset package are already installed. The harness reaches that server over the host network
-when local or through a tunnel when remote. `colocated` instead runs the server inside the harness
-runtime; this is useful when both must see the same filesystem or processes, but a remote sandbox
-must then upload and install verifiers plus the taskset package for every rollout.
+The default placement is the toolset's own subprocess runtime on the host, where verifiers and the taskset package are already installed. The harness reaches that server over the host network when local or through a tunnel when remote. `colocated` instead runs the server inside the harness runtime; this is useful when both must see the same filesystem or processes, but a remote sandbox must then upload and install verifiers plus the taskset package for every rollout.
 
 | Field | Type | Default | Notes |
 | --- | --- | --- | --- |
@@ -507,23 +448,16 @@ must then upload and install verifiers plus the taskset package for every rollou
 
 ### `SharedToolsetConfig` — `Taskset.tools`
 
-A taskset-scoped tool uses one framework-launched server per environment worker, or reuses a
-configured external `url` without launching a server. Its matching config field lives directly on
-the taskset config, not under `task`.
+A taskset-scoped tool uses one framework-launched server per environment worker, or reuses a configured external `url` without launching a server. Its matching config field lives directly on the taskset config, not under `task`.
 
-The framework-launched form is intended for expensive task-agnostic setup such as loading a corpus,
-index, or graph: `setup()` runs once per worker and `setup_task()` is not called because no single
-row owns the server. A vf-native shared tool may still use mutable `self.state`; the framework
-attaches each calling rollout's state channel to the shared URL so those values remain per rollout.
-There is no `colocated` option because a shared server has no single harness runtime.
+The framework-launched form is intended for expensive task-agnostic setup such as loading a corpus, index, or graph: `setup()` runs once per worker and `setup_task()` is not called because no single row owns the server. A vf-native shared tool may still use mutable `self.state`; the framework attaches each calling rollout's state channel to the shared URL so those values remain per rollout. There is no `colocated` option because a shared server has no single harness runtime.
 
 | Field | Type | Default | Notes |
 | --- | --- | --- | --- |
 | `runtime` | `RuntimeConfig` | `SubprocessConfig()` | The framework-launched server's own runtime. Host subprocess is cheapest; a remote runtime pays setup once per worker. See [Runtime configs](#runtime-configs). |
 | `url` | `str \| None` | `None` | Existing streamable-HTTP MCP endpoint reused across workers and rollouts instead of launching a server. |
 
-There is no `shared` boolean on `ToolsetConfig`: declare the class on `Task.tools` or
-`Taskset.tools` and use the matching config type to choose its scope.
+There is no `shared` boolean on `ToolsetConfig`: declare the class on `Task.tools` or `Taskset.tools` and use the matching config type to choose its scope.
 
 ---
 
@@ -540,20 +474,13 @@ There is no `shared` boolean on `ToolsetConfig`: declare the class on `Task.tool
 
 ## Judge config
 
-`verifiers/v1/judge.py`. `TaskConfig.judges` holds plugged judge configs that `Task.score`
-constructs and runs after the task's own rewards. Each list entry needs an `id`; the loader resolves
-that plugin's concrete `JudgeConfig` subclass before validation, just like tasksets and harnesses.
-Duplicate reward keys are rejected unless entries receive distinct `name` values.
+`verifiers/v1/judge.py`. `TaskConfig.judges` holds plugged judge configs that `Task.score` constructs and runs after the task's own rewards. Each list entry needs an `id`; the loader resolves that plugin's concrete `JudgeConfig` subclass before validation, just like tasksets and harnesses. Duplicate reward keys are rejected unless entries receive distinct `name` values.
 
-A task may instead declare a custom `JudgeConfig` field on its own `TaskConfig`, construct the
-judge inside a reward, and call `evaluate()` directly. That direct-use config may leave `id` empty.
+A task may instead declare a custom `JudgeConfig` field on its own `TaskConfig`, construct the judge inside a reward, and call `evaluate()` directly. That direct-use config may leave `id` empty.
 
 ### `JudgeConfig(BaseClientConfig)`
 
-Inherits `base_url`, `api_key_var`, and `headers` from
-[`BaseClientConfig`](#client-config). The default Prime endpoint, key, and team header use the same
-Prime CLI/environment fallback as the rollout client. Subclass `JudgeConfig` for additional knobs
-needed by a custom or plugin judge.
+Inherits `base_url`, `api_key_var`, and `headers` from [`BaseClientConfig`](#client-config). The default Prime endpoint, key, and team header use the same Prime CLI/environment fallback as the rollout client. Subclass `JudgeConfig` for additional knobs needed by a custom or plugin judge.
 
 | Field | Type | Default | Notes |
 | --- | --- | --- | --- |
@@ -567,9 +494,7 @@ needed by a custom or plugin judge.
 
 ### `JudgeSamplingConfig(SamplingConfig)`
 
-The same extensible shape as the rollout's [`SamplingConfig`](#sampling-config): `temperature`,
-`top_p`, `reasoning_effort`, and `max_tokens`, plus provider-specific keys because
-`extra='allow'`. Values passed directly to `complete()` override these configured defaults.
+The same extensible shape as the rollout's [`SamplingConfig`](#sampling-config): `temperature`, `top_p`, `reasoning_effort`, and `max_tokens`, plus provider-specific keys because `extra='allow'`. Values passed directly to `complete()` override these configured defaults.
 
 ### Judge class behavior
 
@@ -578,12 +503,9 @@ A judge class may define:
 - `prompt: str | None` — the default template formatted by `build_messages(**fields)`. A configured
   `prompt` or `prompt_file` overrides it for that instance.
 - `schema: type[BaseModel] | None` — a Pydantic schema for structured output. `evaluate()` sends it
-  through the OpenAI-compatible parsed-completion path and places the validated object on
-  `JudgeResponse.parsed`; without a schema, `parse()` receives the text response.
+  through the OpenAI-compatible parsed-completion path and places the validated object on `JudgeResponse.parsed`; without a schema, `parse()` receives the text response.
 
-`evaluate()` renders the prompt, performs one judge completion, and calls `parse()`. When a trace
-is supplied, billed judge usage is recorded even if parsing later fails. Plugin judges implement
-`score(task, trace)` so `Task.score` can record the verdict under the configured key and weight.
+`evaluate()` renders the prompt, performs one judge completion, and calls `parse()`. When a trace is supplied, billed judge usage is recorded even if parsing later fails. Plugin judges implement `score(task, trace)` so `Task.score` can record the verdict under the configured key and weight.
 
 ---
 
@@ -616,21 +538,14 @@ Plus all inherited `EnvServerConfig` fields (`env`, `pool`, legacy).
 
 ## ValidateConfig — the validate CLI
 
-`verifiers/v1/configs/validate.py` — `ValidateConfig(BaseConfig)`. Model-free validation has no
-harness, model client, or sampling. For every selected task, the default mode runs two independent
-checks in separate fresh runtimes:
+`verifiers/v1/configs/validate.py` — `ValidateConfig(BaseConfig)`. Model-free validation has no harness, model client, or sampling. For every selected task, the default mode runs two independent checks in separate fresh runtimes:
 
 1. **gold:** start the runtime, run `Task.setup`, call `Task.validate`, then tear down;
 2. **setup:** start another runtime, run `Task.setup`, mark it valid if setup returns, then tear down.
 
-The independent result separates basic provisioning/setup viability from the task's gold-check
-result. A task whose `validate()` returns `False` is `invalid`; a timeout is `timeout`; an exception
-is `error`. The base `Task.validate()` returns `True`, so tasks without a custom gold check still
-receive the setup checks.
+The independent result separates basic provisioning/setup viability from the task's gold-check result. A task whose `validate()` returns `False` is `invalid`; a timeout is `timeout`; an exception is `error`. The base `Task.validate()` returns `True`, so tasks without a custom gold check still receive the setup checks.
 
-Use `only_gold` or `only_setup` to select one mode; setting both is rejected. The CLI writes no
-config or traces to disk. Its output is the live dashboard when `rich` is enabled, otherwise one
-log line per task.
+Use `only_gold` or `only_setup` to select one mode; setting both is rejected. The CLI writes no config or traces to disk. Its output is the live dashboard when `rich` is enabled, otherwise one log line per task.
 
 | Field | Type | Default | Aliases | Notes |
 | --- | --- | --- | --- | --- |
@@ -657,27 +572,14 @@ log line per task.
 ## Notes & conventions
 
 - **Plugin resolution.** The run's `env` field narrows to the selected env's config class
-  (`--env.id`, else the taskset's exported env, else `SingleAgentEnvConfig`) *before*
-  validation; inside it, `taskset` narrows by its id and each pinned agent `harness` by its id.
-  Entries in `TaskConfig.judges` are similarly narrowed by each judge `id`. This is why local
-  and Hub plugin fields remain typed and appear in CLI validation instead of living in an
-  untyped arguments dictionary.
+  (`--env.id`, else the taskset's exported env, else `SingleAgentEnvConfig`) *before* validation; inside it, `taskset` narrows by its id and each pinned agent `harness` by its id. Entries in `TaskConfig.judges` are similarly narrowed by each judge `id`. This is why local and Hub plugin fields remain typed and appear in CLI validation instead of living in an untyped arguments dictionary.
 - **Dotted flags.** Every nested field is part of the same CLI tree
-  (`--env.agent.harness.runtime.type docker`, `--env.taskset.split test`,
-  `--pool.max_workers 8`, `--env.agent.retries.max_retries 2`). An `@ file.toml` describes
-  the identical tree; explicit CLI values layer over values loaded from the file.
+  (`--env.agent.harness.runtime.type docker`, `--env.taskset.split test`, `--pool.max_workers 8`, `--env.agent.retries.max_retries 2`). An `@ file.toml` describes the identical tree; explicit CLI values layer over values loaded from the file.
 - **Runtime precedence.** An explicit, non-default CLI/TOML `workdir` or resource field wins over
-  `TaskData`; otherwise a non-`None` row value fills it, and otherwise the runtime/provider default
-  remains. `TaskData.image` is the required image for that row and replaces the runtime's base
-  image. Unsupported resource fields are ignored; evaluation warns once per runtime/field.
+  `TaskData`; otherwise a non-`None` row value fills it, and otherwise the runtime/provider default remains. `TaskData.image` is the required image for that row and replaces the runtime's base image. Unsupported resource fields are ignored; evaluation warns once per runtime/field.
 - **Timeout precedence.** For eval stages, a non-`None` agent-level `TimeoutConfig` value
-  (`--env.<agent>.timeout.*`) wins over the corresponding `TaskData.timeout` value; if both are
-  `None`, there is no framework timeout. The setup value is one deadline shared by task setup and
-  harness provisioning.
-  Validate uses `CheckTimeoutConfig.setup`, then falls back to `TaskData.timeout.setup`, while
-  `CheckTimeoutConfig.total` independently bounds `Task.validate`.
+  (`--env.<agent>.timeout.*`) wins over the corresponding `TaskData.timeout` value; if both are `None`, there is no framework timeout. The setup value is one deadline shared by task setup and harness provisioning. Validate uses `CheckTimeoutConfig.setup`, then falls back to `TaskData.timeout.setup`, while `CheckTimeoutConfig.total` independently bounds `Task.validate`.
 - **Discriminated unions** are selected by their `type` field: `client.type` (eval|train), `pool.type` (static|elastic), `env.<agent>.harness.runtime.type` / `runtime.type` (subprocess|docker|prime|modal).
 - **Frozen models.** `TaskData`, `TaskResources`, and `TaskTimeout` are immutable wire input, not
-  mutable runtime state. Put per-rollout coordination on typed `trace.state`. `RolloutLimits` is an
-  immutable framework limit derived from the env's `max_*` fields.
+  mutable runtime state. Put per-rollout coordination on typed `trace.state`. `RolloutLimits` is an immutable framework limit derived from the env's `max_*` fields.
 - **Legacy v0.** Set the run-level `id` (leave `env.taskset` unset) to run a classic `load_environment` env through the bridge. `--resume` is not supported for legacy evals.

--- a/skills/evaluate-environments/references/REFERENCE.md
+++ b/skills/evaluate-environments/references/REFERENCE.md
@@ -39,7 +39,7 @@ Sibling entrypoints reuse the same tree: [`ServeConfig`](#serveconfig--the-env-s
 `verifiers/v1/configs/eval.py` — `EvalConfig(EnvServerConfig)`. The single config object the eval CLI parses. Inherits [`EnvServerConfig`](#envserverconfig--the-pool) (the `env` block + `--pool.*` + the legacy v0 fields) and adds the run knobs. Everything environment-shaped lives under `--env.*` / `[env]`.
 
 | Field | Type | Default | Aliases | Notes |
-|---|---|---|---|---|
+| --- | --- | --- | --- | --- |
 | `uuid` | `str` | `uuid4()` | — | Auto-generated run id; the leaf of the output dir. Excluded from the saved config. |
 | `model` | `str` | `"deepseek/deepseek-v4-flash"` | `model`, `m` | Model id. |
 | `client` | `ClientConfig` | `EvalClientConfig()` | — | The model client (discriminated union — see [Client config](#client-config)). |
@@ -67,7 +67,7 @@ Inherited from `EnvServerConfig`: [`env`](#envconfig--the-environment), [`pool`]
 `verifiers/v1/types.py` — `SamplingConfig(BaseModel)` (alias `Sampling`). Used as `EvalConfig.sampling` and embedded in [`JudgeSamplingConfig`](#judge-config). `extra='allow'`, so provider-specific keys pass through.
 
 | Field | Type | Default | Aliases | Notes |
-|---|---|---|---|---|
+| --- | --- | --- | --- | --- |
 | `temperature` | `float \| None` | `None` | — | Sampling temperature. |
 | `top_p` | `float \| None` | `None` | — | Nucleus sampling. |
 | `reasoning_effort` | `str \| None` | `None` | — | Provider reasoning-effort level. |
@@ -81,20 +81,23 @@ Inherited from `EnvServerConfig`: [`env`](#envconfig--the-environment), [`pool`]
 `verifiers/v1/clients/config.py`. Discriminated on `type` (`eval` | `train`); selected with `--client.type`.
 
 ### `BaseClientConfig` (common)
+
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `base_url` | `str` | `https://api.pinference.ai/api/v1` | OpenAI-compatible endpoint. Falls back to the active Prime CLI config (or `PRIME_INFERENCE_URL`). |
 | `api_key_var` | `str` | `"PRIME_API_KEY"` | Env var the key is read from. |
 | `headers` | `dict[str, str]` | `{}` | Extra HTTP headers on every request. `X-Prime-Team-ID` auto-set for pinference hosts. |
 
 ### `EvalClientConfig(BaseClientConfig)` — `type: "eval"` (default)
+
 The default: forward each request to a matching endpoint. No extra fields.
 
 ### `TrainClientConfig(BaseClientConfig)` — `type: "train"`
+
 A vLLM `/inference/v1/generate` endpoint with client-side tokenization (responses carry token ids + logprobs). Needs a running vLLM engine.
 
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `renderer` | `RendererConfig \| None` | `None` | The `renderers.RendererConfig`. `None` auto-resolves from the model (falls back to the default renderer — no tool support — for unknown models). |
 | `pool_size` | `int` | `1` | Renderer slots shared across concurrent rollouts (client-side tokenization). |
 | `renderer_model_name` | `str \| None` | `None` | Model the tokenizer/renderer pool is built for. Pin to the base model so a LoRA adapter name never drives tokenizer loading. Falls back to the per-request model. |
@@ -113,7 +116,7 @@ the row's behavior, tools, user simulator, and scoring; only its `TaskData` is s
 trace.
 
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `id` | `ID` | `""` | Which `Environment` (control flow between agents) runs: a bundled env (`best-of-n`, `agentic-judge`), a local package, or a Hub `org/name[@version]`. Empty = the taskset's own story (its exported `Environment` subclass, else `SingleAgentEnv`). |
 | `taskset` | `TasksetConfig \| None` | `None` | The seed taskset every rollout starts from; resolved to its concrete subclass by `--env.taskset.id` (positional shorthand: `eval <taskset-id>`). See [Taskset config](#taskset-config). `None` only for a taskset-less env; every bundled env requires one. |
 | *(agents)* | `AgentConfig` | env-declared | Each declared agent: `agent` on `SingleAgentEnvConfig`, `solver`/`judge` on the agentic-judge env, the env's own names elsewhere. See [Agent config](#agent-config). |
@@ -132,7 +135,7 @@ does not: an unpinned agent runs the taskset's default harness; a declared pin i
 author's per-agent default; partial overrides deep-merge onto it (an `id` switch replaces it).
 
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `harness` | `HarnessConfig \| None` | `None` | The agent's program + runtime policy; resolved to its concrete subclass by `--env.<agent>.harness.id`. `None` = the taskset's default harness (its bundled one, else `bash`). See [Harness config](#harness-config). |
 | `model` | `str \| None` | `None` | Pin a model for this agent (None = the run's `--model`). |
 | `client` | `ClientConfig \| None` | `None` | Pin an endpoint (None = the run's `--client.*`) — route a frozen judge or user sim off the training endpoint. |
@@ -151,7 +154,7 @@ On `EnvServerConfig` (below): set `id` (leave `env.taskset` unset) to run a clas
 `verifiers.load_environment` env through the legacy bridge.
 
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `id` | `ID \| None` | `None` | Classic v0 env id (`name`, `org/name`, or `org/name@version`). |
 | `args` | `dict` | `{}` | Construction kwargs forwarded to `load_environment(id, **args)`. |
 | `extra_env_kwargs` | `dict` | `{}` | Post-load kwargs applied via `env.set_kwargs(**...)` (e.g. `max_total_completion_tokens`, `max_seq_len`, `timeout_seconds`). |
@@ -164,7 +167,7 @@ On `EnvServerConfig` (below): set `id` (leave `env.taskset` unset) to run a clas
 fields. Shared by the `serve` CLI, server-backed eval, and prime-rl's orchestrator.
 
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `env` | `EnvConfig` | `SingleAgentEnvConfig()` | The environment (above). `SerializeAsAny`, so the resolved subclass's agents and knobs survive `model_dump` onto the wire. |
 | `pool` | `PoolConfig` | `ElasticPoolConfig()` | See [Pool config](#pool-config). |
 
@@ -175,7 +178,7 @@ fields. Shared by the `serve` CLI, server-backed eval, and prime-rl's orchestrat
 `verifiers/v1/env.py` — `TimeoutConfig(BaseConfig)`. Framework-enforced wall-clock timeouts per rollout stage, in seconds (None = no limit). An **agent** field (`--env.<agent>.timeout.*`); precedence: cli/toml > per-task [`TaskTimeout`](#task-resources--timeouts) > default.
 
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `setup` | `float \| None` | `None` | Shared wall-clock budget for `Task.setup` and harness provisioning. |
 | `rollout` | `float \| None` | `None` | Max wall-clock for the rollout (the harness run). |
 | `finalize` | `float \| None` | `None` | Max wall-clock for the task's `finalize` hook. |
@@ -192,10 +195,11 @@ fields. Shared by the `serve` CLI, server-backed eval, and prime-rl's orchestrat
 `verifiers/v1/retries.py`. Per-call model/runtime retries are owned by the harness/runtime SDKs; the framework keeps only **whole-run** retries, in two atoms sharing one shape: each agent's own (`--env.<agent>.retries.*` — rerun that agent's rollout; never into a borrowed box) and the env's whole-episode fallback (`--env.retries.*` — for faults no agent owns; a retried episode reruns whole).
 
 ### `RolloutRetryConfig`
+
 Rerun when the run ends with a captured error. Matching is by the error's **exception type name**.
 
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `max_retries` | `int` | `0` (≥0) | Retries beyond the first attempt (0 = no retry). |
 | `include` | `list[str]` | `[]` | Only retry errors whose type is listed. Empty = retry anything not excluded. |
 | `exclude` | `list[str]` | `[]` | Never retry these types (wins over `include`). |
@@ -207,6 +211,7 @@ Rerun when the run ends with a captured error. Matching is by the error's **exce
 `verifiers/v1/env.py`. Discriminated on `type`; selected with `--pool.type static|elastic`. Drives the env-server worker pool (the `--server` path).
 
 ### `StaticPoolConfig` — `type: "static"`
+
 Fixed pool: pre-spawn `num_workers` up front.
 
 | Field | Type | Default | Notes |
@@ -214,10 +219,11 @@ Fixed pool: pre-spawn `num_workers` up front.
 | `num_workers` | `int` | `4` (≥1) | Worker processes to pre-spawn (1 = a single in-process server, no pool). |
 
 ### `ElasticPoolConfig` — `type: "elastic"` (default)
+
 Elastic pool: start at one worker and scale up on demand.
 
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `max_workers` | `int \| None` | `None` | Upper bound on workers (None = unbounded). |
 | `multiplex` | `int` | `128` (≥1) | Rollouts per worker for the scale-up trigger: add a worker once in-flight rollouts reach 90% of `workers * multiplex`. |
 
@@ -231,7 +237,7 @@ and similar load-time choices. The concrete subclass is selected through `env.ta
 its fields become typed dotted flags such as `--env.taskset.split test`.
 
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `id` | `ID` | `""` | Local package or Hub `org/name[@version]`; selects the taskset and its config type. Set via `--env.taskset.id` or the positional `eval <taskset-id>`. |
 | `task` | `TaskConfig` | `TaskConfig()` | Task-facing config passed to every constructed task. `SerializeAsAny` preserves a narrowed subclass. Set through `--env.taskset.task.*`. |
 
@@ -258,8 +264,9 @@ that subclass. These are run-wide knobs, not per-row data; the row itself belong
 `verifiers/v1/harness.py` — `HarnessConfig(BaseConfig)`. The base; **subclass per harness to add run knobs**. A harness belongs to an agent: the concrete subclass is resolved by `--env.<agent>.harness.id` (`--env.agent.harness.id` on the single-agent env); an unpinned agent runs the taskset's bundled harness, else `bash`. Mirrors `TasksetConfig`.
 
 ### Base `HarnessConfig`
+
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `id` | `ID` | `"bash"` | The harness id, which selects it. Set via `--env.<agent>.harness.id`. |
 | `runtime` | `RuntimeConfig` | `SubprocessConfig()` | Where the harness runs. Discriminated union — see [Runtime configs](#runtime-configs). Set with `--env.<agent>.harness.runtime.type docker\|prime\|modal`. |
 | `env` | `dict[str, str]` | `{}` | Additional env vars for the harness program. Harness-owned endpoint/auth/model vars take precedence. |
@@ -276,14 +283,16 @@ A harness class also declares capability flags (ClassVars, not user-settable):
 All inherit the base `HarnessConfig` fields (`id`, `runtime`, `env`, `forward_env`, `disabled_tools`).
 
 #### `BashHarnessConfig` — `id: "bash"` (the fallback)
+
 A growing-message-list chat loop with a local `bash` tool, plus optional `edit`/`search`. A uv script (deps: `openai`, `mcp`).
 
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `edit` | `bool` | `True` | Offer the local `edit` tool (single-occurrence string replacement) alongside `bash`. |
 | `search` | `bool` | `False` | Offer a `search` tool (Google web results via serper.dev). Requires `SERPER_API_KEY` in the eval environment. |
 
 #### `NullHarnessConfig` — `id: "null"`
+
 A growing-message-list chat loop with the task- and taskset-scoped MCP tools, and **no built-in
 tools of its own**. It runs as a uv script whose dependencies are `openai` and `mcp`, so setup
 bootstraps everything it needs in the selected runtime. `NullHarnessConfig` adds no fields beyond
@@ -291,6 +300,7 @@ the base `HarnessConfig` fields. Use it for pure chat or tasksets whose entire t
 provided through MCP; use an agentic harness for shell/edit capabilities.
 
 #### `CodexHarnessConfig` — `id: "codex"`
+
 Installs the Codex CLI into the runtime and runs `codex exec`.
 
 | Field | Type | Default | Notes |
@@ -298,16 +308,18 @@ Installs the Codex CLI into the runtime and runs `codex exec`.
 | `version` | `str` | `"0.144.5"` | Codex release to install (the `rust-v<version>` GitHub release); pinned. |
 
 #### `RLMHarnessConfig` — `id: "rlm"`
+
 Installs the rlm CLI and runs it. Knobs map onto `RLM_*` env vars; base `HarnessConfig.env` passes any other `RLM_*` var through verbatim.
 
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `version` | `str` | `"main"` | Git ref (branch/tag/commit) of rlm to install. |
 | `max_depth` | `int` | `0` | Recursion depth rlm may spawn sub-harnesses to (`RLM_MAX_DEPTH`). |
 | `skills` | `list["edit" \| "search"]` | `[]` | Built-in rlm skills to enable (`RLM_SKILLS`). Empty enables none. |
 | `summarize_at_tokens` | `int \| (int, int) \| None` | `None` | Auto-compaction threshold (`RLM_SUMMARIZE_AT_TOKENS`): compact once context grows past this many tokens. An int is fixed; a `(lo, hi)` pair draws a per-group threshold (seeded by task index). `None` disables. Ints must be positive. |
 
 #### `MiniSWEAgentHarnessConfig` — `id: "mini-swe-agent"`
+
 Runs the native bash-tool agent through LiteLLM.
 
 | Field | Type | Default | Notes |
@@ -315,6 +327,7 @@ Runs the native bash-tool agent through LiteLLM.
 | `version` | `str` | `"2.4.5"` | mini-swe-agent release to install, pinned. |
 
 #### `Terminus2HarnessConfig` — `id: "terminus-2"`
+
 Runs Harbor's tmux agent through LiteLLM.
 
 | Field | Type | Default | Notes |
@@ -322,6 +335,7 @@ Runs Harbor's tmux agent through LiteLLM.
 | `version` | `str` | `"0.14.0"` | Harbor release to install, pinned. |
 
 #### `KimiCodeHarnessConfig` — `id: "kimi-code"`
+
 Installs the Kimi Code CLI and runs it headlessly.
 
 | Field | Type | Default | Notes |
@@ -335,15 +349,17 @@ Installs the Kimi Code CLI and runs it headlessly.
 `verifiers/v1/runtimes/`. Discriminated on `type`; selected with the agent's `--env.<agent>.harness.runtime.type` (or `--runtime.type` for the validate CLI). The same union is reused as `ToolsetConfig.runtime` and `UserConfig.runtime`.
 
 ### `SubprocessConfig` — `type: "subprocess"` (default)
+
 Run on the host in a fresh `/tmp/<name>` workspace per rollout. **No extra fields.** Implicit
 host inheritance removes names containing `API_KEY`; explicit values passed in the runtime `env`
 mapping are merged afterward and inherited by child processes.
 
 ### `DockerConfig` — `type: "docker"`
+
 Local Docker container sharing the host network (`--network host`).
 
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `image` | `str` | `"python:3.11-slim"` | Container image. |
 | `workdir` | `str` | `"/app"` | Working directory. |
 | `cpu` | `float \| None` | `None` | Pin to this many CPU cores (`docker --cpus`). None = unlimited. |
@@ -352,10 +368,11 @@ Local Docker container sharing the host network (`--network host`).
 | `disk` | `float \| None` | `None` | Advisory disk request in GB. Docker has no portable per-container size limit, so accepted but **not enforced**. |
 
 ### `PrimeConfig` — `type: "prime"`
+
 Remote Prime sandbox; reached via native port exposure.
 
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `image` | `str` | `"python:3.11-slim"` | Container image. |
 | `workdir` | `str` | `"/app"` | Working directory. |
 | `network_access` | `bool` | `True` | Allow outbound network from the sandbox. |
@@ -371,10 +388,11 @@ Remote Prime sandbox; reached via native port exposure.
 | `creates_per_min` | `int \| None` | `None` | Pace sandbox creation to this many per minute, host-wide across every env-server worker (None/≤0 disables). Tunnel creation is limited separately and globally. |
 
 ### `ModalConfig` — `type: "modal"`
+
 Remote Modal sandbox; reached via Modal's own port forwarding (`encrypted_ports`).
 
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `image` | `str` | `"python:3.11-slim"` | Container image (registry). |
 | `workdir` | `str` | `"/app"` | Working directory. |
 | `network_access` | `bool` | `True` | Allow outbound network (`block_network` is the negation). |
@@ -416,34 +434,37 @@ trace. Replay validates each recorded row as the taskset's declared `TaskData`, 
 declared task class, and propagates validation failures instead of changing task types.
 
 ### `TaskResources` (frozen)
+
 Portable runtime resources requested by one row. CPU is measured in cores; memory and disk are in
 gigabytes. `None` means “do not override the chosen runtime/provider default.” Values are applied
 only to runtime fields that remain at their defaults; any non-default runtime-config value wins.
 Unsupported fields are ignored; evaluation warns once per runtime/field combination.
 
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `cpu` | `float \| None` | `None` | CPU cores. Docker treats this as a hard `--cpus` limit; sandbox providers receive the same core count. |
 | `memory` | `float \| None` | `None` | Memory in GB. Docker enforces it as a hard limit; Modal receives the value converted to MB. |
 | `gpu` | `str \| None` | `None` | GPU spec such as `"A100"` or `"A100:2"` (`type[:count]`; a bare count lets supported providers choose the type). |
 | `disk` | `float \| None` | `None` | Disk in GB. Enforced by Prime; accepted but advisory/not enforced by Docker and Modal. |
 
 ### `TaskTimeout` (frozen)
+
 Per-row wall-clock timeout requests, in seconds, one for each rollout stage. For eval, a non-`None`
 value in the agent's `TimeoutConfig` (`--env.<agent>.timeout.*`) wins; otherwise the corresponding
 row value is used. If both are `None`, that stage has no framework timeout. Remote harness execution
 is capped at the provider's 24-hour sandbox lifetime.
 
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `setup` | `float \| None` | `None` | Task and harness setup stage. Overridden by the agent's `timeout.setup`; validate uses it for `Task.setup` when `CheckTimeoutConfig.setup` is unset. |
 | `harness` | `float \| None` | `None` | Harness execution. Overridden by the agent's `timeout.rollout`. |
 | `finalize` | `float \| None` | `None` | Task `finalize` hook. Overridden by the agent's `timeout.finalize`. |
 | `scoring` | `float \| None` | `None` | Task rewards/metrics/judges and harness metrics. Overridden by the agent's `timeout.scoring`. |
 
 ### `TaskData` (frozen)
+
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `idx` | `int` | — | Stable integer index within the taskset. Used for selection, grouping, display, and reproducibility. |
 | `name` | `str \| None` | `None` | Optional human-readable label used in logs and dashboards. |
 | `description` | `str \| None` | `None` | Optional human-readable description. |
@@ -479,7 +500,7 @@ runtime; this is useful when both must see the same filesystem or processes, but
 must then upload and install verifiers plus the taskset package for every rollout.
 
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `colocated` | `bool` | `False` | Run inside the harness's own runtime and reach the tool on an in-runtime local port. The separate `runtime` field is ignored. |
 | `runtime` | `RuntimeConfig` | `SubprocessConfig()` | The server's own runtime when not colocated. Select Docker/Prime/Modal to isolate it from the host. See [Runtime configs](#runtime-configs). |
 | `url` | `str \| None` | `None` | Existing streamable-HTTP MCP endpoint. When set, verifiers connects to it instead of launching the class, so placement fields do not take effect. |
@@ -497,7 +518,7 @@ attaches each calling rollout's state channel to the shared URL so those values 
 There is no `colocated` option because a shared server has no single harness runtime.
 
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `runtime` | `RuntimeConfig` | `SubprocessConfig()` | The framework-launched server's own runtime. Host subprocess is cheapest; a remote runtime pays setup once per worker. See [Runtime configs](#runtime-configs). |
 | `url` | `str \| None` | `None` | Existing streamable-HTTP MCP endpoint reused across workers and rollouts instead of launching a server. |
 
@@ -511,7 +532,7 @@ There is no `shared` boolean on `ToolsetConfig`: declare the class on `Task.tool
 `UserConfig` controls a simulator declared on `Task.user`; its matching config field belongs on `TaskConfig` under `--env.taskset.task.*`.
 
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `colocated` | `bool` | `False` | Run the user simulator inside the harness's runtime (its port is published back to the host so the framework can still drive it). |
 | `runtime` | `RuntimeConfig` | `SubprocessConfig()` | The user simulator's own runtime, used unless `colocated`. See [Runtime configs](#runtime-configs). |
 
@@ -535,7 +556,7 @@ Prime CLI/environment fallback as the rollout client. Subclass `JudgeConfig` for
 needed by a custom or plugin judge.
 
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `id` | `ID` | `""` | Judge plugin id: built-in (`reference`, `rubric`), local package, or Hub package. Required in `TaskConfig.judges`; empty is allowed for direct calls from task code. |
 | `name` | `str` | `""` | Reward-key override for a plugged judge. When empty, the plugin id supplies the key. |
 | `weight` | `float` | `1.0` | Weight applied when the plugged judge records its verdict into aggregate `trace.reward`. |
@@ -571,7 +592,7 @@ is supplied, billed judge usage is recorded even if parsing later fails. Plugin 
 `verifiers/v1/interception/server.py` — `RolloutLimits` (frozen dataclass). Not directly user-settable; built from the `max_*` fields of the run's agent ([`AgentConfig`](#agent-config)). Checked before each turn is served; the first limit reached refuses the turn (the same mechanism as a `@stop`) and becomes the trace's stop condition. Token caps are **soft by one turn** (the turn that crosses a cap still completes).
 
 | Field | Type | Default | Maps from | Caps |
-|---|---|---|---|---|
+| --- | --- | --- | --- | --- |
 | `max_turns` | `int \| None` | `None` | `AgentConfig.max_turns` | `trace.num_turns` |
 | `max_input_tokens` | `int \| None` | `None` | `AgentConfig.max_input_tokens` | `trace.num_input_tokens` |
 | `max_output_tokens` | `int \| None` | `None` | `AgentConfig.max_output_tokens` | `trace.num_output_tokens` |
@@ -584,7 +605,7 @@ is supplied, billed judge usage is recorded even if parsing later fails. Plugin 
 `verifiers/v1/configs/serve.py` — `ServeConfig(EnvServerConfig)`. The env-server CLI. Inherits the `env` block + pool, so `--env.*` / `--pool.*` are the same flags as eval. Adds only CLI-specific serving knobs.
 
 | Field | Type | Default | Aliases | Notes |
-|---|---|---|---|---|
+| --- | --- | --- | --- | --- |
 | `address` | `str` | `"tcp://127.0.0.1:5000"` | `address`, `a` | ZMQ address the ROUTER binds. |
 | `verbose` | `bool` | `False` | `verbose`, `v` | Log at debug level. |
 | `dry_run` | `bool` | `False` | — | Resolve + validate and dump, then exit. |
@@ -612,7 +633,7 @@ config or traces to disk. Its output is the live dashboard when `rich` is enable
 log line per task.
 
 | Field | Type | Default | Aliases | Notes |
-|---|---|---|---|---|
+| --- | --- | --- | --- | --- |
 | `taskset` | `TasksetConfig` | `TasksetConfig()` | — | Selected by `--taskset.id` or the bare positional id. Narrowed to the concrete taskset config before validation and serialized as that subclass. |
 | `runtime` | `RuntimeConfig` | `DockerConfig()` | — | Runtime used for setup and validation. Docker is the default because gold checks often need the row's image; use subprocess only when no selected task requires a container. Row image/workdir/resources are resolved as described above. |
 | `timeout` | `CheckTimeoutConfig` | `CheckTimeoutConfig()` | — | Nested setup and check budgets; see below. |
@@ -627,7 +648,7 @@ log line per task.
 ### `CheckTimeoutConfig`
 
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `setup` | `float \| None` | `None` | Maximum seconds for `Task.setup`. When unset, validation falls back to the row's `TaskData.timeout.setup`; if that is also `None`, setup is unlimited. |
 | `total` | `float \| None` | `None` | Maximum seconds for the gold check's `Task.validate` call. `None` means no limit. The setup-only mode has no action after setup, so this field does not apply there. |
 

--- a/verifiers/envs/experimental/README.md
+++ b/verifiers/envs/experimental/README.md
@@ -2,10 +2,7 @@
 
 Newer and more experimental environment classes that may have some sharper edges + change more frequently.
 
-For new taskset/harness environments, use the `verifiers.v1` `Taskset` /
-`Harness` format (`vf.Env`, `vf.Taskset`, and `vf.Harness`). The legacy
-experimental `ComposableEnv` stack remains in this subtree for existing
-experiments, but new environments should not be built on that format.
+For new taskset/harness environments, use the `verifiers.v1` `Taskset` / `Harness` format (`vf.Env`, `vf.Taskset`, and `vf.Harness`). The legacy experimental `ComposableEnv` stack remains in this subtree for existing experiments, but new environments should not be built on that format.
 
 ## SandboxMixin
 

--- a/verifiers/envs/experimental/composable/README.md
+++ b/verifiers/envs/experimental/composable/README.md
@@ -1,8 +1,6 @@
 # Legacy Composable Task / Agent Architecture
 
-This is the legacy experimental taskset/harness stack. New environments should
-use the `verifiers.v1` `Taskset` / `Harness` format (`vf.Env`, `vf.Taskset`,
-and `vf.Harness`) instead.
+This is the legacy experimental taskset/harness stack. New environments should use the `verifiers.v1` `Taskset` / `Harness` format (`vf.Env`, `vf.Taskset`, and `vf.Harness`) instead.
 
 This stack separates **what to solve** (the task) from **how to solve it** (the agent) by reusing the battle-tested `CliAgentEnv` and delegating task-specific behavior to a `TaskSet`.
 
@@ -113,21 +111,16 @@ class MySWETaskSet(SandboxTaskSet):
 
 ## Scoring
 
-Each taskset provides its own rubric via `get_rubric()`. The rubric owns **all
-scoring logic** — running tests, reading files, computing rewards. It is NOT
-just a state reader.
+Each taskset provides its own rubric via `get_rubric()`. The rubric owns **all scoring logic** — running tests, reading files, computing rewards. It is NOT just a state reader.
 
-Use `keep_sandbox_for_scoring=True` on the environment so the sandbox stays
-alive after the rollout for the rubric to use.
+Use `keep_sandbox_for_scoring=True` on the environment so the sandbox stays alive after the rollout for the rubric to use.
 
 ```
 Rollout completes → sandbox kept alive → rubric.score_rollout() runs tests
     → rubric.cleanup() deletes sandbox
 ```
 
-This enables **retrying scoring independently of the rollout**: if scoring
-fails (transient sandbox error), the rubric can retry without re-running the
-agent.
+This enables **retrying scoring independently of the rollout**: if scoring fails (transient sandbox error), the rubric can retry without re-running the agent.
 
 ### Writing a rubric
 
@@ -155,8 +148,7 @@ class MySWERubric(vf.Rubric):
 
 ## State context
 
-All `SandboxTaskSet` methods (`setup`, `validate_instance`) and rubric reward
-functions receive `state` which contains:
+All `SandboxTaskSet` methods (`setup`, `validate_instance`) and rubric reward functions receive `state` which contains:
 
 - `state["sandbox_client"]` — the async sandbox client
 - `state["sandbox_id"]` — current sandbox ID

--- a/verifiers/envs/experimental/composable/tasksets/swe/README.md
+++ b/verifiers/envs/experimental/composable/tasksets/swe/README.md
@@ -5,9 +5,7 @@
 - Prime images: ✅ means task images are available in our registry; ❌ means
   they are not known to be available there yet.
 - Validation: ✅ means the taskset has a linked `prime-data` PR and was
-  validated with
-  [`SandboxDebugEnv`](../../../../../../docs/v0/environments.md#integrations-and-experimental-environments),
-  — not yet complete.
+  validated with [`SandboxDebugEnv`](../../../../../../docs/v0/environments.md#integrations-and-experimental-environments), — not yet complete.
 
 ## Progress
 
@@ -300,12 +298,8 @@
 1. Add or port the taskset under this directory and register its backend in
    [`make_swe_taskset(...)`](swe_tasksets.py).
 2. Mirror task images that will run at scale into the Prime image registry so
-   sandbox startup uses quick pulls and large sweeps avoid upstream registry
-   rate limits.
+   sandbox startup uses quick pulls and large sweeps avoid upstream registry rate limits.
 3. Prefer the upstream dataset shape and evaluation lifecycle, then publish a
-   filtered Prime dataset through `prime-data` when validation identifies rows
-   to exclude.
+   filtered Prime dataset through `prime-data` when validation identifies rows to exclude.
 4. Validate with
-   [`SandboxDebugEnv`](../../sandbox_debug_env.py): no-op runs should fail real tasks,
-   gold-patch runs should pass, and repeated passes should separate task
-   quality issues from sandbox or infrastructure failures.
+   [`SandboxDebugEnv`](../../sandbox_debug_env.py): no-op runs should fail real tasks, gold-patch runs should pass, and repeated passes should separate task quality issues from sandbox or infrastructure failures.

--- a/verifiers/envs/integrations/README.md
+++ b/verifiers/envs/integrations/README.md
@@ -3,7 +3,7 @@
 Integrations with third-party environment libraries, which may require additional dependencies.
 
 | Environment | Extra | Install Command |
-|-------------|-------|-----------------|
+| ------------- | ------- | ----------------- |
 | `TextArenaEnv` | `ta` | `uv add 'verifiers[ta]'` |
 | `ReasoningGymEnv` | `rg` | `uv add 'verifiers[rg]'` |
 | `BrowserEnv` | `browser` | `uv add 'verifiers[browser]'` |
@@ -57,7 +57,7 @@ env = BrowserEnv(
 ### DOM Mode Options
 
 | Parameter | Default | Description |
-|-----------|---------|-------------|
+| ----------- | --------- | ------------- |
 | `stagehand_model` | `"openai/gpt-4o-mini"` | Model Stagehand uses for page understanding |
 | `model_api_key` | `MODEL_API_KEY` env | API key for Stagehand's model |
 | `proxy_model_to_stagehand` | `False` | Route LLM calls through verifiers client |
@@ -80,7 +80,7 @@ CUA mode automatically deploys the CUA server to Browserbase sandboxes using a p
 #### Execution Modes
 
 | Mode | Parameter | Startup | Use Case |
-|------|-----------|---------|----------|
+| ------ | ----------- | --------- | ---------- |
 | **Pre-built Image** (default) | `use_prebuilt_image=True` | ~5-10s | Production, fastest startup |
 | **Binary Upload** | `use_prebuilt_image=False` | ~30-60s | Custom server modifications |
 | **Manual Server** | `use_sandbox=False` | Manual | Local development/debugging |

--- a/verifiers/envs/integrations/README.md
+++ b/verifiers/envs/integrations/README.md
@@ -137,9 +137,7 @@ Locally, export these in your shell. On the [Environments Hub](https://app.prime
 
 Drop-in adapter for [OpenEnv](https://github.com/meta-pytorch/OpenEnv) environments. Always runs in Prime Sandboxes and uses OpenEnv's schema to choose between simulation (step/reset) and MCP tool-calling.
 
-The Verifiers adapter uses OpenEnv's public async clients. The bundled OpenEnv
-project under `proj/` declares its own server dependencies for the sandbox
-image.
+The Verifiers adapter uses OpenEnv's public async clients. The bundled OpenEnv project under `proj/` declares its own server dependencies for the sandbox image.
 
 ### Quick Start
 
@@ -197,5 +195,4 @@ Define a prompt renderer that converts each OpenEnv observation into a non-empty
 - `environments/openenv_echo/proj`: verbatim copy of OpenEnv `envs/echo_env` (MCP contract).
 - `environments/openenv_textarena/proj`: verbatim copy of OpenEnv `envs/textarena_env` (gym contract, default `Wordle-v0`).
 
-Include both `proj/` and `.build.json` in your environment package so installs
-from the Environments Hub work without extra setup.
+Include both `proj/` and `.build.json` in your environment package so installs from the Environments Hub work without extra setup.


### PR DESCRIPTION
## Summary

- apply the safe automatic fixes from `markdownlint-cli@0.49.1 --fix` across the repository Markdown files
- normalize blank lines, trailing whitespace, list spacing, and table delimiter formatting
- preserve explicitly numbered workflow steps where markdownlint's default MD007/MD029 autofix would change their structure
- unwrap 92 soft-wrapped prose blocks to match the repository's dominant one-line-per-paragraph style, removing 208 source lines without changing rendered content

## Validation

- `git diff --check`
- verified the prose-only follow-up is identical after whitespace normalization
- independently reviewed the prose-unwrapping diff for accidental Markdown structure or content changes
- reran `markdownlint-cli@0.49.1` over all 34 Markdown files
  - findings before this PR: 1,705
  - findings after: 1,165
  - resolved: 540

The remaining findings require manual content/configuration decisions, primarily line length (MD013), inline HTML (MD033), and table alignment (MD060). The repository predominantly uses one source line per prose paragraph, so MD013 is expected for long paragraphs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and formatting only; no runtime, config parsing, or application code changes.
> 
> **Overview**
> Applies **automatic `markdownlint-cli` fixes** across repository Markdown (docs, skills, READMEs, workflow docs) with no intended semantic or content changes.
> 
> **Formatting normalization** includes inserting blank lines before headings, lists, and fenced code blocks; removing trailing whitespace; and standardizing **table header separator** spacing (e.g. `| --- | --- |`).
> 
> **Prose style** reflows ~92 soft-wrapped paragraphs into **one source line per paragraph**, matching the repo’s dominant style and dropping ~208 lines without changing rendered output.
> 
> A few spots keep **manual structure** where autofix would break numbered steps (e.g. workflow README). Remaining markdownlint rules (line length, inline HTML, table alignment) are left for follow-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bd214b8ec46c3e36bd24da84b3ec2edbc3a1f7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Apply markdownlint formatting fixes across documentation files
> Applies automatic markdownlint fixes to documentation and README files throughout the repository. Changes include reflowing multi-line paragraphs into single lines, normalizing Markdown table header separator spacing, inserting blank lines before code fences and subheadings, and removing trailing whitespace. No content or semantic changes are made.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7bd214b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->