### PR TITLE
docs: Fystash as experimental Harbor cloud env (-e fystash)

### DIFF
--- a/docs/v1/harbor.md
+++ b/docs/v1/harbor.md
@@ -87,6 +87,29 @@ added automatically; evaluator-provided `allow` entries add exceptions and `bloc
 entries can narrow them. Restricted Harbor tasks require Docker or a Prime VM; Prime
 accepts host-level entries and rejects combinations that need both policy modes.
 
+## Fystash cloud sandboxes (experimental)
+
+[Fystash](https://fystash.ai) provides warm Firecracker rooms as a Harbor cloud
+environment (`-e fystash`). Use it when you want denser episode-style runtimes
+under the same Verifiers `HarborTaskset` path — not as Environments Hub content.
+
+Upstream Harbor provider PR (merge out of band):
+https://github.com/harbor-framework/harbor/pull/2491
+
+```bash
+export FYSTASH_API=https://api.fystash.ai
+export FYSTASH_API_KEY=key-…   # https://fystash.ai/signup → Account
+# optional: FYSTASH_TEMPLATE_ID=default|docker
+
+harbor run -d "<org/dataset>" -a "<agent>" -m "<model>" -e fystash -n 4
+```
+
+Partner notes: https://docs.fystash.ai/guides/verifiers
+
+Treat as experimental until the Harbor PR merges and you validate your taskset
+on Fystash. Fystash is not a Prime Sandboxes SDK plugin and is not listed on
+Environments Hub.
+
 ## Shortcomings
 
 verifiers does not have parity with Harbor yet, so some features are missing and currently being worked on. The most notable missing features right now are:


### PR DESCRIPTION
## Summary

Adds a short **Fystash** subsection to `docs/v1/harbor.md` so Verifiers `HarborTaskset` users can point Harbor at warm Firecracker rooms via `-e fystash`.

- Links the open Harbor provider PR: https://github.com/harbor-framework/harbor/pull/2491
- Partner how-to: https://docs.fystash.ai/guides/verifiers
- Honesty: experimental until Harbor merge; **not** Environments Hub; **not** a Prime Sandboxes SDK plugin

## Why

Verifiers already routes Harbor tasksets through Harbor’s pluggable environments. Fystash is landing as a Harbor cloud sandbox (same surface as Daytona/Modal). This docs note makes that path discoverable without claiming Environments Hub listing.

## Test plan

- [ ] Docs render on ReadTheDocs / local docs build
- [ ] Links resolve
- [ ] Optional: after Harbor merge, smoke `harbor run … -e fystash` under a HarborTaskset


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document Fystash as an experimental Harbor cloud environment (-e fystash)
> Adds a new 'Fystash cloud sandboxes (experimental)' section to [harbor.md](https://github.com/PrimeIntellect-ai/verifiers/pull/2143/files#diff-d8d09cc1710620a4b331918e5a18abfb2455ba35e98102261ffe78c19139974b) covering environment variable setup (`FYSTASH_API`, `FYSTASH_API_KEY`, optional `FYSTASH_TEMPLATE_ID`), an example `harbor run` command, and a link to the upstream Harbor provider PR. Includes disclaimers that Fystash is experimental and not part of the Prime Sandboxes SDK or Environments Hub.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a07594a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->