### PR TITLE
Split deterministic v1 tests from live E2Es

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,10 +23,6 @@ jobs:
   test:
     name: Verifiers
     runs-on: ubuntu-latest
-    env:
-      PRIME_API_KEY: ${{ secrets.PRIME_API_KEY }}
-      PRIME_TEAM_ID: ${{ secrets.PRIME_TEAM_ID }}
-      HF_TOKEN: ${{ secrets.HF_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -56,13 +52,48 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
-      - name: Install prime
-        run: uv pip install prime
-
       - name: Run tests
         run: |
           uv run pytest tests/ -v --ignore=tests/v1 -m "not prime" --cov=verifiers --cov-report=xml --cov-report=term
 
-      - name: Run v1 tests
+      - name: Run deterministic v1 tests
         run: |
-          uv run pytest tests/v1 -vv -n auto -m "not prime and not modal" --cov=verifiers --cov-append --cov-report=xml --cov-report=term
+          uv run pytest tests/v1 -vv -n auto -m "not e2e" --cov=verifiers --cov-append --cov-report=xml --cov-report=term
+
+  v1-e2e:
+    name: V1 live E2E (Python 3.12)
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    env:
+      PRIME_API_KEY: ${{ secrets.PRIME_API_KEY }}
+      PRIME_TEAM_ID: ${{ secrets.PRIME_TEAM_ID }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Cache Hugging Face tokenizers
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.HF_HOME }}
+          key: hf-tokenizers-${{ runner.os }}-${{ hashFiles('uv.lock', 'tests/test_renderer_client.py', 'tests/test_renderer_e2e.py') }}
+          restore-keys: |
+            hf-tokenizers-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run live v1 E2Es
+        run: |
+          uv run pytest tests/v1 -vv -n 2 -m "e2e and not prime and not modal" --cov=verifiers --cov-report=xml --cov-report=term

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,9 @@ on:
 env:
   HF_HOME: ${{ github.workspace }}/.cache/huggingface
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Verifiers
@@ -62,7 +65,10 @@ jobs:
 
   v1-e2e:
     name: V1 live E2E (Python 3.12)
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login != 'dependabot[bot]')
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
   test:
     name: Verifiers
     runs-on: ubuntu-latest
+    env:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,4 +104,4 @@ jobs:
 
       - name: Run live v1 E2Es
         run: |
-          uv run pytest tests/v1 -vv -n 2 -m "e2e and not prime and not modal" --cov=verifiers --cov-report=xml --cov-report=term
+          uv run pytest tests/v1 -vv -n auto -m "e2e and not prime and not modal" --cov=verifiers --cov-report=xml --cov-report=term

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -17,7 +17,8 @@ one without `indirect=True` fails loudly.
 Every combination carries its axes' pytest marks, so subsets select with `-m`:
 
     uv run pytest tests/v1 -n auto                                # everything (needs modal setup)
-    uv run pytest tests/v1 -n auto -m "not prime and not modal"  # the CI set (host + docker only)
+    uv run pytest tests/v1 -n auto -m "not e2e"                   # deterministic CI matrix
+    uv run pytest tests/v1 -n 2 -m "e2e and not prime and not modal"  # live CI job
     uv run pytest tests/v1 -n auto -m docker                      # any case touching the docker runtime
     uv run pytest tests/v1 -n auto -m bash                        # only the bash harness
     uv run pytest tests/v1 -n auto -m prime                       # only prime (real sandboxes; local)
@@ -27,8 +28,8 @@ Marks: runtimes `subprocess` / `docker` / `prime` / `modal`, placement `colocate
 harnesses `null` / `bash` / `rlm` / `kimi_code` / `pi` / `pool` / `codex` / `claude_code`.
 A mark is applied per axis, so it selects every case touching that value on ANY axis; for one exact
 combination use `-k` on the test id (e.g. `-k "harness-in-docker-with-tool-in-subprocess"`).
-prime/modal provision real remote sandboxes (slow, infra-flaky, need setup), so they're local-only
-— CI runs `-m "not prime and not modal"`.
+prime/modal provision real remote sandboxes (slow, infra-flaky, need setup), so they're local-only.
+CI runs deterministic tests across the Python matrix and the remaining live E2Es once.
 """
 
 import os

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -18,7 +18,7 @@ Every combination carries its axes' pytest marks, so subsets select with `-m`:
 
     uv run pytest tests/v1 -n auto                                # everything (needs modal setup)
     uv run pytest tests/v1 -n auto -m "not e2e"                   # deterministic CI matrix
-    uv run pytest tests/v1 -n 2 -m "e2e and not prime and not modal"  # live CI job
+    uv run pytest tests/v1 -n auto -m "e2e and not prime and not modal"  # live CI job
     uv run pytest tests/v1 -n auto -m docker                      # any case touching the docker runtime
     uv run pytest tests/v1 -n auto -m bash                        # only the bash harness
     uv run pytest tests/v1 -n auto -m prime                       # only prime (real sandboxes; local)


### PR DESCRIPTION
## Overview

Separate deterministic v1 coverage from live, provider-dependent end-to-end evaluations while preserving both test surfaces.

## Changes

- Keep deterministic v1 tests on the full Python 3.11, 3.12, and 3.13 matrix through the existing `e2e` marker boundary.
- Run live v1 evaluations in a dedicated Python 3.12 job with bounded test concurrency and a job timeout.
- Keep Prime and Modal runtime placements local-only, matching the existing CI boundary.
- Scope provider credentials to the live job and skip that job for fork pull requests where secrets are unavailable.
- Remove the standalone Prime CLI installation from the deterministic matrix.
- Document the deterministic and live pytest selectors alongside the v1 fixtures.

## Impact

Deterministic regressions remain covered across every supported Python version, while provider, runtime, server, and dynamic-tool behavior stays visible in a dedicated CI result with controlled resource usage.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split deterministic v1 tests from live E2E tests in CI
> - Deterministic v1 tests now run in the main matrix job via `-m "not e2e"` without PRIME credentials; the main job also excludes `tests/v1` from its own test run to avoid duplication.
> - A new `v1-e2e` job (Python 3.12 only) runs live E2E tests via `-m "e2e and not prime and not modal"` with PRIME credentials, and is skipped for external PRs and Dependabot.
> - Updates [tests/v1/conftest.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2127/files#diff-bc28790d38dc6e7e4f2c44639d40bc33dea724d6c73149abf7ba82b37d14f40b) comments to reflect the new split run instructions.
> - A top-level `permissions: contents: read` block is added to [test.yml](https://github.com/PrimeIntellect-ai/verifiers/pull/2127/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88).
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #2127 opened
>
> - Changed pytest-xdist parallel worker configuration from fixed count to auto-detection [4f1bbc9]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 28314f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions wiring and test-selection markers; no application runtime or auth logic is modified.
> 
> **Overview**
> **CI now runs v1 in two lanes:** the main **Verifiers** matrix (Python 3.11–3.13) runs non-v1 tests with `--ignore=tests/v1`, then deterministic v1 via `-m "not e2e"` without Prime credentials or a separate `prime` install. Live model E2Es move to a new **`v1-e2e`** job on Python 3.12 only (`-m "e2e and not prime and not modal"`), with a 120-minute timeout and `PRIME_*` secrets scoped to that job.
> 
> The live job is **skipped for fork PRs and Dependabot** (when secrets aren’t available). Workflow **`permissions: contents: read`** is added. **`tests/v1/conftest.py`** comments are updated to document the deterministic vs live pytest selectors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f1bbc93aa640a58b3d54d4614d4b2949b4f2507. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->