### PR TITLE
fix(v1): keep standalone Docker tool test runtimes unrestricted

### DIFF
--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -62,6 +62,8 @@ def tool_runtime(request) -> dict:
     runtime) or its own runtime, by type."""
     if request.param == "colocated":
         return {"colocated": True}
+    if request.param == "docker":
+        return {"runtime": {"type": "docker", "allow": ["*"]}}
     return {"runtime": {"type": request.param}}
 
 


### PR DESCRIPTION
## Overview

Updates the v1 end-to-end tool-runtime fixture so standalone Docker tool servers explicitly opt into unrestricted networking. This keeps Docker tool placement coverage aligned with the runtime policy while leaving colocated and other runtime cases unchanged.

## Details

- Set `allow = ["*"]` for standalone Docker tool runtime fixtures.
- Preserve the existing configuration for colocated, subprocess, Prime, and Modal placements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test fixture-only change with no production runtime or security logic touched.
> 
> **Overview**
> The v1 e2e **`tool_runtime`** fixture now treats **`docker`** as its own branch: standalone Docker tool servers get **`allow: ["*"]`** on the runtime config instead of only `{"runtime": {"type": "docker"}}`.
> 
> Colocated placement and other runtime types (`subprocess`, Prime, Modal, etc.) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77775aaa93df834870d61d8ccafa4505911a617a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix standalone Docker tool test runtime to allow all tools
> The `tool_runtime` fixture in [conftest.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2113/files#diff-bc28790d38dc6e7e4f2c44639d40bc33dea724d6c73149abf7ba82b37d14f40b) now returns `{"runtime": {"type": "docker", "allow": ["*"]}}` when parametrized with `"docker"`, instead of omitting the `allow` field. This restores unrestricted tool access for Docker-based test runtimes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 77775aa.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->