### PR TITLE
fix(v1): reject invalid sampled logprobs

### DIFF
--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -32,6 +32,7 @@ from verifiers.v1.types import (
     ToolCall,
     TurnTokens,
     Usage,
+    parse_sampled_logprobs,
 )
 
 
@@ -116,6 +117,14 @@ def response_from_generate(
     ] or None
     prompt_ids = result.get("prompt_ids") or []
     completion_ids = result.get("completion_ids") or []
+    try:
+        completion_logprobs = parse_sampled_logprobs(
+            result.get("completion_logprobs", []),
+            len(completion_ids),
+            what="generate response",
+        )
+    except ValueError as e:
+        raise model_error(str(e)) from e
     # Per-message token spans (the renderer's attribution) let the trace graph store each
     # message's tokens once; carried transiently on TurnTokens and consumed by turn.commit().
     attribution = result.get("prompt_attribution")
@@ -140,12 +149,12 @@ def response_from_generate(
         usage=Usage(
             prompt_tokens=len(prompt_ids), completion_tokens=len(completion_ids)
         ),
-        # generate() returns owned, typed lists. Skip revalidation here to avoid copying
-        # million-token contexts synchronously on the event loop.
+        # The token lists are generate()-owned. Validate the small sampled-evidence list above,
+        # then bypass model copies of the potentially million-token context lists.
         tokens=TurnTokens.model_construct(
             prompt_ids=prompt_ids,
             completion_ids=completion_ids,
-            completion_logprobs=result.get("completion_logprobs") or [],
+            completion_logprobs=completion_logprobs,
             message_spans=message_spans,
             is_content=attribution.is_content if attribution is not None else None,
             multi_modal_data=result.get("multi_modal_data"),

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -34,6 +34,7 @@ from verifiers.v1.types import (
     ToolMessage,
     Usage,
     content_text,
+    parse_sampled_logprobs,
 )
 
 logger = logging.getLogger(__name__)
@@ -152,18 +153,31 @@ class Branch(StrictBaseModel):
         """Per-token sampling logprobs aligned to `token_ids` — the node logprobs spread onto
         their sampled positions, 0.0 on every non-sampled token."""
         out: list[float] = []
-        for node in self.nodes:
+        for node_index, node in enumerate(self.nodes):
             mask = node.mask
-            sampled = sum(mask) if node.logprobs else 0
+            if len(mask) != len(node.token_ids):
+                raise ValueError(
+                    f"branch {self.index} node {node_index} has {len(mask)} mask entries "
+                    f"for {len(node.token_ids)} token ids"
+                )
+            if any(not isinstance(sampled, bool) for sampled in mask):
+                raise ValueError(
+                    f"branch {self.index} node {node_index} mask entries must be booleans"
+                )
+            sampled = sum(mask)
+            logprobs = parse_sampled_logprobs(
+                node.logprobs,
+                sampled,
+                what=f"branch {self.index} node {node_index}",
+            )
             # Bulk-fill the canonical unsampled-prefix/sampled-suffix layout.
             if not sampled or all(mask[-sampled:]):
-                out += [0.0] * (len(mask) - sampled) + node.logprobs[:sampled]
-                out += [0.0] * max(0, sampled - len(node.logprobs))
+                out += [0.0] * (len(mask) - sampled) + logprobs
                 continue
             li = 0
-            for sampled in mask:
-                if sampled:
-                    out.append(node.logprobs[li] if li < len(node.logprobs) else 0.0)
+            for is_sampled in mask:
+                if is_sampled:
+                    out.append(logprobs[li])
                     li += 1
                 else:
                     out.append(0.0)

--- a/verifiers/v1/types.py
+++ b/verifiers/v1/types.py
@@ -1,3 +1,4 @@
+import math
 from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Annotated, Any, Literal
@@ -30,6 +31,31 @@ ContentPart = Annotated[
 ]
 MessageContent = str | list[ContentPart]
 """Plain text or typed multimodal content parts."""
+
+
+def parse_sampled_logprobs(
+    values: object, sampled_count: int, *, what: str
+) -> list[float]:
+    """Parse one finite real logprob per sampled token into built-in floats."""
+    if not isinstance(values, list):
+        raise ValueError(f"{what} logprobs must be a list")
+    if len(values) != sampled_count:
+        raise ValueError(
+            f"{what} has {len(values)} logprobs for {sampled_count} sampled tokens"
+        )
+
+    parsed: list[float] = []
+    for value in values:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(f"{what} logprobs must be finite real numbers")
+        try:
+            value = float(value)
+        except OverflowError as exc:
+            raise ValueError(f"{what} logprobs must be finite real numbers") from exc
+        if not math.isfinite(value):
+            raise ValueError(f"{what} logprobs must be finite real numbers")
+        parsed.append(value)
+    return parsed
 
 
 def content_to_parts(content) -> MessageContent:


### PR DESCRIPTION
## Description

The v1 renderer path currently persists completion token IDs and sampled logprobs independently through `TurnTokens.model_construct`. If the logprob list is short, `Branch.logprobs` silently fills the missing sampled positions with `0.0`; if it is long, it truncates it.

At a sampled position, `0.0` asserts probability 1.0. Repairing malformed evidence this way changes the behavior-policy signal used for training.

This change:

- requires exactly one finite real logprob per completion token before persistence and reports malformed responses as `ProviderError`;
- applies the same parser when projecting a branch, so mismatched or non-finite evidence reaching projection fails instead of being truncated or zero-padded;
- validates that each node's token and mask streams remain aligned;
- keeps `0.0` only for genuinely unsampled positions.

It deliberately does not tighten the persisted Pydantic field types, so historical `0`/`1` masks keep their existing loading behavior.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

Malformed sampled evidence that previously flowed into training now fails closed.

## Testing

- [x] All existing tests pass when running `uv run pytest tests/ -q` locally (provider E2E cases requiring `PRIME_API_KEY` skipped).
- [ ] New tests have been added to cover the changes

Per `AGENTS.md`, no unit tests are added. A temporary adversarial probe covered aligned and interleaved masks; short, long, missing, non-list, non-finite, Boolean, and string logprobs; mask/token mismatches; and `ProviderError` translation.

Additional checks:

- `uv run pre-commit run --all-files`
- `uv run ruff check .`
- pre-push Ty check
- independent final-diff review

## Checklist

- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (not applicable; no public interface changed)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Draft blocker

Released Renderers `0.1.8` can normalize missing evidence to an apparently aligned `0.0` before Verifiers receives it, losing both missing-versus-real-zero provenance and per-entry token identity.

[Renderers #108](https://github.com/PrimeIntellect-ai/renderers/pull/108) is merged and adds strict wire validation plus `MalformedGenerateResponseError`, but it is currently available only in the `0.1.9.dev5` prerelease. Before this PR is marked ready, the next stable Renderers release should be available; this branch can then translate that exact exception to `ProviderError` and advance the dependency floor and lock without catching unrelated `ValueError` failures.
