### PR TITLE
feat(v1): expose MCP tools to Codex

### DIFF
--- a/verifiers/v1/harnesses/codex/harness.py
+++ b/verifiers/v1/harnesses/codex/harness.py
@@ -4,9 +4,12 @@ The static musl binary runs in Linux containers without additional runtime depen
 """
 
 import base64
+import hashlib
+import json
 import logging
 import re
 import shlex
+from collections import Counter
 
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
@@ -47,7 +50,7 @@ class CodexHarnessConfig(HarnessConfig):
 
 class CodexHarness(Harness[CodexHarnessConfig]):
     APPENDS_SYSTEM_PROMPT = False  # TODO
-    SUPPORTS_MCP = False  # TODO
+    SUPPORTS_MCP = True
     SUPPORTS_RESUME = True
     SUPPORTS_SKILLS = True
 
@@ -128,7 +131,7 @@ class CodexHarness(Harness[CodexHarnessConfig]):
         argv = [
             CODEX_BIN,
             "exec",
-            *self._config_args(ctx, endpoint),
+            *self._config_args(ctx, endpoint, mcp_urls),
             *image_args,
             "--",
             prompt,
@@ -196,7 +199,7 @@ class CodexHarness(Harness[CodexHarnessConfig]):
             "exec",
             "resume",
             "--last",
-            *self._config_args(ctx, endpoint),
+            *self._config_args(ctx, endpoint, mcp_urls),
             "--",
             "\n\n".join(texts),
         ]
@@ -228,7 +231,12 @@ class CodexHarness(Harness[CodexHarnessConfig]):
             "CODEX_HOME": home,
         }
 
-    def _config_args(self, ctx: ModelContext, endpoint: str) -> list[str]:
+    def _config_args(
+        self,
+        ctx: ModelContext,
+        endpoint: str,
+        mcp_urls: dict[str, str],
+    ) -> list[str]:
         # Values are Codex feature names such as `shell_tool`; Codex owns validation.
         # https://developers.openai.com/codex/config-reference#features
         tool_config = [
@@ -236,6 +244,49 @@ class CodexHarness(Harness[CodexHarnessConfig]):
             for tool in self.config.disabled_tools or []
             for arg in ("--disable", tool)
         ]
+        # Set the whole table so dots in quoted server IDs are not interpreted as
+        # `-c` path separators.
+        mcp_config = (
+            [
+                "-c",
+                "mcp_servers={"
+                + ",".join(
+                    (
+                        f"{json.dumps(name, ensure_ascii=False)}="
+                        f"{{url={json.dumps(url, ensure_ascii=False)},required=true,"
+                        "startup_timeout_sec=60.0,tool_timeout_sec=600.0}"
+                    )
+                    for name, url in mcp_urls.items()
+                )
+                + "}",
+            ]
+            if mcp_urls
+            else []
+        )
+
+        # Codex keeps raw server IDs for MCP calls but normalizes the namespaces
+        # exposed to the model. Mirror rust-v0.144.5's per-character replacement,
+        # optional prefix, collision hash, and possible 49-character truncation.
+        namespace_bases: dict[str, str] = {}
+        for name in mcp_urls:
+            namespace = re.sub(r"[^a-zA-Z0-9_]", "_", name) or "_"
+            namespace_bases[name] = (
+                namespace if namespace.startswith("mcp__") else f"mcp__{namespace}"
+            )
+        namespace_counts = Counter(namespace_bases.values())
+        direct_mcp_namespaces: list[str] = []
+        for name, namespace in namespace_bases.items():
+            if namespace_counts[namespace] > 1:
+                suffix = hashlib.sha1(f"{name}\0{name}\0".encode()).hexdigest()[:12]
+                namespace = (
+                    f"{namespace[:-2]}_{suffix}__"
+                    if namespace.endswith("__")
+                    else f"{namespace}_{suffix}"
+                )
+            direct_mcp_namespaces.append(namespace)
+            if len(namespace) > 49:
+                direct_mcp_namespaces.append(namespace[:49])
+        direct_mcp_namespaces = list(dict.fromkeys(direct_mcp_namespaces))
         # `-c` values parse as TOML, falling back to a raw string (so the url / `responses`
         # come through literally); `requires_openai_auth=false` parses as a bool.
         return [
@@ -266,4 +317,16 @@ class CodexHarness(Harness[CodexHarnessConfig]):
             "-c",
             f"model_providers.{PROVIDER}.requires_openai_auth=false",
             *tool_config,
+            *mcp_config,
+            *(
+                [
+                    "-c",
+                    (
+                        "features.code_mode.direct_only_tool_namespaces="
+                        f"{json.dumps(direct_mcp_namespaces)}"
+                    ),
+                ]
+                if direct_mcp_namespaces
+                else []
+            ),
         ]


### PR DESCRIPTION
## Summary

- advertise MCP support from the Codex harness
- configure each task MCP HTTP server for both initial and resumed Codex exec segments
- expose the corresponding MCP namespaces directly to the model
- preserve Verifiers MCP server names and leave task prompts unchanged

## Validation

- `uv run ruff check --fix .`
- `uv run pytest tests/` — 909 passed, 63 skipped (credentialed e2e cases require `PRIME_API_KEY`)
- `uv run pre-commit run --all-files`
- pre-push `ty (ci parity)`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Codex is launched with external MCP dependencies and namespace mapping; misconfiguration could break tool exposure or resume segments, but scope is limited to the Codex harness.
> 
> **Overview**
> **Codex rollouts can now use task MCP HTTP servers** on both initial `exec` and `exec resume --last` segments, aligned with other agent harnesses.
> 
> `CodexHarness` sets **`SUPPORTS_MCP = True`** and threads `mcp_urls` into `_config_args`, which emits a single `-c mcp_servers={...}` table (so dotted server IDs are not split as TOML paths) with `required=true` and fixed startup/tool timeouts. When MCP is present, it also sets **`features.code_mode.direct_only_tool_namespaces`** using namespaces derived from server names—sanitized `mcp__` prefixes, SHA1 suffixes on collisions, and 49-character truncation—to match Codex v0.144.5’s exposed tool namespaces while keeping Verifiers server IDs unchanged in config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c533f0539d6ec82ad4da98623ff9c45deb21ad2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose MCP tools to Codex by passing server URLs and namespaces through `CodexHarness`
> - Sets `SUPPORTS_MCP = True` on `CodexHarness` so the harness advertises MCP capability at runtime.
> - Updates `launch` and `resume` in [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2140/files#diff-904c37fe437bb3b42e0238258ed85a8c6cede02461216bcf9c7417c5f3b72b7b) to pass `mcp_urls` into `_config_args`.
> - `_config_args` now builds a TOML `mcp_servers` config entry (with `required=true`, 60s startup timeout, 600s tool timeout) and a `features.code_mode.direct_only_tool_namespaces` list from the provided URLs.
> - Namespace strings are normalized (non-`[a-zA-Z0-9_]` chars replaced with `_`, `mcp__` prefix enforced), collision-detected with a 12-hex SHA1 suffix, and truncated to 49 chars if needed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c533f05.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->