### PR TITLE
Fix shared Docker state bridge routing

### DIFF
--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -23,7 +23,6 @@ from verifiers.v1.runtimes import (
     NetworkPolicyConfig,
     Runtime,
     make_runtime,
-    runtime_is_local,
 )
 from verifiers.v1.runtimes.base import _ENSURE_UV
 
@@ -248,6 +247,7 @@ async def serve(
     *,
     state_secret: str = "",
     state_base: str | None = None,
+    runtime: Runtime | None = None,
 ):
     cfg = server.config
     colocated = getattr(cfg, "colocated", False)
@@ -268,7 +268,7 @@ async def serve(
         if colocated and harness_runtime is not None:
             runtime = harness_runtime
         else:
-            runtime = make_runtime(cfg.runtime)
+            runtime = runtime or make_runtime(cfg.runtime)
             await runtime.start()
             stack.push_async_callback(runtime.stop)
         # Only consumers outside the server runtime need its fixed published port. Colocated tools
@@ -315,7 +315,8 @@ class SharedToolServer:
     """One live taskset-scoped (shared) server, as the rollouts see it: its eval-level
     `url` plus whether its runtime is `local` (host-reachable) — a remote one is an
     interception consumer, so the interception must be exposed for it to reach the
-    `/state` channel (see `Env._requires_tunnel`). An `external` server (a
+    `/state` channel (see `Env._requires_tunnel`). `runtime` is retained for translating
+    that channel into the server's network. An `external` server (a
     config-`url` endpoint) was not launched by the framework and sits outside its state
     machinery entirely: rollouts get its URL bare — no state tag (and no per-rollout
     secret sent to a third party)."""
@@ -323,6 +324,7 @@ class SharedToolServer:
     url: str
     local: bool
     external: bool = False
+    runtime: Runtime | None = None
 
 
 @contextlib.asynccontextmanager
@@ -359,11 +361,18 @@ async def serve_shared(toolsets: list[Toolset], harness_is_local: bool = True):
                     url=cfg.url, local=False, external=True
                 )
             else:
+                runtime = make_runtime(cfg.runtime)
                 url = await stack.enter_async_context(
-                    serve(toolset, harness_is_local=harness_is_local)
+                    serve(
+                        toolset,
+                        harness_is_local=harness_is_local,
+                        runtime=runtime,
+                    )
                 )
                 servers[name] = SharedToolServer(
-                    url=url, local=runtime_is_local(cfg.runtime)
+                    url=url,
+                    local=runtime.is_local,
+                    runtime=runtime,
                 )
             logger.info("shared tool server '%s': %s", name, servers[name].url)
         yield servers
@@ -395,8 +404,8 @@ async def serve_tools(
     taskset-scoped `shared` servers — already
     running eval-level (see `serve_shared`) — join under their per-rollout state tag.
     `state_base`/`state_secret` wire each server to the interception server's shared-state
-    channel — `state_base` is universally reachable, so every server (per-rollout or
-    `shared`, any runtime) uses it directly."""
+    channel. Each launched server translates the host-local base for its own runtime;
+    external servers stay untagged."""
     urls: dict[str, str] = {}
     async with contextlib.AsyncExitStack() as stack:
         for name, server in (shared or {}).items():
@@ -408,7 +417,12 @@ async def serve_tools(
                 logger.info("tool server '%s' (shared, external): %s", name, server.url)
                 continue
             url = harness_runtime.host_url(server.url) if server.local else server.url
-            urls[name] = _shared_url_for_rollout(url, state_base, state_secret)
+            shared_state_base = (
+                server.runtime.host_url(state_base.rstrip("/"))
+                if server.runtime is not None and state_base
+                else state_base
+            )
+            urls[name] = _shared_url_for_rollout(url, shared_state_base, state_secret)
             # The tagged URL contains the bearer secret; log only the untagged base URL.
             logger.info("tool server '%s' (shared): %s", name, server.url)
         for toolset in toolsets:


### PR DESCRIPTION
## Overview

Fix per-rollout state-channel routing for taskset-scoped tool servers by retaining the runtime that actually hosts each shared server.

## Details

The state bridge URL is now translated through the shared server runtime's existing `host_url()` behavior. This reuses Docker's platform-aware networking rules: macOS containers use `host.docker.internal`, Linux host-network containers keep loopback, and restricted containers use the framework host alias.

Tool endpoint translation remains owned by the harness runtime. External server URLs remain untagged, so per-rollout state secrets are not attached to third-party endpoints.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout wiring for shared MCP servers in non-local runtimes; mis-translation would break per-rollout state/task fetch, but scope is limited to shared-server URL tagging and runtime lifecycle in launch.
> 
> **Overview**
> Fixes **per-rollout state-channel routing** for taskset-scoped (shared) MCP tool servers when those servers run in their own sandbox (e.g. Docker), not on the harness host.
> 
> **`serve`** can take an optional pre-built **`runtime`**; otherwise it still creates one. **`serve_shared`** creates a single runtime per shared server, passes it into **`serve`**, and stores it on **`SharedToolServer`** along with **`local=runtime.is_local`** (replacing config-based **`runtime_is_local`**).
> 
> When **`serve_tools`** tags shared server URLs with the rollout's **`state_base`**, that base is now translated via **`server.runtime.host_url(...)`** before **`_shared_url_for_rollout`**, so the `/state` query parameter points at an address reachable **inside the shared server's network** (Docker bridge, **`host.docker.internal`**, restricted-network host alias, etc.). Tool MCP URLs are still adjusted through the harness runtime; **external** shared endpoints stay untagged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 503f08bc88381020e010b62ae0ba03a2208cc4b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix shared Docker state bridge routing by translating state URLs through each server's runtime
> - Shared tool servers in [launch.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2123/files#diff-989d87123d40d48511f9e1df74594d2e30776e9a99c11eca49d9cc20bf9e2230) now create a single `Runtime` instance that is retained on `SharedToolServer` and passed into `serve`, preventing duplicate runtime creation.
> - When tagging shared-server URLs, `state_base` is translated through `server.runtime.host_url(...)` so the shared-state channel is reachable within the server's own network rather than the caller's.
> - Locality of shared servers is now determined from `runtime.is_local` instead of the config-based `runtime_is_local` predicate.
> - Behavioral Change: shared-state URLs passed to `_shared_url_for_rollout` may now differ from `state_base` when the server runtime has a distinct host address (e.g. inside a Docker bridge network).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 503f08b.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->