### PR TITLE
Preserve MCP tool error outcomes

### DIFF
--- a/verifiers/v1/dialects/anthropic.py
+++ b/verifiers/v1/dialects/anthropic.py
@@ -106,6 +106,7 @@ def parse_messages(body: dict) -> Messages:
                     ToolMessage(
                         tool_call_id=block.get("tool_use_id", ""),
                         content=parse_content(block.get("content")),
+                        is_error=bool(block.get("is_error")),
                     )
                 )
             else:

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -166,7 +166,7 @@ def message_to_wire(message: Message, *, include_internal: bool = False) -> dict
                 TOOL_ERROR_PREFIX + content
                 if isinstance(content, str)
                 else [
-                    {"type": "text", "text": TOOL_ERROR_PREFIX.rstrip()},
+                    {"type": "text", "text": TOOL_ERROR_PREFIX},
                     *content,
                 ]
             )

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -48,6 +48,8 @@ FINISH_REASONS = frozenset({"stop", "length", "tool_calls"})
 # `reasoning` (vLLM / Together / OpenRouter), `reasoning_content` (DeepSeek / Qwen / SGLang /
 # Fireworks / Kimi), `reasoning_details` (OpenRouter / MiniMax).
 REASONING_FIELDS = ("reasoning", "reasoning_content", "reasoning_details")
+TOOL_ERROR_KEY = "_vf_is_error"
+TOOL_ERROR_PREFIX = "Tool execution failed:\n"
 
 
 def reasoning_text(data: Mapping[str, Any]) -> str | None:
@@ -87,6 +89,7 @@ def parse_message(raw: dict) -> Message:
             tool_call_id=raw.get("tool_call_id", ""),
             content=content_to_parts(content),
             name=raw.get("name"),
+            is_error=bool(raw.get(TOOL_ERROR_KEY)),
         )
     if role == "assistant":
         details = raw.get("reasoning_details")
@@ -139,7 +142,7 @@ def _content_to_wire(content):
     return [part.model_dump() for part in content]
 
 
-def message_to_wire(message: Message) -> dict:
+def message_to_wire(message: Message, *, include_internal: bool = False) -> dict:
     if message.role == "assistant":
         wire: dict = {"role": "assistant", "content": message.content}
         if message.provider_state:
@@ -157,13 +160,25 @@ def message_to_wire(message: Message) -> dict:
             ]
         return wire
     if message.role == "tool":
+        content = _content_to_wire(message.content)
+        if message.is_error and not include_internal:
+            content = (
+                TOOL_ERROR_PREFIX + content
+                if isinstance(content, str)
+                else [
+                    {"type": "text", "text": TOOL_ERROR_PREFIX.rstrip()},
+                    *content,
+                ]
+            )
         wire = {
             "role": "tool",
             "tool_call_id": message.tool_call_id,
-            "content": _content_to_wire(message.content),
+            "content": content,
         }
         if message.name:
             wire["name"] = message.name
+        if include_internal and message.is_error:
+            wire[TOOL_ERROR_KEY] = True
         return wire
     return {"role": message.role, "content": _content_to_wire(message.content)}
 
@@ -350,4 +365,14 @@ class ChatDialect(Dialect[dict, ChatCompletion]):
     def apply_overrides(self, body: dict, model: str, sampling: SamplingConfig) -> dict:
         # Preserve the program's native fields, overlaying only what the eval owns: the model and
         # the sampling knobs it set (later keys win, so the eval's override the program's).
-        return {**body, "model": model, **sampling.model_dump(exclude_none=True)}
+        return {
+            **body,
+            "messages": [
+                message_to_wire(parse_message(message))
+                if message.get(TOOL_ERROR_KEY)
+                else message
+                for message in body.get("messages", [])
+            ],
+            "model": model,
+            **sampling.model_dump(exclude_none=True),
+        }

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -284,6 +284,7 @@ def message_hash(message: Message) -> str:
     elif isinstance(message, ToolMessage):
         add("tool_call_id")
         add(message.tool_call_id)
+        add("error" if message.is_error else "success")
     return digest.hexdigest()
 
 

--- a/verifiers/v1/harnesses/bash/harness.py
+++ b/verifiers/v1/harnesses/bash/harness.py
@@ -112,7 +112,9 @@ class BashHarness(Harness[BashHarnessConfig]):
             path = f".vf-initial-messages-{trace.id}.json"
             await runtime.write(
                 path,
-                json.dumps([message_to_wire(m) for m in prompt]).encode(),
+                json.dumps(
+                    [message_to_wire(m, include_internal=True) for m in prompt]
+                ).encode(),
             )
             args.append(f"--initial-messages-file={path}")
         program = await runtime.prepare_uv_script(

--- a/verifiers/v1/harnesses/minimal/program.py
+++ b/verifiers/v1/harnesses/minimal/program.py
@@ -461,7 +461,10 @@ async def chat(
     client: AsyncOpenAI, model: str, messages: list[dict], tools: list[dict]
 ):
     completion = await client.chat.completions.create(
-        model=model, messages=messages, tools=tools or None
+        model=model,
+        messages=messages,
+        tools=tools or None,
+        extra_body={"messages": messages},  # preserve private fields for interception
     )
     return completion.choices[0].message
 
@@ -551,9 +554,7 @@ async def main() -> None:
                 continue
             is_error = False
             if name in dispatch:
-                content, is_error = await call_mcp(
-                    servers, dispatch, name, tool_args
-                )
+                content, is_error = await call_mcp(servers, dispatch, name, tool_args)
             elif name == "bash" and args.bash:
                 content = await asyncio.to_thread(
                     run_bash, tool_args.get("command", "")
@@ -582,4 +583,3 @@ async def main() -> None:
 
 if __name__ == "__main__":
     asyncio.run(main())
-

--- a/verifiers/v1/harnesses/minimal/program.py
+++ b/verifiers/v1/harnesses/minimal/program.py
@@ -24,6 +24,7 @@ from tenacity import (
 )
 
 SERPER_URL = "https://google.serper.dev/search"
+TOOL_ERROR_KEY = "_vf_is_error"
 
 MCP_CALL_ATTEMPTS = 6
 MCP_CANCELLED_CLOSE_GRACE = 1.0  # then re-cancel a hung stateful-session DELETE
@@ -286,7 +287,7 @@ def mcp_content_to_chat_content(blocks) -> str | list[dict]:
 
 async def call_mcp(
     servers: dict, dispatch: dict, name: str, arguments: dict
-) -> str | list[dict]:
+) -> tuple[str | list[dict], bool]:
     """Call once after initialization; a lost response is never replayed in this session."""
     server, raw = dispatch[name]
 
@@ -297,7 +298,7 @@ async def call_mcp(
             return await session.call_tool(raw, arguments)
 
     result = await with_retry(call)
-    return mcp_content_to_chat_content(result.content)
+    return mcp_content_to_chat_content(result.content), result.isError
 
 
 BASH_TOOL = {
@@ -548,8 +549,11 @@ async def main() -> None:
                     }
                 )
                 continue
+            is_error = False
             if name in dispatch:
-                content = await call_mcp(servers, dispatch, name, tool_args)
+                content, is_error = await call_mcp(
+                    servers, dispatch, name, tool_args
+                )
             elif name == "bash" and args.bash:
                 content = await asyncio.to_thread(
                     run_bash, tool_args.get("command", "")
@@ -570,10 +574,12 @@ async def main() -> None:
                 )
             else:
                 content = f"error: unknown tool {name!r}"
-            messages.append(
-                {"role": "tool", "tool_call_id": call.id, "content": content}
-            )
+            message = {"role": "tool", "tool_call_id": call.id, "content": content}
+            if is_error:
+                message[TOOL_ERROR_KEY] = True
+            messages.append(message)
 
 
 if __name__ == "__main__":
     asyncio.run(main())
+

--- a/verifiers/v1/harnesses/null/harness.py
+++ b/verifiers/v1/harnesses/null/harness.py
@@ -63,7 +63,9 @@ class NullHarness(Harness[NullHarnessConfig]):
             path = f".vf-initial-messages-{trace.id}.json"
             await runtime.write(
                 path,
-                json.dumps([message_to_wire(m) for m in prompt]).encode(),
+                json.dumps(
+                    [message_to_wire(m, include_internal=True) for m in prompt]
+                ).encode(),
             )
             args.append(f"--initial-messages-file={path}")
         program = await runtime.prepare_uv_script(

--- a/verifiers/v1/types.py
+++ b/verifiers/v1/types.py
@@ -85,6 +85,8 @@ class ToolMessage(BaseModel):
     content: MessageContent
     name: str | None = None
     """Needed by templates such as Harmony when bridge tails omit the issuing call."""
+    is_error: bool = False
+    """Whether the tool returned a model-visible failure rather than a successful result."""
 
 
 Message = Annotated[


### PR DESCRIPTION
## Overview

Preserves MCP tool-declared outcome semantics across harness execution, typed messages, traces, replay, and provider conversion.

This PR is stacked on #2134 and adds structured tool-error transport on top of its shared null/bash lifecycle and replay-safety foundation.

## Details

MCP `CallToolResult` contains both model-visible content and an `isError` outcome. The shared MCP client now returns both values, and the harness program carries the outcome into `ToolMessage.is_error`.

The typed outcome participates in graph identity and trace serialization, so success and failure results with identical content remain distinguishable after persistence and resume.

For chat-compatible providers, the localhost harness handoff uses a private marker that is removed before the provider request while adding a readable failure label to the model-visible content. Anthropic-native `tool_result.is_error` maps directly into the same typed representation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `message_hash` now differs for error vs success tool messages, which can change graph dedup for existing traces; provider-facing tool content also gains a failure prefix on chat wire output.
> 
> **Overview**
> Adds **`ToolMessage.is_error`** so tool failures are typed end-to-end instead of living only in message text.
> 
> **MCP harness:** `call_mcp` now returns MCP **`isError`**; tool messages can carry a private **`_vf_is_error`** marker, and chat requests use **`extra_body.messages`** so that marker survives the localhost interception path.
> 
> **Wire / providers:** Chat serialization prefixes model-visible content with **`Tool execution failed:`** when not using internal mode; harness handoff writes initial messages with **`include_internal=True`**. Anthropic **`tool_result.is_error`** maps into the same field. **`apply_overrides`** re-normalizes messages that still carry the internal marker before the upstream request.
> 
> **Traces:** **`message_hash`** for tool nodes includes **error vs success**, so identical content from a failed vs successful tool call stays distinct after persistence and resume.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daab68fde0309d18f53f47a957e69bd0f8093adb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve MCP tool error outcomes across harness, transcript, and retry logic
> - Adds `is_error` to `ToolMessage` in [types.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2138/files#diff-88a4e4ee0c58ac5dc7344161a011374082a3767eda2ad32af97c942dca982112) and propagates it through Anthropic and chat dialect parsing/serialization, including a `_vf_is_error` internal key and a human-visible `Tool execution failed:` prefix on wire output.
> - Introduces `MCPTransportError` and `MCPDeliveryUnknownError` in [errors.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2138/files#diff-5621d6869aa43b8c83352b3f958fe94b199952c4ae37c042fe2a25106962cb5b); the harness raises these instead of a generic `HarnessError` when the program emits a `VF_MCP_ERROR=` JSON marker.
> - Consolidates the null and bash harness programs into a single [minimal/program.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2138/files#diff-cfa9a2dff501160af71f3c07beb4c6ca40926e64e93b43f217548811dcc78a36) with a `--bash` flag; both harnesses now write initial messages with `include_internal=True` to preserve error markers.
> - `mcp_session` in the minimal program classifies MCP failures as transient/non-transient and replay-safe/unsafe, and `with_retry` narrows retries to replay-safe transport failures only.
> - Episodes containing `MCPDeliveryUnknownError` are blocked from retry in [retries.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2138/files#diff-dd324cbc3488c3521fea600c7be4001a3f62becf8988cb8290ccbf4c9a487106) unless explicitly opted in via retry config.
> - Risk: `message_hash` in [graph.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2138/files#diff-64c9d635eb215902a512c9e8ab316fd9b9967c36db03d4049aacc812cdfbd740) now differs between error and success tool outcomes, which may invalidate cached hashes for existing tool messages.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized daab68f. 13 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->