### PR TITLE
Fix Prime runtime config example

### DIFF
--- a/docs/v1/evaluation.md
+++ b/docs/v1/evaluation.md
@@ -82,7 +82,7 @@ Prime VM sandboxes (`vm = true`) take either a host-level `allow` list or a `blo
 list:
 
 ```toml
-[env.agent.harness.runtime]
+[env.agent.runtime]
 type = "prime"
 vm = true
 allow = ["*.wikipedia.org", "1.1.1.1"]


### PR DESCRIPTION
## Overview

Correct the Prime runtime configuration example in the V1 evaluation documentation.

## Details

Runtime configuration belongs directly to `AgentConfig`, so the Prime network policy example now uses `[env.agent.runtime]`. This aligns the documentation with the current configuration layout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only correction with no runtime or config parsing changes.
> 
> **Overview**
> Updates the **Prime host policies** example in the V1 evaluation docs so the TOML header is `[env.agent.runtime]` instead of `[env.agent.harness.runtime]`.
> 
> Runtime settings sit on the agent config next to harness config, matching the other examples on the same page (Docker network policy and the top-level eval sample).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9510bbc904da4c23e02bc687f4af207db1309cc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix TOML section header in Prime runtime config example
> Corrects the section header in the TOML snippet in [evaluation.md](https://github.com/PrimeIntellect-ai/verifiers/pull/2122/files#diff-dcded4c488b9e44f4750d10743f8f2319c8ff959fae7ca1a23d3d81c88a64848) from `[env.agent.harness.runtime]` to `[env.agent.runtime]`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9510bbc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->