### PR TITLE
Fix oversized evaluation sample uploads

### DIFF
--- a/verifiers/v1/push.py
+++ b/verifiers/v1/push.py
@@ -6,6 +6,7 @@ contract as `prime eval push`, done inline at the end of a run. Auth + base URL
 come from `$PRIME_API_KEY` / `~/.prime/config.json`.
 """
 
+import json
 import logging
 import os
 from dataclasses import dataclass
@@ -22,6 +23,8 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_API_URL = "https://api.primeintellect.ai"
 DEFAULT_FRONTEND_URL = "https://app.primeintellect.ai"
+# Repeated /samples posts append; match the Prime Evals client's request ceiling.
+_MAX_SAMPLES_PAYLOAD_BYTES = 25 * 1024 * 1024
 
 
 @dataclass
@@ -224,7 +227,32 @@ def push_traces(
                     **team,
                 },
             )["evaluation_id"]
-            post(f"/evaluations/{eval_id}/samples", {"samples": samples})
+            batch = []
+            payload_bytes = len(b'{"samples":[]}')
+            for i, sample in enumerate(samples):
+                sample_bytes = len(
+                    json.dumps(
+                        sample,
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                        allow_nan=False,
+                    ).encode("utf-8")
+                )
+                next_payload_bytes = payload_bytes + (1 if batch else 0) + sample_bytes
+                if batch and next_payload_bytes > _MAX_SAMPLES_PAYLOAD_BYTES:
+                    post(f"/evaluations/{eval_id}/samples", {"samples": batch})
+                    batch = []
+                    payload_bytes = len(b'{"samples":[]}')
+                    next_payload_bytes = payload_bytes + sample_bytes
+                if next_payload_bytes > _MAX_SAMPLES_PAYLOAD_BYTES:
+                    raise ValueError(
+                        f"sample {i} is too large to upload "
+                        f"({next_payload_bytes} > {_MAX_SAMPLES_PAYLOAD_BYTES} bytes)"
+                    )
+                batch.append(sample)
+                payload_bytes = next_payload_bytes
+            if batch or not samples:
+                post(f"/evaluations/{eval_id}/samples", {"samples": batch})
             post(f"/evaluations/{eval_id}/finalize", {"metrics": metrics})
     except Exception as e:
         logger.warning("--push: upload failed (%s: %s); skipping", type(e).__name__, e)

--- a/verifiers/v1/push.py
+++ b/verifiers/v1/push.py
@@ -203,6 +203,41 @@ def push_traces(
     # The run is done and its results saved; a network blip here must not crash it
     # — log and skip the upload instead.
     try:
+        batches: list[list[dict[str, Any]]] = []
+        batch: list[dict[str, Any]] = []
+        payload_bytes = len(b'{"samples":[]}')
+        skipped_samples = 0
+        for i, sample in enumerate(samples):
+            sample_bytes = len(
+                json.dumps(
+                    sample,
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                    allow_nan=False,
+                ).encode("utf-8")
+            )
+            sample_payload_bytes = len(b'{"samples":[]}') + sample_bytes
+            if sample_payload_bytes > _MAX_SAMPLES_PAYLOAD_BYTES:
+                logger.warning(
+                    "--push: sample %d is too large to upload (%d > %d bytes); "
+                    "skipping sample",
+                    i,
+                    sample_payload_bytes,
+                    _MAX_SAMPLES_PAYLOAD_BYTES,
+                )
+                skipped_samples += 1
+                continue
+            next_payload_bytes = payload_bytes + (1 if batch else 0) + sample_bytes
+            if batch and next_payload_bytes > _MAX_SAMPLES_PAYLOAD_BYTES:
+                batches.append(batch)
+                batch = []
+                payload_bytes = len(b'{"samples":[]}')
+                next_payload_bytes = payload_bytes + sample_bytes
+            batch.append(sample)
+            payload_bytes = next_payload_bytes
+        if batch or not samples:
+            batches.append(batch)
+
         with httpx.Client(headers=headers, timeout=300.0) as client:
 
             def post(path: str, body: dict) -> dict:
@@ -227,37 +262,25 @@ def push_traces(
                     **team,
                 },
             )["evaluation_id"]
-            batch = []
-            payload_bytes = len(b'{"samples":[]}')
-            for i, sample in enumerate(samples):
-                sample_bytes = len(
-                    json.dumps(
-                        sample,
-                        ensure_ascii=False,
-                        separators=(",", ":"),
-                        allow_nan=False,
-                    ).encode("utf-8")
+            for batch in batches:
+                body = json.dumps(
+                    {"samples": batch},
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                    allow_nan=False,
+                ).encode("utf-8")
+                resp = client.post(
+                    f"{api}/evaluations/{eval_id}/samples",
+                    content=body,
                 )
-                next_payload_bytes = payload_bytes + (1 if batch else 0) + sample_bytes
-                if batch and next_payload_bytes > _MAX_SAMPLES_PAYLOAD_BYTES:
-                    post(f"/evaluations/{eval_id}/samples", {"samples": batch})
-                    batch = []
-                    payload_bytes = len(b'{"samples":[]}')
-                    next_payload_bytes = payload_bytes + sample_bytes
-                if next_payload_bytes > _MAX_SAMPLES_PAYLOAD_BYTES:
-                    raise ValueError(
-                        f"sample {i} is too large to upload "
-                        f"({next_payload_bytes} > {_MAX_SAMPLES_PAYLOAD_BYTES} bytes)"
-                    )
-                batch.append(sample)
-                payload_bytes = next_payload_bytes
-            if batch or not samples:
-                post(f"/evaluations/{eval_id}/samples", {"samples": batch})
+                resp.raise_for_status()
             post(f"/evaluations/{eval_id}/finalize", {"metrics": metrics})
     except Exception as e:
         logger.warning("--push: upload failed (%s: %s); skipping", type(e).__name__, e)
         return finish(error=f"{type(e).__name__}: {e}")
 
     url = f"{frontend}/dashboard/evaluations/{eval_id}"
-    logger.info("--push: uploaded %d samples -> %s", len(samples), url)
+    logger.info(
+        "--push: uploaded %d samples -> %s", len(samples) - skipped_samples, url
+    )
     return finish(url=url)

--- a/verifiers/v1/push.py
+++ b/verifiers/v1/push.py
@@ -206,7 +206,6 @@ def push_traces(
         batches: list[list[dict[str, Any]]] = []
         batch: list[dict[str, Any]] = []
         payload_bytes = len(b'{"samples":[]}')
-        skipped_samples = 0
         for i, sample in enumerate(samples):
             sample_bytes = len(
                 json.dumps(
@@ -218,15 +217,11 @@ def push_traces(
             )
             sample_payload_bytes = len(b'{"samples":[]}') + sample_bytes
             if sample_payload_bytes > _MAX_SAMPLES_PAYLOAD_BYTES:
-                logger.warning(
-                    "--push: sample %d is too large to upload (%d > %d bytes); "
-                    "skipping sample",
-                    i,
-                    sample_payload_bytes,
-                    _MAX_SAMPLES_PAYLOAD_BYTES,
+                raise ValueError(
+                    f"sample {i} is too large to upload "
+                    f"({sample_payload_bytes} > "
+                    f"{_MAX_SAMPLES_PAYLOAD_BYTES} bytes)"
                 )
-                skipped_samples += 1
-                continue
             next_payload_bytes = payload_bytes + (1 if batch else 0) + sample_bytes
             if batch and next_payload_bytes > _MAX_SAMPLES_PAYLOAD_BYTES:
                 batches.append(batch)
@@ -280,7 +275,5 @@ def push_traces(
         return finish(error=f"{type(e).__name__}: {e}")
 
     url = f"{frontend}/dashboard/evaluations/{eval_id}"
-    logger.info(
-        "--push: uploaded %d samples -> %s", len(samples) - skipped_samples, url
-    )
+    logger.info("--push: uploaded %d samples -> %s", len(samples), url)
     return finish(url=url)


### PR DESCRIPTION
## Overview

Bound evaluation sample upload request sizes so complete large runs can be published reliably.

## Details

- Build sample batches using exact UTF-8 JSON payload sizes with a 25 MiB ceiling.
- Preserve the existing single-request behavior for small evaluations.
- Upload batches sequentially and finalize only after every batch succeeds.
- Reject individually oversized samples before creating an evaluation, preventing partial or inconsistent published runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the push upload path for all `--push` runs; partial batch failure or oversized single samples can leave evaluations incomplete on the platform while local runs still succeed.
> 
> **Overview**
> Large eval runs no longer send every sample in one `/evaluations/{id}/samples` request. **`push_traces`** now groups samples into batches whose UTF-8 JSON bodies stay under a **25 MiB** cap (aligned with the Prime Evals client), posts each batch in order (append semantics), and only calls **finalize** after all batches succeed.
> 
> Batch sizing uses compact `json.dumps` byte counts; uploads use explicit `content=` bodies instead of `json=`. A sample that alone exceeds the limit raises **`ValueError`**, which is caught like other upload failures so the run still completes locally without crashing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01dbaf298b397fc0454bebdc0fe9c960dc849518. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix oversized evaluation sample uploads by batching POST requests in `push_traces`
> - Samples are now split into batches capped at 25 MiB each before being posted to `/evaluations/{eval_id}/samples`, replacing a single unbounded POST.
> - Each sample's JSON size is computed before batching; if a single sample exceeds 25 MiB, a `ValueError` is raised and the upload is skipped with a logged warning.
> - Batches are serialized with `json.dumps` (minified, `allow_nan=False`) and sent as raw bytes via the existing HTTP client in [verifiers/v1/push.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2114/files#diff-c5f6c769d7b0eae44c38fc5ada1ba8094390535c93bd137ec41c5d0e014b133f).
> - Behavioral Change: evaluations with large payloads now produce multiple POST requests instead of one, and any single sample over 25 MiB causes the upload to be skipped rather than attempted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 01dbaf2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->