### PR TITLE
Fix provider state graph identity

### DIFF
--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -212,12 +212,17 @@ def _canonical_tool_arguments(arguments: str) -> str:
         return arguments
 
 
+# Responses, chat reasoning details, and Anthropic thinking blocks use these payload keys.
+_OPAQUE_PROVIDER_STATE_FIELDS = frozenset({"encrypted_content", "signature", "data"})
+
+
 def message_hash(message: Message) -> str:
     """Stable content hash on the fields that round-trip through a prompt — role, content
     (None and "" equal), assistant reasoning content when present, assistant tool calls,
-    tool call id. Two messages hash equal iff they're the same conversational message, so a
-    re-stated prefix message dedups to one node. The dedup key for sharing a prefix across
-    turns/branches; salt-free so it is identical across processes and after deserialization."""
+    opaque continuation state, tool call id. Two messages hash equal iff they're the same
+    conversational message, so a re-stated prefix message dedups to one node. The dedup key
+    for sharing a prefix across turns/branches; salt-free so it is identical across processes
+    and after deserialization."""
     digest = hashlib.blake2b(digest_size=16)
 
     def add(value: str) -> None:
@@ -241,10 +246,17 @@ def message_hash(message: Message) -> str:
         if message.reasoning_content is not None:
             add("reasoning_content")
             add(message.reasoning_content)
-        if message.provider_state:
-            # Signed/encrypted continuation state distinguishes otherwise equal turns.
+        for item in message.provider_state or []:
+            opaque_state = {
+                key: item[key]
+                for key in _OPAQUE_PROVIDER_STATE_FIELDS
+                if item.get(key) is not None
+            }
+            if not opaque_state:
+                continue
             add("provider_state")
-            add(json.dumps(message.provider_state, sort_keys=True))
+            add(item.get("type") or "")
+            add(json.dumps(opaque_state, sort_keys=True))
         for tc in message.tool_calls or []:
             add("tool_call")
             add(tc.id)

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -248,21 +248,30 @@ def message_hash(message: Message) -> str:
             add(message.reasoning_content)
         for item in message.provider_state or []:
             kind = item.get("type") or ""
-            opaque_state = {
+            hashed_state = {
                 key: item[key]
                 for key in _OPAQUE_PROVIDER_STATE_FIELDS
                 if item.get(key) is not None
             }
+            if kind == "message":
+                # Keep content parts the typed message does not expose, such as refusals.
+                unparsed_content = [
+                    part
+                    for part in item.get("content") or []
+                    if part.get("type") not in ("input_text", "output_text")
+                ]
+                if unparsed_content:
+                    hashed_state["content"] = unparsed_content
             represented = kind in ("message", "reasoning") or (
                 kind in ("function_call", "custom_tool_call")
                 and any(
                     call.id == item.get("call_id") for call in message.tool_calls or []
                 )
             )
-            if represented and not opaque_state:
+            if represented and not hashed_state:
                 continue
             # Unknown provider items still distinguish built-in calls and actions.
-            state = opaque_state or item
+            state = hashed_state or item
             add("provider_state")
             add(kind)
             add(json.dumps(state, sort_keys=True))

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -247,16 +247,25 @@ def message_hash(message: Message) -> str:
             add("reasoning_content")
             add(message.reasoning_content)
         for item in message.provider_state or []:
+            kind = item.get("type") or ""
             opaque_state = {
                 key: item[key]
                 for key in _OPAQUE_PROVIDER_STATE_FIELDS
                 if item.get(key) is not None
             }
-            if not opaque_state:
+            represented = kind in ("message", "reasoning") or (
+                kind in ("function_call", "custom_tool_call")
+                and any(
+                    call.id == item.get("call_id") for call in message.tool_calls or []
+                )
+            )
+            if represented and not opaque_state:
                 continue
+            # Unknown provider items still distinguish built-in calls and actions.
+            state = opaque_state or item
             add("provider_state")
-            add(item.get("type") or "")
-            add(json.dumps(opaque_state, sort_keys=True))
+            add(kind)
+            add(json.dumps(state, sort_keys=True))
         for tc in message.tool_calls or []:
             add("tool_call")
             add(tc.id)

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -212,8 +212,8 @@ def _canonical_tool_arguments(arguments: str) -> str:
         return arguments
 
 
-# Responses, chat reasoning details, and Anthropic thinking blocks use these payload keys.
-_OPAQUE_PROVIDER_STATE_FIELDS = frozenset({"encrypted_content", "signature", "data"})
+# Provider-specific fields not represented by typed messages but required on replay.
+_PROVIDER_STATE_FIELDS = frozenset({"encrypted_content", "signature", "data", "phase"})
 
 
 def message_hash(message: Message) -> str:
@@ -247,10 +247,12 @@ def message_hash(message: Message) -> str:
             add("reasoning_content")
             add(message.reasoning_content)
         for item in message.provider_state or []:
-            kind = item.get("type") or ""
+            kind = item.get("type") or (
+                "message" if item.get("role") == "assistant" else ""
+            )
             hashed_state = {
                 key: item[key]
-                for key in _OPAQUE_PROVIDER_STATE_FIELDS
+                for key in _PROVIDER_STATE_FIELDS
                 if item.get(key) is not None
             }
             if kind == "message" and isinstance(item.get("content"), list):

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -253,7 +253,7 @@ def message_hash(message: Message) -> str:
                 for key in _OPAQUE_PROVIDER_STATE_FIELDS
                 if item.get(key) is not None
             }
-            if kind == "message":
+            if kind == "message" and isinstance(item.get("content"), list):
                 # Keep content parts the typed message does not expose, such as refusals.
                 unparsed_content = [
                     part
@@ -271,7 +271,7 @@ def message_hash(message: Message) -> str:
             if represented and not hashed_state:
                 continue
             # Unknown provider items still distinguish built-in calls and actions.
-            state = hashed_state or item
+            state = hashed_state if represented else item
             add("provider_state")
             add(kind)
             add(json.dumps(state, sort_keys=True))


### PR DESCRIPTION
## Summary

Keep replayed assistant turns on the same trace path when provider response metadata changes shape between the response and the next request.

## Details

Graph identity hashes only opaque continuation payloads (`encrypted_content`, `signature`, or redacted `data`) for provider items already represented by the message's visible content, reasoning, or typed tool calls. This prevents response-only metadata such as IDs, statuses, and format labels from creating false branches.

Responses message content that is not exposed by the typed message, such as refusal parts, is hashed separately so distinct visible refusals cannot collapse into the same graph node.

Provider items that are not represented by those typed fields, such as built-in code-interpreter or computer calls, retain their full state in the identity so distinct calls and actions cannot collapse into the same graph node.

The complete provider state remains stored on the trace, while genuinely different hidden reasoning states and unsupported provider actions still receive different graph identities.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix provider state graph identity hashing in `message_hash`
> - Previously, `AssistantMessage` hashing in [graph.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2130/files#diff-64c9d635eb215902a512c9e8ab316fd9b9967c36db03d4049aacc812cdfbd740) serialized the entire `provider_state` object, causing identity mismatches when irrelevant fields changed.
> - Hashing now iterates `provider_state` items, classifies each by kind (message/reasoning/function_call/custom_tool_call), and limits hashed fields to a fixed set defined in `_PROVIDER_STATE_FIELDS` (`encrypted_content`, `signature`, `data`, `phase`).
> - Items that are "represented" (i.e. their content already appears in `message.tool_calls` or is of kind message/reasoning) are skipped entirely when no relevant fields are present.
> - Behavioral Change: `AssistantMessage` hashes will differ from those produced by the old logic for any message with a non-empty `provider_state`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ed76a65.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dedup identity for all `AssistantMessage` nodes carrying `provider_state`, which can alter graph prefix sharing and caching; logic is nuanced but localized to `message_hash`.
> 
> **Overview**
> **`message_hash`** no longer JSON-hashes the entire `AssistantMessage.provider_state` blob. It walks provider items one-by-one and mixes each item’s `kind` plus a selective payload into the Blake2b digest.
> 
> For items already covered by typed fields (assistant `message`/`reasoning`, or `function_call`/`custom_tool_call` matching a `tool_calls` entry), only opaque continuation fields (`encrypted_content`, `signature`, `data`, `phase`) count—and refusal-like `content` parts not exposed on the typed message. Items with no such extras are **skipped**, so response-only metadata (IDs, statuses, format labels) no longer forks the graph on replay.
> 
> Unrepresented provider actions (e.g. built-in code interpreter / computer use) still hash the **full** item so distinct hidden calls cannot collapse to one node.
> 
> **Behavioral impact:** any assistant turn with `provider_state` may get a different hash than before, affecting prefix dedup in `_head_index` / `prepare_turn` and trace branching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed76a650df2aba304458227c0f947911c364cd48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->