### PR TITLE
fix(v1): prepare Docker runtime once

### DIFF
--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -241,7 +241,6 @@ class RolloutRun:
             if self._owns_runtime:
                 await runtime.start()
             await runtime.prepare_setup()
-            await runtime.prepare_setup()
             now = time.time()
             self.trace.timing.boot.end = now
             self.trace.timing.setup.start = now


### PR DESCRIPTION
## What

- remove the duplicate `runtime.prepare_setup()` call from `RolloutRun.open()`

## Why

PR #2049 left two consecutive setup calls in the merged tree. A filtered Docker
runtime treats setup as a single-rollout claim, so the first call succeeds and the
second immediately fails with:

`SandboxError: network-filtered Docker runtimes are single-rollout`

This caused the main Test workflow to fail across ordinary Docker rollout cases.

## Impact

Each rollout now prepares its runtime exactly once, restoring filtered Docker
startup without changing the runtime lifecycle or policy.

## Checks

- setup-only default filtered Docker probe: `opened=True errors=0`
- `UV_FROZEN=1 uv run pytest tests/ -q` (live-model e2e skipped without `PRIME_API_KEY`)
- `UV_FROZEN=1 uv run pre-commit run --all-files`
- pre-push Markdown, Ruff, formatting, and Ty hooks


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `RolloutRun.open` to call `runtime.prepare_setup()` only once
> Removes a duplicate consecutive call to `runtime.prepare_setup()` in [rollout.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2112/files#diff-f886b7f4717cf8fce9270bd4ff4790f3182aa1016abb9efb7f6e57efe18d1bf2), leaving a single invocation before setup timing is recorded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0105cdd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line removal of a mistaken duplicate call; restores intended single-rollout setup behavior with no new logic.
> 
> **Overview**
> **Fixes a duplicate setup claim in `RolloutRun.open()`** by dropping the second consecutive `await runtime.prepare_setup()` after `runtime.start()`.
> 
> Network-filtered Docker runtimes treat `prepare_setup()` as a **single-rollout** claim (`_setup_claimed`), so the extra call made the second invocation fail with `SandboxError: network-filtered Docker runtimes are single-rollout` and broke ordinary Docker rollout tests. Lifecycle is unchanged: one prepare before setup timing and task/harness setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0105cdd660f8f3daa285b6d8ae5ec9c0edc566af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->