### PR TITLE
feat: prime host-level allow/block egress lists

### DIFF
--- a/docs/v1/evaluation.md
+++ b/docs/v1/evaluation.md
@@ -72,9 +72,31 @@ Setting `skills` on a harness without native skill support fails up front.
 
 ## Runtime network policies
 
-Prime and Modal expose provider-native `network_access` switches. Docker instead uses
-URL-level `allow` and `block` lists, with a trusted setup phase before enforcement; the
-same policy vocabulary can extend to other runtimes when their sandbox APIs support it.
+Modal exposes a provider-native `network_access` switch. Prime takes host-level `allow`
+and `block` lists enforced by the platform; Docker uses URL-level `allow` and `block`
+lists enforced by a host-side proxy. Both keep a trusted setup phase online before
+enforcement.
+
+### Prime host policies
+
+Prime VM sandboxes (`vm = true`) take at most one of `allow` (egress allowlist) or
+`block` (egress denylist):
+
+```toml
+[env.agent.harness.runtime]
+type = "prime"
+vm = true
+allow = ["*.wikipedia.org", "1.1.1.1"]
+```
+
+Entries are exact hostnames, leftmost-label `*.` wildcards, IPv4 addresses, or IPv4
+CIDRs — no schemes, ports, or paths. Setup runs with open networking; the policy is
+applied right before the agent starts, with the framework routes the agent needs
+(interception tunnel, MCP URLs) added to an allowlist automatically — so `allow = []`
+permits only those, and leaving both unset keeps egress unrestricted. Enforcement is
+host-level at the platform (no CONNECT/SNI inspection), it only governs new connections
+(established flows are not revoked), and a `block` entry naming a framework route's host
+does cut the agent off from it.
 
 ### Docker URL policies
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "openai>=2.9.0",
     "openai-agents>=0.8.2",
     "prime-tunnel>=0.1.8",
-    "prime-sandboxes>=0.2.31",
+    "prime-sandboxes>=0.2.33",
     "pydantic>=2.12.3",
     "requests",
     "rich>=11.0.0",

--- a/skills/evaluate-environments/references/REFERENCE.md
+++ b/skills/evaluate-environments/references/REFERENCE.md
@@ -353,15 +353,16 @@ Remote Prime sandbox; reached via native port exposure.
 | --- | --- | --- | --- |
 | `image` | `str` | `"python:3.11-slim"` | Container image. |
 | `workdir` | `str` | `"/app"` | Working directory. |
-| `network_access` | `bool` | `True` | Allow outbound network from the sandbox. |
+| `allow` | `list[str] \| None` | `None` | Host-level egress allowlist (exact hostnames, `*.` wildcards, IPv4 addresses/CIDRs — no schemes or ports), enforced after trusted setup, right before the agent starts. Framework routes (interception, MCP) are added automatically, so `[]` permits only those; `None` leaves egress unrestricted. VM-only; mutually exclusive with `block`. |
+| `block` | `list[str] \| None` | `None` | Host-level egress denylist (same entry syntax), enforced after trusted setup. `None` (or `[]`) denies nothing. VM-only; mutually exclusive with `allow`. |
 | `vm` | `bool` | `False` | Run as a micro-VM (kernel features / stronger isolation). |
 | `guaranteed` | `bool` | `False` | Request guaranteed (vs best-effort) capacity. |
 | `region` | `str \| None` | `None` | Region to provision in (None = provider-chosen). Note: port exposure is region-gated; `us` supports it. |
 | `labels` | `list[str]` | `[]` | Labels attached to the sandbox. |
-| `cpu` | `float` | `1.0` | CPU cores. |
-| `memory` | `float` | `2.0` | Memory in GB. |
+| `cpu` | `float \| None` | `None` | CPU cores (None = SDK default). |
+| `memory` | `float \| None` | `None` | Memory in GB (None = SDK default). |
 | `gpu` | `str \| None` | `None` | GPU spec, e.g. `"A100"` or `"A100:2"` (bare count = provider-chosen type). |
-| `disk` | `float` | `5.0` | Disk in GB. |
+| `disk` | `float \| None` | `None` | Disk in GB (None = SDK default). |
 | `idle_timeout` | `float \| None` | `3600` | Seconds of inactivity before the sandbox is deleted; `None` disables it. |
 | `creates_per_min` | `int \| None` | `None` | Pace sandbox creation to this many per minute, host-wide across every env-server worker (None/≤0 disables). Tunnel creation is limited separately and globally. |
 

--- a/uv.lock
+++ b/uv.lock
@@ -681,9 +681,9 @@ name = "claude-agent-sdk"
 version = "0.2.116"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "mcp" },
-    { name = "sniffio" },
+    { name = "anyio", marker = "python_full_version >= '3.12'" },
+    { name = "mcp", marker = "python_full_version >= '3.12'" },
+    { name = "sniffio", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/b0f01a18bb119e595cc1e66d4adbe39bb09879a570e54793c222a142b662/claude_agent_sdk-0.2.116.tar.gz", hash = "sha256:37d6c9d98960c7ea41d1a7fd3331ad0b1bef68e559ed9cc5ccf9d00ae68adfcd", size = 268648, upload-time = "2026-07-11T01:04:47.192Z" }
 wheels = [
@@ -1003,7 +1003,7 @@ name = "deprecation"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
 wheels = [
@@ -1024,7 +1024,7 @@ name = "dirhash"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "scantree" },
+    { name = "scantree", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/70/49f93897f3a4f7ab5f20a854ebc91aad47854e9fb2cd169e3a4452fa3f5e/dirhash-0.5.0.tar.gz", hash = "sha256:e60760f0ab2e935d8cb088923ea2c6492398dca42cec785df778985fd4cd5386", size = 21377, upload-time = "2024-08-03T22:14:13.322Z" }
 wheels = [
@@ -1573,26 +1573,26 @@ name = "harbor"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "claude-agent-sdk" },
-    { name = "datasets" },
-    { name = "dirhash" },
-    { name = "fastapi" },
-    { name = "httpx" },
-    { name = "jinja2" },
-    { name = "litellm" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "rich" },
-    { name = "shortuuid" },
-    { name = "supabase" },
-    { name = "tenacity" },
-    { name = "toml" },
-    { name = "typer" },
-    { name = "uvicorn" },
+    { name = "claude-agent-sdk", marker = "python_full_version >= '3.12'" },
+    { name = "datasets", marker = "python_full_version >= '3.12'" },
+    { name = "dirhash", marker = "python_full_version >= '3.12'" },
+    { name = "fastapi", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", marker = "python_full_version >= '3.12'" },
+    { name = "jinja2", marker = "python_full_version >= '3.12'" },
+    { name = "litellm", marker = "python_full_version >= '3.12'" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
+    { name = "pathspec", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.12'" },
+    { name = "requests", marker = "python_full_version >= '3.12'" },
+    { name = "rich", marker = "python_full_version >= '3.12'" },
+    { name = "shortuuid", marker = "python_full_version >= '3.12'" },
+    { name = "supabase", marker = "python_full_version >= '3.12'" },
+    { name = "tenacity", marker = "python_full_version >= '3.12'" },
+    { name = "toml", marker = "python_full_version >= '3.12'" },
+    { name = "typer", marker = "python_full_version >= '3.12'" },
+    { name = "uvicorn", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/f3/cba38a11b0cca01ecd471437869f1cd57d86a3b1e4091b8fd3d112cba8af/harbor-0.14.0.tar.gz", hash = "sha256:0ffffc25a618e4b7bf2b901a8c717c8bc28877f5aa8c37be47f1ec8c301cb0b6", size = 1241271, upload-time = "2026-06-17T16:43:23.495Z" }
 wheels = [
@@ -1704,7 +1704,7 @@ wheels = [
 
 [package.optional-dependencies]
 http2 = [
-    { name = "h2" },
+    { name = "h2", marker = "python_full_version >= '3.12'" },
 ]
 
 [[package]]
@@ -2124,18 +2124,18 @@ name = "litellm"
 version = "1.91.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp" },
-    { name = "click" },
-    { name = "fastuuid" },
-    { name = "httpx" },
-    { name = "importlib-metadata" },
-    { name = "jinja2" },
-    { name = "jsonschema" },
-    { name = "openai" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "tiktoken" },
-    { name = "tokenizers" },
+    { name = "aiohttp", marker = "python_full_version >= '3.12'" },
+    { name = "click", marker = "python_full_version >= '3.12'" },
+    { name = "fastuuid", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", marker = "python_full_version >= '3.12'" },
+    { name = "importlib-metadata", marker = "python_full_version >= '3.12'" },
+    { name = "jinja2", marker = "python_full_version >= '3.12'" },
+    { name = "jsonschema", marker = "python_full_version >= '3.12'" },
+    { name = "openai", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
+    { name = "tiktoken", marker = "python_full_version >= '3.12'" },
+    { name = "tokenizers", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6b/5d/2dfda0e057511ba24904c5c9af720512b1fc86893821947fa52f4cc0231b/litellm-1.91.2.tar.gz", hash = "sha256:e9aa292b95f25fa9d127e47a6e7266a2a99f7a1645f41100a411d7a8a77a6a46", size = 14872927, upload-time = "2026-07-11T06:04:18.847Z" }
 wheels = [
@@ -3139,10 +3139,10 @@ name = "postgrest"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "deprecation" },
-    { name = "httpx", extra = ["http2"] },
-    { name = "pydantic" },
-    { name = "yarl" },
+    { name = "deprecation", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", extra = ["http2"], marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "yarl", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e2/22/88c470d8838d2678a44e0172d061630b8837cba3fb7fb492e28f6578c309/postgrest-2.31.0.tar.gz", hash = "sha256:2f395d84b2ee34fc57622ff2f711df603e2ede625f98e5015240741888f7bd0c", size = 14419, upload-time = "2026-06-04T13:37:20.474Z" }
 wheels = [
@@ -3184,7 +3184,7 @@ toml = [
 
 [[package]]
 name = "prime-sandboxes"
-version = "0.2.32"
+version = "0.2.33"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -3194,9 +3194,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "tenacity" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/fd/f57ad87b273ae1696ca620deaac2c56e28a54905d2d2791a5b9a387f443c/prime_sandboxes-0.2.32.tar.gz", hash = "sha256:ea3d6230cdfb5af2e4542814996257bad60fc9913f15f776a65ca1ef05f4f504", size = 77656, upload-time = "2026-07-17T17:41:02.296Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/a9/880685cefd503aa92d2b49da46b60ba807015f8839c344a83d8c5bc02f30/prime_sandboxes-0.2.33.tar.gz", hash = "sha256:4253a3c345ccf6c07b41a81790f8515763333f094d20bc405a257432461e81d8", size = 81228, upload-time = "2026-07-22T23:23:55.715Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/a3/c345509abf8f7707c0c3e9d6badba2e057781d1c05a88a46733ab67521e5/prime_sandboxes-0.2.32-py3-none-any.whl", hash = "sha256:4fe730622e51c489f8f86e7ad959fd8320db6d7a9fe22442ae3c680687da4c22", size = 40897, upload-time = "2026-07-17T17:41:00.935Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/1b/10b1044b8aaef561c32a34140f4a13c7310f73f92f9546337e2e8e6a5239/prime_sandboxes-0.2.33-py3-none-any.whl", hash = "sha256:92c9647557e76191ba926ac8ed01708de9ec4450142131b673cd5cf8d9d7ea56", size = 42773, upload-time = "2026-07-22T23:23:54.381Z" },
 ]
 
 [[package]]
@@ -3931,9 +3931,9 @@ name = "realtime"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic" },
-    { name = "typing-extensions" },
-    { name = "websockets" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+    { name = "websockets", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/34/54a1eaaefa24db5cb12596fd74792e08efa53ed30dc5bce2c0a68ded6146/realtime-2.31.0.tar.gz", hash = "sha256:9e641cb4d77ca0fe768515f8cf9f83550c79f49ce1550a95afc2dc0e252be8c9", size = 18716, upload-time = "2026-06-04T13:37:22.089Z" }
 wheels = [
@@ -4263,8 +4263,8 @@ name = "scantree"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
-    { name = "pathspec" },
+    { name = "attrs", marker = "python_full_version >= '3.12'" },
+    { name = "pathspec", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/e4/40998faefc72ba1ddeb640a44fba92935353525dba110488806da8339c0b/scantree-0.0.4.tar.gz", hash = "sha256:15bd5cb24483b04db2c70653604e8ea3522e98087db7e38ab8482f053984c0ac", size = 24643, upload-time = "2024-08-03T20:08:59.413Z" }
 wheels = [
@@ -4287,8 +4287,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -4442,10 +4442,10 @@ name = "storage3"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "deprecation" },
-    { name = "httpx", extra = ["http2"] },
-    { name = "pydantic" },
-    { name = "yarl" },
+    { name = "deprecation", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", extra = ["http2"], marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "yarl", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/13/30/fee43d523d3f680a833a4aae5bf8094de0b9031b0c2bddb3e0bc6e829e1b/storage3-2.31.0.tar.gz", hash = "sha256:d2161e2ea650dc115a1787c30e09b118365589ac772f4dd8643e3a503ecfc667", size = 20348, upload-time = "2026-06-04T13:37:23.703Z" }
 wheels = [
@@ -4466,13 +4466,13 @@ name = "supabase"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
-    { name = "postgrest" },
-    { name = "realtime" },
-    { name = "storage3" },
-    { name = "supabase-auth" },
-    { name = "supabase-functions" },
-    { name = "yarl" },
+    { name = "httpx", marker = "python_full_version >= '3.12'" },
+    { name = "postgrest", marker = "python_full_version >= '3.12'" },
+    { name = "realtime", marker = "python_full_version >= '3.12'" },
+    { name = "storage3", marker = "python_full_version >= '3.12'" },
+    { name = "supabase-auth", marker = "python_full_version >= '3.12'" },
+    { name = "supabase-functions", marker = "python_full_version >= '3.12'" },
+    { name = "yarl", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fe/8e/54a2f950629689b1613434a61fc3bff5f92f84ba6b20213f5b2add05c1bb/supabase-2.31.0.tar.gz", hash = "sha256:3467b09d00482b9a0138235bdbde7a350426f93cf2a1342372eaddfc669f1206", size = 9805, upload-time = "2026-06-04T13:37:25.22Z" }
 wheels = [
@@ -4484,9 +4484,9 @@ name = "supabase-auth"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx", extra = ["http2"] },
-    { name = "pydantic" },
-    { name = "pyjwt", extra = ["crypto"] },
+    { name = "httpx", extra = ["http2"], marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "pyjwt", extra = ["crypto"], marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/8a/408689cf39820f0d46d2731d6747ff94dbefc87ae977b4b5c4066da5b070/supabase_auth-2.31.0.tar.gz", hash = "sha256:0945b33fa96239c76dc8eaf96d7d2c94991950d24b4cfe4a5c2da9aa5e909663", size = 39151, upload-time = "2026-06-04T13:37:27.375Z" }
 wheels = [
@@ -4498,9 +4498,9 @@ name = "supabase-functions"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx", extra = ["http2"] },
-    { name = "strenum" },
-    { name = "yarl" },
+    { name = "httpx", extra = ["http2"], marker = "python_full_version >= '3.12'" },
+    { name = "strenum", marker = "python_full_version >= '3.12'" },
+    { name = "yarl", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/5d/61c2446ed26a57fa5543f9c270a731320911569202340d15341f72cdba7c/supabase_functions-2.31.0.tar.gz", hash = "sha256:4ad027b3ae3bd28b31233339f4db1da6965affd3546f655b421baf40cee2690f", size = 4683, upload-time = "2026-06-04T13:37:28.878Z" }
 wheels = [
@@ -4995,7 +4995,7 @@ requires-dist = [
     { name = "openai-agents", specifier = ">=0.8.2" },
     { name = "openenv", marker = "extra == 'openenv'", specifier = ">=0.4.1" },
     { name = "prime-pydantic-config", extras = ["toml"], specifier = ">=0.4.2" },
-    { name = "prime-sandboxes", specifier = ">=0.2.31" },
+    { name = "prime-sandboxes", specifier = ">=0.2.33" },
     { name = "prime-tunnel", specifier = ">=0.1.8" },
     { name = "pydantic", specifier = ">=2.12.3" },
     { name = "python-dotenv", marker = "extra == 'browser'", specifier = ">=1.0.0" },

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -14,6 +14,7 @@ import shlex
 import tempfile
 from pathlib import Path, PurePosixPath
 from typing import ClassVar, Literal
+from urllib.parse import urlsplit
 
 from pydantic import model_validator
 from pydantic_config import BaseConfig
@@ -42,7 +43,16 @@ class PrimeConfig(BaseConfig):
     ~10 minutes) and caches the result, so later sandboxes on the same ref start in
     seconds."""
     workdir: str = "/app"
-    network_access: bool = True
+    allow: list[str] | None = None
+    """Host-level egress allowlist (exact hostnames, `*.` wildcards, IPv4 addresses/CIDRs
+    — no schemes or ports), enforced after trusted setup, right before the agent starts.
+    Framework routes (interception, MCP) are added automatically, so an empty list allows
+    only those; None leaves egress unrestricted. VM-only, mutually exclusive with
+    `block`."""
+    block: list[str] | None = None
+    """Host-level egress denylist (same entry syntax as `allow`), enforced after trusted
+    setup. None (or an empty list) denies nothing. VM-only, mutually exclusive with
+    `allow`."""
     vm: bool = False
     """Run as a micro-VM rather than a container (kernel features / stronger isolation)."""
     guaranteed: bool = False
@@ -52,20 +62,35 @@ class PrimeConfig(BaseConfig):
     labels: list[str] = []
     """Labels attached to the sandbox."""
     # TaskData.resources uses these units; non-default runtime config values take precedence.
-    cpu: float = 1.0
-    """CPU cores."""
-    memory: float = 2.0
-    """Memory in GB."""
+    cpu: float | None = None
+    """CPU cores. None = SDK default."""
+    memory: float | None = None
+    """Memory in GB. None = SDK default."""
     gpu: str | None = None
     """GPU spec, e.g. "A100" or "A100:2" (a bare count = provider-chosen type)."""
-    disk: float = 5.0
-    """Disk in GB."""
+    disk: float | None = None
+    """Disk in GB. None = SDK default."""
     idle_timeout: float | None = 3600
     """Seconds of inactivity before the sandbox self-deletes (None disables)."""
     creates_per_min: int | None = None
     """Pace sandbox creation to this many per minute, enforced host-wide across every
     env-server worker process (None/<= 0 disables it). (Tunnel creation is limited separately
     and globally — see interception.tunnel.prime.TUNNEL_LIMITER.)"""
+
+    @model_validator(mode="after")
+    def _validate_egress(self) -> "PrimeConfig":
+        # Mirror the SDK's egress contract here so a bad policy fails at config parse
+        # instead of on every rollout.
+        if self.allow is None and self.block is None:
+            return self
+        if not self.vm:
+            raise ValueError(
+                "allow/block egress lists are only supported for VM sandboxes (vm=true)"
+            )
+        from prime_sandboxes.models import validate_egress_lists
+
+        validate_egress_lists(self.allow, self.block)
+        return self
 
     @model_validator(mode="after")
     def _validate_idle_timeout(self) -> "PrimeConfig":
@@ -111,6 +136,9 @@ class PrimeRuntime(Runtime):
             if self.config.idle_timeout is not None and not self.config.vm
             else None
         )
+        # None values are dropped below, deferring to the SDK's defaults. The egress
+        # policy (`allow`/`block`) is NOT set at create — setup runs with open
+        # networking and `prepare_execution` applies the policy before the agent starts.
         options = {
             "cpu_cores": self.config.cpu,
             "memory_gb": self.config.memory,
@@ -133,7 +161,6 @@ class PrimeRuntime(Runtime):
                         name=self.name,
                         labels=self.config.labels,
                         docker_image=self.config.image,
-                        network_access=self.config.network_access,
                         vm=self.config.vm,
                         guaranteed=self.config.guaranteed,
                         **{k: v for k, v in options.items() if v is not None},
@@ -164,6 +191,50 @@ class PrimeRuntime(Runtime):
             Exception
         ) as e:  # provisioning failure is one rollout's problem, not the eval's
             raise SandboxError(f"prime sandbox provisioning failed: {e}") from e
+
+    async def prepare_execution(self, routes: list[str]) -> None:
+        # Apply the configured egress policy now that trusted setup is done, keeping the
+        # framework `routes` (interception, MCP) reachable: their hosts are prepended to
+        # an allowlist. `set_network` is a full replacement; new connections follow it
+        # only once `applied` (egress stays open until then, and established flows are
+        # never revoked), so the agent must not start before the data plane acks.
+        if self.config.allow is None and self.config.block is None:
+            return
+        try:
+            if self.config.allow is not None:
+                hosts = [h for h in (urlsplit(r).hostname for r in routes) if h]
+                entries = list(dict.fromkeys([*hosts, *self.config.allow]))
+                status = await self._client.set_network(
+                    self.info.id, **({"allow": entries} if entries else {"deny": ["*"]})
+                )
+            elif not self.config.block:  # an empty denylist denies nothing
+                return
+            else:
+                status = await self._client.set_network(
+                    self.info.id, deny=list(self.config.block)
+                )
+            try:
+                async with asyncio.timeout(60):
+                    delay = 0.1
+                    while not status.applied:
+                        await asyncio.sleep(delay)
+                        delay = min(delay * 2, 3)
+                        status = await self._client.get_network(self.info.id)
+            except TimeoutError as e:
+                raise SandboxError(
+                    f"egress policy accepted but not applied within 60s on sandbox "
+                    f"{self.info.id} (the agent must not start unrestricted)"
+                ) from e
+        except SandboxError:
+            raise
+        except Exception as e:
+            raise SandboxError(f"prime egress policy failed: {e}") from e
+        logger.info(
+            "prime: egress policy applied on sandbox %s (allow=%s block=%s)",
+            self.info.id,
+            self.config.allow,
+            self.config.block,
+        )
 
     async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
         try:


### PR DESCRIPTION
## Summary

- Bump `prime-sandboxes` to `>=0.2.33` and adopt its new egress-policy surface: `PrimeConfig` takes host-level `allow` / `block` lists (exact hostnames, leftmost-label `*.` wildcards, IPv4 addresses/CIDRs) instead of the removed `network_access` switch. VM-only and mutually exclusive, validated at config parse by mirroring the SDK contract (`validate_egress_lists`).
- The policy is applied through an update request (`set_network`) in `prepare_execution` — after trusted setup, right before the agent starts — matching Docker's trusted-setup-then-restrict shape. Framework routes (interception endpoint, MCP URLs) are auto-allowlisted, so `allow = []` permits only those. Since `set_network` only governs new connections once the data plane acks (`applied`), the rollout polls for that and fails closed with a `SandboxError` after 60s rather than starting the agent unrestricted.
- `cpu` / `memory` / `disk` now default to `None` and are only sent when set, deferring to the sandbox SDK defaults (task-declared `TaskData.resources` still apply on top of unset values via `resolve_runtime_config`).
- Docs: `docs/v1/evaluation.md` gains a "Prime host policies" section; the prime table in `skills/evaluate-environments/references/REFERENCE.md` is updated.

## Breaking

- `PrimeConfig.network_access` is removed (the field no longer exists in the SDK's `CreateSandboxRequest`). Migration: `network_access = false` → `vm = true` + `allow = []` (blocks all agent-phase egress except framework routes); `network_access = true` is the default (leave `allow`/`block` unset).
- `PrimeConfig.cpu` / `memory` / `disk` defaults change from `1.0` / `2.0` / `5.0` to `None` (unset → SDK defaults, currently the same values). Pin them explicitly to keep provisioning independent of SDK defaults.

## Verification

Dummy agent rollouts (bash harness in a prime VM sandbox, agent instructed to probe `example.com` and `google.com` and report reachability, reward = report matches the scenario's expected reachability):

| Scenario | Runtime config | Result |
| --- | --- | --- |
| open | no lists | reward 1.0 — both hosts reachable, agent completed |
| partial allow | `allow = ["example.com"]` | fails closed: `SandboxError` (policy accepted, never `applied`) |
| blocked | `allow = []` | fails closed: `SandboxError` (policy accepted, never `applied`) |
| deny one | `block = ["example.com"]` | fails closed: `SandboxError` (policy accepted, never `applied`) |

The fail-closed results are a **platform-side gap, not an integration bug**: direct SDK probes (no verifiers involved) show the egress-policy data plane never converges right now — `applied_generation` stays `-1` for 6+ minutes in both the provider-default and `us` regions, on both paths:

- create-time `network_allowlist=["example.com"]` → all egress blocked (even the allowlisted host), `applied=False` forever;
- `set_network` on a running VM → policy accepted (`generation=1`) but egress stays fully open, `applied=False` forever.

Given `set_network` is fail-open until `applied`, the 60s ack-wait in `prepare_execution` is what keeps these rollouts from silently running unrestricted. Once the platform's policy agent ships, the same rollouts should go green with no changes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sandbox networking and rollout gating (fail-closed on policy apply); breaking config surface for Prime, though behavior aligns with Docker’s post-setup restriction model.
> 
> **Overview**
> **Prime VM egress** replaces the removed `network_access` flag with optional host-level **`allow`** / **`block`** lists (validated at config parse, VM-only, mutually exclusive). Sandboxes still provision with open networking; **`prepare_execution`** calls `set_network`, auto-prepends interception/MCP route hosts to an allowlist, and **polls up to 60s** for `applied` before the agent runs—otherwise it raises **`SandboxError`** instead of starting unrestricted.
> 
> **Provisioning** no longer sends `network_access` on create; **`cpu`**, **`memory`**, and **`disk`** default to **`None`** and are omitted so **`prime-sandboxes>=0.2.33`** SDK defaults apply.
> 
> **Docs** add a Prime host-policies section in `evaluation.md` and refresh the Prime table in the evaluate-environments reference.
> 
> **Breaking:** migrate `network_access=false` → `vm=true` + `allow=[]`; pin resource fields if you relied on the old fixed defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a013c391086d12c865e23e22e6c0112aae417c69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add host-level allow/block egress lists to Prime runtime
> - Replaces the `network_access: bool` field in `PrimeConfig` with `allow: list[str] | None` and `block: list[str] | None` fields that define host-level egress allow/deny lists, validated at config parse time via `prime_sandboxes.models.validate_egress_lists`.
> - Adds `PrimeRuntime.prepare_execution` which applies the egress policy after trusted setup and before the agent starts, automatically prepending framework route hostnames to allow lists and polling until the data plane acknowledges the policy (60s timeout).
> - An empty allow list results in denying all traffic except framework routes; allow and block are mutually exclusive and VM-only.
> - `cpu`, `memory`, and `disk` fields now accept `None` to defer to SDK defaults instead of fixed numeric defaults.
> - Risk: network policy is no longer applied at sandbox creation time; it is applied in `prepare_execution`, which is a behavioral change from the previous `network_access` approach.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a013c39.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->