### PR TITLE
Preserve MCP tool error outcomes

### DIFF
--- a/verifiers/v1/dialects/anthropic.py
+++ b/verifiers/v1/dialects/anthropic.py
@@ -106,6 +106,7 @@ def parse_messages(body: dict) -> Messages:
                     ToolMessage(
                         tool_call_id=block.get("tool_use_id", ""),
                         content=parse_content(block.get("content")),
+                        is_error=bool(block.get("is_error")),
                     )
                 )
             else:

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -47,6 +47,8 @@ FINISH_REASONS = frozenset({"stop", "length", "tool_calls"})
 # `reasoning` (vLLM / Together / OpenRouter), `reasoning_content` (DeepSeek / Qwen / SGLang /
 # Fireworks / Kimi), `reasoning_details` (OpenRouter / MiniMax).
 REASONING_FIELDS = ("reasoning", "reasoning_content", "reasoning_details")
+TOOL_ERROR_KEY = "_vf_is_error"
+TOOL_ERROR_PREFIX = "Tool execution failed:\n"
 
 
 def reasoning_text(data: Mapping[str, Any]) -> str | None:
@@ -86,6 +88,7 @@ def parse_message(raw: dict) -> Message:
             tool_call_id=raw.get("tool_call_id", ""),
             content=content_to_parts(content),
             name=raw.get("name"),
+            is_error=bool(raw.get(TOOL_ERROR_KEY)),
         )
     if role == "assistant":
         details = raw.get("reasoning_details")
@@ -138,7 +141,7 @@ def _content_to_wire(content):
     return [part.model_dump() for part in content]
 
 
-def message_to_wire(message: Message) -> dict:
+def message_to_wire(message: Message, *, include_internal: bool = False) -> dict:
     if message.role == "assistant":
         wire: dict = {"role": "assistant", "content": message.content}
         if message.provider_state:
@@ -156,13 +159,25 @@ def message_to_wire(message: Message) -> dict:
             ]
         return wire
     if message.role == "tool":
+        content = _content_to_wire(message.content)
+        if message.is_error and not include_internal:
+            content = (
+                TOOL_ERROR_PREFIX + content
+                if isinstance(content, str)
+                else [
+                    {"type": "text", "text": TOOL_ERROR_PREFIX.rstrip()},
+                    *content,
+                ]
+            )
         wire = {
             "role": "tool",
             "tool_call_id": message.tool_call_id,
-            "content": _content_to_wire(message.content),
+            "content": content,
         }
         if message.name:
             wire["name"] = message.name
+        if include_internal and message.is_error:
+            wire[TOOL_ERROR_KEY] = True
         return wire
     return {"role": message.role, "content": _content_to_wire(message.content)}
 
@@ -349,4 +364,14 @@ class ChatDialect(Dialect[dict, ChatCompletion]):
     def apply_overrides(self, body: dict, model: str, sampling: SamplingConfig) -> dict:
         # Preserve the program's native fields, overlaying only what the eval owns: the model and
         # the sampling knobs it set (later keys win, so the eval's override the program's).
-        return {**body, "model": model, **sampling.model_dump(exclude_none=True)}
+        return {
+            **body,
+            "messages": [
+                message_to_wire(parse_message(message))
+                if message.get(TOOL_ERROR_KEY)
+                else message
+                for message in body.get("messages", [])
+            ],
+            "model": model,
+            **sampling.model_dump(exclude_none=True),
+        }

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -285,6 +285,7 @@ def message_hash(message: Message) -> str:
     elif isinstance(message, ToolMessage):
         add("tool_call_id")
         add(message.tool_call_id)
+        add("error" if message.is_error else "success")
     return digest.hexdigest()
 
 

--- a/verifiers/v1/harnesses/bash/harness.py
+++ b/verifiers/v1/harnesses/bash/harness.py
@@ -119,7 +119,9 @@ class BashHarness(Harness[BashHarnessConfig]):
             path = f".vf-initial-messages-{trace.id}.json"
             await runtime.write(
                 path,
-                json.dumps([message_to_wire(m) for m in prompt]).encode(),
+                json.dumps(
+                    [message_to_wire(m, include_internal=True) for m in prompt]
+                ).encode(),
             )
             args.append(f"--initial-messages-file={path}")
         program = await runtime.prepare_uv_script(

--- a/verifiers/v1/harnesses/bash/program.py
+++ b/verifiers/v1/harnesses/bash/program.py
@@ -16,6 +16,7 @@ from openai import AsyncOpenAI
 SERPER_URL = "https://google.serper.dev/search"
 
 # <vf:mcp-client>
+TOOL_ERROR_KEY = "_vf_is_error"
 
 BASH_TOOL = {
     "type": "function",
@@ -263,8 +264,9 @@ async def main() -> None:
                     }
                 )
                 continue
+            is_error = False
             if name in dispatch:
-                content = await call_mcp(  # noqa: F821
+                content, is_error = await call_mcp(  # noqa: F821
                     servers, dispatch, name, tool_args
                 )
             elif name == "bash" and args.bash:
@@ -287,9 +289,10 @@ async def main() -> None:
                 )
             else:
                 content = f"error: unknown tool {name!r}"
-            messages.append(
-                {"role": "tool", "tool_call_id": call.id, "content": content}
-            )
+            message = {"role": "tool", "tool_call_id": call.id, "content": content}
+            if is_error:
+                message[TOOL_ERROR_KEY] = True
+            messages.append(message)
 
 
 if __name__ == "__main__":

--- a/verifiers/v1/harnesses/mcp_client.py
+++ b/verifiers/v1/harnesses/mcp_client.py
@@ -270,7 +270,7 @@ def mcp_content_to_chat_content(blocks) -> str | list[dict]:
 
 async def call_mcp(
     servers: dict, dispatch: dict, name: str, arguments: dict
-) -> str | list[dict]:
+) -> tuple[str | list[dict], bool]:
     """Call once after initialization; a lost response is never replayed in this session."""
     server, raw = dispatch[name]
 
@@ -281,4 +281,4 @@ async def call_mcp(
             return await session.call_tool(raw, arguments)
 
     result = await with_retry(call)
-    return mcp_content_to_chat_content(result.content)
+    return mcp_content_to_chat_content(result.content), result.isError

--- a/verifiers/v1/harnesses/null/harness.py
+++ b/verifiers/v1/harnesses/null/harness.py
@@ -63,7 +63,9 @@ class NullHarness(Harness[NullHarnessConfig]):
             path = f".vf-initial-messages-{trace.id}.json"
             await runtime.write(
                 path,
-                json.dumps([message_to_wire(m) for m in prompt]).encode(),
+                json.dumps(
+                    [message_to_wire(m, include_internal=True) for m in prompt]
+                ).encode(),
             )
             args.append(f"--initial-messages-file={path}")
         program = await runtime.prepare_uv_script(

--- a/verifiers/v1/types.py
+++ b/verifiers/v1/types.py
@@ -89,6 +89,8 @@ class ToolMessage(StrictBaseModel):
     content: MessageContent
     name: str | None = None
     """Needed by templates such as Harmony when bridge tails omit the issuing call."""
+    is_error: bool = False
+    """Whether the tool returned a model-visible failure rather than a successful result."""
 
 
 Message = Annotated[


### PR DESCRIPTION
## Overview

Preserves MCP tool-declared outcome semantics across harness execution, typed messages, traces, replay, and provider conversion.

This PR is stacked on #2134, which owns the shared null/bash MCP client and its session lifecycle and replay-safety behavior.

## Details

MCP `CallToolResult` contains both model-visible content and an `isError` outcome. The shared MCP client now returns both values, and the harness program carries the outcome into `ToolMessage.is_error`.

The typed outcome participates in graph identity and trace serialization, so success and failure results with identical content remain distinguishable after persistence and resume.

For chat-compatible providers, the localhost harness handoff uses a private marker that is removed before the provider request while adding a readable failure label to the model-visible content. Anthropic-native `tool_result.is_error` maps directly into the same typed representation.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve MCP tool error outcomes through the verifier pipeline
> - Adds `is_error` field to `ToolMessage` in [types.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2135/files#diff-88a4e4ee0c58ac5dc7344161a011374082a3767eda2ad32af97c942dca982112) and propagates it from `call_mcp` through the bash/null harness programs and into parsed messages.
> - Introduces `_vf_is_error` as an internal wire flag in [chat.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2135/files#diff-5d2fcbf59a03489b63b0626038a853eee89543b591074597161ee29aab901280); when serializing for external consumption the flag is replaced with a `"Tool execution failed:\n"` content prefix, while internal paths (harness launch) preserve the machine-readable flag via `include_internal=True`.
> - The Anthropic dialect in [anthropic.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2135/files#diff-abc86b3ad07c2d6ab09cd923f50271c4f6c4cb928a9bb82c12f6e97aac17b04d) reads `is_error` from `tool_result` blocks, and `message_hash` in [graph.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2135/files#diff-64c9d635eb215902a512c9e8ab316fd9b9967c36db03d4049aacc812cdfbd740) incorporates error vs. success into the digest so error and success tool messages hash differently.
> - `ChatDialect.apply_overrides` rewrites messages containing `_vf_is_error` to error-prefixed content before forwarding upstream.
> - Behavioral Change: tool messages that were previously indistinguishable from successful ones now carry a visible error prefix when sent to upstream models, and produce different cache keys.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e47ec2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->