### PR TITLE
fix(v1): keep Responses traces linear

### DIFF
--- a/tests/v1/test_graph.py
+++ b/tests/v1/test_graph.py
@@ -4,6 +4,7 @@ import numpy as np
 
 import verifiers.v1 as vf
 from verifiers.v1 import graph
+from verifiers.v1.dialects.responses import OpenAIResponse, ResponsesDialect
 from verifiers.v1.types import TurnTokens
 
 
@@ -160,6 +161,88 @@ def test_reasoning_content_participates_in_graph_prefix_matching():
         if isinstance(node.message, vf.AssistantMessage) and node.message.tool_calls
     ]
     assert len(tool_call_nodes) == 2
+
+
+def test_responses_provider_state_round_trip_stays_linear():
+    dialect = ResponsesDialect()
+    output = [
+        {
+            "id": "rs_tmp",
+            "type": "reasoning",
+            "status": "completed",
+            "summary": [],
+            "encrypted_content": "opaque",
+            "format": "openai-responses-v1",
+        },
+        {
+            "id": "msg_tmp",
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [
+                {
+                    "type": "output_text",
+                    "text": "Looking it up.",
+                    "annotations": [],
+                    "logprobs": [],
+                }
+            ],
+            "phase": "commentary",
+        },
+        {
+            "id": "fc_tmp",
+            "type": "function_call",
+            "status": "completed",
+            "call_id": "call_0",
+            "name": "lookup",
+            "arguments": "{}",
+        },
+    ]
+    first = dialect.parse_response(OpenAIResponse.model_validate({"output": output}))
+    user = vf.UserMessage(content="Find it")
+    trace = vf.Trace(
+        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="Find it"))
+    )
+    first_node = graph.prepare_turn(trace, [user]).commit(first)
+
+    prompt, _ = dialect.parse_request(
+        {
+            "input": [
+                {"role": "user", "content": "Find it"},
+                {
+                    "type": "reasoning",
+                    "summary": [],
+                    "content": None,
+                    "encrypted_content": "opaque",
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "Looking it up."}],
+                    "phase": "commentary",
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call_0",
+                    "name": "lookup",
+                    "arguments": "{}",
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_0",
+                    "output": "found",
+                },
+            ]
+        }
+    )
+    assert prompt[1] == first.message
+
+    graph.prepare_turn(trace, prompt).commit(
+        _response(vf.AssistantMessage(content="Done"))
+    )
+
+    assert trace.num_branches == 1
+    assert [node.parent for node in trace.nodes] == [None, 0, first_node, 2]
 
 
 def test_renderer_level_break_forks_by_token_id():

--- a/verifiers/v1/dialects/responses.py
+++ b/verifiers/v1/dialects/responses.py
@@ -45,6 +45,8 @@ _TERMINAL_MARKERS = tuple(
 )
 # Sampling knobs the eval owns, in this format's shape (Responses uses `max_output_tokens`).
 _SAMPLING_KEYS = frozenset({"temperature", "top_p", "max_output_tokens", "max_tokens"})
+_RESPONSE_ONLY_ITEM_FIELDS = frozenset({"id", "status", "format"})
+_RESPONSE_ONLY_CONTENT_FIELDS = frozenset({"annotations", "logprobs"})
 
 
 class ProviderUsageInputTokensDetails(BaseModel):
@@ -96,6 +98,32 @@ def parse_content(content) -> str | list[ContentPart]:
     return parts
 
 
+def _normalize_provider_state(items: list[dict] | None) -> list[dict] | None:
+    """Match response output items to the replay form sent in the next request."""
+    if not items:
+        return items
+    normalized: list[dict] = []
+    for raw in items:
+        item = {
+            key: value
+            for key, value in raw.items()
+            if key not in _RESPONSE_ONLY_ITEM_FIELDS and value is not None
+        }
+        if isinstance(content := item.get("content"), list):
+            item["content"] = [
+                {
+                    key: value
+                    for key, value in part.items()
+                    if key not in _RESPONSE_ONLY_CONTENT_FIELDS and value is not None
+                }
+                if isinstance(part, dict)
+                else part
+                for part in content
+            ]
+        normalized.append(item)
+    return normalized
+
+
 def fold_assistant(items: list[dict]) -> AssistantMessage:
     """One run of assistant-side items (reasoning / message / function_call) -> one typed
     assistant message."""
@@ -129,7 +157,7 @@ def fold_assistant(items: list[dict]) -> AssistantMessage:
         content=content or None,
         reasoning_content="\n".join(r for r in reasoning if r) or None,
         tool_calls=calls or None,
-        provider_state=items,
+        provider_state=_normalize_provider_state(items),
     )
 
 
@@ -189,7 +217,7 @@ def response_from_wire(response: OpenAIResponse) -> Response:
             content=content or None,
             reasoning_content="\n".join(r for r in reasoning if r) or None,
             tool_calls=tool_calls,
-            provider_state=data.get("output"),
+            provider_state=_normalize_provider_state(data.get("output")),
         ),
         finish_reason=finish,
         usage=usage,


### PR DESCRIPTION
## Summary

Normalize response-only metadata before storing Responses API `provider_state`.

Codex receives output items with temporary IDs, status fields, response formatting metadata, annotations, and logprobs, but replays those items without that metadata on its next request. The graph previously hashed the two wire shapes as different assistant messages, turning every Codex model turn into a separate branch.

The normalized state retains continuation-relevant data such as encrypted reasoning content and tool payloads, while allowing the next request to reuse the sampled assistant node.

## Validation

- `uv run pytest tests/v1/test_graph.py` (`7 passed`)
- `uv run ruff check verifiers/v1/dialects/responses.py tests/v1/test_graph.py`
- pre-push `markdownlint-cli2`, `ruff check`, `ruff format`, and `ty` hooks
- live combined eval with #2129: Codex 0.144.5, `openai/gpt-5.5`, Prime sandbox, reward `1.0`
- live trace: 3 sampled turns, 9 nodes in one linear parent chain, exactly one leaf, and call records aligned to sampled nodes `4, 6, 8`