### PR TITLE
chore: lint Markdown in pre-commit

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,50 @@
+config:
+  MD013: false
+  MD033:
+    allowed_elements:
+      - Warning
+  MD060:
+    style: compact
+overrides:
+  - filter:
+      - README.md
+    config:
+      MD033:
+        allowed_elements:
+          - img
+          - p
+          - picture
+          - source
+      MD041: false
+    combine: merge
+  - filter:
+      - CLAUDE.md
+    config:
+      MD041: false
+    combine: merge
+  - filter:
+      - skills/brainstorm/SKILL.md
+    config:
+      MD007: false
+      MD029: false
+    combine: merge
+  - filter:
+      - skills/evaluate-environments/SKILL.md
+    config:
+      MD029: false
+    combine: merge
+  - filter:
+      - verifiers/envs/experimental/composable/tasksets/swe/README.md
+    config:
+      MD033:
+        allowed_elements:
+          - a
+          - code
+          - strong
+          - table
+          - tbody
+          - td
+          - th
+          - thead
+          - tr
+    combine: merge

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,10 @@
 default_install_hook_types: [pre-commit, pre-push]
-# Exclude Harbor task assets from linting
-exclude: ^environments/.*/tasks/
-
 repos:
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.23.1
+    hooks:
+      - id: markdownlint-cli2
+
   - repo: local
     hooks:
       - id: ruff-check
@@ -10,11 +12,13 @@ repos:
         entry: uv run ruff check --fix
         language: system
         types_or: [python, pyi]
+        exclude: ^environments/.*/tasks/
       - id: ruff-format
         name: ruff format
         entry: uv run ruff format
         language: system
         types_or: [python, pyi]
+        exclude: ^environments/.*/tasks/
       - id: ty
         name: ty (ci parity)
         entry: uv run --python 3.13 ty check verifiers

--- a/assets/templates/browserbase/cua/README.md
+++ b/assets/templates/browserbase/cua/README.md
@@ -51,7 +51,7 @@ env = BrowserEnv(
 
 ## Architecture
 
-```
+```text
 External Agent -> Fastify API -> BrowserSessionManager -> Stagehand Page -> Browser
 ```
 
@@ -64,7 +64,7 @@ npm install @browserbasehq/stagehand fastify
 ## Environment Variables
 
 | Variable | Default | Description |
-|----------|---------|-------------|
+| ---------- | --------- | ------------- |
 | `CUA_SERVER_PORT` | `3000` | Server port |
 | `CUA_SERVER_HOST` | `0.0.0.0` | Server host |
 
@@ -171,7 +171,7 @@ Returns:
 ### Keyboard Actions
 
 | Action | Parameters | Description |
-|--------|------------|-------------|
+| -------- | ------------ | ------------- |
 | `type` | `text` | Type text into focused element |
 | `keypress` | `keys` (string or array) | Press keyboard keys |
 
@@ -187,7 +187,7 @@ Returns:
 ### Utility Actions
 
 | Action | Parameters | Description |
-|--------|------------|-------------|
+| -------- | ------------ | ------------- |
 | `wait` | `timeMs?` (default: 1000) | Wait for duration |
 | `screenshot` | - | No-op (always returned in response) |
 
@@ -261,7 +261,7 @@ Errors return appropriate HTTP status codes:
 
 ## File Structure
 
-```
+```text
 cua-server/
 ├── index.ts           # Entry point
 ├── server.ts          # Fastify routes

--- a/docs/v0/development.md
+++ b/docs/v0/development.md
@@ -43,7 +43,7 @@ uv run pre-commit install
 
 ## Project Structure
 
-```
+```text
 verifiers/
 ├── verifiers/          # Main package
 │   ├── envs/           # Environment classes

--- a/docs/v0/environments.md
+++ b/docs/v0/environments.md
@@ -354,12 +354,12 @@ For simple cases, metrics can be added directly to a rubric via `add_metric()` a
 
 Many environment types automatically include a monitor rubric that tracks metrics specific to their level of the environment class hierarchy:
 
-| Environment    | Tracked Metrics                                             |
+| Environment | Tracked Metrics |
 | -------------- | ----------------------------------------------------------- |
-| `MultiTurnEnv` | `num_turns`                                                 |
-| `ToolEnv`      | `total_tool_calls`, per-tool counts                         |
-| `SandboxEnv`   | `sandbox_ready_wait_time`, `sandbox_command_execution_time` |
-| `PythonEnv`    | `python_ready_wait_time`                                    |
+| `MultiTurnEnv` | `num_turns` |
+| `ToolEnv` | `total_tool_calls`, per-tool counts |
+| `SandboxEnv` | `sandbox_ready_wait_time`, `sandbox_command_execution_time` |
+| `PythonEnv` | `python_ready_wait_time` |
 
 These metrics appear automatically in rollout results alongside any custom reward functions.
 
@@ -672,7 +672,7 @@ prime env init my-env       # v0 stub
 
 This creates the following structure:
 
-```
+```text
 environments/my_env/
 ├── my_env.py          # environment implementation
 ├── pyproject.toml     # package metadata and dependencies

--- a/docs/v0/overview.md
+++ b/docs/v0/overview.md
@@ -36,7 +36,7 @@ prime lab setup
 
 This sets up a Python project if needed (with `uv init`), installs `verifiers` (with `uv add verifiers`), creates the recommended workspace structure, and downloads useful starter files:
 
-```
+```text
 configs/
 ├── endpoints.toml      # OpenAI-compatible API endpoint configuration
 ├── rl/                 # Example configs for Hosted Training
@@ -71,7 +71,7 @@ prime env init my-env # creates a v0 stub in ./environments/my_env
 
 This will create a new module called `my_env` with a runnable environment template.
 
-```
+```text
 environments/my_env/
 ├── my_env.py           # Main implementation
 ├── pyproject.toml      # Dependencies and metadata

--- a/docs/v0/training.md
+++ b/docs/v0/training.md
@@ -16,12 +16,12 @@ This section covers how to use Verifiers environments for RL training with our H
 - [RL Rules of Thumb](#rl-rules-of-thumb)
   - [Before Training](#before-training)
   - [Performance Trade-offs](#performance-trade-offs)
+  - [Inference Client Types](#inference-client-types)
   - [Common Issues](#common-issues)
 - [Other Trainers](#other-trainers)
   - [Tinker](#tinker)
   - [SkyRL](#skyrl)
   - [rLLM](#rllm)
-  - [Integrating with Other Trainers](#integrating-with-other-trainers)
 
 ## Hosted Training
 
@@ -37,7 +37,7 @@ prime lab setup
 
 This will download example TOML configs for Hosted Training into `configs/rl/`, example eval configs into `configs/eval/`, along with `configs/endpoints.toml` and GEPA starter configs in `configs/gepa/`:
 
-```
+```text
 configs/
 ├── endpoints.toml
 ├── eval/
@@ -193,7 +193,7 @@ For production RL training, use `openai_chat_completions_token` — it's the tri
 
 ### Common Issues
 
-**Non-Increasing Chat Templates:** The Qwen3 and DeepSeek-R1 model series both remove `<think>` sections from messages when processing inputs, which violates the increasing context requirement for multi-turn training. We provide versions of many of these models with modified chat templates [here](https://huggingface.co/collections/willcb/qwen3-68434f4883925bfdb4570ee5).
+**Non-Increasing Chat Templates:** The Qwen3 and DeepSeek-R1 model series both remove `<think>` sections from messages when processing inputs, which violates the increasing context requirement for multi-turn training. We provide versions of many of these models with [modified chat templates](https://huggingface.co/collections/willcb/qwen3-68434f4883925bfdb4570ee5).
 
 **OOM during generation:**
 

--- a/docs/v1/getting_started.md
+++ b/docs/v1/getting_started.md
@@ -1,4 +1,4 @@
-### Installation
+# Installation
 
 verifiers runs locally with `uv`. Install it, clone the repo, and sync dependencies:
 
@@ -11,6 +11,6 @@ uv sync
 
 You can now run tasksets directly, e.g. `uv run eval <taskset-id>`, and scaffold new ones with `uv run init <name>`.
 
-### Skills
+## Skills
 
 To equip your agent with the necessary knowledge, we highly recommend the skills in this repository's [`skills/`](../../skills/) directory (alongside [`AGENTS.md`](../../AGENTS.md)). They are more comprehensive than these docs, which are meant for human consumption.

--- a/skills/evaluate-environments/references/REFERENCE.md
+++ b/skills/evaluate-environments/references/REFERENCE.md
@@ -4,7 +4,7 @@ A complete reference of every settable config field for **evaluating tasksets in
 
 The root config the eval CLI parses is [`EvalConfig`](#evalconfig--the-run). It composes the environment (`env` — the whole `[env]` block: taskset, agents, limits) with the run knobs (model, sampling, counts) and the worker pool. The tree:
 
-```
+```text
 EvalConfig                          (the run)
 ├─ model, sampling, client, num_tasks, num_rollouts, shuffle, max_concurrent, …
 ├─ env: EnvConfig                   (subclass resolved by --env.id, else the taskset's env)
@@ -195,7 +195,7 @@ Rerun when the run ends with a captured error. Matching is by the error's **exce
 Fixed pool: pre-spawn `num_workers` up front.
 
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `num_workers` | `int` | `4` (≥1) | Worker processes to pre-spawn (1 = a single in-process server, no pool). |
 
 ### `ElasticPoolConfig` — `type: "elastic"` (default)
@@ -227,7 +227,7 @@ A taskset implements `load()` and declares exactly one task type through its gen
 `TaskConfig` contains knobs read by task behavior. Subclass it for scoring parameters and task-scoped `ToolsetConfig` or `UserConfig` fields, then narrow the taskset config's `task` field to that subclass. These are run-wide knobs, not per-row data; the row itself belongs on `TaskData`.
 
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `judges` | `Judges` | `[]` | Judge plugins run by `Task.score`; set through `--env.taskset.task.judges`. |
 
 ---
@@ -272,7 +272,7 @@ A growing-message-list chat loop with the task- and taskset-scoped MCP tools, an
 Installs the Codex CLI into the runtime and runs `codex exec`.
 
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `version` | `str` | `"0.144.5"` | Codex release to install (the `rust-v<version>` GitHub release); pinned. |
 
 #### `RLMHarnessConfig` — `id: "rlm"`
@@ -291,7 +291,7 @@ Installs the rlm CLI and runs it. Knobs map onto `RLM_*` env vars; base `Harness
 Runs the native bash-tool agent through LiteLLM.
 
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `version` | `str` | `"2.4.5"` | mini-swe-agent release to install, pinned. |
 
 #### `Terminus2HarnessConfig` — `id: "terminus-2"`
@@ -299,7 +299,7 @@ Runs the native bash-tool agent through LiteLLM.
 Runs Harbor's tmux agent through LiteLLM.
 
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `version` | `str` | `"0.14.0"` | Harbor release to install, pinned. |
 
 #### `KimiCodeHarnessConfig` — `id: "kimi-code"`
@@ -307,7 +307,7 @@ Runs Harbor's tmux agent through LiteLLM.
 Installs the Kimi Code CLI and runs it headlessly.
 
 | Field | Type | Default | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `version` | `str` | `"0.27.0"` | Kimi Code release to install, pinned. |
 
 ---

--- a/verifiers/envs/experimental/composable/README.md
+++ b/verifiers/envs/experimental/composable/README.md
@@ -115,7 +115,7 @@ Each taskset provides its own rubric via `get_rubric()`. The rubric owns **all s
 
 Use `keep_sandbox_for_scoring=True` on the environment so the sandbox stays alive after the rollout for the rubric to use.
 
-```
+```text
 Rollout completes → sandbox kept alive → rubric.score_rollout() runs tests
     → rubric.cleanup() deletes sandbox
 ```

--- a/verifiers/envs/integrations/README.md
+++ b/verifiers/envs/integrations/README.md
@@ -139,7 +139,7 @@ Drop-in adapter for [OpenEnv](https://github.com/meta-pytorch/OpenEnv) environme
 
 The Verifiers adapter uses OpenEnv's public async clients. The bundled OpenEnv project under `proj/` declares its own server dependencies for the sandbox image.
 
-### Quick Start
+### OpenEnv Quick Start
 
 Initialize an OpenEnv environment with the template:
 


### PR DESCRIPTION
## Summary

- add `markdownlint-cli2` to the pre-commit pipeline for all tracked Markdown
- preserve the repository's one-line-per-paragraph convention by disabling MD013
- narrowly configure existing root, skill, and embedded-HTML conventions
- normalize the remaining Markdown baseline, including table delimiters, fence languages, heading hierarchy, and stale documentation links
- retain the existing Harbor task exclusion for Ruff only, rather than unintentionally excluding Markdown from the new hook

## Validation

- `uv run pre-commit run --all-files`
- `uv run pre-commit run`
- `git diff --cached --check`
- independent diff/config review


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add markdownlint-cli2 pre-commit hook and fix Markdown lint errors across docs
> - Adds a [markdownlint-cli2](https://github.com/PrimeIntellect-ai/verifiers/pull/2103/files#diff-2a7fead57f7c323860561f88108bea9da390f1fcccc08278680b62b0ff6e1d5b) pre-commit hook at `v0.23.1` with per-file overrides to disable or adjust rules (MD007, MD013, MD029, MD033, MD041) for files that need exceptions.
> - Fixes lint errors across multiple docs and READMEs: fenced code blocks get explicit `text` language tags, table spacing is normalized, and heading levels are corrected.
> - Moves the `exclude: ^environments/.*/tasks/` pattern from the top-level pre-commit config into the individual `ruff check` and `ruff format` hooks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e99c19e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and developer-tooling only; no runtime, auth, or application logic changes.
> 
> **Overview**
> Adds **markdownlint-cli2** (`v0.23.1`) to pre-commit for all tracked Markdown, with a new **`.markdownlint-cli2.yaml`** that turns off line-length (MD013), allows selected inline HTML where needed, and applies **per-path overrides** for root README, skills, and similar files.
> 
> The former global **`environments/.*/tasks/`** exclude is removed from the top of pre-commit and applied **only to Ruff** (`ruff check` / `ruff format`), so Harbor task Markdown is no longer skipped by the new hook.
> 
> Remaining changes are **lint-driven doc edits**: `text` language tags on diagram fences, compact table column spacing, a v1 getting-started heading fix (`# Installation`), a small v0 training TOC/link tweak, and renaming an OpenEnv subsection heading for clarity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e99c19eb57d69574a0f50f52ff937f117a56d8a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->