### PR TITLE
fix(v1): enforce trainable standing against the trainable model context

### DIFF
--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -18,7 +18,13 @@ from pydantic_config import BaseConfig
 
 from verifiers.v1.agent import Agent, AgentConfig, Agents, _EpisodeAgent
 from verifiers.v1.harness import Harness, HarnessConfig
-from verifiers.v1.clients import Client, ClientConfig, ModelContext, resolve_client
+from verifiers.v1.clients import (
+    Client,
+    ClientConfig,
+    ModelContext,
+    TrainClient,
+    resolve_client,
+)
 from verifiers.v1.types import ID
 from verifiers.v1.interception import (
     ElasticInterceptionPoolConfig,
@@ -289,6 +295,8 @@ class Env(ABC, Generic[ConfigT]):
         self._agent_clients: dict[str, Client] = {}
         # Resource warnings dedupe env-wide (agents are per-episode).
         self._warned_resources: set = set()
+        # Agents already demoted from trainable, so the warning fires once.
+        self._demoted_trainable: set[str] = set()
 
     # --- the multi-agent surface (override these) ------------------------------
 
@@ -382,6 +390,41 @@ class Env(ABC, Generic[ConfigT]):
             self._agent_clients[key] = resolve_client(config)
         return self._agent_clients[key]
 
+    def _resolve_trainable_standing(self, agents: Agents, ctx: ModelContext) -> None:
+        """One model context is trainable — `ctx`. Every trainable agent must
+        point to it: the same `model`, no pinned `client`. On a training run
+        (a `TrainClient` — its tokens exist to be trained on) a divergent
+        trainable agent is a config error; on any other run it is demoted,
+        warned once — an eval must not fail over a training-only concern, but
+        standing filters metrics and records, so it must stay honest. Resolved
+        after `setup()` (which declares standing), before any tokens burn."""
+        for name in self._agent_specs:
+            agent = getattr(agents, name)
+            if not agent.trainable:
+                continue
+            if agent.config.model == ctx.model and agent.config.client is None:
+                continue
+            if isinstance(ctx.client, TrainClient):
+                raise ValueError(
+                    f"trainable agent {name!r} doesn't use the trainable model "
+                    f"({ctx.model!r}) — mark it untrainable in "
+                    f"{type(self).__name__}.setup() "
+                    f"(`agents.{name}.trainable = False`)"
+                )
+            agent.trainable = False
+            if name in self._demoted_trainable:
+                continue
+            self._demoted_trainable.add(name)
+            logger.warning(
+                "agent %r is declared trainable but doesn't use the trainable "
+                "model context (%r): its traces are marked untrainable. Declare "
+                "`agents.%s.trainable = False` in %s.setup() to silence this.",
+                name,
+                ctx.model,
+                name,
+                type(self).__name__,
+            )
+
     async def run_episode(
         self,
         task: Task,
@@ -404,6 +447,7 @@ class Env(ABC, Generic[ConfigT]):
             async with asyncio.timeout(self.config.timeout.episode):
                 async with boundary(EnvError, f"{type(self).__name__}.setup()"):
                     await self.setup(agents)
+                self._resolve_trainable_standing(agents, ctx)
                 async with boundary(EnvError, f"{type(self).__name__}.run()"):
                     await self.run(task, agents)
                     if not episode.traces:


### PR DESCRIPTION
## What

`Env.run_episode` now resolves trainable standing right after `setup()` and before any agent runs. One model context is trainable — the run's `ctx` — and every trainable agent must point to it (the same `model`, no pinned `client`). The run's client decides what divergence means:

- **Training run** (`ctx.client` is a `TrainClient` — its tokens exist to be trained on): a divergent trainable agent is a config error; the episode fails loudly.
- **Any other run** (eval): the agent is **demoted to untrainable**, with a warning fired once per agent — an eval must not fail over a training-only concern, but standing filters metrics and records, so it must stay honest.

Either way the message names the one-line fix: `agents.<name>.trainable = False` in the env's `setup()`.

## Why

`AgentInfo.trainable` means "these tokens train the trainable model". An agent whose model context points anywhere else makes that a false statement, but nothing corrected it: its traces shipped stamped `trainable: true`, and consumers degraded silently — in prime-rl the trace enters GRPO's group baseline while shipping zero renderer tokens (baseline skew with no error), eval metric filtering counts judge traces as policy traces, and saved records marked `trainable: true` from another model would poison later SFT-from-traces.

Design notes:

- **The client type is the run's purpose, not a new knob**: trainable tokens only exist when sampled through a `TrainClient` (that's what carries renderer tokens), so "refuse when training, demote when measuring" needs no wire or config surface.
- **After `setup()`** — the only site that declares `trainable` (`AgentConfig` deliberately has no such field), so standing is final; **before `run()`** — no tokens burn on a doomed training episode, and eval traces are stamped with corrected standing from the first token.
- Compared on the **resolved** config: an agent explicitly pinning the run's own model string stays trainable; `client` is checked as "pinned at all", since `_episode_agents` hands the run's client to every unpinned agent.

Companion prime-rl PR: PrimeIntellect-ai/prime-rl#3108 (gates group-relative advantages to a single trainable agent — the consumer half of the invariant).

## Validation

Throwaway probe over the `duet-v1` fixture (no model calls; standing reported by a sentinel raised at the top of `run()`), both run types:

- eval ctx: unpinned agent stays trainable; `model`/`client` pins demote before `run()` (one warning across 3 episodes); an env that already declares the agent untrainable is untouched, no warning
- train ctx: the same pins fail the episode with `ValueError: trainable agent 'a' doesn't use the trainable model ('run-model') …`; unpinned and declared-untrainable envs reach `run()`

(`ruff check` / `format` on `verifiers/v1/env.py`: the import-sort and reformat complaints are pre-existing on `main` with the locked ruff 0.15.21; this diff's lines are clean and no unrelated churn is included.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)