### PR TITLE
Tear down MathRubric workers in tests

### DIFF
--- a/tests/test_math_rubric.py
+++ b/tests/test_math_rubric.py
@@ -51,9 +51,11 @@ class TestMathRubric:
         state["trajectory"] = []
         state["timing"] = RolloutTiming()
 
-        await rubric.score_rollout(state)
-
-        assert state["metrics"]["correct_answer"] == 1.0
+        try:
+            await rubric.score_rollout(state)
+            assert state["metrics"]["correct_answer"] == 1.0
+        finally:
+            await rubric.teardown()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -79,9 +81,11 @@ class TestMathRubric:
         state["trajectory"] = []
         state["timing"] = RolloutTiming()
 
-        await rubric.score_rollout(state)
-
-        assert state["metrics"]["correct_answer"] == 0.0
+        try:
+            await rubric.score_rollout(state)
+            assert state["metrics"]["correct_answer"] == 0.0
+        finally:
+            await rubric.teardown()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("timeout_seconds", [0.1, 10])
@@ -106,13 +110,16 @@ class TestMathRubric:
         state["trajectory"] = []
         state["timing"] = RolloutTiming()
 
-        await rubric.score_rollout(state)
+        try:
+            await rubric.score_rollout(state)
 
-        # rollout should only pass for large timeout
-        if timeout_seconds == 10:
-            assert state["metrics"]["correct_answer"] == 1.0
-        else:
-            assert state["metrics"]["correct_answer"] == 0.0
+            # rollout should only pass for large timeout
+            if timeout_seconds == 10:
+                assert state["metrics"]["correct_answer"] == 1.0
+            else:
+                assert state["metrics"]["correct_answer"] == 0.0
+        finally:
+            await rubric.teardown()
 
 
 class TestVerifyResponseExceptionHandling:


### PR DESCRIPTION
## Overview

Ensure MathRubric tests always release their process-pool workers after scoring.

## Details

The valid-answer, invalid-answer, and timeout cases now own the lifecycle of the `MathRubric` instances they create. Each test calls `teardown()` from a `finally` block, including when scoring or an assertion fails.

This prevents executor workers from surviving until Python interpreter shutdown and keeps the timeout-path cleanup consistent with normal scoring.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only lifecycle cleanup with no production or scoring logic changes.
> 
> **Overview**
> **MathRubric** scoring tests now always call **`await rubric.teardown()`** in a **`finally`** block after **`score_rollout`**, including when assertions fail.
> 
> This applies to valid-answer, invalid-answer, and timeout parametrized cases so process-pool workers are released promptly instead of lingering until interpreter shutdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9d0462f14942c9a4d20237dd80a10ddd0e1101a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Tear down `MathRubric` workers in tests after each test case
> Adds `try/finally` blocks to all three `TestMathRubric` tests in [test_math_rubric.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2126/files#diff-5640415ffd6062e8ce512c5f9e95ed18c3727c9fdfd2a470bc7d97c19e5432a0) so that `rubric.teardown()` is always awaited, even when a test assertion fails. This prevents worker processes from leaking between test runs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f9d0462.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->