### PR TITLE
feat: flatten the harness config onto the agent config

### DIFF
--- a/configs/agentic_judge.toml
+++ b/configs/agentic_judge.toml
@@ -17,11 +17,11 @@ id = "agentic-judge"
 [env.taskset]
 id = "gsm8k-v1"
 
-[env.solver.harness]
-id = "null"
+[env.solver]
+harness = "null"
 
 [env.judge]
 model = "z-ai/glm-5.2"
 
-[env.judge.harness.runtime]
+[env.judge.runtime]
 type = "docker"

--- a/configs/alphabet_sort.toml
+++ b/configs/alphabet_sort.toml
@@ -10,7 +10,5 @@ min_turns = 2
 max_turns = 2
 
 [env.agent]
+harness = "null"
 max_turns = 4
-
-[env.agent.harness]
-id = "null"

--- a/configs/gsm8k_rlm.toml
+++ b/configs/gsm8k_rlm.toml
@@ -3,15 +3,15 @@
 #   uv run eval @ configs/gsm8k_rlm.toml
 #
 # The discriminator ids (which taskset, which harness) come from this file's
-# [env.taskset] / [env.agent.harness] `id` — they select the schema, and the rest of the
+# [env.taskset] `id` / [env.agent] `harness` — they select the schema, and the rest of the
 # file fills the typed config, each side validated against its specific type (GSM8KConfig /
-# RLMHarnessConfig). prime-rl consumes the same [env] shape, reading the ids straight from
-# its config (TOML-driven there too).
+# RLMHarnessConfig, whose knobs sit flat on the agent). prime-rl consumes the same [env]
+# shape, reading the ids straight from its config (TOML-driven there too).
 num_tasks = 1
 
 [env.taskset]
 id = "gsm8k-v1"
 
-[env.agent.harness]
-id = "rlm"
+[env.agent]
+harness = "rlm"
 version = "main"

--- a/configs/harbor.toml
+++ b/configs/harbor.toml
@@ -8,6 +8,6 @@ num_tasks = 10
 id = "harbor"
 dataset = "terminal-bench/terminal-bench-2"
 
-[env.agent.harness]
-id = "bash"
+[env.agent]
+harness = "bash"
 runtime = { type = "docker" }

--- a/configs/textarena.toml
+++ b/configs/textarena.toml
@@ -12,7 +12,5 @@ id = "textarena"
 game = "Wordle-v0"
 
 [env.agent]
+harness = "null"
 max_turns = 15
-
-[env.agent.harness]
-id = "null"

--- a/configs/wiki_search_compact.toml
+++ b/configs/wiki_search_compact.toml
@@ -7,5 +7,5 @@ num_tasks = 1
 [env.taskset]
 id = "wiki-search-v1"
 
-[env.agent.harness]
-id = "compact"
+[env.agent]
+harness = "compact"

--- a/configs/wordle.toml
+++ b/configs/wordle.toml
@@ -8,7 +8,5 @@ num_rollouts = 2
 id = "wordle-v1"
 
 [env.agent]
+harness = "null"
 max_turns = 8
-
-[env.agent.harness]
-id = "null"

--- a/docs/v1/evaluation.md
+++ b/docs/v1/evaluation.md
@@ -17,8 +17,8 @@ temperature = 1.0
 [env.taskset]
 id = "primeintellect/terminal-bench-2"
 
-[env.agent.harness]
-id = "codex"
+[env.agent]
+harness = "codex"
 version = "0.116.0"
 ```
 
@@ -33,7 +33,7 @@ The output from evaluations are written into `outputs/<env>--<model>--<harness>/
 - `model` — the model id to evaluate, e.g. `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B`
 - `sampling` — generation params passed to the model, e.g. `sampling.temperature`
 - `env.taskset.id` — pick the taskset (or the positional `eval <taskset-id>`)
-- `env.agent.harness.id` — pick the agent's harness (`[env.agent.harness]` in TOML)
+- `env.agent.harness` — pick the agent's harness (`harness = "..."` in the TOML `[env.agent]` block); its knobs sit flat on the agent
 - `num_tasks` — how many tasks to evaluate. Not setting a value means all tasks; an
   infinite taskset (a procedural generator, e.g. `wordle-v1`) requires it
 - `num_rollouts` — rollouts per task
@@ -50,7 +50,7 @@ The output from evaluations are written into `outputs/<env>--<model>--<harness>/
 Almost every harness comes with a `disabled_tools` list, which can be used to disable one or multiple tools:
 
 ```toml
-[env.agent.harness]
+[env.agent]
 disabled_tools = ["shell_tool"]
 ```
 
@@ -68,7 +68,7 @@ Docker harnesses can keep trusted setup online, then restrict the agent to decla
 HTTP(S) destinations:
 
 ```toml
-[env.agent.harness.runtime]
+[env.agent.runtime]
 type = "docker"
 allow = ["https://*.wikipedia.org"]
 block = ["https://upload.wikimedia.org"]

--- a/docs/v1/gepa.md
+++ b/docs/v1/gepa.md
@@ -16,8 +16,8 @@ model = "deepseek/deepseek-v4-flash"
 [env.taskset]
 id = "reverse-text-v1"
 
-[env.agent.harness]
-id = "bash"
+[env.agent]
+harness = "bash"
 
 [sampling]
 temperature = 1.0

--- a/docs/v1/harnesses.md
+++ b/docs/v1/harnesses.md
@@ -6,12 +6,13 @@ verifiers supports a range of harnesses out of the box, including Claude Code, C
 
 ```python
 from verifiers.v1.clients import ModelContext
-from verifiers.v1.harness import Harness, HarnessConfig
+from verifiers.v1.harness import AgentConfig, Harness
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.trace import Trace
 
-class MyHarnessConfig(HarnessConfig):
-    # These are the values that the users are allowed to set and change.
+class MyHarnessConfig(AgentConfig):
+    # These are the values that the users are allowed to set and change; they sit
+    # flat on the agent (`--env.agent.version 0.0.2`).
     version: str = "0.0.1"
 
 class MyHarness(Harness[MyHarnessConfig]):

--- a/docs/v1/tasksets.md
+++ b/docs/v1/tasksets.md
@@ -23,7 +23,7 @@ The command also supports:
   - Use this to create custom tools which are installed into supported harnesses via MCP.
 - `-U`, `--add-user` — also scaffold a `vf.User` simulator at `servers/user.py`
   - Use this to simulate a user interacting with the model. Not all harnesses support user simulation.
-- `-H`, `--add-harness` — also scaffold a custom `vf.Harness` at `harness.py`, selectable via `--env.agent.harness.id <name>`
+- `-H`, `--add-harness` — also scaffold a custom `vf.Harness` at `harness.py`, selectable via `--env.agent.harness <name>`
   - Prefer a built-in harness unless the model needs to run inside a custom program.
 
 Most tasksets do not need specific tools, user simulations or custom harnesses.

--- a/environments/compact/compact/harness.py
+++ b/environments/compact/compact/harness.py
@@ -11,7 +11,7 @@ the harness program.
 import json
 from pathlib import Path
 
-from verifiers.v1.harness import Harness, HarnessConfig
+from verifiers.v1.harness import AgentConfig, Harness
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.trace import Trace
@@ -19,7 +19,7 @@ from verifiers.v1.trace import Trace
 PROGRAM_SOURCE = (Path(__file__).resolve().parent / "program.py").read_text()
 
 
-class CompactingHarnessConfig(HarnessConfig):
+class CompactingHarnessConfig(AgentConfig):
     """A context-rewrite harness: it rebuilds its prompt from carried-over notes each
     compaction instead of appending, so the trajectory branches at every compaction."""
 

--- a/skills/evaluate-environments/SKILL.md
+++ b/skills/evaluate-environments/SKILL.md
@@ -48,10 +48,10 @@ When the user requests a full run, do not restrict the number of tasks. Ask for 
 - `owner/name` installs a Hub package on demand.
 - `owner/name@version` pins a Hub version.
 
-The leading ID is shorthand for `--env.taskset.id`. A harness belongs to an agent — `--env.agent.harness.*` on the single-agent env, `--env.<agent>.harness.*` on a multi-agent one (there is no run-level `--harness.*`):
+The leading ID is shorthand for `--env.taskset.id`. A harness belongs to an agent, its config flat on the seat — `--env.agent.harness <id>` picks it on the single-agent env, `--env.<agent>.harness <id>` on a multi-agent one, and its knobs address as `--env.<agent>.<knob>` (there is no run-level `--harness`):
 
 ```bash
-prime eval run owner/name --env.agent.harness.id codex --env.agent.harness.runtime.type prime
+prime eval run owner/name --env.agent.harness codex --env.agent.runtime.type prime
 ```
 
 The env — the control flow between agents — owns the whole `[env]` block. Empty `--env.id` keeps the taskset's own story (its exported `Environment` subclass, else the single-agent env); `--env.id` pairs a reusable env with any taskset, its knobs typed under `--env.*`:
@@ -59,7 +59,7 @@ The env — the control flow between agents — owns the whole `[env]` block. Em
 ```bash
 prime eval run my-task-v1 --env.id best-of-n --env.n 8      # pass@k / rejection sampling
 prime eval run my-task-v1 --env.id agentic-judge \
-  --env.judge.harness.runtime.type docker                   # a judge agent verifies each attempt in a sandbox
+  --env.judge.runtime.type docker                           # a judge agent verifies each attempt in a sandbox
 ```
 
 When specifying Hub tasksets, always include the owner to resolve them correctly.
@@ -69,7 +69,7 @@ When specifying Hub tasksets, always include the owner to resolve them correctly
 Almost every harness comes with a `disabled_tools` list, which can be used to disable one or multiple tools:
 
 ```toml
-[env.agent.harness]
+[env.agent]
 disabled_tools = ["shell_tool"]
 ```
 
@@ -87,10 +87,10 @@ Harness and runtime settings:
 
 ```bash
 prime eval run my-task-v1 \
-  --env.agent.harness.id rlm \
-  --env.agent.harness.runtime.type docker \
-  --env.agent.harness.runtime.cpu 4 \
-  --env.agent.harness.runtime.memory 8
+  --env.agent.harness rlm \
+  --env.agent.runtime.type docker \
+  --env.agent.runtime.cpu 4 \
+  --env.agent.runtime.memory 8
 ```
 
 Sampling:
@@ -120,8 +120,8 @@ model = "openai/gpt-5-mini"
 id = "my-task-v1"
 split = "test"
 
-[env.agent.harness]
-id = "bash"
+[env.agent]
+harness = "bash"
 runtime = { type = "subprocess" }
 
 [sampling]

--- a/skills/evaluate-environments/references/REFERENCE.md
+++ b/skills/evaluate-environments/references/REFERENCE.md
@@ -1,6 +1,6 @@
 # REFERENCE.md
 
-A complete reference of every settable config field for **evaluating tasksets in `verifiers.v1`**. The config tree is parsed from CLI flags (dotted, e.g. `--env.agent.harness.runtime.type docker`) and/or `@ file.toml` by `prime-pydantic-config`; every field below is settable either way unless noted.
+A complete reference of every settable config field for **evaluating tasksets in `verifiers.v1`**. The config tree is parsed from CLI flags (dotted, e.g. `--env.agent.runtime.type docker`) and/or `@ file.toml` by `prime-pydantic-config`; every field below is settable either way unless noted.
 
 The root config the eval CLI parses is [`EvalConfig`](#evalconfig--the-run). It composes the environment (`env` — the whole `[env]` block: taskset, agents, limits) with the run knobs (model, sampling, counts) and the worker pool. The tree:
 
@@ -12,9 +12,12 @@ EvalConfig                          (the run)
 │  ├─ taskset: TasksetConfig | None (subclass resolved by --env.taskset.id / positional)
 │  │  └─ task: TaskConfig           (judges, scoring knobs, task-scoped server config)
 │  ├─ <agent>: AgentConfig          (per-agent harness/model/client/sampling +
-│  │  │                              per-run caps; `agent` on the single-agent env)
-│  │  ├─ harness: HarnessConfig     (subclass resolved by --env.<agent>.harness.id)
-│  │  │  └─ runtime: RuntimeConfig  (subprocess | docker | prime | modal)
+│  │  │                              per-run caps; `agent` on the single-agent env;
+│  │  │                              subclass resolved by --env.<agent>.harness —
+│  │  │                              harness knobs sit flat on the seat)
+│  │  ├─ harness                    (the harness id; None = the taskset's default)
+│  │  ├─ runtime: RuntimeConfig     (subprocess | docker | prime | modal)
+│  │  ├─ env / forward_env / disabled_tools
 │  │  ├─ timeout: TimeoutConfig     (per-stage: setup/rollout/finalize/scoring)
 │  │  ├─ retries: RolloutRetryConfig (per-agent whole-run retries)
 │  │  └─ max_turns / max_input_tokens / max_output_tokens / max_total_tokens
@@ -24,7 +27,7 @@ EvalConfig                          (the run)
 └─ pool: PoolConfig                 (static | elastic) — env-server only
 ```
 
-There is no run-level harness: each agent pins its own (`--env.agent.harness.*` on the single-agent env), an unpinned agent runs the taskset's default harness (its bundled one, else `bash`), and a declared pin is the env author's default. The retired flat axes error with a pointer: `--taskset.*` → `--env.taskset.*`, `--harness.*` → `--env.<agent>.harness.*`.
+There is no run-level harness: each agent pins its own (`--env.agent.harness <id>` on the single-agent env), an unpinned agent runs the taskset's default harness (its bundled one, else `bash`), and a declared pin is the env author's default. The harness's config is flat on the agent: its knobs address as `--env.<agent>.<knob>`. The retired flat axes error with a pointer: `--taskset.*` → `--env.taskset.*`, `--harness.*` → `--env.<agent>.harness`.
 
 Sibling entrypoints reuse the same tree: [`ServeConfig`](#serveconfig--the-env-server-cli) (env server) and [`ValidateConfig`](#validateconfig--the-validate-cli) (per-task validation). All three live in `verifiers/v1/configs/`.
 
@@ -117,11 +120,15 @@ Per-run caps (turns, tokens, stage timeouts, retries) are agent fields, not env 
 
 ### Agent config
 
-`verifiers/v1/agent.py` — `AgentConfig(BaseConfig)`. One per declared agent, addressed `--env.<agent>.*`. The **model context** defaults to the run's own (the serve protocol carries model/client/sampling per rollout request — what makes self-play trainable). The **harness** does not: an unpinned agent runs the taskset's default harness; a declared pin is the env author's per-agent default; partial overrides deep-merge onto it (an `id` switch replaces it).
+`verifiers/v1/harness.py` — `AgentConfig(BaseConfig)`. One per declared agent, addressed `--env.<agent>.*`. The seat's config **is** the harness's config: a harness subclasses `AgentConfig` to add its run knobs, the seat narrows to that subclass by `--env.<agent>.harness`, and the knobs sit flat on the seat (`--env.<agent>.<knob>`). The **model context** defaults to the run's own (the serve protocol carries model/client/sampling per rollout request — what makes self-play trainable). The **harness** does not: an unpinned agent runs the taskset's default harness; a declared pin is the env author's per-agent default; partial overrides deep-merge onto it.
 
 | Field | Type | Default | Notes |
 | --- | --- | --- | --- |
-| `harness` | `HarnessConfig \| None` | `None` | The agent's program + runtime policy; resolved to its concrete subclass by `--env.<agent>.harness.id`. `None` = the taskset's default harness (its bundled one, else `bash`). See [Harness config](#harness-config). |
+| `harness` | `ID \| None` | `None` | The harness id — the agent's program, selecting the seat's concrete config subclass. `None` = the taskset's default harness (its bundled one, else `bash`). See [Harness config](#harness-config). |
+| `runtime` | `RuntimeConfig` | `SubprocessConfig()` | Where the harness runs. Discriminated union — see [Runtime configs](#runtime-configs). Set with `--env.<agent>.runtime.type docker\|prime\|modal`. |
+| `env` | `dict[str, str]` | `{}` | Additional env vars for the harness program. Harness-owned endpoint/auth/model vars take precedence. |
+| `forward_env` | `list[str]` | `[]` | Names of env vars to forward from `os.environ` into the harness program's runtime (for secrets not in checked-in config). Absent names are skipped; explicit `env` wins. |
+| `disabled_tools` | `list[str] \| None` | `None` | Harness-specific tool names to disable. |
 | `model` | `str \| None` | `None` | Pin a model for this agent (None = the run's `--model`). |
 | `client` | `ClientConfig \| None` | `None` | Pin an endpoint (None = the run's `--client.*`) — route a frozen judge or user sim off the training endpoint. |
 | `sampling` | `SamplingConfig \| None` | `None` | Pin sampling (None = the run's). |
@@ -234,17 +241,7 @@ A taskset implements `load()` and declares exactly one task type through its gen
 
 ## Harness config
 
-`verifiers/v1/harness.py` — `HarnessConfig(BaseConfig)`. The base; **subclass per harness to add run knobs**. A harness belongs to an agent: the concrete subclass is resolved by `--env.<agent>.harness.id` (`--env.agent.harness.id` on the single-agent env); an unpinned agent runs the taskset's bundled harness, else `bash`. Mirrors `TasksetConfig`.
-
-### Base `HarnessConfig`
-
-| Field | Type | Default | Notes |
-| --- | --- | --- | --- |
-| `id` | `ID` | `"bash"` | The harness id, which selects it. Set via `--env.<agent>.harness.id`. |
-| `runtime` | `RuntimeConfig` | `SubprocessConfig()` | Where the harness runs. Discriminated union — see [Runtime configs](#runtime-configs). Set with `--env.<agent>.harness.runtime.type docker\|prime\|modal`. |
-| `env` | `dict[str, str]` | `{}` | Additional env vars for the harness program. Harness-owned endpoint/auth/model vars take precedence. |
-| `forward_env` | `list[str]` | `[]` | Names of env vars to forward from `os.environ` into the harness program's runtime (for secrets not in checked-in config). Absent names are skipped; explicit `env` wins. |
-| `disabled_tools` | `list[str] \| None` | `None` | Harness-specific tool names to disable. |
+A harness's config is **flat on the agent**: each harness subclasses [`AgentConfig`](#agent-config) to add its run knobs, the seat narrows to that subclass by `--env.<agent>.harness` (`--env.agent.harness` on the single-agent env), and the knobs address as `--env.<agent>.<knob>`. An unpinned agent runs the taskset's bundled harness, else `bash`.
 
 `.name` → the package name; `.resolved_env` → `env` merged with forwarded `forward_env` vars.
 
@@ -252,9 +249,9 @@ A harness class also declares capability flags (ClassVars, not user-settable): `
 
 ### Built-in harness configs
 
-All inherit the base `HarnessConfig` fields (`id`, `runtime`, `env`, `forward_env`, `disabled_tools`).
+All inherit the base `AgentConfig` fields (`harness`, `runtime`, `env`, `forward_env`, `disabled_tools`, the model-context pins, and the per-run caps).
 
-#### `BashHarnessConfig` — `id: "bash"` (the fallback)
+#### `BashHarnessConfig` — `harness = "bash"` (the fallback)
 
 A growing-message-list chat loop with a local `bash` tool, plus optional `edit`/`search`. A uv script (deps: `openai`, `mcp`).
 
@@ -263,11 +260,11 @@ A growing-message-list chat loop with a local `bash` tool, plus optional `edit`/
 | `edit` | `bool` | `True` | Offer the local `edit` tool (single-occurrence string replacement) alongside `bash`. |
 | `search` | `bool` | `False` | Offer a `search` tool (Google web results via serper.dev). Requires `SERPER_API_KEY` in the eval environment. |
 
-#### `NullHarnessConfig` — `id: "null"`
+#### `NullHarnessConfig` — `harness = "null"`
 
-A growing-message-list chat loop with the task- and taskset-scoped MCP tools, and **no built-in tools of its own**. It runs as a uv script whose dependencies are `openai` and `mcp`, so setup bootstraps everything it needs in the selected runtime. `NullHarnessConfig` adds no fields beyond the base `HarnessConfig` fields. Use it for pure chat or tasksets whose entire tool surface is provided through MCP; use an agentic harness for shell/edit capabilities.
+A growing-message-list chat loop with the task- and taskset-scoped MCP tools, and **no built-in tools of its own**. It runs as a uv script whose dependencies are `openai` and `mcp`, so setup bootstraps everything it needs in the selected runtime. `NullHarnessConfig` adds no fields beyond the base `AgentConfig` fields. Use it for pure chat or tasksets whose entire tool surface is provided through MCP; use an agentic harness for shell/edit capabilities.
 
-#### `CodexHarnessConfig` — `id: "codex"`
+#### `CodexHarnessConfig` — `harness = "codex"`
 
 Installs the Codex CLI into the runtime and runs `codex exec`.
 
@@ -275,9 +272,9 @@ Installs the Codex CLI into the runtime and runs `codex exec`.
 | --- | --- | --- | --- |
 | `version` | `str` | `"0.144.5"` | Codex release to install (the `rust-v<version>` GitHub release); pinned. |
 
-#### `RLMHarnessConfig` — `id: "rlm"`
+#### `RLMHarnessConfig` — `harness = "rlm"`
 
-Installs the rlm CLI and runs it. Knobs map onto `RLM_*` env vars; base `HarnessConfig.env` passes any other `RLM_*` var through verbatim.
+Installs the rlm CLI and runs it. Knobs map onto `RLM_*` env vars; the base `env` field passes any other `RLM_*` var through verbatim.
 
 | Field | Type | Default | Notes |
 | --- | --- | --- | --- |
@@ -286,7 +283,7 @@ Installs the rlm CLI and runs it. Knobs map onto `RLM_*` env vars; base `Harness
 | `skills` | `list["edit" \| "search"]` | `[]` | Built-in rlm skills to enable (`RLM_SKILLS`). Empty enables none. |
 | `summarize_at_tokens` | `int \| (int, int) \| None` | `None` | Auto-compaction threshold (`RLM_SUMMARIZE_AT_TOKENS`): compact once context grows past this many tokens. An int is fixed; a `(lo, hi)` pair draws a per-group threshold (seeded by task index). `None` disables. Ints must be positive. |
 
-#### `MiniSWEAgentHarnessConfig` — `id: "mini-swe-agent"`
+#### `MiniSWEAgentHarnessConfig` — `harness = "mini-swe-agent"`
 
 Runs the native bash-tool agent through LiteLLM.
 
@@ -294,7 +291,7 @@ Runs the native bash-tool agent through LiteLLM.
 | --- | --- | --- | --- |
 | `version` | `str` | `"2.4.5"` | mini-swe-agent release to install, pinned. |
 
-#### `Terminus2HarnessConfig` — `id: "terminus-2"`
+#### `Terminus2HarnessConfig` — `harness = "terminus-2"`
 
 Runs Harbor's tmux agent through LiteLLM.
 
@@ -302,7 +299,7 @@ Runs Harbor's tmux agent through LiteLLM.
 | --- | --- | --- | --- |
 | `version` | `str` | `"0.14.0"` | Harbor release to install, pinned. |
 
-#### `KimiCodeHarnessConfig` — `id: "kimi-code"`
+#### `KimiCodeHarnessConfig` — `harness = "kimi-code"`
 
 Installs the Kimi Code CLI and runs it headlessly.
 
@@ -314,7 +311,7 @@ Installs the Kimi Code CLI and runs it headlessly.
 
 ## Runtime configs
 
-`verifiers/v1/runtimes/`. Discriminated on `type`; selected with the agent's `--env.<agent>.harness.runtime.type` (or `--runtime.type` for the validate CLI). The same union is reused as `ToolsetConfig.runtime` and `UserConfig.runtime`.
+`verifiers/v1/runtimes/`. Discriminated on `type`; selected with the agent's `--env.<agent>.runtime.type` (or `--runtime.type` for the validate CLI). The same union is reused as `ToolsetConfig.runtime` and `UserConfig.runtime`.
 
 ### `SubprocessConfig` — `type: "subprocess"` (default)
 
@@ -581,14 +578,14 @@ Use `only_gold` or `only_setup` to select one mode; setting both is rejected. Th
 ## Notes & conventions
 
 - **Plugin resolution.** The run's `env` field narrows to the selected env's config class
-  (`--env.id`, else the taskset's exported env, else `SingleAgentEnvConfig`) *before* validation; inside it, `taskset` narrows by its id and each pinned agent `harness` by its id. Entries in `TaskConfig.judges` are similarly narrowed by each judge `id`. This is why local and Hub plugin fields remain typed and appear in CLI validation instead of living in an untyped arguments dictionary.
+  (`--env.id`, else the taskset's exported env, else `SingleAgentEnvConfig`) *before* validation; inside it, `taskset` narrows by its id and each seat by its `harness` id. Entries in `TaskConfig.judges` are similarly narrowed by each judge `id`. This is why local and Hub plugin fields remain typed and appear in CLI validation instead of living in an untyped arguments dictionary.
 - **Dotted flags.** Every nested field is part of the same CLI tree
-  (`--env.agent.harness.runtime.type docker`, `--env.taskset.split test`, `--pool.max_workers 8`, `--env.agent.retries.max_retries 2`). An `@ file.toml` describes the identical tree; explicit CLI values layer over values loaded from the file.
+  (`--env.agent.runtime.type docker`, `--env.taskset.split test`, `--pool.max_workers 8`, `--env.agent.retries.max_retries 2`). An `@ file.toml` describes the identical tree; explicit CLI values layer over values loaded from the file.
 - **Runtime precedence.** An explicit, non-default CLI/TOML `workdir` or resource field wins over
   `TaskData`; otherwise a non-`None` row value fills it, and otherwise the runtime/provider default remains. `TaskData.image` is the required image for that row and replaces the runtime's base image. Unsupported resource fields are ignored; evaluation warns once per runtime/field.
 - **Timeout precedence.** For eval stages, a non-`None` agent-level `TimeoutConfig` value
   (`--env.<agent>.timeout.*`) wins over the corresponding `TaskData.timeout` value; if both are `None`, there is no framework timeout. The setup value is one deadline shared by task setup and harness provisioning. Validate uses `CheckTimeoutConfig.setup`, then falls back to `TaskData.timeout.setup`, while `CheckTimeoutConfig.total` independently bounds `Task.validate`.
-- **Discriminated unions** are selected by their `type` field: `client.type` (eval|train), `pool.type` (static|elastic), `env.<agent>.harness.runtime.type` / `runtime.type` (subprocess|docker|prime|modal).
+- **Discriminated unions** are selected by their `type` field: `client.type` (eval|train), `pool.type` (static|elastic), `env.<agent>.runtime.type` / `runtime.type` (subprocess|docker|prime|modal).
 - **Frozen models.** `TaskData`, `TaskResources`, and `TaskTimeout` are immutable wire input, not
   mutable runtime state. Put per-rollout coordination on typed `trace.state`. `RolloutLimits` is an immutable framework limit derived from the env's `max_*` fields.
 - **Legacy v0.** Set the run-level `id` (leave `env.taskset` unset) to run a classic `load_environment` env through the bridge. `--resume` is not supported for legacy evals.

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -152,9 +152,9 @@ def _eval_config(
     env_cfg = dict(env or {})
     _configure_prime_runtimes(taskset_cfg)
     if harness:
-        harness_cfg = {"id": harness, **(harness_overrides or {})}
+        harness_cfg = {"harness": harness, **(harness_overrides or {})}
         _configure_prime_runtimes(harness_cfg)
-        env_cfg.setdefault("agent", {})["harness"] = harness_cfg
+        env_cfg.setdefault("agent", {}).update(harness_cfg)
     # Per-run caps live on the seats: resolve the env's declared roles and cap
     # each one (a test's own seat dict wins over the shared defaults).
     config_cls = vf.env_config_type(taskset, env_cfg.get("id", ""))

--- a/tests/v1/fixtures/duet_v1.py
+++ b/tests/v1/fixtures/duet_v1.py
@@ -16,8 +16,8 @@ from echo_v1 import EchoTaskset, lenient_match
 
 class DuetEnvConfig(vf.EnvConfig):
     # Both seats pin the lean `null` chat loop.
-    a: vf.AgentConfig = vf.AgentConfig(harness=vf.HarnessConfig(id="null"))
-    b: vf.AgentConfig = vf.AgentConfig(harness=vf.HarnessConfig(id="null"))
+    a: vf.AgentConfig = vf.AgentConfig(harness="null")
+    b: vf.AgentConfig = vf.AgentConfig(harness="null")
 
 
 class DuetEnv(vf.Env[DuetEnvConfig]):

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -301,7 +301,7 @@ async def test_env_id_best_of_n(run_v1, tmp_path):
     traces = await run_v1(
         "echo-v1",
         harness=None,  # a multi-agent env refuses the run-level harness
-        env={"id": "best-of-n", "n": 2, "agent": {"harness": {"id": "null"}}},
+        env={"id": "best-of-n", "n": 2, "agent": {"harness": "null"}},
         output_dir=tmp_path,
         max_turns=2,
     )
@@ -323,11 +323,11 @@ async def test_env_id_agentic_judge(run_v1, tmp_path):
         harness=None,  # seats pin their own harness; there is no run-level one
         env={
             "id": "agentic-judge",
-            "solver": {"harness": {"id": "null"}},
+            "solver": {"harness": "null"},
             # The judge reads the transcript and reasons before it writes the
             # verdict file; the shared 2048-token run cap truncates it mid-audit.
             "judge": {
-                "harness": {"runtime": {"type": "docker"}},
+                "runtime": {"type": "docker"},
                 "max_output_tokens": 8192,
             },
         },

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -22,7 +22,6 @@ from verifiers.v1.configs.env import (
 from verifiers.v1.env import (
     EnvConfig,
     Env,
-    default_agent_harness,
 )
 from verifiers.v1.envs.single_agent import SingleAgentEnv, SingleAgentEnvConfig
 from verifiers.v1.errors import (
@@ -37,7 +36,7 @@ from verifiers.v1.errors import (
     TunnelError,
     UserError,
 )
-from verifiers.v1.harness import Harness, HarnessConfig
+from verifiers.v1.harness import Harness
 from verifiers.v1.judge import (
     Judge,
     JudgeConfig,
@@ -234,7 +233,6 @@ __all__ = [
     "TasksetConfig",
     "BaseConfig",
     "Harness",
-    "HarnessConfig",
     "ModelContext",
     "Runtime",
     "RuntimeConfig",
@@ -251,7 +249,6 @@ __all__ = [
     "AgentConfig",
     "StaticPoolConfig",
     "ElasticPoolConfig",
-    "default_agent_harness",
     "pool_serve_kwargs",
     "RetryConfig",
     # agent

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -10,20 +10,16 @@ from collections.abc import Callable, Iterator, Mapping
 from contextlib import asynccontextmanager, nullcontext
 from typing import AsyncIterator
 
-from pydantic import SerializeAsAny, model_validator
-from pydantic_config import BaseConfig
-
 from verifiers.v1.clients import (
     Client,
-    ClientConfig,
     EvalClientConfig,
     ModelContext,
     resolve_client,
 )
-from verifiers.v1.harness import HarnessConfig
+from verifiers.v1.harness import AgentConfig, TimeoutConfig
 from verifiers.v1.interception import Interception, InterceptionServer
 from verifiers.v1.mcp import SharedToolServer
-from verifiers.v1.retries import RetryConfig, backoff, trace_should_retry
+from verifiers.v1.retries import backoff, trace_should_retry
 from verifiers.v1.rollout import RolloutRun
 from verifiers.v1.runtimes import (
     DockerConfig,
@@ -36,62 +32,35 @@ from verifiers.v1.runtimes import (
 from verifiers.v1.session import RolloutLimits
 from verifiers.v1.task import Task
 from verifiers.v1.trace import Trace
-from verifiers.v1.types import Sampling, SamplingConfig
+from verifiers.v1.types import Sampling
 from verifiers.v1.utils.compile import (
     cap_remote_harness_timeout,
     resolve_runtime_config,
     validate_pairing,
 )
 
+__all__ = ["Agent", "AgentConfig", "Agents", "TimeoutConfig", "make_agent"]
+
 logger = logging.getLogger(__name__)
 
 
-class TimeoutConfig(BaseConfig):
-    """Per-agent wall-clock timeouts per rollout stage, in seconds (None = no
-    limit); each stage falls back to the task's own `TaskTimeout` when unset."""
+def resolve_agent_config(config: AgentConfig, default_harness: str) -> AgentConfig:
+    """The config narrowed to its harness's own type with the harness id stamped
+    (`harness=None` resolves to `default_harness`) — what an `Agent` is built from.
+    A config already of the right type passes through untouched."""
+    from verifiers.v1.loaders import harness_config_type
 
-    setup: float | None = None  # one shared budget: task setup + provisioning
-    rollout: float | None = None
-    finalize: float | None = None
-    scoring: float | None = None
-
-
-class AgentConfig(BaseConfig):
-    """One env agent: who plays it, and its per-run caps. It pins only what
-    makes it a different actor; everything unpinned falls back — the model context
-    to the run's own, the harness to the taskset's default."""
-
-    harness: SerializeAsAny[HarnessConfig] | None = None
-    """The agent's program + runtime policy (None = the taskset's default harness)."""
-    model: str | None = None
-    """Model id (None = the run's model, i.e. the policy under evaluation/training)."""
-    client: ClientConfig | None = None
-    """Endpoint override (None = the run's client)."""
-    sampling: SamplingConfig | None = None
-    """Sampling override (None = the run's sampling)."""
-    timeout: TimeoutConfig = TimeoutConfig()
-    retries: RetryConfig = RetryConfig()
-    """Whole-run retries: rerun this agent's rollout while its trace ends with a
-    retryable error (never into a borrowed box)."""
-    max_turns: int | None = None
-    """Max model turns per run (None = no limit). Framework-enforced (the
-    interception server refuses turns past it), so it applies to any harness."""
-    max_input_tokens: int | None = None
-    max_output_tokens: int | None = None
-    max_total_tokens: int | None = None
-    """Token caps per run (None = no limit); framework-enforced between turns."""
-
-    @model_validator(mode="before")
-    @classmethod
-    def _resolve_harness(cls, data):
-        """Narrow a pinned `harness` to its concrete config type by `id` (absent
-        stays None = the taskset's default). The lazy import keeps class-body
-        `AgentConfig()` defaults constructible while this module initializes."""
-        if isinstance(data, dict) and data.get("harness") is not None:
-            from verifiers.v1.loaders import harness_config_type, narrow_plugin_field
-
-            narrow_plugin_field(data, "harness", harness_config_type, "bash")
-        return data
+    ident = config.harness or default_harness
+    expected = harness_config_type(ident)
+    if isinstance(config, expected):
+        return (
+            config
+            if config.harness == ident
+            else config.model_copy(update={"harness": ident})
+        )
+    return expected.model_validate(
+        {**config.model_dump(serialize_as_any=True), "harness": ident}
+    )
 
 
 def _check_borrowed_placement(
@@ -150,8 +119,8 @@ class Agent:
 
     Built from an `AgentConfig` alone; `client=`/`interception=` inject live
     resources to borrow — agents on one endpoint should share one `Client`, and a
-    live `Interception`'s owner keeps its lifecycle. The harness config's
-    `runtime` is a *policy*: each `run` provisions a fresh box from it, resolved
+    live `Interception`'s owner keeps its lifecycle. The config's `runtime` is a
+    *policy*: each `run` provisions a fresh box from it, resolved
     per task; `run(runtime=...)` places the run into an existing box instead
     (borrowed boxes are never started or torn down by the run)."""
 
@@ -162,18 +131,18 @@ class Agent:
         client: Client | None = None,
         interception: Interception | None = None,
     ) -> None:
-        from verifiers.v1.loaders import harness_config_type, load_harness
+        from verifiers.v1.loaders import load_harness
 
         if config.model is None:
             raise ValueError(
                 "AgentConfig.model is unset; an Agent needs a pinned model "
                 "(inside an env the run's own model fills it in)"
             )
-        harness_config = config.harness
-        if harness_config is None:
-            harness_config = harness_config_type("bash")(id="bash")
+        # `harness=None` means `bash` here: the taskset's default is an env
+        # concern, and the env resolves it before building its agents.
+        config = resolve_agent_config(config, "bash")
         self.config = config
-        self.harness = load_harness(harness_config)
+        self.harness = load_harness(config)
         self._owns_client = client is None
         if self._owns_client:
             client = resolve_client(config.client or EvalClientConfig())
@@ -183,7 +152,7 @@ class Agent:
             sampling=config.sampling if config.sampling is not None else Sampling(),
         )
         self._closed = False
-        self.runtime_config: RuntimeConfig = self.harness.config.runtime
+        self.runtime_config: RuntimeConfig = config.runtime
         self.interception = interception
         self.limits = RolloutLimits(
             max_turns=config.max_turns,

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -163,7 +163,7 @@ def _warning(config: EvalConfig) -> Text | None:
     from verifiers.v1.loaders import harness_class
 
     if any(
-        h.runtime.type == "subprocess" and harness_class(h.id).EXECUTES_CODE
+        h.runtime.type == "subprocess" and harness_class(h.harness).EXECUTES_CODE
         for h in config.env.agent_harnesses().values()
     ):
         return Text(
@@ -252,14 +252,14 @@ def Overview(config: EvalConfig) -> Table:
     grid.add_row("model", f"{model}  via {config.client.base_url}")
     # Non-default knobs the user set, one row each when non-empty. `escape` the cell: an override
     # value (or our `[...]`/`{...}` delimiters) can carry Rich markup that would otherwise be
-    # parsed as styling and dropped. `id` is in the `env` row; harness `runtime.type` too (hidden
-    # here), but only for the harness — `taskset.task.tools.runtime.type` has no other display.
+    # parsed as styling and dropped. `id` is in the `env` row; the seat's `harness` and
+    # `runtime.type` too (hidden here) — `taskset.task.tools.runtime.type` has no other display.
     if taskset_over := overrides(taskset, skip=frozenset({"id"})):
         grid.add_row("taskset", escape("  ·  ".join(taskset_over)))
     for role, h in seats.items():
-        if harness_over := overrides(h, skip=frozenset({"id", "runtime.type"})):
-            label = f"{role}.harness" if len(seats) > 1 else "harness"
-            grid.add_row(label, escape("  ·  ".join(harness_over)))
+        if agent_over := overrides(h, skip=frozenset({"harness", "runtime.type"})):
+            label = role if len(seats) > 1 else "agent"
+            grid.add_row(label, escape("  ·  ".join(agent_over)))
     limits, timeouts = _aligned([_limits(config), _timeouts(config)])
     grid.add_row("limits", limits)
     grid.add_row("timeouts", timeouts)

--- a/verifiers/v1/cli/init.py
+++ b/verifiers/v1/cli/init.py
@@ -180,8 +180,9 @@ def _harness_py(prefix: str) -> str:
 import verifiers.v1 as vf
 
 
-class {prefix}HarnessConfig(vf.HarnessConfig):
-    """Run knobs for this harness. Add fields here (e.g. a CLI version to install)."""
+class {prefix}HarnessConfig(vf.AgentConfig):
+    """Run knobs for this harness, flat on the seat. Add fields here (e.g. a CLI
+    version to install), addressable as `--env.agent.<field>`."""
 
 
 class {prefix}Harness(vf.Harness[{prefix}HarnessConfig]):
@@ -220,7 +221,7 @@ def _readme(
         )
     if add_harness:
         layout.append(
-            f"- `{pkg}/harness.py` — a custom harness, selectable with `--env.agent.harness.id {dash}`."
+            f"- `{pkg}/harness.py` — a custom harness, selectable with `--env.agent.harness {dash}`."
         )
     layout_block = "\n".join(layout)
     return f"""\

--- a/verifiers/v1/cli/output.py
+++ b/verifiers/v1/cli/output.py
@@ -54,7 +54,9 @@ def write_config(config: BaseModel, results_dir: Path) -> Path:
     path. mode="json" makes values TOML-friendly (Path -> str, etc.); exclude_none drops the
     nulls TOML can't represent."""
     results_dir.mkdir(parents=True, exist_ok=True)
-    toml = tomli_w.dumps(config.model_dump(mode="json", exclude_none=True))
+    toml = tomli_w.dumps(
+        config.model_dump(mode="json", exclude_none=True, serialize_as_any=True)
+    )
     config_path = results_dir / CONFIG_FILE
     config_path.write_text(toml)
     return config_path

--- a/verifiers/v1/cli/serve.py
+++ b/verifiers/v1/cli/serve.py
@@ -49,7 +49,9 @@ def main(argv: list[str] | None = None) -> None:
         sys.argv = [sys.argv[0], *argv]
         config = cli(config_type)
     if config.dry_run:
-        print(config.model_dump_json(indent=2, exclude_none=True))
+        print(
+            config.model_dump_json(indent=2, exclude_none=True, serialize_as_any=True)
+        )
         return
     level = "DEBUG" if config.verbose else "INFO"
     setup_logging(level)

--- a/verifiers/v1/configs/env.py
+++ b/verifiers/v1/configs/env.py
@@ -26,9 +26,9 @@ def resolve_env_field(data: dict, narrowed: "type[EnvConfig] | None" = None) -> 
         )
     if "harness" in data:
         raise ValueError(
-            "a harness belongs to an agent now: --env.agent.harness.* on the "
-            "single-agent env, --env.<agent>.harness.* on a multi-agent one "
-            "(TOML: [env.agent.harness])"
+            "a harness belongs to an agent now: --env.agent.harness <id> on the "
+            "single-agent env, --env.<agent>.harness <id> on a multi-agent one "
+            '(TOML: harness = "..." in [env.agent])'
         )
     raw = data.get("env")
     if raw is None:
@@ -37,7 +37,9 @@ def resolve_env_field(data: dict, narrowed: "type[EnvConfig] | None" = None) -> 
         if narrowed is not None:
             if not isinstance(raw, narrowed):
                 data["env"] = narrowed.model_validate(
-                    raw.model_dump() if isinstance(raw, BaseConfig) else raw
+                    raw.model_dump(serialize_as_any=True)
+                    if isinstance(raw, BaseConfig)
+                    else raw
                 )
             return data
         from verifiers.v1.loaders import resolve_env_config

--- a/verifiers/v1/configs/init.py
+++ b/verifiers/v1/configs/init.py
@@ -14,7 +14,7 @@ class InitConfig(BaseConfig):
     add_user: bool = Field(False, validation_alias=AliasChoices("add_user", "U"))
     """Also scaffold a `vf.User` declared on the task (`-U`)."""
     add_harness: bool = Field(False, validation_alias=AliasChoices("add_harness", "H"))
-    """Also scaffold a custom `vf.Harness` (`harness.py`), selectable via `--env.agent.harness.id <name>` (`-H`)."""
+    """Also scaffold a custom `vf.Harness` (`harness.py`), selectable via `--env.agent.harness <name>` (`-H`)."""
     v0: bool = False
     """Scaffold a legacy v0 environment (a `load_environment` package) instead of a v1 taskset."""
     force: bool = False

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -16,8 +16,14 @@ from typing import (
 from pydantic import SerializeAsAny, model_validator
 from pydantic_config import BaseConfig
 
-from verifiers.v1.agent import Agent, AgentConfig, Agents, _EpisodeAgent
-from verifiers.v1.harness import Harness, HarnessConfig
+from verifiers.v1.agent import (
+    Agent,
+    AgentConfig,
+    Agents,
+    _EpisodeAgent,
+    resolve_agent_config,
+)
+from verifiers.v1.harness import Harness
 from verifiers.v1.clients import Client, ClientConfig, ModelContext, resolve_client
 from verifiers.v1.types import ID
 from verifiers.v1.interception import (
@@ -85,12 +91,14 @@ class EnvConfig(BaseConfig):
             return f"{self.id}+{self.taskset.id}"
         return self.taskset.id or self.id
 
-    def agent_harnesses(self) -> dict[str, HarnessConfig]:
-        """Each declared role's resolved harness config (pin, else the taskset's
-        default) — known without constructing the env."""
-        default = default_agent_harness(self.taskset.id)
+    def agent_harnesses(self) -> dict[str, AgentConfig]:
+        """Each declared role's config with its harness resolved (pin, else the
+        taskset's default) — known without constructing the env."""
+        from verifiers.v1.loaders import default_harness_id
+
+        default = default_harness_id(self.taskset.id)
         return {
-            name: cfg.harness if cfg.harness is not None else default
+            name: cfg if cfg.harness else cfg.model_copy(update={"harness": default})
             for name, cfg in _declared_agent_configs(self).items()
         }
 
@@ -105,17 +113,17 @@ class EnvConfig(BaseConfig):
             and "harness" not in cls.model_fields
         ):
             raise ValueError(
-                "a harness belongs to a seat: --env.agent.harness.* on the "
-                "single-agent env, --env.<role>.harness.* on a multi-agent role "
-                "(TOML: [env.agent.harness])"
+                "a harness belongs to a seat: --env.agent.harness <id> on the "
+                "single-agent env, --env.<role>.harness <id> on a multi-agent role "
+                '(TOML: harness = "..." in [env.agent])'
             )
         return data
 
     @model_validator(mode="before")
     @classmethod
     def _resolve_taskset(cls, data):
-        """Narrow `taskset` to its concrete config type by `id`; lazy import for
-        the same reason as `AgentConfig._resolve_harness`."""
+        """Narrow `taskset` to its concrete config type by `id`. The lazy import
+        keeps class-body defaults constructible while this module initializes."""
         if isinstance(data, dict) and data.get("taskset") is not None:
             from verifiers.v1.loaders import narrow_plugin_field, taskset_config_type
 
@@ -124,17 +132,33 @@ class EnvConfig(BaseConfig):
 
     @model_validator(mode="before")
     @classmethod
-    def _merge_role_defaults(cls, data):
-        """Deep-merge partial role data over the field's declared default — plain
-        validation would replace the instance wholesale, resetting its other pins."""
-        if isinstance(data, dict):
-            for name, field in cls.model_fields.items():
-                if isinstance(field.default, AgentConfig) and isinstance(
-                    data.get(name), dict
-                ):
-                    data[name] = deep_merge(
-                        field.default.model_dump(exclude_none=True), data[name]
-                    )
+    def _resolve_roles(cls, data):
+        """Deep-merge partial role data over the field's declared default (plain
+        validation would replace the instance wholesale, resetting its other pins),
+        then narrow it to its harness's config type — harness fields validate flat
+        on the seat, addressed as `--env.<role>.<knob>`."""
+        if not isinstance(data, dict):
+            return data
+        from verifiers.v1.loaders import default_harness_id, narrow_agent_field
+
+        default_id: str | None = None
+        for name, info in cls.model_fields.items():
+            if isinstance(info.default, AgentConfig) and isinstance(
+                data.get(name), dict
+            ):
+                data[name] = deep_merge(
+                    info.default.model_dump(exclude_none=True, serialize_as_any=True),
+                    data[name],
+                )
+                if default_id is None:
+                    taskset = data.get("taskset")
+                    taskset_id = (
+                        taskset.get("id", "")
+                        if isinstance(taskset, dict)
+                        else getattr(taskset, "id", "")
+                    ) or ""
+                    default_id = default_harness_id(taskset_id)
+                narrow_agent_field(data, name, default_id)
         return data
 
     @classmethod
@@ -169,15 +193,6 @@ def _declared_agent_configs(config: EnvConfig) -> dict[str, AgentConfig]:
         for name, field in type(config).model_fields.items()
         if isinstance(field.default, AgentConfig)
     }
-
-
-def default_agent_harness(taskset_id: str) -> HarnessConfig:
-    """What an unpinned role's `harness=None` resolves to: the taskset's bundled
-    harness when it ships one, else the built-in `bash`."""
-    from verifiers.v1.loaders import default_harness_id, harness_config_type
-
-    ident = default_harness_id(taskset_id)
-    return harness_config_type(ident).model_validate({"id": ident})
 
 
 logger = logging.getLogger(__name__)
@@ -225,7 +240,11 @@ class Env(ABC, Generic[ConfigT]):
     task the agent actually receives — an env-minted task carries its own needs."""
 
     def __init__(self, config: ConfigT) -> None:
-        from verifiers.v1.loaders import load_harness, load_taskset
+        from verifiers.v1.loaders import (
+            default_harness_id,
+            load_harness,
+            load_taskset,
+        )
 
         config_cls = generic_type(type(self), EnvConfig, origin=Env) or EnvConfig
         if not isinstance(config, config_cls):
@@ -243,25 +262,28 @@ class Env(ABC, Generic[ConfigT]):
                 "`eval <taskset-id>`)"
             )
         self.taskset = load_taskset(config.taskset)
-        self._default_harness = default_agent_harness(config.taskset.id)
         task_cls = type(self.taskset).task_type()
         self._task_cls: type[Task] = task_cls
-        self._agent_specs: dict[str, AgentConfig] = _declared_agent_configs(self.config)
-        if not self._agent_specs:
+        declared = _declared_agent_configs(self.config)
+        if not declared:
             raise ValueError(
                 f"{type(self).__name__} declares no agents; declare each as an "
                 "AgentConfig field on the env's config "
                 "(`solver: vf.AgentConfig = vf.AgentConfig()`) — the field name is "
                 "the agent's name. The single-agent case is SingleAgentEnv."
             )
-        # Same harness config -> one loaded object (harnesses are stateless values).
+        default_id = default_harness_id(config.taskset.id)
+        self._agent_specs: dict[str, AgentConfig] = {
+            name: resolve_agent_config(spec, default_id)
+            for name, spec in declared.items()
+        }
+        # Same agent config -> one loaded object (harnesses are stateless values).
         loaded: dict[str, Harness] = {}
         self._harnesses: dict[str, Harness] = {}
         for name, spec in self._agent_specs.items():
-            cfg = self._agent_harness(spec)
-            key = cfg.model_dump_json()
+            key = spec.model_dump_json()
             if key not in loaded:
-                loaded[key] = load_harness(cfg)
+                loaded[key] = load_harness(spec)
             self._harnesses[name] = loaded[key]
         warned: set[str] = set()
         for name, harness in self._harnesses.items():
@@ -269,15 +291,15 @@ class Env(ABC, Generic[ConfigT]):
             if (
                 harness.EXECUTES_CODE
                 and isinstance(harness.config.runtime, SubprocessConfig)
-                and harness.config.id not in warned
+                and harness.config.harness not in warned
             ):
-                warned.add(harness.config.id)
+                warned.add(harness.config.harness)
                 logger.warning(
                     "Harness %r is running in the subprocess runtime on the local system. "
                     "Local files and settings may affect the evaluation; use subprocess only "
-                    "for debugging. Use --env.<role>.harness.runtime.type docker or prime "
+                    "for debugging. Use --env.<role>.runtime.type docker or prime "
                     "for an isolated run.",
-                    harness.config.id,
+                    harness.config.harness,
                 )
         # Serving resources, live only inside `serving()`; the env's agents borrow them.
         self._shared_tools: dict[str, SharedToolServer] = {}
@@ -325,10 +347,6 @@ class Env(ABC, Generic[ConfigT]):
 
     # --- machinery (the base owns everything below) -----------------------------
 
-    def _agent_harness(self, agent: AgentConfig) -> HarnessConfig:
-        """The role's harness config: its own pin, else the taskset's default."""
-        return agent.harness if agent.harness is not None else self._default_harness
-
     def _episode_agents(
         self,
         ctx: ModelContext,
@@ -341,12 +359,11 @@ class Env(ABC, Generic[ConfigT]):
         resources (nothing shared across concurrent episodes); `setup()` sees them first."""
 
         def make(name: str, spec: AgentConfig) -> Agent:
-            # Unpinned fields fall back to the run's ctx / the taskset's harness.
+            # Unpinned fields fall back to the run's ctx; the harness was resolved
+            # (id stamped, config narrowed) once at construction.
+            spec = self._agent_specs[name]
             resolved = spec.model_copy(
                 update={
-                    "harness": spec.harness
-                    if spec.harness is not None
-                    else self._default_harness,
                     "model": spec.model if spec.model is not None else ctx.model,
                     "sampling": spec.sampling
                     if spec.sampling is not None

--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -115,7 +115,7 @@ class AgenticJudgeEnvConfig(vf.EnvConfig):
     solver: vf.AgentConfig = vf.AgentConfig()
     judge: vf.AgentConfig = vf.AgentConfig()
     """The judge agent. Its runtime must be a container:
-    `--env.judge.harness.runtime.type docker|prime`."""
+    `--env.judge.runtime.type docker|prime`."""
 
 
 class AgenticJudgeEnv(vf.Env[AgenticJudgeEnvConfig]):
@@ -129,7 +129,7 @@ class AgenticJudgeEnv(vf.Env[AgenticJudgeEnvConfig]):
         if not harness.EXECUTES_CODE:
             raise ValueError(
                 "agentic-judge plays a code-executing judge in its own sandbox, but "
-                f"harness {harness.config.id!r} is a tool-less chat loop — a verdict "
+                f"harness {harness.config.harness!r} is a tool-less chat loop — a verdict "
                 "that needs no execution is a plugged judge "
                 "(--env.taskset.task.judges), not an agent."
             )
@@ -137,7 +137,7 @@ class AgenticJudgeEnv(vf.Env[AgenticJudgeEnvConfig]):
             raise ValueError(
                 "agentic-judge plays its judge in a container (JudgeTask mirrors "
                 "the solver task's image), but the judge resolves to the "
-                "subprocess runtime; use --env.judge.harness.runtime.type docker "
+                "subprocess runtime; use --env.judge.runtime.type docker "
                 "or prime."
             )
 

--- a/verifiers/v1/envs/single_agent/env.py
+++ b/verifiers/v1/envs/single_agent/env.py
@@ -15,7 +15,7 @@ class SingleAgentEnvConfig(EnvConfig):
 
     agent: AgentConfig = AgentConfig()
     """The one seat — the policy under evaluation/training; pin
-    `--env.agent.harness.*` to choose its program or runtime."""
+    `--env.agent.harness` / `--env.agent.runtime.*` to choose its program or runtime."""
 
 
 class SingleAgentEnv(Env[SingleAgentEnvConfig]):

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -6,12 +6,13 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar
 
-from pydantic import Field
+from pydantic import Field, model_validator
 from pydantic_config import BaseConfig
 
-from verifiers.v1.clients import ModelContext
+from verifiers.v1.clients import ClientConfig, ModelContext
 from verifiers.v1.decorators import discover_decorated, invoke_all
 from verifiers.v1.errors import HarnessError, boundary
+from verifiers.v1.retries import RetryConfig
 from verifiers.v1.utils.install import env_name
 from verifiers.v1.runtimes import (
     ProgramResult,
@@ -20,20 +21,38 @@ from verifiers.v1.runtimes import (
     SubprocessConfig,
 )
 from verifiers.v1.task import TaskData
-from verifiers.v1.types import ID, Messages
+from verifiers.v1.types import ID, Messages, SamplingConfig
 
 if TYPE_CHECKING:
     # Annotation-only: the runtime import goes trace -> harness (AgentInfo embeds
-    # HarnessConfig), not the other way around.
+    # AgentConfig), not the other way around.
     from verifiers.v1.trace import Trace
 
 logger = logging.getLogger(__name__)
 
 
-class HarnessConfig(BaseConfig):
-    id: ID = "bash"
-    """Local package or Hub `org/name[@version]`, set through the seat's
-    `--env.<role>.harness.id` (`--env.agent.harness.id` on the single-agent env)."""
+class TimeoutConfig(BaseConfig):
+    """Per-agent wall-clock timeouts per rollout stage, in seconds (None = no
+    limit); each stage falls back to the task's own `TaskTimeout` when unset."""
+
+    setup: float | None = None  # one shared budget: task setup + provisioning
+    rollout: float | None = None
+    finalize: float | None = None
+    scoring: float | None = None
+
+
+class AgentConfig(BaseConfig):
+    """One env agent: who plays it, flat — the harness (by id) with its knobs
+    directly on the seat, and the agent's per-run caps. A harness declares its
+    extra knobs by subclassing `AgentConfig`; the seat's config narrows to that
+    subclass by `harness`, so harness fields address flat (`--env.<role>.<knob>`).
+    It pins only what makes it a different actor; everything unpinned falls back —
+    the model context to the run's own, the harness to the taskset's default."""
+
+    harness: ID | None = None
+    """The harness program — local package or Hub `org/name[@version]`, set through
+    the seat's `--env.<role>.harness` (`--env.agent.harness` on the single-agent
+    env). None = the taskset's default harness."""
     runtime: RuntimeConfig = SubprocessConfig()
     """Runtime for the harness program; tool servers choose their placement separately."""
     env: dict[str, str] = Field(default_factory=dict)
@@ -41,10 +60,39 @@ class HarnessConfig(BaseConfig):
     forward_env: list[str] = Field(default_factory=list)
     """Host variables to forward without writing secrets into config; explicit `env` wins."""
     disabled_tools: list[str] | None = None
+    model: str | None = None
+    """Model id (None = the run's model, i.e. the policy under evaluation/training)."""
+    client: ClientConfig | None = None
+    """Endpoint override (None = the run's client)."""
+    sampling: SamplingConfig | None = None
+    """Sampling override (None = the run's sampling)."""
+    timeout: TimeoutConfig = TimeoutConfig()
+    retries: RetryConfig = RetryConfig()
+    """Whole-run retries: rerun this agent's rollout while its trace ends with a
+    retryable error (never into a borrowed box)."""
+    max_turns: int | None = None
+    """Max model turns per run (None = no limit). Framework-enforced (the
+    interception server refuses turns past it), so it applies to any harness."""
+    max_input_tokens: int | None = None
+    max_output_tokens: int | None = None
+    max_total_tokens: int | None = None
+    """Token caps per run (None = no limit); framework-enforced between turns."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _flat_harness(cls, data):
+        """Point nested harness data (the old shape) at the flat surface."""
+        if isinstance(data, dict) and isinstance(data.get("harness"), dict):
+            raise ValueError(
+                "the harness config is flat on the agent: set `harness` to the id "
+                "(--env.agent.harness bash) and its knobs directly on the seat "
+                "(--env.agent.runtime.type docker; TOML [env.agent.runtime])"
+            )
+        return data
 
     @property
     def name(self) -> str:
-        return env_name(self.id)
+        return env_name(self.harness) if self.harness else "?"
 
     @property
     def resolved_env(self) -> dict[str, str]:
@@ -52,7 +100,7 @@ class HarnessConfig(BaseConfig):
         return {**forwarded, **self.env}
 
 
-ConfigT = TypeVar("ConfigT", bound=HarnessConfig)
+ConfigT = TypeVar("ConfigT", bound=AgentConfig)
 
 
 class Harness(ABC, Generic[ConfigT]):
@@ -80,7 +128,7 @@ class Harness(ABC, Generic[ConfigT]):
             and not self.SUPPORTS_MESSAGE_PROMPT
         ):
             raise ValueError(
-                f"Harness {self.config.id!r} does not support a Messages prompt; "
+                f"Harness {self.config.harness!r} does not support a Messages prompt; "
                 "task.prompt must be a string or None."
             )
         system = task.system_prompt
@@ -88,14 +136,14 @@ class Harness(ABC, Generic[ConfigT]):
             return system if self.APPENDS_SYSTEM_PROMPT else None, prompt
         if not isinstance(prompt, str):
             raise ValueError(
-                f"Harness {self.config.id!r} cannot fold a system prompt into a "
+                f"Harness {self.config.harness!r} cannot fold a system prompt into a "
                 f"{'Messages' if prompt is not None else 'None'} prompt; set "
                 "APPENDS_SYSTEM_PROMPT to emit it as a system message."
             )
         logger.warning(
             "Harness %r does not support a separate system prompt; prepending "
             "task.system_prompt to the user prompt.",
-            self.config.id,
+            self.config.harness,
         )
         return None, f"{system}\n\n{prompt}"
 
@@ -111,7 +159,7 @@ class Harness(ABC, Generic[ConfigT]):
         secret: str,
         mcp_urls: dict[str, str],
     ) -> None:
-        async with boundary(HarnessError, f"harness {self.config.id!r}"):
+        async with boundary(HarnessError, f"harness {self.config.harness!r}"):
             result = await self.launch(ctx, trace, runtime, endpoint, secret, mcp_urls)
         if trace.stop_condition is not None:
             return  # a @stop refused a turn mid-rollout; the harness's exit is expected
@@ -119,7 +167,7 @@ class Harness(ABC, Generic[ConfigT]):
             # The real cause is at the END of a traceback, so keep the tail.
             detail = (result.stderr or result.stdout).strip()[-2000:] or "<no output>"
             raise HarnessError(
-                f"harness {self.config.id!r} exited {result.exit_code}: {detail}"
+                f"harness {self.config.harness!r} exited {result.exit_code}: {detail}"
             )
         trace.stop("agent_completed")
 
@@ -129,7 +177,7 @@ class Harness(ABC, Generic[ConfigT]):
         `runtime`) and can read what the harness left behind in the runtime."""
         available = {"task": trace.task.data, "trace": trace, "runtime": runtime}
         fns = discover_decorated(self, "metric")
-        async with boundary(HarnessError, f"harness {self.config.id!r} metric"):
+        async with boundary(HarnessError, f"harness {self.config.harness!r} metric"):
             results = await invoke_all(fns, available)
         for fn, result in zip(fns, results):
             if isinstance(result, Mapping):

--- a/verifiers/v1/harnesses/bash/harness.py
+++ b/verifiers/v1/harnesses/bash/harness.py
@@ -2,7 +2,7 @@ import json
 import os
 from pathlib import Path
 
-from verifiers.v1.harness import Harness, HarnessConfig
+from verifiers.v1.harness import AgentConfig, Harness
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.dialects.chat import message_to_wire
 from verifiers.v1.runtimes import ProgramResult, Runtime
@@ -25,7 +25,7 @@ SEARCH_PROMPT = (
 )
 
 
-class BashHarnessConfig(HarnessConfig):
+class BashHarnessConfig(AgentConfig):
     edit: bool = True
     """Offer the local `edit` tool (single-occurrence string replacement in a file) alongside
     `bash`. On by default; set `--env.agent.harness.edit false` for a bash-only agent."""

--- a/verifiers/v1/harnesses/claude_code/harness.py
+++ b/verifiers/v1/harnesses/claude_code/harness.py
@@ -6,7 +6,7 @@ import shlex
 from pydantic import Field
 
 from verifiers.v1.clients import ModelContext
-from verifiers.v1.harness import Harness, HarnessConfig
+from verifiers.v1.harness import AgentConfig, Harness
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.trace import Trace
 
@@ -20,7 +20,7 @@ curl -fsSL https://claude.ai/install.sh | HOME={home} bash -s {version}
 """
 
 
-class ClaudeCodeHarnessConfig(HarnessConfig):
+class ClaudeCodeHarnessConfig(AgentConfig):
     version: str = Field(default="2.1.214", pattern=r"^[A-Za-z0-9._+-]+$")
     """Claude Code release to install; pinned for reproducibility."""
 

--- a/verifiers/v1/harnesses/codex/harness.py
+++ b/verifiers/v1/harnesses/codex/harness.py
@@ -9,7 +9,7 @@ import re
 import shlex
 
 from verifiers.v1.clients import ModelContext
-from verifiers.v1.harness import Harness, HarnessConfig
+from verifiers.v1.harness import AgentConfig, Harness
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.trace import Trace
 from verifiers.v1.types import TextContentPart
@@ -35,7 +35,7 @@ chmod +x {bin}
 """
 
 
-class CodexHarnessConfig(HarnessConfig):
+class CodexHarnessConfig(AgentConfig):
     version: str = "0.144.5"
     """Codex release to install (the `rust-v<version>` GitHub release); pinned for reproducibility."""
     multi_agent: bool = False

--- a/verifiers/v1/harnesses/kimi_code/harness.py
+++ b/verifiers/v1/harnesses/kimi_code/harness.py
@@ -5,7 +5,7 @@ import logging
 import shlex
 
 from verifiers.v1.clients import ModelContext
-from verifiers.v1.harness import Harness, HarnessConfig
+from verifiers.v1.harness import AgentConfig, Harness
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.trace import Trace
 
@@ -31,7 +31,7 @@ env \
 """
 
 
-class KimiCodeHarnessConfig(HarnessConfig):
+class KimiCodeHarnessConfig(AgentConfig):
     version: str = "0.27.0"
     """Kimi Code release to install, pinned for reproducibility."""
 

--- a/verifiers/v1/harnesses/mini_swe_agent/harness.py
+++ b/verifiers/v1/harnesses/mini_swe_agent/harness.py
@@ -1,14 +1,14 @@
 from pathlib import Path
 
 from verifiers.v1.clients import ModelContext
-from verifiers.v1.harness import Harness, HarnessConfig
+from verifiers.v1.harness import AgentConfig, Harness
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.trace import Trace
 
 PROGRAM_SOURCE = (Path(__file__).resolve().parent / "program.py").read_text()
 
 
-class MiniSWEAgentHarnessConfig(HarnessConfig):
+class MiniSWEAgentHarnessConfig(AgentConfig):
     version: str = "2.4.5"
     """mini-swe-agent release to install, pinned for reproducibility."""
 

--- a/verifiers/v1/harnesses/null/harness.py
+++ b/verifiers/v1/harnesses/null/harness.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-from verifiers.v1.harness import Harness, HarnessConfig
+from verifiers.v1.harness import AgentConfig, Harness
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.dialects.chat import message_to_wire
 from verifiers.v1.runtimes import ProgramResult, Runtime
@@ -10,7 +10,7 @@ from verifiers.v1.trace import Trace
 PROGRAM_SOURCE = (Path(__file__).resolve().parent / "program.py").read_text()
 
 
-class NullHarnessConfig(HarnessConfig):
+class NullHarnessConfig(AgentConfig):
     pass
 
 

--- a/verifiers/v1/harnesses/pi/harness.py
+++ b/verifiers/v1/harnesses/pi/harness.py
@@ -11,7 +11,7 @@ import re
 import shlex
 
 from verifiers.v1.clients import ModelContext
-from verifiers.v1.harness import Harness, HarnessConfig
+from verifiers.v1.harness import AgentConfig, Harness
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.trace import Trace
 from verifiers.v1.types import SystemMessage, TextContentPart, UserMessage
@@ -86,7 +86,7 @@ export default async function isolatedMcp(pi) {{
 """.strip()
 
 
-class PiHarnessConfig(HarnessConfig):
+class PiHarnessConfig(AgentConfig):
     version: str = "0.80.10"
     """Pi release to install, pinned for reproducibility."""
 

--- a/verifiers/v1/harnesses/pool/harness.py
+++ b/verifiers/v1/harnesses/pool/harness.py
@@ -6,7 +6,7 @@ import shlex
 from pydantic import Field
 
 from verifiers.v1.clients import ModelContext
-from verifiers.v1.harness import Harness, HarnessConfig
+from verifiers.v1.harness import AgentConfig, Harness
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.trace import Trace
 from verifiers.v1.types import SystemMessage, TextContentPart, UserMessage
@@ -26,7 +26,7 @@ chmod +x "{dir}/pool"
 """
 
 
-class PoolHarnessConfig(HarnessConfig):
+class PoolHarnessConfig(AgentConfig):
     version: str = Field(default="1.0.11", pattern=r"^[A-Za-z0-9._+-]+$")
     """Pool release to install, pinned for reproducibility."""
 

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -8,7 +8,7 @@ from typing import Literal
 
 from pydantic import model_validator
 
-from verifiers.v1.harness import Harness, HarnessConfig
+from verifiers.v1.harness import AgentConfig, Harness
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.decorators import metric
 from verifiers.v1.runtimes import ProgramResult, Runtime
@@ -26,7 +26,7 @@ RLM_DIR = "/tmp/vf-rlm"
 RLM_BIN = f"{RLM_DIR}/bin/rlm"
 
 
-class RLMHarnessConfig(HarnessConfig):
+class RLMHarnessConfig(AgentConfig):
     version: str = "main"
     """Git ref (branch, tag, or commit) of rlm to install."""
     max_depth: int = 0

--- a/verifiers/v1/harnesses/terminus_2/harness.py
+++ b/verifiers/v1/harnesses/terminus_2/harness.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 
 from verifiers.v1.clients import ModelContext
-from verifiers.v1.harness import Harness, HarnessConfig
+from verifiers.v1.harness import AgentConfig, Harness
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.trace import Trace
 
@@ -10,7 +10,7 @@ PROGRAM_SOURCE = (Path(__file__).resolve().parent / "program.py").read_text()
 logger = logging.getLogger(__name__)
 
 
-class Terminus2HarnessConfig(HarnessConfig):
+class Terminus2HarnessConfig(AgentConfig):
     version: str = "0.14.0"
     """Harbor release to install, pinned for reproducibility."""
 
@@ -28,7 +28,7 @@ class Terminus2Harness(Harness[Terminus2HarnessConfig]):
             raise RuntimeError(
                 "Terminus 2 drives tmux and is unsafe on the subprocess (host) runtime — its tmux "
                 "cleanup can kill the host's tmux server. Run it in a container runtime "
-                "(--env.agent.harness.runtime.type docker|prime|modal)."
+                "(--env.agent.runtime.type docker|prime|modal)."
             )
         source = PROGRAM_SOURCE.replace("{version}", self.config.version)
         await runtime.prepare_uv_script(source, self.config.resolved_env)

--- a/verifiers/v1/loaders.py
+++ b/verifiers/v1/loaders.py
@@ -13,7 +13,7 @@ from pydantic_config import BaseConfig
 from verifiers.v1.env import EnvConfig, Env
 from verifiers.v1.utils.generic import prefix_validation_error
 from verifiers.v1.envs.single_agent import SingleAgentEnv
-from verifiers.v1.harness import Harness, HarnessConfig
+from verifiers.v1.harness import AgentConfig, Harness
 from verifiers.v1.judge import Judge, JudgeConfig, judge_config_cls
 from verifiers.v1.utils.install import ensure_installed
 from verifiers.v1.utils.generic import generic_type
@@ -39,25 +39,19 @@ def narrow_plugin_field(
     data: dict,
     field: str,
     resolve: Callable[[str], type],
-    default_id: str | None = None,
 ) -> None:
     raw = data.get(field)
     if isinstance(raw, BaseConfig):
         raw = raw.model_dump()
     raw = dict(raw or {})
-    ident = raw.get("id") or default_id
+    ident = raw.get("id")
     if not ident:
         return
     if not isinstance(ident, str):
         # A dangling `--<field>.id` (no value) parses as boolean True.
-        hint = (
-            f"; the built-in harnesses are: {', '.join(builtin_harness_ids())}"
-            if field == "harness"
-            else ""
-        )
         raise ValueError(
             f"{field}.id needs an id, and none was given (got {ident!r}); "
-            f"pass the id right after the flag{hint}"
+            "pass the id right after the flag"
         )
     if skip_plugin_install.get():
         # keep the plugin id-only; don't import/install from the Hub
@@ -72,6 +66,39 @@ def narrow_plugin_field(
         raise prefix_validation_error(e, (field,)) from None
 
 
+def narrow_agent_field(data: dict, field: str, default_id: str) -> None:
+    """Narrow a role's raw data to its harness's config type by the flat `harness`
+    id (absent = `default_id`, the taskset's default), so harness-specific fields
+    validate flat on the seat. The narrowed instance keeps `harness=None` for an
+    unpinned role — pin vs. default stays observable after validation."""
+    raw = data.get(field)
+    if not isinstance(raw, dict):
+        return
+    ident = raw.get("harness")
+    if isinstance(ident, dict):
+        # The old nested shape ([env.agent.harness] id = ...): point at the flat one.
+        raise ValueError(
+            f"the harness config is flat on the seat: set `{field}.harness` to the "
+            f"id (--env.{field}.harness bash) and its knobs directly on the seat "
+            f"(--env.{field}.runtime.type docker; TOML [env.{field}.runtime])"
+        )
+    if ident is not None and not isinstance(ident, str):
+        # A dangling `--<field>.harness` (no value) parses as boolean True.
+        raise ValueError(
+            f"{field}.harness needs a harness id, and none was given (got {ident!r}); "
+            f"the built-in harnesses are: {', '.join(builtin_harness_ids())}"
+        )
+    if skip_plugin_install.get():
+        # keep the seat's base fields; don't import/install the harness from the Hub
+        data[field] = {k: v for k, v in raw.items() if k in AgentConfig.model_fields}
+        return
+    try:
+        data[field] = harness_config_type(ident or default_id).model_validate(raw)
+    except ValidationError as e:
+        # As in narrow_plugin_field: keep the user's flag path in the error.
+        raise prefix_validation_error(e, (field,)) from None
+
+
 def _import_plugin(plugin_id: str, kind: str, group: str) -> ModuleType:
     module = ensure_installed(plugin_id)
     namespaced = f"{group}.{module}"
@@ -82,7 +109,7 @@ def _import_plugin(plugin_id: str, kind: str, group: str) -> ModuleType:
         if kind == "harness" and plugin_id == "default":
             raise ModuleNotFoundError(
                 "the `default` harness was renamed to `bash`: "
-                "--env.agent.harness.id bash (or your env's role name)"
+                "--env.agent.harness bash (or your env's role name)"
             ) from e
         hint = (
             f" The built-in harnesses are: {', '.join(builtin_harness_ids())}."
@@ -194,8 +221,13 @@ def load_taskset(config: TasksetConfig) -> Taskset:
     return taskset_class(config.id)(config)
 
 
-def load_harness(config: HarnessConfig) -> Harness:
-    return harness_class(config.id)(config)
+def load_harness(config: AgentConfig) -> Harness:
+    if config.harness is None:
+        raise ValueError(
+            "AgentConfig.harness is unset; resolve it first "
+            "(agent.resolve_agent_config fills in the default)"
+        )
+    return harness_class(config.harness)(config)
 
 
 def load_judge(config: JudgeConfig) -> Judge:
@@ -210,11 +242,12 @@ def taskset_config_type(taskset_id: str) -> type[TasksetConfig]:
     )
 
 
-def harness_config_type(harness_id: str) -> type[HarnessConfig]:
-    """Resolve the harness's config specialization through its MRO."""
+def harness_config_type(harness_id: str) -> type[AgentConfig]:
+    """Resolve the harness's config specialization (`Harness[YourConfig]`, an
+    `AgentConfig` subclass) through its MRO — what a seat's config narrows to."""
     return (
-        generic_type(harness_class(harness_id), HarnessConfig, origin=Harness)
-        or HarnessConfig
+        generic_type(harness_class(harness_id), AgentConfig, origin=Harness)
+        or AgentConfig
     )
 
 
@@ -241,7 +274,7 @@ def resolve_env_config(data: dict | EnvConfig | None) -> EnvConfig:
         cls = env_config_type(data.taskset.id, data.id)
         if isinstance(data, cls):
             return data  # already at least as specifically typed — keep
-        data = data.model_dump()
+        data = data.model_dump(serialize_as_any=True)
     raw = dict(data or {})
     taskset = raw.get("taskset")
     taskset_id = (

--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -265,7 +265,7 @@ def env_config_data(env: EnvConfig) -> dict:
     """A picklable dict of a (possibly dynamically-narrowed, unpicklable) env config —
     ship this across a process boundary, then rebuild via `resolve_env_config`
     (re-narrowing to the env's concrete config class)."""
-    return env.model_dump(mode="json")
+    return env.model_dump(mode="json", serialize_as_any=True)
 
 
 def serve_env(

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 from verifiers.v1 import graph
 from verifiers.v1.errors import ProviderError
 from verifiers.v1.graph import MessageNode
-from verifiers.v1.harness import HarnessConfig
+from verifiers.v1.harness import AgentConfig
 from verifiers.v1.runtimes import RuntimeInfo
 from verifiers.v1.state import State, StateT
 from verifiers.v1.task import DataT, WireTaskData
@@ -265,7 +265,7 @@ _NODE_DUMP_EXCLUDE: dict = {
 """Raw tensor fields kept on the msgpack wire but excluded from JSON records."""
 
 
-TRACE_VERSION = 2
+TRACE_VERSION = 3
 """Version of the trace record schema (see `Trace.model_json_schema()`). Bumped on
 breaking shape changes; optional-with-default fields are additive and don't bump it."""
 
@@ -314,9 +314,10 @@ class AgentInfo(StrictBaseModel):
     """The model identifier requested from the client."""
     sampling: SamplingConfig | None = None
     """The resolved sampling settings the rollout ran with."""
-    harness: HarnessConfig | None = None
-    """The driving harness's config. Typed as the base config, so a custom harness's
-    extra fields don't serialize — records round-trip without importing the harness."""
+    harness: AgentConfig | None = None
+    """The agent's resolved config — the driving harness's id and its flat knobs.
+    Typed as the base config, so a custom harness's extra fields don't serialize —
+    records round-trip without importing the harness."""
     name: str = "agent"
     """The env agent that produced this trace — the config field name (`solver`,
     `judge`); the default outside an env and for `SingleAgentEnv`'s sole agent.

--- a/verifiers/v1/utils/compile.py
+++ b/verifiers/v1/utils/compile.py
@@ -91,22 +91,22 @@ def validate_pairing(
     live servers alike mean MCP is in play."""
     if not harness.SUPPORTS_MCP and (task_cls.tools or shared_tools):
         raise ValueError(
-            f"Harness {harness.config.id!r} does not support MCP tools, but "
+            f"Harness {harness.config.harness!r} does not support MCP tools, but "
             f"{task_cls.__name__} exposes tool servers (MCP). Run it with a harness that "
-            f"supports MCP (e.g. --env.agent.harness.id bash), or use tasks without tools."
+            f"supports MCP (e.g. --env.agent.harness bash), or use tasks without tools."
         )
     if not harness.SUPPORTS_USER_SIM and task_cls.user is not None:
         raise ValueError(
-            f"Harness {harness.config.id!r} does not drive a user simulator, but "
+            f"Harness {harness.config.harness!r} does not drive a user simulator, but "
             f"{task_cls.__name__} defines one (Task.user). Run it with a harness that "
-            f"supports user simulation (e.g. --env.agent.harness.id bash), or use tasks "
+            f"supports user simulation (e.g. --env.agent.harness bash), or use tasks "
             "without one."
         )
     if task_cls.NEEDS_CONTAINER and isinstance(runtime_config, SubprocessConfig):
         raise ValueError(
             f"{task_cls.__name__} needs a container runtime (NEEDS_CONTAINER), but "
             "this run resolves to the subprocess runtime; use "
-            "--env.<agent>.harness.runtime.type docker or prime."
+            "--env.<agent>.runtime.type docker or prime."
         )
 
 


### PR DESCRIPTION
## Summary

- `HarnessConfig` is dissolved into `AgentConfig`: the seat's config *is* the harness's config. `AgentConfig` (moved to `harness.py`) carries the harness id as a flat `harness: ID | None` field (`None` = the taskset's default) plus the program knobs (`runtime`, `env`, `forward_env`, `disabled_tools`) alongside the existing model-context pins and per-run caps.
- A harness declares its extra knobs by subclassing `AgentConfig` (`class RLMHarnessConfig(vf.AgentConfig)`); the seat narrows to that subclass by its `harness` id, so harness fields address flat: `--env.agent.harness rlm --env.agent.runtime.type docker --env.agent.version main`.
- Narrowing happens at `EnvConfig` role validation (`narrow_agent_field`, keeping `harness=None` observable for unpinned seats) and at `Agent` construction (`resolve_agent_config`, which also stamps the resolved default). The old nested shape (`[env.agent.harness]` / `--env.agent.harness.id`) errors with a pointer to the flat surface.
- Env-config dumps that cross a boundary (env-server wire, saved `config.toml`, `resolve_env_config` round-trip) pass `serialize_as_any=True` so a narrowed seat's harness fields survive base-annotated role fields.
- `AgentInfo.harness` on the trace now records the resolved (base-typed) `AgentConfig`; `TRACE_VERSION` bumped to 3.
- All builtin harnesses, the bundled `compact` environment, the `agentic-judge` env, `configs/*.toml`, docs, skills references, scaffolds, and tests updated to the flat shape.

## Breaking

- `vf.HarnessConfig` is removed — custom harness configs subclass `vf.AgentConfig` instead, and read the harness id from `self.config.harness` (was `self.config.id`).
- Config surface: `--env.<role>.harness.id <id>` → `--env.<role>.harness <id>`; every other harness field moves up one level (`--env.<role>.harness.runtime.*` → `--env.<role>.runtime.*`, same for `env`, `forward_env`, `disabled_tools`, and harness-specific knobs). TOML: `[env.agent.harness]` blocks become flat keys on `[env.agent]`. The old nested shape fails validation with a migration pointer.
- `vf.default_agent_harness` is removed (use `loaders.default_harness_id` + `agent.resolve_agent_config`); `EnvConfig.agent_harnesses()` now returns resolved `AgentConfig`s.
- Trace records: `agent.harness` now serializes the flat agent config (`{"harness": "rlm", "runtime": ..., ...}` instead of `{"id": "rlm", ...}`); `TRACE_VERSION` is 3.

## Verification

- `uv run eval @ configs/<each>.toml --dry-run` passes for all 9 configs (flat shape validates, harness-specific fields narrow, e.g. `RLMHarnessConfig.version`).
- Round-trip check: `EnvConfig.model_dump(serialize_as_any=True)` → `resolve_env_config` preserves harness-specific fields; nested `[env.agent.harness]` input errors with the migration pointer.
- `uv run pytest tests/v1 -k "not docker and not prime and not modal"`: passes except two pre-existing macOS-only failures (rlm/kimi-code harness installs hard-code `flock`, unavailable on macOS) and `test_env_id_agentic_judge` (needs docker, absent on this machine) — all unrelated to this change.
- `uv run ruff check .` and `uv run pre-commit run --all-files` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking config and trace schema changes affect every eval/GEPA TOML, CLI flag path, and downstream trace consumers; runtime behavior is largely unchanged once configs are migrated.
> 
> **Overview**
> **Harness configuration is flattened onto each agent seat.** `HarnessConfig` is removed: `AgentConfig` (now in `harness.py`) holds `harness` as an id string plus runtime/env/tool caps and model pins on one object. Custom harnesses subclass `AgentConfig` and read `self.config.harness` instead of `self.config.id`.
> 
> **Config surface changes:** TOML/CLI move from `[env.agent.harness]` / `--env.agent.harness.id` to flat `[env.agent]` with `harness = "..."` and `--env.<role>.runtime.*` (and harness-specific knobs as `--env.<role>.<knob>`). Nested harness dicts fail validation with a migration error. `EnvConfig` narrows each role via `narrow_agent_field`; `resolve_agent_config` stamps defaults at `Agent` construction.
> 
> **Serialization:** Env dumps and saved `config.toml` use `serialize_as_any=True` so narrowed harness fields survive wire round-trips. Trace `agent.harness` records the flat `AgentConfig`; **`TRACE_VERSION` is 3**. Public exports drop `HarnessConfig` and `default_agent_harness`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 614bbcc236df9067264ea40c33a489cf919f112a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Flatten harness config onto agent seat config, replacing nested `[env.agent.harness]` blocks
> - Merges `HarnessConfig` into `AgentConfig` so the harness id is set as a flat string field (`harness = "bash"`) directly on the seat, replacing the old nested `[env.agent.harness] id = "bash"` TOML structure.
> - All harness-specific config classes (bash, null, rlm, etc.) now subclass `AgentConfig` instead of `HarnessConfig`; `HarnessConfig` and `default_agent_harness` are removed from the public API.
> - Seat configs are narrowed to the correct harness-specific subclass at config-parse time via a new `resolve_agent_config` helper and `_resolve_roles` validator, replacing per-episode resolution.
> - `serialize_as_any=True` is added to config serialization paths so specialized agent fields are preserved in saved TOML, dry-run output, and wire payloads.
> - Trace version is bumped to 3; `AgentInfo.harness` now holds a full `AgentConfig` instead of a `HarnessConfig`.
> - Risk: breaking change to all TOML configs, CLI flags (`--env.agent.harness` replaces `--env.agent.harness.id`), and any code importing `HarnessConfig` or `default_agent_harness` from `verifiers.v1`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 614bbcc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->