### PR TITLE
Let rollout timeout own null harness generations

### DIFF
--- a/verifiers/v1/harnesses/null/program.py
+++ b/verifiers/v1/harnesses/null/program.py
@@ -158,7 +158,11 @@ async def main() -> None:
         payload = path.read_bytes()
         path.unlink()
         initial = json.loads(payload)
-    client = AsyncOpenAI(base_url=args.base_url, api_key=args.api_key)
+    client = AsyncOpenAI(
+        base_url=args.base_url,
+        api_key=args.api_key,
+        timeout=httpx.Timeout(None, connect=5.0),
+    )
     config = json.loads(args.mcp_config or "{}")
     if config.get("mcpServers"):
         # Bound only tool enumeration; each session is opened and closed within this task.


### PR DESCRIPTION
## Overview

Allow long-running null-harness model generations to run until the configured Verifiers rollout deadline instead of being cut off by the OpenAI SDK default request timeout.

## Details

The null harness constructed its OpenAI client with the SDK defaults. For non-streaming generations, a healthy provider can produce no response bytes until the full answer is ready, so sufficiently long responses were misclassified as stalled requests and retried internally.

Configure the harness client with no read, write, or pool deadline while retaining a five-second localhost connection timeout. The configured rollout deadline remains the single owner of generation duration, so long-but-live responses can complete and genuinely hung providers are still stopped by the outer Verifiers timeout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-client timeout tweak in the null harness; rollout-level timeouts still bound hung work, with only a faster fail on bad localhost connections.
> 
> **Overview**
> The null harness **AsyncOpenAI** client no longer uses the SDK’s default HTTP deadlines for read/write/pool. It now sets **`httpx.Timeout(None, connect=5.0)`**, so long non-streaming completions that stay silent until the full response is ready are not treated as stalled and retried internally.
> 
> **Connection** to the local/base URL is still capped at five seconds; **overall generation length** is left to the outer Verifiers rollout **`timeout_seconds`** (e.g. **`asyncio.wait_for`** on the rollout loop), which remains the single wall-clock limit for hung providers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4615d221ebced9a9b3cf2611b0a94e24d1ad6dbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set explicit httpx timeout on null harness AsyncOpenAI client
> Passes `httpx.Timeout(None, connect=5.0)` to the `AsyncOpenAI` client in [program.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2133/files#diff-d4e93ef3c6afb0d7441cceeef2d60bd8618168a7d72b8d1df78f16dbe0289304), enforcing a 5s connection timeout with no overall request timeout. Previously the client relied on httpx defaults, which apply a total request timeout that can interrupt long rollout-owned generations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4615d22.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->