### PR TITLE
fix(v1): trace Responses custom tools

### DIFF
--- a/tests/v1/test_graph.py
+++ b/tests/v1/test_graph.py
@@ -4,6 +4,7 @@ import numpy as np
 
 import verifiers.v1 as vf
 from verifiers.v1 import graph
+from verifiers.v1.dialects.responses import OpenAIResponse, ResponsesDialect
 from verifiers.v1.types import TurnTokens
 
 
@@ -160,6 +161,45 @@ def test_reasoning_content_participates_in_graph_prefix_matching():
         if isinstance(node.message, vf.AssistantMessage) and node.message.tool_calls
     ]
     assert len(tool_call_nodes) == 2
+
+
+def test_responses_custom_tool_calls_are_typed():
+    dialect = ResponsesDialect()
+    patch = "*** Begin Patch\n*** End Patch"
+    output = [
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "Applying the fix."}],
+        },
+        {
+            "type": "custom_tool_call",
+            "call_id": "call_0",
+            "name": "apply_patch",
+            "input": patch,
+        },
+    ]
+
+    response = dialect.parse_response(OpenAIResponse.model_validate({"output": output}))
+    prompt, _ = dialect.parse_request(
+        {
+            "input": [
+                {"role": "user", "content": "Fix it"},
+                *output,
+                {
+                    "type": "custom_tool_call_output",
+                    "call_id": "call_0",
+                    "output": "Done!",
+                },
+            ]
+        }
+    )
+
+    call = vf.ToolCall(id="call_0", name="apply_patch", arguments=patch)
+    assert response.finish_reason == "tool_calls"
+    assert response.message.tool_calls == [call]
+    assert prompt[1].tool_calls == [call]
+    assert prompt[2] == vf.ToolMessage(tool_call_id="call_0", content="Done!")
 
 
 def test_renderer_level_break_forks_by_token_id():

--- a/tests/v1/test_graph.py
+++ b/tests/v1/test_graph.py
@@ -4,7 +4,6 @@ import numpy as np
 
 import verifiers.v1 as vf
 from verifiers.v1 import graph
-from verifiers.v1.dialects.responses import OpenAIResponse, ResponsesDialect
 from verifiers.v1.types import TurnTokens
 
 
@@ -161,45 +160,6 @@ def test_reasoning_content_participates_in_graph_prefix_matching():
         if isinstance(node.message, vf.AssistantMessage) and node.message.tool_calls
     ]
     assert len(tool_call_nodes) == 2
-
-
-def test_responses_custom_tool_calls_are_typed():
-    dialect = ResponsesDialect()
-    patch = "*** Begin Patch\n*** End Patch"
-    output = [
-        {
-            "type": "message",
-            "role": "assistant",
-            "content": [{"type": "output_text", "text": "Applying the fix."}],
-        },
-        {
-            "type": "custom_tool_call",
-            "call_id": "call_0",
-            "name": "apply_patch",
-            "input": patch,
-        },
-    ]
-
-    response = dialect.parse_response(OpenAIResponse.model_validate({"output": output}))
-    prompt, _ = dialect.parse_request(
-        {
-            "input": [
-                {"role": "user", "content": "Fix it"},
-                *output,
-                {
-                    "type": "custom_tool_call_output",
-                    "call_id": "call_0",
-                    "output": "Done!",
-                },
-            ]
-        }
-    )
-
-    call = vf.ToolCall(id="call_0", name="apply_patch", arguments=patch)
-    assert response.finish_reason == "tool_calls"
-    assert response.message.tool_calls == [call]
-    assert prompt[1].tool_calls == [call]
-    assert prompt[2] == vf.ToolMessage(tool_call_id="call_0", content="Done!")
 
 
 def test_renderer_level_break_forks_by_token_id():

--- a/verifiers/v1/dialects/responses.py
+++ b/verifiers/v1/dialects/responses.py
@@ -1,9 +1,9 @@
 """The OpenAI Responses dialect (codex and friends).
 
 Request parsing walks the `input` items, folding each run of assistant-side items (reasoning /
-assistant message / function_call) into one typed assistant message; response parsing reads the
-`output` items. Relay-only: the eval client forwards the program's bytes to a `/responses`
-endpoint and this dialect parses a copy for the trace. Server-side statefulness
+assistant message / function or custom tool call) into one typed assistant message; response
+parsing reads the `output` items. Relay-only: the eval client forwards the program's bytes to a
+`/responses` endpoint and this dialect parses a copy for the trace. Server-side statefulness
 (`previous_response_id`) is not emulated — the endpoint owns it.
 """
 
@@ -96,9 +96,17 @@ def parse_content(content) -> str | list[ContentPart]:
     return parts
 
 
+def _parse_tool_call(item: dict) -> ToolCall:
+    arguments_key = "input" if item.get("type") == "custom_tool_call" else "arguments"
+    return ToolCall(
+        id=item.get("call_id", ""),
+        name=item.get("name", ""),
+        arguments=item.get(arguments_key, ""),
+    )
+
+
 def fold_assistant(items: list[dict]) -> AssistantMessage:
-    """One run of assistant-side items (reasoning / message / function_call) -> one typed
-    assistant message."""
+    """One run of assistant-side items -> one typed assistant message."""
     content = ""
     reasoning: list[str] = []
     calls: list[ToolCall] = []
@@ -106,14 +114,8 @@ def fold_assistant(items: list[dict]) -> AssistantMessage:
         if item.get("type") == "reasoning":
             reasoning += [s.get("text", "") for s in item.get("summary") or []]
             reasoning += [c.get("text", "") for c in item.get("content") or []]
-        elif item.get("type") == "function_call":
-            calls.append(
-                ToolCall(
-                    id=item.get("call_id", ""),
-                    name=item.get("name", ""),
-                    arguments=item.get("arguments", ""),
-                )
-            )
+        elif item.get("type") in ("function_call", "custom_tool_call"):
+            calls.append(_parse_tool_call(item))
         else:  # an assistant message item
             raw = item.get("content")
             content += (
@@ -151,14 +153,8 @@ def response_from_wire(response: OpenAIResponse) -> Response:
         elif kind == "reasoning":
             reasoning += [s.get("text", "") for s in item.get("summary") or []]
             reasoning += [c.get("text", "") for c in item.get("content") or []]
-        elif kind == "function_call":
-            calls.append(
-                ToolCall(
-                    id=item.get("call_id", ""),
-                    name=item.get("name", ""),
-                    arguments=item.get("arguments", ""),
-                )
-            )
+        elif kind in ("function_call", "custom_tool_call"):
+            calls.append(_parse_tool_call(item))
     tool_calls = calls or None
     finish: FinishReason = (
         "length"
@@ -279,7 +275,10 @@ class ResponsesDialect(Dialect[dict, OpenAIResponse]):
                 run = []
             if assistant:
                 run.append(item)
-            elif item.get("type") == "function_call_output":
+            elif item.get("type") in (
+                "function_call_output",
+                "custom_tool_call_output",
+            ):
                 output = item.get("output")
                 content = (
                     parse_content(output)

--- a/verifiers/v1/dialects/responses.py
+++ b/verifiers/v1/dialects/responses.py
@@ -96,15 +96,6 @@ def parse_content(content) -> str | list[ContentPart]:
     return parts
 
 
-def _parse_tool_call(item: dict) -> ToolCall:
-    arguments_key = "input" if item.get("type") == "custom_tool_call" else "arguments"
-    return ToolCall(
-        id=item.get("call_id", ""),
-        name=item.get("name", ""),
-        arguments=item.get(arguments_key, ""),
-    )
-
-
 def fold_assistant(items: list[dict]) -> AssistantMessage:
     """One run of assistant-side items -> one typed assistant message."""
     content = ""
@@ -115,7 +106,13 @@ def fold_assistant(items: list[dict]) -> AssistantMessage:
             reasoning += [s.get("text", "") for s in item.get("summary") or []]
             reasoning += [c.get("text", "") for c in item.get("content") or []]
         elif item.get("type") in ("function_call", "custom_tool_call"):
-            calls.append(_parse_tool_call(item))
+            calls.append(
+                ToolCall(
+                    id=item.get("call_id", ""),
+                    name=item.get("name", ""),
+                    arguments=item.get("arguments", item.get("input", "")),
+                )
+            )
         else:  # an assistant message item
             raw = item.get("content")
             content += (
@@ -154,7 +151,13 @@ def response_from_wire(response: OpenAIResponse) -> Response:
             reasoning += [s.get("text", "") for s in item.get("summary") or []]
             reasoning += [c.get("text", "") for c in item.get("content") or []]
         elif kind in ("function_call", "custom_tool_call"):
-            calls.append(_parse_tool_call(item))
+            calls.append(
+                ToolCall(
+                    id=item.get("call_id", ""),
+                    name=item.get("name", ""),
+                    arguments=item.get("arguments", item.get("input", "")),
+                )
+            )
     tool_calls = calls or None
     finish: FinishReason = (
         "length"


### PR DESCRIPTION
## Summary

Parse Responses API `custom_tool_call` and `custom_tool_call_output` items into Verifiers' existing typed `ToolCall` and `ToolMessage` representation.

Codex uses custom tool items for tools such as `apply_patch`. The Responses dialect previously recognized only function calls, so the patch call was absent from the assistant message and its result appeared as an empty user node in saved traces.

Custom tool input is now retained as the tool-call arguments, the output is linked by call ID, and responses containing custom calls correctly report a tool-call finish reason.

## Validation

- `uv run pytest tests/v1/test_graph.py` (`7 passed`)
- `uv run ruff check verifiers/v1/dialects/responses.py tests/v1/test_graph.py`
- pre-push `markdownlint-cli2`, `ruff check`, `ruff format`, and `ty` hooks
- live combined eval with #2128: Codex 0.144.5, `openai/gpt-5.5`, Prime sandbox, reward `1.0`
- live trace captured `apply_patch` as a typed assistant tool call at node 4 and its linked tool result at node 5; the subsequent shell verification and final answer were also preserved

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow parsing change in the Responses dialect trace path; no auth or runtime execution changes, with existing graph tests noted in the PR.
> 
> **Overview**
> **Extends the Responses dialect** so OpenAI-style **`custom_tool_call`** and **`custom_tool_call_output`** items are handled like function tools when building eval traces.
> 
> On **request parsing**, custom tool outputs become linked **`ToolMessage`** nodes (by `call_id`) instead of falling through as empty user messages. When **folding assistant runs** and **parsing wire responses**, custom calls are collected as **`ToolCall`** entries, using **`input`** when **`arguments`** is absent (e.g. Codex **`apply_patch`**). Responses that only contain custom calls now get a **`tool_calls`** finish reason.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 472e3f619eaa923f340516d7208194d7ba6b5255. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ## Summary
>
> Parse Responses API `custom_tool_call` and `custom_tool_call_output` items into Verifiers' existing typed `ToolCall` and `ToolMessage` representation.
>
> Codex uses custom tool items for tools such as `apply_patch`. The Responses dialect previously recognized only function calls, so the patch call was absent from the assistant message and its result appeared as an empty user node in saved traces.
>
> Custom tool input is now retained as the tool-call arguments, the output is linked by call ID, and responses containing custom calls correctly report a tool-call finish reason.
>
> ## Validation
>
> - `uv run pytest tests/v1/test_graph.py` (`7 passed`)
> - `uv run ruff check verifiers/v1/dialects/responses.py tests/v1/test_graph.py`
> - pre-push `markdownlint-cli2`, `ruff check`, `ruff format`, and `ty` hooks
> - live combined eval with #2128: Codex 0.144.5, `openai/gpt-5.5`, Prime sandbox, reward `1.0`
> - live trace captured `apply_patch` as a typed assistant tool call at node 4 and its linked tool result at node 5; the subsequent shell verification and final answer were also preserved
>
> <!-- CURSOR_SUMMARY -->
> ---
>
> > [!NOTE]
> > **Low Risk**
> > Narrow parsing change in the Responses dialect trace path; no auth or runtime execution changes, with existing graph tests noted in the PR.
> > 
> > **Overview**
> > **Extends the Responses dialect** so OpenAI-style **`custom_tool_call`** and **`custom_tool_call_output`** items are handled like function tools when building eval traces.
> > 
> > On **request parsing**, custom tool outputs become linked **`ToolMessage`** nodes (by `call_id`) instead of falling through as empty user messages. When **folding assistant runs** and **parsing wire responses**, custom calls are collected as **`ToolCall`** entries, using **`input`** when **`arguments`** is absent (e.g. Codex **`apply_patch`**). Responses that only contain custom calls now get a **`tool_calls`** finish reason.
> > 
> > <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 472e3f619eaa923f340516d7208194d7ba6b5255. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
> <!-- /CURSOR_SUMMARY --><!-- Macroscope's changelog starts here -->
> #### Changes since #2129 opened
>
> - Changed `ToolCall` construction in `ResponsesDialect.fold_assistant` and `ResponsesDialect.response_from_wire` to prioritize the `arguments` field over `input` field for both `custom_tool_call` and `function_call` item types [472e3f6]
> - Removed test case `test_responses_custom_tool_calls_are_typed` and its associated imports from the test suite [472e3f6]
> <!-- Macroscope's changelog ends here -->
>
<!-- Macroscope's pull request summary ends here -->