### PR TITLE
feat(rlm): max_compactions harness config

### DIFF
--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -39,6 +39,11 @@ class RLMHarnessConfig(HarnessConfig):
     past this many tokens. An int is a fixed threshold; a `(lo, hi)` pair draws a per-group
     threshold (seeded by the task index, so a task's rollouts share one draw and tasks vary).
     `None` disables auto-compaction; ints must be positive."""
+    max_compactions: int | None = None
+    """Cap on auto-compactions (RLM_MAX_COMPACTIONS): once a branch has compacted this many
+    times it stops compacting and the context grows to the model's natural limit, restoring
+    the context-length stop that `summarize_at_tokens` otherwise removes. `None` = unlimited.
+    Requires an rlm `version` that understands RLM_MAX_COMPACTIONS."""
 
     @model_validator(mode="after")
     def validate_limits(self) -> "RLMHarnessConfig":
@@ -54,6 +59,10 @@ class RLMHarnessConfig(HarnessConfig):
         elif value is not None and value <= 0:
             raise ValueError(
                 "`summarize_at_tokens` must be positive, or None to disable."
+            )
+        if self.max_compactions is not None and self.max_compactions <= 0:
+            raise ValueError(
+                "`max_compactions` must be positive, or None for unlimited."
             )
         return self
 
@@ -123,6 +132,8 @@ class RLMHarness(Harness[RLMHarnessConfig]):
         }
         if system_prompt is not None:
             env["RLM_APPEND_TO_SYSTEM_PROMPT"] = system_prompt
+        if self.config.max_compactions is not None:
+            env["RLM_MAX_COMPACTIONS"] = str(self.config.max_compactions)
         if self.config.skills:
             env["RLM_SKILLS"] = ",".join(self.config.skills)
         if mcp_urls:


### PR DESCRIPTION
Plumbs a `max_compactions` field on `RLMHarnessConfig` through to the `RLM_MAX_COMPACTIONS` env var (companion to PrimeIntellect-ai/rlm-harness#117): once a branch has compacted that many times, auto-compaction disables and the context grows to the model's natural limit. `None` keeps unlimited compaction. Validated positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `max_compactions` config field to `RLMHarnessConfig`
> Adds an optional `max_compactions` integer field to [`RLMHarnessConfig`](https://github.com/PrimeIntellect-ai/verifiers/pull/2111/files#diff-3955da24b5fd88f62482297bbda7ba0936f633927f15576db27fed6e58f668ec). When set, the value is passed to the rlm subprocess as the `RLM_MAX_COMPACTIONS` environment variable. The `validate_limits` validator rejects non-positive values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c7a312.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->