### PR TITLE
fix: sync docs to public-docs on release tags only

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -2,10 +2,10 @@ name: Sync Docs to Public Docs
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - 'docs/**'
+    tags:
+      # Sync docs on stable releases only, not on every commit to main.
+      - 'v*'
+      - '!v*dev*'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- Change the `Sync Docs to Public Docs` workflow to trigger on stable `v*` tag pushes instead of every commit to `main` that touches `docs/`, so the public docs only update on releases.
- Exclude `v*dev*` tags so dev pre-release tags never trigger a sync.
- Keep `workflow_dispatch` for manual syncs.

On a tag push `github.sha` resolves to the tagged commit, so the `ref` sent to public-docs remains correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI trigger-only change with no runtime, auth, or application code impact; public docs may update less frequently until a release tag is pushed.
> 
> **Overview**
> **Public docs sync no longer runs on every `main` push that touches `docs/`.** The `Sync Docs to Public Docs` workflow now runs on **tag pushes** matching stable `v*` releases, with **`v*dev*` tags excluded** so dev pre-releases do not publish.
> 
> **Manual syncs are unchanged** via `workflow_dispatch`. The dispatch step still sends `github.sha` as `ref`, which on a tag push is the tagged commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f896b0ad9b71e228e904bc75d8113fd005713a1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Trigger docs sync workflow on stable release tags only
> Updates [sync-docs.yml](.github/workflows/sync-docs.yml) to fire on tag pushes matching `v*` (excluding `v*dev*`) instead of pushes to `main` that modify `docs/**`. This ensures docs are only synced to public-docs on stable releases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f896b0a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->