### PR TITLE
Support Prime sandbox egress policies

### DIFF
--- a/docs/v1/evaluation.md
+++ b/docs/v1/evaluation.md
@@ -72,9 +72,36 @@ Setting `skills` on a harness without native skill support fails up front.
 
 ## Runtime network policies
 
-Prime and Modal expose provider-native `network_access` switches. Docker instead uses
-URL-level `allow` and `block` lists, with a trusted setup phase before enforcement; the
-same policy vocabulary can extend to other runtimes when their sandbox APIs support it.
+Modal exposes a provider-native `network_access` switch. Prime and Docker use `allow`
+and `block` lists after a trusted setup phase; Prime enforces host-level rules in the
+platform, while Docker supports URL-level rules through a host-side proxy.
+
+### Prime host policies
+
+Prime VM sandboxes (`vm = true`) take either a host-level `allow` list or a `block`
+list:
+
+```toml
+[env.agent.harness.runtime]
+type = "prime"
+vm = true
+allow = ["*.wikipedia.org", "1.1.1.1"]
+```
+
+Entries are exact hostnames, leftmost-label `*.` wildcards, IPv4 addresses, or IPv4
+CIDRs; schemes, ports, paths, and IPv6 are not supported. The default `allow = ["*"]`
+keeps egress unrestricted. An empty `allow` list permits only the interception and MCP
+route hosts, which Verifiers adds automatically before enforcement.
+
+Setup stays online. Immediately before the agent starts, Verifiers replaces the
+sandbox's policy and waits up to 60 seconds for the platform to report it applied; the
+rollout fails closed if that acknowledgement never arrives. The provider policy governs
+new connections and does not revoke connections already established during trusted
+setup. Filtered Prime runtimes are therefore single-rollout.
+
+Prime's API accepts only one effective policy mode: a concrete `allow` list cannot be
+combined with `block`. A denylist cannot exempt framework hosts, so do not block an
+interception or MCP route host.
 
 ### Docker URL policies
 
@@ -88,11 +115,11 @@ allow = ["https://*.wikipedia.org"]
 block = ["https://upload.wikimedia.org"]
 ```
 
-Docker is deny-by-default: an empty `allow` list permits only the interception URL and
-every MCP URL, which are added automatically before user entries. A bare `"*"` with no
-block entries opts out of filtering and keeps Docker's host-network behavior; adding a
-block entry enables filtering and narrows the wildcard. User block rules win over user
-allow rules; framework interception and MCP routes always remain reachable. Under every
+Docker defaults to unrestricted with `allow = ["*"]` and no block entries. An empty
+`allow` list enables deny-by-default filtering and permits only the interception URL and
+every MCP URL, which are added automatically before user entries. Adding a block entry
+also enables filtering and narrows the wildcard. User block rules win over user allow
+rules; framework interception and MCP routes always remain reachable. Under every
 filtered policy, non-global destinations—including host-loopback, private, and link-local
 addresses—are reserved for framework routes, so user `allow` rules cannot expose host/LAN
 services or cloud metadata endpoints.
@@ -113,10 +140,11 @@ HTTP(S) leaves through a policy proxy and direct non-HTTP egress is removed. As 
 user deny rules win over user allows.
 
 Per-task `TaskData.network_allow` and `TaskData.network_block` entries are merged into
-the Docker runtime lists. The task's default `network_allow=["*"]` is neutral and leaves
-the evaluator policy intact. A concrete list replaces an evaluator wildcard; two
-concrete lists are combined, all block entries are retained, and block entries win. Any
-non-wildcard task URL policy requires Docker's framework-aware policy support.
+Docker or Prime runtime lists. The task's default `network_allow=["*"]` is neutral and
+leaves the evaluator policy intact. Docker combines concrete task/runtime lists and
+retains every block entry. Prime requires `vm = true`, accepts host-level entries, and
+rejects a task/runtime combination that would require both an allowlist and a blocklist.
+Other runtimes reject non-neutral task network policies.
 
 The restriction begins after task and harness setup and remains active through agent
 execution, finalization, and scoring. Debug actions apply it after task setup as well.

--- a/docs/v1/harbor.md
+++ b/docs/v1/harbor.md
@@ -71,11 +71,11 @@ The `timeout_multiplier` multiplies both the agent and verifier timeout, while t
 
 ## Network policies
 
-Harbor's effective agent network policy is applied to Docker harness runtimes. An
-`[agent].network_mode` override takes precedence over the `[environment]` baseline;
-legacy `[environment].allow_internet` is normalized by Harbor's schema.
+Harbor's effective agent network policy is applied to Docker or Prime VM harness
+runtimes. An `[agent].network_mode` override takes precedence over the `[environment]`
+baseline; legacy `[environment].allow_internet` is normalized by Harbor's schema.
 
-| Harbor mode | Docker execution policy |
+| Harbor mode | Task network policy |
 | --- | --- |
 | `public` | Sets the task allowlist to `["*"]`, leaving the evaluator policy intact. |
 | `no-network` | Sets the task allowlist to `[]` (framework routes only). |
@@ -84,8 +84,8 @@ legacy `[environment].allow_internet` is normalized by Harbor's schema.
 Trusted task and harness setup remains online. The policy starts immediately before the
 agent and stays active through finalization and scoring. Interception and MCP URLs are
 added automatically; evaluator-provided `allow` entries add exceptions and `block`
-entries can narrow them. Restricted Harbor tasks require the Docker runtime because the
-other runtimes do not provide framework-aware URL filtering.
+entries can narrow them. Restricted Harbor tasks require Docker or a Prime VM; Prime
+accepts host-level entries and rejects combinations that need both policy modes.
 
 ## Shortcomings
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "openai>=2.9.0",
     "openai-agents>=0.8.2",
     "prime-tunnel>=0.1.8",
-    "prime-sandboxes>=0.2.31",
+    "prime-sandboxes>=0.2.33",
     "pydantic>=2.12.3",
     "requests",
     "rich>=11.0.0",

--- a/skills/evaluate-environments/references/REFERENCE.md
+++ b/skills/evaluate-environments/references/REFERENCE.md
@@ -342,7 +342,7 @@ every narrower policy uses an isolated bridge during agent execution.
 | `memory` | `float \| None` | `None` | Hard memory limit in GB (`docker --memory`). None = unlimited. |
 | `gpu` | `str \| None` | `None` | GPU spec, e.g. `"A100"` or `"2"` (`docker --gpus` uses the count; needs the nvidia toolkit). |
 | `disk` | `float \| None` | `None` | Advisory disk request in GB. Docker has no portable per-container size limit, so accepted but **not enforced**. |
-| `allow` | `list[str]` | `[]` | URL origins or host patterns allowed during execution, e.g. `"https://*.wikipedia.org"`. Empty permits only automatically added interception/MCP routes; bare `"*"` with no block entries opts out of filtering. Wildcards are supported; `*.example.com` also matches the apex. URL paths are ignored. An explicit HTTPS origin authorizes a nonstandard CONNECT port; CONNECT authority and TLS SNI must both match policy. Under filtered policies, non-global addresses (including host loopback, private, and link-local) are reserved for framework routes. |
+| `allow` | `list[str]` | `["*"]` | URL origins or host patterns allowed during execution, e.g. `"https://*.wikipedia.org"`. The default wildcard leaves egress unrestricted; `[]` permits only automatically added interception/MCP routes. Wildcards are supported; `*.example.com` also matches the apex. URL paths are ignored. An explicit HTTPS origin authorizes a nonstandard CONNECT port; CONNECT authority and TLS SNI must both match policy. Under filtered policies, non-global addresses (including host loopback, private, and link-local) are reserved for framework routes. |
 | `block` | `list[str]` | `[]` | URL origins or host patterns denied during execution. Block wins over user `allow`; interception and MCP routes always remain reachable. |
 
 ### `PrimeConfig` — `type: "prime"`
@@ -353,7 +353,8 @@ Remote Prime sandbox; reached via native port exposure.
 | --- | --- | --- | --- |
 | `image` | `str` | `"python:3.11-slim"` | Container image. |
 | `workdir` | `str` | `"/app"` | Working directory. |
-| `network_access` | `bool` | `True` | Allow outbound network from the sandbox. |
+| `allow` | `list[str]` | `["*"]` | Host-level egress allowlist applied after trusted setup (exact hostnames, leftmost-label `*.` wildcards, IPv4 addresses/CIDRs; no schemes or ports). `["*"]` leaves egress unrestricted; framework route hosts are added automatically, so `[]` permits only interception/MCP. VM-only when restrictive. |
+| `block` | `list[str]` | `[]` | Host-level egress denylist applied after trusted setup. VM-only and mutually exclusive with a concrete `allow` list; cannot exempt a blocked framework route host. |
 | `vm` | `bool` | `False` | Run as a micro-VM (kernel features / stronger isolation). |
 | `guaranteed` | `bool` | `False` | Request guaranteed (vs best-effort) capacity. |
 | `region` | `str \| None` | `None` | Region to provision in (None = provider-chosen). Note: port exposure is region-gated; `us` supports it. |
@@ -389,10 +390,9 @@ Before each rollout or validation check, `resolve_runtime_config` combines the s
   class's default. Any non-default runtime-config workdir wins.
 - Non-`None` `TaskData.resources` values similarly fill supported runtime fields only while those
   fields remain at their defaults. Any non-default runtime-config resource value wins.
-- Non-wildcard task URL policy fields require framework-aware Docker policy support.
-  `TaskData.network_allow=["*"]` is neutral; a concrete task list replaces an evaluator
-  wildcard, otherwise concrete task/runtime lists combine. `TaskData.network_block`
-  combines with runtime `block`, and every block rule wins over allow rules.
+- Non-wildcard task network policy fields require Docker or Prime. `TaskData.network_allow=["*"]`
+  is neutral. Docker combines concrete task/runtime lists and retains every block rule.
+  Prime requires `vm=true`, host-level entries, and a single allowlist or blocklist mode.
 - A resource field unsupported by the chosen runtime is ignored; evaluation warns once per
   runtime/field combination. Docker and Modal accept `disk` so portable task data validates, but neither enforces a disk limit.
 
@@ -439,8 +439,8 @@ Per-row wall-clock timeout requests, in seconds, one for each rollout stage. For
 | `system_prompt` | `str \| None` | `None` | Optional system prompt. Harnesses with `APPENDS_SYSTEM_PROMPT` emit a real system message; otherwise a string prompt is prefixed with a warning. A separate system prompt cannot be folded into `Messages` or `None`. |
 | `image` | `str \| None` | `None` | Required container/sandbox image for this row. It replaces the base runtime image; subprocess is refused when set. |
 | `workdir` | `str \| None` | `None` | Working directory for harness execution and task hooks. Applied when the runtime supports it and its config remains at the default. |
-| `network_allow` | `list[str]` | `["*"]` | Docker destinations needed by the task. The wildcard is neutral and leaves evaluator policy intact; empty requests framework-only access. |
-| `network_block` | `list[str]` | `[]` | Destinations merged into Docker's `block` list. A non-empty list requires Docker filtering. |
+| `network_allow` | `list[str]` | `["*"]` | Docker or Prime destinations needed by the task. The wildcard is neutral and leaves evaluator policy intact; empty requests framework-only access. Prime accepts host-level entries and requires `vm=true`. |
+| `network_block` | `list[str]` | `[]` | Destinations merged into Docker or Prime's `block` list. Prime cannot combine this with an allowlist. |
 | `timeout` | `TaskTimeout` | `TaskTimeout()` | Per-stage timeout requests described above. |
 | `resources` | `TaskResources` | `TaskResources()` | Portable runtime resource requests described above. |
 

--- a/tests/v1/fixtures/pyproject.toml
+++ b/tests/v1/fixtures/pyproject.toml
@@ -15,6 +15,7 @@ build-backend = "hatchling.build"
 [tool.hatch.build]
 include = [
     "counter_tool_v1.py",
+    "echo_acp_resume_v1.py",
     "echo_tool_v1.py",
     "tool_response_image_v1.py",
     "pyproject.toml",

--- a/uv.lock
+++ b/uv.lock
@@ -18,14 +18,10 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-verifiers = false
-prime-pydantic-config = false
-tasksets = false
 prime-tunnel = false
 prime-sandboxes = false
+prime-pydantic-config = false
 renderers = false
-harnesses = false
-prime = false
 
 [[package]]
 name = "aiofile"
@@ -685,9 +681,9 @@ name = "claude-agent-sdk"
 version = "0.2.116"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "mcp" },
-    { name = "sniffio" },
+    { name = "anyio", marker = "python_full_version >= '3.12'" },
+    { name = "mcp", marker = "python_full_version >= '3.12'" },
+    { name = "sniffio", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/b0f01a18bb119e595cc1e66d4adbe39bb09879a570e54793c222a142b662/claude_agent_sdk-0.2.116.tar.gz", hash = "sha256:37d6c9d98960c7ea41d1a7fd3331ad0b1bef68e559ed9cc5ccf9d00ae68adfcd", size = 268648, upload-time = "2026-07-11T01:04:47.192Z" }
 wheels = [
@@ -1007,7 +1003,7 @@ name = "deprecation"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
 wheels = [
@@ -1028,7 +1024,7 @@ name = "dirhash"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "scantree" },
+    { name = "scantree", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/70/49f93897f3a4f7ab5f20a854ebc91aad47854e9fb2cd169e3a4452fa3f5e/dirhash-0.5.0.tar.gz", hash = "sha256:e60760f0ab2e935d8cb088923ea2c6492398dca42cec785df778985fd4cd5386", size = 21377, upload-time = "2024-08-03T22:14:13.322Z" }
 wheels = [
@@ -1577,26 +1573,26 @@ name = "harbor"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "claude-agent-sdk" },
-    { name = "datasets" },
-    { name = "dirhash" },
-    { name = "fastapi" },
-    { name = "httpx" },
-    { name = "jinja2" },
-    { name = "litellm" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "rich" },
-    { name = "shortuuid" },
-    { name = "supabase" },
-    { name = "tenacity" },
-    { name = "toml" },
-    { name = "typer" },
-    { name = "uvicorn" },
+    { name = "claude-agent-sdk", marker = "python_full_version >= '3.12'" },
+    { name = "datasets", marker = "python_full_version >= '3.12'" },
+    { name = "dirhash", marker = "python_full_version >= '3.12'" },
+    { name = "fastapi", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", marker = "python_full_version >= '3.12'" },
+    { name = "jinja2", marker = "python_full_version >= '3.12'" },
+    { name = "litellm", marker = "python_full_version >= '3.12'" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
+    { name = "pathspec", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.12'" },
+    { name = "requests", marker = "python_full_version >= '3.12'" },
+    { name = "rich", marker = "python_full_version >= '3.12'" },
+    { name = "shortuuid", marker = "python_full_version >= '3.12'" },
+    { name = "supabase", marker = "python_full_version >= '3.12'" },
+    { name = "tenacity", marker = "python_full_version >= '3.12'" },
+    { name = "toml", marker = "python_full_version >= '3.12'" },
+    { name = "typer", marker = "python_full_version >= '3.12'" },
+    { name = "uvicorn", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/f3/cba38a11b0cca01ecd471437869f1cd57d86a3b1e4091b8fd3d112cba8af/harbor-0.14.0.tar.gz", hash = "sha256:0ffffc25a618e4b7bf2b901a8c717c8bc28877f5aa8c37be47f1ec8c301cb0b6", size = 1241271, upload-time = "2026-06-17T16:43:23.495Z" }
 wheels = [
@@ -1708,7 +1704,7 @@ wheels = [
 
 [package.optional-dependencies]
 http2 = [
-    { name = "h2" },
+    { name = "h2", marker = "python_full_version >= '3.12'" },
 ]
 
 [[package]]
@@ -2128,18 +2124,18 @@ name = "litellm"
 version = "1.91.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp" },
-    { name = "click" },
-    { name = "fastuuid" },
-    { name = "httpx" },
-    { name = "importlib-metadata" },
-    { name = "jinja2" },
-    { name = "jsonschema" },
-    { name = "openai" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "tiktoken" },
-    { name = "tokenizers" },
+    { name = "aiohttp", marker = "python_full_version >= '3.12'" },
+    { name = "click", marker = "python_full_version >= '3.12'" },
+    { name = "fastuuid", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", marker = "python_full_version >= '3.12'" },
+    { name = "importlib-metadata", marker = "python_full_version >= '3.12'" },
+    { name = "jinja2", marker = "python_full_version >= '3.12'" },
+    { name = "jsonschema", marker = "python_full_version >= '3.12'" },
+    { name = "openai", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
+    { name = "tiktoken", marker = "python_full_version >= '3.12'" },
+    { name = "tokenizers", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6b/5d/2dfda0e057511ba24904c5c9af720512b1fc86893821947fa52f4cc0231b/litellm-1.91.2.tar.gz", hash = "sha256:e9aa292b95f25fa9d127e47a6e7266a2a99f7a1645f41100a411d7a8a77a6a46", size = 14872927, upload-time = "2026-07-11T06:04:18.847Z" }
 wheels = [
@@ -3143,10 +3139,10 @@ name = "postgrest"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "deprecation" },
-    { name = "httpx", extra = ["http2"] },
-    { name = "pydantic" },
-    { name = "yarl" },
+    { name = "deprecation", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", extra = ["http2"], marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "yarl", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e2/22/88c470d8838d2678a44e0172d061630b8837cba3fb7fb492e28f6578c309/postgrest-2.31.0.tar.gz", hash = "sha256:2f395d84b2ee34fc57622ff2f711df603e2ede625f98e5015240741888f7bd0c", size = 14419, upload-time = "2026-06-04T13:37:20.474Z" }
 wheels = [
@@ -3935,9 +3931,9 @@ name = "realtime"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic" },
-    { name = "typing-extensions" },
-    { name = "websockets" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+    { name = "websockets", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/34/54a1eaaefa24db5cb12596fd74792e08efa53ed30dc5bce2c0a68ded6146/realtime-2.31.0.tar.gz", hash = "sha256:9e641cb4d77ca0fe768515f8cf9f83550c79f49ce1550a95afc2dc0e252be8c9", size = 18716, upload-time = "2026-06-04T13:37:22.089Z" }
 wheels = [
@@ -4267,8 +4263,8 @@ name = "scantree"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
-    { name = "pathspec" },
+    { name = "attrs", marker = "python_full_version >= '3.12'" },
+    { name = "pathspec", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/e4/40998faefc72ba1ddeb640a44fba92935353525dba110488806da8339c0b/scantree-0.0.4.tar.gz", hash = "sha256:15bd5cb24483b04db2c70653604e8ea3522e98087db7e38ab8482f053984c0ac", size = 24643, upload-time = "2024-08-03T20:08:59.413Z" }
 wheels = [
@@ -4291,8 +4287,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -4446,10 +4442,10 @@ name = "storage3"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "deprecation" },
-    { name = "httpx", extra = ["http2"] },
-    { name = "pydantic" },
-    { name = "yarl" },
+    { name = "deprecation", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", extra = ["http2"], marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "yarl", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/13/30/fee43d523d3f680a833a4aae5bf8094de0b9031b0c2bddb3e0bc6e829e1b/storage3-2.31.0.tar.gz", hash = "sha256:d2161e2ea650dc115a1787c30e09b118365589ac772f4dd8643e3a503ecfc667", size = 20348, upload-time = "2026-06-04T13:37:23.703Z" }
 wheels = [
@@ -4470,13 +4466,13 @@ name = "supabase"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
-    { name = "postgrest" },
-    { name = "realtime" },
-    { name = "storage3" },
-    { name = "supabase-auth" },
-    { name = "supabase-functions" },
-    { name = "yarl" },
+    { name = "httpx", marker = "python_full_version >= '3.12'" },
+    { name = "postgrest", marker = "python_full_version >= '3.12'" },
+    { name = "realtime", marker = "python_full_version >= '3.12'" },
+    { name = "storage3", marker = "python_full_version >= '3.12'" },
+    { name = "supabase-auth", marker = "python_full_version >= '3.12'" },
+    { name = "supabase-functions", marker = "python_full_version >= '3.12'" },
+    { name = "yarl", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fe/8e/54a2f950629689b1613434a61fc3bff5f92f84ba6b20213f5b2add05c1bb/supabase-2.31.0.tar.gz", hash = "sha256:3467b09d00482b9a0138235bdbde7a350426f93cf2a1342372eaddfc669f1206", size = 9805, upload-time = "2026-06-04T13:37:25.22Z" }
 wheels = [
@@ -4488,9 +4484,9 @@ name = "supabase-auth"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx", extra = ["http2"] },
-    { name = "pydantic" },
-    { name = "pyjwt", extra = ["crypto"] },
+    { name = "httpx", extra = ["http2"], marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "pyjwt", extra = ["crypto"], marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/8a/408689cf39820f0d46d2731d6747ff94dbefc87ae977b4b5c4066da5b070/supabase_auth-2.31.0.tar.gz", hash = "sha256:0945b33fa96239c76dc8eaf96d7d2c94991950d24b4cfe4a5c2da9aa5e909663", size = 39151, upload-time = "2026-06-04T13:37:27.375Z" }
 wheels = [
@@ -4502,9 +4498,9 @@ name = "supabase-functions"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx", extra = ["http2"] },
-    { name = "strenum" },
-    { name = "yarl" },
+    { name = "httpx", extra = ["http2"], marker = "python_full_version >= '3.12'" },
+    { name = "strenum", marker = "python_full_version >= '3.12'" },
+    { name = "yarl", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/5d/61c2446ed26a57fa5543f9c270a731320911569202340d15341f72cdba7c/supabase_functions-2.31.0.tar.gz", hash = "sha256:4ad027b3ae3bd28b31233339f4db1da6965affd3546f655b421baf40cee2690f", size = 4683, upload-time = "2026-06-04T13:37:28.878Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -18,10 +18,14 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
+verifiers = false
+prime-pydantic-config = false
+tasksets = false
 prime-tunnel = false
 prime-sandboxes = false
-prime-pydantic-config = false
 renderers = false
+harnesses = false
+prime = false
 
 [[package]]
 name = "aiofile"
@@ -3184,7 +3188,7 @@ toml = [
 
 [[package]]
 name = "prime-sandboxes"
-version = "0.2.32"
+version = "0.2.33"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -3194,9 +3198,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "tenacity" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/fd/f57ad87b273ae1696ca620deaac2c56e28a54905d2d2791a5b9a387f443c/prime_sandboxes-0.2.32.tar.gz", hash = "sha256:ea3d6230cdfb5af2e4542814996257bad60fc9913f15f776a65ca1ef05f4f504", size = 77656, upload-time = "2026-07-17T17:41:02.296Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/a9/880685cefd503aa92d2b49da46b60ba807015f8839c344a83d8c5bc02f30/prime_sandboxes-0.2.33.tar.gz", hash = "sha256:4253a3c345ccf6c07b41a81790f8515763333f094d20bc405a257432461e81d8", size = 81228, upload-time = "2026-07-22T23:23:55.715Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/a3/c345509abf8f7707c0c3e9d6badba2e057781d1c05a88a46733ab67521e5/prime_sandboxes-0.2.32-py3-none-any.whl", hash = "sha256:4fe730622e51c489f8f86e7ad959fd8320db6d7a9fe22442ae3c680687da4c22", size = 40897, upload-time = "2026-07-17T17:41:00.935Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/1b/10b1044b8aaef561c32a34140f4a13c7310f73f92f9546337e2e8e6a5239/prime_sandboxes-0.2.33-py3-none-any.whl", hash = "sha256:92c9647557e76191ba926ac8ed01708de9ec4450142131b673cd5cf8d9d7ea56", size = 42773, upload-time = "2026-07-22T23:23:54.381Z" },
 ]
 
 [[package]]
@@ -4995,7 +4999,7 @@ requires-dist = [
     { name = "openai-agents", specifier = ">=0.8.2" },
     { name = "openenv", marker = "extra == 'openenv'", specifier = ">=0.4.1" },
     { name = "prime-pydantic-config", extras = ["toml"], specifier = ">=0.4.2" },
-    { name = "prime-sandboxes", specifier = ">=0.2.31" },
+    { name = "prime-sandboxes", specifier = ">=0.2.33" },
     { name = "prime-tunnel", specifier = ">=0.1.8" },
     { name = "pydantic", specifier = ">=2.12.3" },
     { name = "python-dotenv", marker = "extra == 'browser'", specifier = ">=1.0.0" },

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -115,7 +115,7 @@ def _check_borrowed_placement(
     image mismatch on a container only warns, since sharing its world is the point."""
     task_policy = "*" not in task.data.network_allow or bool(task.data.network_block)
     base_policy = base_config if isinstance(base_config, NetworkPolicyConfig) else None
-    if task_policy or (base_policy is not None and base_policy.network_isolated):
+    if task_policy or (base_policy is not None and base_policy.network_restricted):
         config = runtime.config
         if not isinstance(config, NetworkPolicyConfig):
             raise ValueError(

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -30,7 +30,7 @@ from verifiers.v1.mcp import SharedToolServer
 from verifiers.v1.retries import RetryConfig, backoff, trace_should_retry
 from verifiers.v1.rollout import RolloutRun, _as_messages
 from verifiers.v1.runtimes import (
-    DockerConfig,
+    NetworkPolicyConfig,
     Runtime,
     RuntimeConfig,
     SubprocessConfig,
@@ -114,20 +114,26 @@ def _check_borrowed_placement(
     be honored. Reject requirements that cannot be applied to the running box; an
     image mismatch on a container only warns, since sharing its world is the point."""
     task_policy = "*" not in task.data.network_allow or bool(task.data.network_block)
-    base_docker = base_config if isinstance(base_config, DockerConfig) else None
-    if task_policy or (base_docker is not None and base_docker.network_isolated):
+    base_policy = base_config if isinstance(base_config, NetworkPolicyConfig) else None
+    if task_policy or (base_policy is not None and base_policy.network_isolated):
         config = runtime.config
-        if not isinstance(config, DockerConfig):
+        if not isinstance(config, NetworkPolicyConfig):
             raise ValueError(
-                f"task {task.data.idx!r} requires a Docker URL network policy, but "
-                f"borrowed runtime {runtime.name!r} is not Docker-backed; use "
+                f"task {task.data.idx!r} requires a framework-aware network policy, "
+                f"but borrowed runtime {runtime.name!r} does not support one; use "
                 "agent.provision(task)"
             )
-        policy_base = (
-            base_docker if base_docker is not None else DockerConfig(allow=["*"])
+        if base_policy is not None and type(config) is not type(base_policy):
+            raise ValueError(
+                f"the configured {base_policy.type} network policy cannot be applied "
+                f"to borrowed {config.type} runtime {runtime.name!r}; use "
+                "agent.provision(task)"
+            )
+        policy_base = base_policy or config.model_copy(
+            update={"allow": ["*"], "block": []}
         )
         expected = resolve_runtime_config(policy_base, task)
-        assert isinstance(expected, DockerConfig)
+        assert isinstance(expected, NetworkPolicyConfig)
         # Do not inherit extra destinations from a box provisioned for another task.
         if set(config.allow) != set(expected.allow) or set(config.block) != set(
             expected.block

--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -257,7 +257,7 @@ async def serve(
         # reject it instead of silently leaving its requested policy unenforced.
         if (
             isinstance(cfg.runtime, NetworkPolicyConfig)
-            and cfg.runtime.network_isolated
+            and cfg.runtime.network_restricted
             and not (colocated and harness_runtime is not None)
         ):
             raise ToolsetError(
@@ -303,7 +303,7 @@ async def serve(
                 runtime, port, colocated=colocated, consumer_is_local=consumer_is_local
             )
         )
-        if colocated and harness_runtime is not None and runtime.network_isolated:
+        if colocated and harness_runtime is not None and runtime.network_restricted:
             base = base.replace("127.0.0.1", "localhost", 1)
         elif not colocated and harness_runtime is not None:
             base = harness_runtime.host_url(base)

--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -20,7 +20,7 @@ from verifiers.v1.errors import ToolsetError
 from verifiers.v1.interception.tunnel import PrimeTunnel
 from verifiers.v1.mcp.server import STATE_SECRET_PARAM, STATE_URL_PARAM, ServerBase
 from verifiers.v1.runtimes import (
-    DockerConfig,
+    NetworkPolicyConfig,
     Runtime,
     make_runtime,
     runtime_is_local,
@@ -253,17 +253,17 @@ async def serve(
     colocated = getattr(cfg, "colocated", False)
     async with contextlib.AsyncExitStack() as stack:
         # Colocated servers inherit the harness cut. A separately provisioned filtered
-        # Docker server has neither that lifecycle nor a published port after isolation;
+        # server has neither that lifecycle nor a published port after isolation;
         # reject it instead of silently leaving its requested policy unenforced.
         if (
-            isinstance(cfg.runtime, DockerConfig)
+            isinstance(cfg.runtime, NetworkPolicyConfig)
             and cfg.runtime.network_isolated
             and not (colocated and harness_runtime is not None)
         ):
             raise ToolsetError(
-                "Docker network policies are supported on the harness runtime; "
+                "Runtime network policies are supported on the harness runtime; "
                 f"server {server.server_name!r} must be colocated or use an "
-                "unrestricted Docker runtime"
+                "unrestricted runtime"
             )
         if colocated and harness_runtime is not None:
             runtime = harness_runtime

--- a/verifiers/v1/runtimes/__init__.py
+++ b/verifiers/v1/runtimes/__init__.py
@@ -4,6 +4,7 @@ from pydantic import Field
 
 from verifiers.v1.runtimes.base import (
     BaseRuntimeInfo,
+    NetworkPolicyConfig,
     ProgramResult,
     Runtime,
     register,
@@ -56,6 +57,7 @@ __all__ = [
     "RuntimeConfig",
     "RuntimeInfo",
     "BaseRuntimeInfo",
+    "NetworkPolicyConfig",
     "make_runtime",
     "runtime_is_local",
     "SubprocessConfig",

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -11,10 +11,11 @@ import weakref
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import PurePosixPath
-from typing import ClassVar
+from typing import ClassVar, Self
 
 from pydantic_config import BaseConfig
 
+from verifiers.v1.errors import SandboxError
 from verifiers.v1.utils.aio import run_shielded
 
 logger = logging.getLogger(__name__)
@@ -94,6 +95,33 @@ def cleanup_at_exit() -> None:
             runtime.cleanup()
 
 
+class NetworkPolicyConfig(BaseConfig):
+    """Shared execution-time policy surface for runtimes that support it."""
+
+    allow: list[str] = ["*"]
+    """Destinations allowed during execution; `*` leaves egress unrestricted."""
+    block: list[str] = []
+    """Destinations denied during execution."""
+
+    @property
+    def network_isolated(self) -> bool:
+        return "*" not in self.allow or bool(self.block)
+
+    def with_task_network_policy(self, allow: list[str], block: list[str]) -> Self:
+        if "*" not in allow:
+            allow = (
+                allow
+                if "*" in self.allow
+                else list(dict.fromkeys([*allow, *self.allow]))
+            )
+        else:
+            allow = self.allow
+        block = list(dict.fromkeys([*block, *self.block]))
+        return type(self).model_validate(
+            {**self.model_dump(), "allow": allow, "block": block}
+        )
+
+
 class BaseRuntimeInfo(BaseConfig):
     id: str | None = None
     borrowed: bool = False
@@ -113,6 +141,7 @@ class Runtime(ABC):
         self.name = name or f"vf-{uuid.uuid4().hex[:12]}"
         self._uv_interpreters: dict[str, str] = {}
         self._uv_script_locks: dict[str, asyncio.Lock] = {}
+        self._setup_claimed = False
         self.stopped = False
         """Whether teardown has begun (set by `stop`). A stopped runtime is dead: a rollout
         refuses to borrow one — the owner tore it down, so any use is a lifetime bug in the
@@ -244,6 +273,14 @@ class Runtime(ABC):
 
     async def prepare_setup(self) -> None:
         """Claim the runtime for trusted setup; restricted runtimes may reject reuse."""
+        if not self.network_isolated:
+            return
+        if self._setup_claimed:
+            raise SandboxError(
+                f"network-filtered {self.type} runtimes are single-rollout; "
+                "provision a fresh runtime instead of reusing this one"
+            )
+        self._setup_claimed = True
 
     async def prepare_execution(self, routes: list[str]) -> None:
         """Last setup step, right before the agent starts. Restricted runtimes enforce
@@ -252,7 +289,10 @@ class Runtime(ABC):
     @property
     def network_isolated(self) -> bool:
         """Whether the agent phase uses filtered networking (see `prepare_execution`)."""
-        return False
+        return (
+            isinstance(self.config, NetworkPolicyConfig)
+            and self.config.network_isolated
+        )
 
     @property
     def published_port(self) -> int | None:

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -104,7 +104,7 @@ class NetworkPolicyConfig(BaseConfig):
     """Destinations denied during execution."""
 
     @property
-    def network_isolated(self) -> bool:
+    def network_restricted(self) -> bool:
         return "*" not in self.allow or bool(self.block)
 
     def with_task_network_policy(self, allow: list[str], block: list[str]) -> Self:
@@ -273,7 +273,7 @@ class Runtime(ABC):
 
     async def prepare_setup(self) -> None:
         """Claim the runtime for trusted setup; restricted runtimes may reject reuse."""
-        if not self.network_isolated:
+        if not self.network_restricted:
             return
         if self._setup_claimed:
             raise SandboxError(
@@ -287,11 +287,11 @@ class Runtime(ABC):
         their policy here while keeping the interception and MCP `routes` reachable."""
 
     @property
-    def network_isolated(self) -> bool:
+    def network_restricted(self) -> bool:
         """Whether the agent phase uses filtered networking (see `prepare_execution`)."""
         return (
             isinstance(self.config, NetworkPolicyConfig)
-            and self.config.network_isolated
+            and self.config.network_restricted
         )
 
     @property

--- a/verifiers/v1/runtimes/docker/__init__.py
+++ b/verifiers/v1/runtimes/docker/__init__.py
@@ -13,11 +13,10 @@ from pathlib import PurePosixPath
 from typing import Literal
 from urllib.parse import urlsplit
 
-from pydantic_config import BaseConfig
-
 from verifiers.v1.errors import SandboxError
 from verifiers.v1.runtimes.base import (
     BaseRuntimeInfo,
+    NetworkPolicyConfig,
     ProgramResult,
     Runtime,
     parse_gpu,
@@ -27,7 +26,7 @@ from verifiers.v1.runtimes.docker.egress import HOST_ALIAS, EgressProxy, Network
 logger = logging.getLogger(__name__)
 
 
-class DockerConfig(BaseConfig):
+class DockerConfig(NetworkPolicyConfig):
     type: Literal["docker"] = "docker"
     image: str = "python:3.11-slim"
     workdir: str = "/app"
@@ -42,17 +41,6 @@ class DockerConfig(BaseConfig):
     disk: float | None = None
     """Advisory disk request in GB. Docker has no portable per-container size limit, so
     this is accepted (so a task can declare it without a warning) but not enforced."""
-    allow: list[str] = []
-    """URL origins or host patterns the agent may reach during execution. Framework
-    routes are always added; an empty list allows only those routes and `*` allows all."""
-    block: list[str] = []
-    """URL origins or host patterns denied during execution. Block rules win over
-    `allow`; framework interception and MCP routes always remain reachable."""
-
-    @property
-    def network_isolated(self) -> bool:
-        """True unless a bare wildcard permits every destination without exceptions."""
-        return "*" not in self.allow or bool(self.block)
 
 
 class DockerRuntimeInfo(DockerConfig, BaseRuntimeInfo):
@@ -96,7 +84,6 @@ class DockerRuntime(Runtime):
         self._proxy: EgressProxy | None = None
         self._proxy_host_ip: str | None = None
         self._stopped = False
-        self._setup_claimed = False
         self._cut = False
 
     async def start(self) -> None:
@@ -245,20 +232,6 @@ class DockerRuntime(Runtime):
         ):
             return url.replace(host, "host.docker.internal", 1)
         return url
-
-    @property
-    def network_isolated(self) -> bool:
-        return self.config.network_isolated
-
-    async def prepare_setup(self) -> None:
-        if not self.network_isolated:
-            return
-        if self._setup_claimed:
-            raise SandboxError(
-                "network-filtered Docker runtimes are single-rollout; provision a "
-                "fresh runtime instead of reusing this one"
-            )
-        self._setup_claimed = True
 
     async def prepare_execution(self, routes: list[str]) -> None:
         """Allow the declared framework routes, then leave the proxy as the only route."""

--- a/verifiers/v1/runtimes/docker/__init__.py
+++ b/verifiers/v1/runtimes/docker/__init__.py
@@ -114,8 +114,8 @@ class DockerRuntime(Runtime):
         _, gpu_count = parse_gpu(self.config.gpu)
         if gpu_count:
             limits += ["--gpus", str(gpu_count)]
-        isolated = self.network_isolated
-        if isolated:
+        restricted = self.network_restricted
+        if restricted:
             network = [
                 "--network",
                 "bridge",
@@ -151,7 +151,7 @@ class DockerRuntime(Runtime):
         self.info.id = run.stdout.strip()[
             :12
         ]  # `docker run -d` prints the container id
-        if isolated:
+        if restricted:
             # Setup is trusted; colocated servers fetch their task from host interception
             # before the final framework routes are known.
             self._proxy = EgressProxy(
@@ -223,10 +223,10 @@ class DockerRuntime(Runtime):
         host = urlsplit(url).hostname
         # Keep numeric loopback container-local; the proxy maps this reserved name to
         # the Verifiers process's loopback for interception and host-local MCP routes.
-        if self.network_isolated and host in ("127.0.0.1", "localhost"):
+        if self.network_restricted and host in ("127.0.0.1", "localhost"):
             return url.replace(host, HOST_ALIAS, 1)
         if (
-            not self.network_isolated
+            not self.network_restricted
             and sys.platform != "linux"
             and host in ("127.0.0.1", "localhost")
         ):
@@ -235,7 +235,7 @@ class DockerRuntime(Runtime):
 
     async def prepare_execution(self, routes: list[str]) -> None:
         """Allow the declared framework routes, then leave the proxy as the only route."""
-        if not self.network_isolated:
+        if not self.network_restricted:
             return
         assert self._proxy is not None
         framework = [

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -69,7 +69,7 @@ class PrimeConfig(NetworkPolicyConfig):
 
     @model_validator(mode="after")
     def _validate_egress(self) -> "PrimeConfig":
-        if not self.network_isolated:
+        if not self.network_restricted:
             return self
         if not self.vm:
             raise ValueError(
@@ -182,7 +182,7 @@ class PrimeRuntime(Runtime):
 
     async def prepare_execution(self, routes: list[str]) -> None:
         """Apply the host policy after setup and wait until the platform enforces it."""
-        if not self.network_isolated:
+        if not self.network_restricted:
             return
         try:
             if self.config.allow == ["*"]:

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -190,6 +190,9 @@ class PrimeRuntime(Runtime):
             else:
                 hosts = [h for h in (urlsplit(route).hostname for route in routes) if h]
                 entries = list(dict.fromkeys([*hosts, *self.config.allow]))
+                from prime_sandboxes.models import validate_egress_lists
+
+                validate_egress_lists(entries, None)
                 policy = {"allow": entries} if entries else {"deny": ["*"]}
             status = await self._client.set_network(self.info.id, **policy)
             try:

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -14,14 +14,15 @@ import shlex
 import tempfile
 from pathlib import Path, PurePosixPath
 from typing import ClassVar, Literal
+from urllib.parse import urlsplit
 
 from pydantic import model_validator
-from pydantic_config import BaseConfig
 
 from verifiers.v1.errors import SandboxError
 from verifiers.v1.runtimes.base import (
     SERVICE_PORT,
     BaseRuntimeInfo,
+    NetworkPolicyConfig,
     ProgramResult,
     Runtime,
     parse_gpu,
@@ -34,7 +35,7 @@ MAX_LIFETIME = 24 * 60 * 60
 """Prime's fixed cap (seconds) on any sandbox's total lifetime."""
 
 
-class PrimeConfig(BaseConfig):
+class PrimeConfig(NetworkPolicyConfig):
     type: Literal["prime"] = "prime"
     image: str = "python:3.11-slim"
     """Docker image to run. Any pullable ref works: on the first use of an image, the
@@ -42,7 +43,6 @@ class PrimeConfig(BaseConfig):
     ~10 minutes) and caches the result, so later sandboxes on the same ref start in
     seconds."""
     workdir: str = "/app"
-    network_access: bool = True
     vm: bool = False
     """Run as a micro-VM rather than a container (kernel features / stronger isolation)."""
     guaranteed: bool = False
@@ -66,6 +66,22 @@ class PrimeConfig(BaseConfig):
     """Pace sandbox creation to this many per minute, enforced host-wide across every
     env-server worker process (None/<= 0 disables it). (Tunnel creation is limited separately
     and globally — see interception.tunnel.prime.TUNNEL_LIMITER.)"""
+
+    @model_validator(mode="after")
+    def _validate_egress(self) -> "PrimeConfig":
+        if not self.network_isolated:
+            return self
+        if not self.vm:
+            raise ValueError(
+                "Prime allow/block egress lists require a VM sandbox (vm=true)"
+            )
+        from prime_sandboxes.models import validate_egress_lists
+
+        allow = None if self.allow == ["*"] else self.allow
+        block = self.block or None
+        if allow is not None or block != ["*"]:
+            validate_egress_lists(allow, block)
+        return self
 
     @model_validator(mode="after")
     def _validate_idle_timeout(self) -> "PrimeConfig":
@@ -133,7 +149,6 @@ class PrimeRuntime(Runtime):
                         name=self.name,
                         labels=self.config.labels,
                         docker_image=self.config.image,
-                        network_access=self.config.network_access,
                         vm=self.config.vm,
                         guaranteed=self.config.guaranteed,
                         **{k: v for k, v in options.items() if v is not None},
@@ -164,6 +179,41 @@ class PrimeRuntime(Runtime):
             Exception
         ) as e:  # provisioning failure is one rollout's problem, not the eval's
             raise SandboxError(f"prime sandbox provisioning failed: {e}") from e
+
+    async def prepare_execution(self, routes: list[str]) -> None:
+        """Apply the host policy after setup and wait until the platform enforces it."""
+        if not self.network_isolated:
+            return
+        try:
+            if self.config.allow == ["*"]:
+                policy = {"deny": self.config.block}
+            else:
+                hosts = [h for h in (urlsplit(route).hostname for route in routes) if h]
+                entries = list(dict.fromkeys([*hosts, *self.config.allow]))
+                policy = {"allow": entries} if entries else {"deny": ["*"]}
+            status = await self._client.set_network(self.info.id, **policy)
+            try:
+                async with asyncio.timeout(60):
+                    delay = 0.1
+                    while not status.applied:
+                        await asyncio.sleep(delay)
+                        delay = min(delay * 2, 3)
+                        status = await self._client.get_network(self.info.id)
+            except TimeoutError as e:
+                raise SandboxError(
+                    "prime egress policy was not applied within 60s on sandbox "
+                    f"{self.info.id}; refusing to start the agent unrestricted"
+                ) from e
+        except SandboxError:
+            raise
+        except Exception as e:
+            raise SandboxError(f"prime egress policy failed: {e}") from e
+        logger.info(
+            "prime: egress policy applied on sandbox %s (allow=%s block=%s)",
+            self.info.id,
+            self.config.allow,
+            self.config.block,
+        )
 
     async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
         try:

--- a/verifiers/v1/task.py
+++ b/verifiers/v1/task.py
@@ -140,11 +140,11 @@ class TaskData(StrictBaseModel):
     workdir: str | None = None
     network_allow: list[str] = ["*"]
     """Execution-time destinations requested by this task. `*` leaves the runtime
-    allowlist unchanged; a concrete list replaces a wildcard or combines with
-    existing entries."""
+    allowlist unchanged; a concrete list replaces a wildcard or combines with existing
+    entries. Prime runtimes accept host-level entries and require `vm=true`."""
     network_block: list[str] = []
     """Execution-time destinations denied by this task and combined with runtime
-    blocks."""
+    blocks. Prime runtimes cannot combine an allowlist and a blocklist."""
     timeout: TaskTimeout = TaskTimeout()
     resources: TaskResources = TaskResources()
 

--- a/verifiers/v1/utils/compile.py
+++ b/verifiers/v1/utils/compile.py
@@ -7,7 +7,7 @@ from collections.abc import Collection
 
 from verifiers.v1.harness import Harness
 from verifiers.v1.runtimes import (
-    DockerConfig,
+    NetworkPolicyConfig,
     RuntimeConfig,
     SubprocessConfig,
     runtime_is_local,
@@ -45,19 +45,13 @@ def resolve_runtime_config(
         task.data.network_block
     )
     if task_network_policy:
-        if not isinstance(config, DockerConfig):
+        if not isinstance(config, NetworkPolicyConfig):
             raise ValueError(
-                f"task {task.data.idx!r} requires a URL network policy, but the "
-                f"{config.type} runtime does not support framework-aware URL policies"
+                f"task {task.data.idx!r} requires a network policy, but the "
+                f"{config.type} runtime does not support framework-aware policies"
             )
-        if "*" not in task.data.network_allow:
-            updates["allow"] = (
-                task.data.network_allow
-                if "*" in config.allow
-                else list(dict.fromkeys([*task.data.network_allow, *config.allow]))
-            )
-        updates["block"] = list(
-            dict.fromkeys([*task.data.network_block, *config.block])
+        config = config.with_task_network_policy(
+            task.data.network_allow, task.data.network_block
         )
     for resource, value in task.data.resources.model_dump(exclude_none=True).items():
         spec = type(config).model_fields.get(resource)


### PR DESCRIPTION
## Overview

Adds execution-time egress policies to Prime VM sandboxes and aligns network-policy handling across Docker and Prime runtimes.

## Details

- Updates `prime-sandboxes` to 0.2.33 and applies Prime policies dynamically after trusted setup.
- Introduces a shared `NetworkPolicyConfig` for unrestricted defaults, task/runtime policy composition, restriction state, single-rollout ownership, borrowed-runtime checks, and MCP placement.
- Preserves interception and MCP hosts automatically in Prime allowlist mode and waits for the provider to confirm policy application before agent execution.
- Supports host allowlists, blocklists, and deny-all behavior on Prime VMs while retaining Docker's URL-level policy enforcement.
- Documents Prime policy constraints and Harbor task-policy mapping.

## Behavior

Docker and Prime both default to unrestricted egress with `allow = ["*"]` and `block = []`. Concrete or empty allowlists and non-empty blocklists enable execution-time filtering. Prime restrictions require a VM and use one effective policy mode at a time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sandbox egress enforcement and Docker default allow semantics; misconfiguration could block agent/MCP traffic, though fail-closed Prime polling and validation reduce silent unrestricted runs.
> 
> **Overview**
> Adds **host-level egress policies for Prime VM sandboxes** and unifies how Docker and Prime handle execution-time network rules.
> 
> **Prime** replaces the boolean `network_access` with `allow` / `block` lists (via `prime-sandboxes` 0.2.33). Restrictive policies require `vm=true`, are validated with `validate_egress_lists`, and are pushed in `prepare_execution` after trusted setup—interception/MCP hosts are folded into allowlist mode, with up to a 60s wait for provider acknowledgement before the agent starts (fail closed on timeout). **Docker** now subclasses the same shared `NetworkPolicyConfig`; its default `allow` changes from `[]` to `["*"]` so unrestricted egress is explicit, while empty allow or any block still enables filtering.
> 
> **Cross-runtime behavior** moves into the base `Runtime`: `network_restricted` (renamed from `network_isolated`), single-rollout `prepare_setup` claiming, and `with_task_network_policy` for merging task `network_allow` / `network_block`. Borrowed-runtime checks, MCP server placement, and `resolve_runtime_config` are generalized beyond Docker. Docs and Harbor guidance are updated for Prime host policies and the new defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2bf1459a495199b2fa0882bea28aaa133da03e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add egress policy support for Prime sandbox runtime
> - Introduces `NetworkPolicyConfig` as a shared base class for `DockerConfig` and `PrimeConfig`, standardizing allow/block list merging and `network_isolated` semantics across runtimes.
> - `PrimeRuntime.prepare_execution` now applies provider-enforced egress policies before agent start, polling until acknowledged (up to 60s) and failing closed on timeout.
> - `PrimeConfig` validates that restrictive policies require `vm=true` and that allow/block entries are valid via `prime_sandboxes.models.validate_egress_lists`.
> - `resolve_runtime_config` and `_check_borrowed_placement` are generalized to support any `NetworkPolicyConfig` runtime, not just Docker.
> - Behavioral Change: `DockerConfig` default changes from `allow=[]` to `allow=["*"]`; single-rollout enforcement for network-filtered runtimes moves to the base `Runtime` class.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #2115 opened
>
> - Renamed `network_isolated` property and variable references to `network_restricted` across the verifiers runtime system [c2bf145]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized c2bf145. 5 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
