### PR TITLE
feat: rely on sandbox SDK defaults for prime/modal resources

### DIFF
--- a/skills/evaluate-environments/references/REFERENCE.md
+++ b/skills/evaluate-environments/references/REFERENCE.md
@@ -376,10 +376,10 @@ Remote Modal sandbox; reached via Modal's own port forwarding (`encrypted_ports`
 | `workdir` | `str` | `"/app"` | Working directory. |
 | `network_access` | `bool` | `True` | Allow outbound network (`block_network` is the negation). |
 | `region` | `str \| None` | `None` | Region to provision in (None = provider-chosen). |
-| `cpu` | `float` | `1.0` | CPU cores. |
-| `memory` | `float` | `2.0` | Memory in GB (sent to Modal as MB). |
+| `cpu` | `float \| None` | `None` | CPU cores (None = SDK default). |
+| `memory` | `float \| None` | `None` | Memory in GB, sent to Modal as MB (None = SDK default). |
 | `gpu` | `str \| None` | `None` | GPU spec, e.g. `"A100"` or `"A100:2"`. |
-| `disk` | `float` | `5.0` | Disk in GB. Modal sandboxes have no disk knob, so **accepted but not enforced**. |
+| `disk` | `float \| None` | `None` | Disk in GB. Modal sandboxes have no disk knob, so **accepted but not enforced**. |
 | `creates_per_sec` | `float \| None` | `40.0` | Pace sandbox creation to this many per second, host-wide across every env-server worker (None/≤0 disables). |
 
 Before each rollout or validation check, `resolve_runtime_config` combines the selected runtime config with the row's `TaskData`:

--- a/skills/evaluate-environments/references/REFERENCE.md
+++ b/skills/evaluate-environments/references/REFERENCE.md
@@ -359,10 +359,10 @@ Remote Prime sandbox; reached via native port exposure.
 | `guaranteed` | `bool` | `False` | Request guaranteed (vs best-effort) capacity. |
 | `region` | `str \| None` | `None` | Region to provision in (None = provider-chosen). Note: port exposure is region-gated; `us` supports it. |
 | `labels` | `list[str]` | `[]` | Labels attached to the sandbox. |
-| `cpu` | `float` | `1.0` | CPU cores. |
-| `memory` | `float` | `2.0` | Memory in GB. |
+| `cpu` | `float \| None` | `None` | CPU cores (None = SDK default). |
+| `memory` | `float \| None` | `None` | Memory in GB (None = SDK default). |
 | `gpu` | `str \| None` | `None` | GPU spec, e.g. `"A100"` or `"A100:2"` (bare count = provider-chosen type). |
-| `disk` | `float` | `5.0` | Disk in GB. |
+| `disk` | `float \| None` | `None` | Disk in GB (None = SDK default). |
 | `idle_timeout` | `float \| None` | `3600` | Seconds of inactivity before the sandbox is deleted; `None` disables it. |
 | `creates_per_min` | `int \| None` | `None` | Pace sandbox creation to this many per minute, host-wide across every env-server worker (None/≤0 disables). Tunnel creation is limited separately and globally. |
 

--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -40,13 +40,13 @@ class ModalConfig(BaseConfig):
     region: str | None = None
     """Region to provision in (None = provider-chosen)."""
     # TaskData.resources uses these units; non-default runtime config values take precedence.
-    cpu: float = 1.0
-    """CPU cores."""
-    memory: float = 2.0
-    """Memory in GB."""
+    cpu: float | None = None
+    """CPU cores. None = SDK default."""
+    memory: float | None = None
+    """Memory in GB. None = SDK default."""
     gpu: str | None = None
     """GPU spec, e.g. "A100" or "A100:2"."""
-    disk: float = 5.0
+    disk: float | None = None
     """Disk in GB. Modal sandboxes have no disk knob, so this is accepted (so a task can
     declare it without a warning) but not enforced."""
     creates_per_sec: float | None = 40.0
@@ -95,8 +95,13 @@ class ModalRuntime(Runtime):
                     # (e.g. SWE task images) never starts the keep-alive and the sandbox dies.
                     image=modal.Image.from_registry(self.config.image).entrypoint([]),
                     workdir=self.config.workdir,
+                    # None defers to Modal's defaults (memory is MB on Modal's side).
                     cpu=self.config.cpu,
-                    memory=int(self.config.memory * 1024),  # Modal memory is MB
+                    memory=(
+                        int(self.config.memory * 1024)
+                        if self.config.memory is not None
+                        else None
+                    ),
                     gpu=self.config.gpu,
                     region=self.config.region,
                     block_network=not self.config.network_access,

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -156,6 +156,11 @@ class PrimeRuntime(Runtime):
                     )
                 )
             self.info.id = sandbox.id
+            # The create response carries the effective resources (the SDK/server
+            # defaults when unset), so the trace records what was actually provisioned.
+            self.info.cpu = sandbox.cpu_cores
+            self.info.memory = sandbox.memory_gb
+            self.info.disk = sandbox.disk_size_gb
             # The create response says whether the platform already has the image:
             # `pending_image_build_id` set means a first-use auto-build is running and the
             # sandbox stays PENDING until it finishes (`wait_for_creation` gives that phase

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -52,14 +52,14 @@ class PrimeConfig(NetworkPolicyConfig):
     labels: list[str] = []
     """Labels attached to the sandbox."""
     # TaskData.resources uses these units; non-default runtime config values take precedence.
-    cpu: float = 1.0
-    """CPU cores."""
-    memory: float = 2.0
-    """Memory in GB."""
+    cpu: float | None = None
+    """CPU cores. None = SDK default."""
+    memory: float | None = None
+    """Memory in GB. None = SDK default."""
     gpu: str | None = None
     """GPU spec, e.g. "A100" or "A100:2" (a bare count = provider-chosen type)."""
-    disk: float = 5.0
-    """Disk in GB."""
+    disk: float | None = None
+    """Disk in GB. None = SDK default."""
     idle_timeout: float | None = 3600
     """Seconds of inactivity before the sandbox self-deletes (None disables)."""
     creates_per_min: int | None = None
@@ -127,6 +127,7 @@ class PrimeRuntime(Runtime):
             if self.config.idle_timeout is not None and not self.config.vm
             else None
         )
+        # None values are dropped below, deferring to the SDK's defaults.
         options = {
             "cpu_cores": self.config.cpu,
             "memory_gb": self.config.memory,


### PR DESCRIPTION
## Summary

- `PrimeConfig` and `ModalConfig` `cpu` / `memory` / `disk` now default to `None` and are only sent to the provider when set, falling back to the sandbox SDK defaults instead of pinning `1.0` / `2.0` / `5.0` in verifiers.
- Prime backfills `info.cpu` / `memory` / `disk` from the create response, so the trace records the resources actually provisioned even when the config leaves them unset. Modal exposes no effective-resource introspection, so its runtime info keeps the configured values (`None` when unset).
- Task-declared `TaskData.resources` still apply on top of unset fields via `resolve_runtime_config`, and explicit runtime-config values still take precedence over the task's (verified for both runtimes).
- Updated the prime and modal tables in `skills/evaluate-environments/references/REFERENCE.md`.

## New defaults

`cpu` / `memory` / `disk` now default to `None` on both `PrimeConfig` and `ModalConfig`, meaning "don't send this field; use the provider's default":

| Field | Old default | New default | Provider default when unset |
| --- | --- | --- | --- |
| `cpu` | `1.0` | `None` | Prime: `1.0` core. Modal: its baseline (fractional core). |
| `memory` | `2.0` | `None` | Prime: `2.0` GB. Modal: its baseline (~128 MiB). |
| `disk` | `5.0` | `None` | Prime: `5.0` GB. Modal: no disk knob (unenforced). |

Prime's server defaults happen to match the old pinned values, so a bare prime runtime is unchanged. Modal's defaults are its (small) baseline container size.

## Breaking

- `PrimeConfig` / `ModalConfig` `cpu` / `memory` / `disk` no longer default to `1.0` / `2.0` / `5.0` — an unset field now provisions at the **provider's** default. On Modal that baseline is smaller than the old pins, so a bare modal runtime gets less CPU/memory than before and a heavy harness can OOM.
- **If your harness needs more than the provider baseline, request it explicitly** on the runtime config:

  ```toml
  [env.agent.harness.runtime]
  type = "modal"   # or "prime"
  cpu = 2
  memory = 4       # GB
  disk = 10        # GB (prime only; modal ignores it)
  ```

  or per-task via `TaskData.resources`. Existing configs that already pin these values are unaffected.

## Verification

Started a `PrimeRuntime` with a default config against the real API: pre-start `info` shows `cpu/memory/disk = None`, the sandbox provisions with the platform defaults, and post-start `info` records the effective `1.0 / 2.0 / 5.0` read back from the create response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
