### PR TITLE
Remove unused v1 code

### DIFF
--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -58,7 +58,6 @@ class ACP:
         path = f"{directory}/config.json"
         try:
             await runtime.write(path, json.dumps(config).encode())
-            result = await runtime.run_program([*program, path], env)
-            return result
+            return await runtime.run_program([*program, path], env)
         finally:
             await run_shielded(runtime.run(["rm", "-rf", directory], {}))

--- a/verifiers/v1/clients/client.py
+++ b/verifiers/v1/clients/client.py
@@ -1,6 +1,5 @@
 """Client interfaces for model inference and relay."""
 
-import logging
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
@@ -8,8 +7,6 @@ from dataclasses import dataclass, field
 from verifiers.v1.dialects import Dialect
 from verifiers.v1.graph import PendingTurn
 from verifiers.v1.types import Response, Sampling, SamplingConfig
-
-logger = logging.getLogger(__name__)
 
 SESSION_ID_HEADER = "X-Session-ID"
 """Per-rollout routing header. Every turn of one rollout sends the same value (the trace id),

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -227,8 +227,7 @@ class Env(ABC, Generic[ConfigT]):
                 warned_resources=self._warned_resources,
             )
 
-        agents = Agents(self.config, make)
-        return agents
+        return Agents(self.config, make)
 
     def _client_for(self, config: ClientConfig) -> Client:
         """Resolve (and cache by config) an agent-pinned endpoint's client."""

--- a/verifiers/v1/legacy.py
+++ b/verifiers/v1/legacy.py
@@ -471,7 +471,7 @@ class LegacyEnvServer(EnvServer):
 # --- in-process v0 eval (the `eval` CLI's `--id` path) -------------------------
 
 
-def _eval_client(client_config: ClientConfig, model: str):
+def _eval_client(client_config: ClientConfig):
     """A v0 chat-completions client built from the v1 eval `ClientConfig` (base url + api
     key var + headers). Eval needs no token ids, so this skips the renderer pool the
     training bridge (`_v0_client`) builds."""
@@ -517,7 +517,7 @@ async def run_legacy_eval(config) -> list[Episode]:
     dataset = env.get_eval_dataset()  # the eval split (falls back to train when unset)
     idxs = sample(list(range(len(dataset))), config.shuffle, config.num_tasks)
 
-    client = _eval_client(config.client, config.model)
+    client = _eval_client(config.client)
     sampling_args = config.sampling.model_dump(exclude_none=True)
     taskset_id = env_name(config.id)  # the same identity the served bridge stamps
     out_dir = _legacy_output_dir(config)

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -4,7 +4,6 @@ import asyncio
 import atexit
 import contextlib
 import hashlib
-import logging
 import shlex
 import uuid
 import weakref
@@ -17,8 +16,6 @@ from pydantic_config import BaseConfig
 
 from verifiers.v1.errors import SandboxError
 from verifiers.v1.utils.aio import run_shielded
-
-logger = logging.getLogger(__name__)
 
 # Ensure the latest `uv` is available for our PEP 723 scripts: prefer pip on Python images,
 # then fall back to the standalone installer (curl/wget), installing curl + CA certs when a

--- a/verifiers/v1/serve/client.py
+++ b/verifiers/v1/serve/client.py
@@ -10,7 +10,6 @@ env). Health is just another request (no dedicated probe thread).
 
 import asyncio
 import contextlib
-import logging
 import time
 import uuid
 from typing import TypeVar
@@ -35,8 +34,6 @@ from verifiers.v1.serve.types import (
 from verifiers.v1.episode import WireEpisode
 from verifiers.v1.trace import WireTrace
 from verifiers.v1.types import SamplingConfig
-
-logger = logging.getLogger(__name__)
 
 ResponseT = TypeVar("ResponseT", bound=BaseResponse)
 

--- a/verifiers/v1/serve/types.py
+++ b/verifiers/v1/serve/types.py
@@ -3,7 +3,6 @@ from typing import ClassVar
 from pydantic import BaseModel, Field, field_serializer, model_validator
 
 from verifiers.v1.clients.config import ClientConfig
-from verifiers.v1.task import WireTaskData  # noqa: F401  (docstring reference)
 from verifiers.v1.episode import WireEpisode
 from verifiers.v1.trace import WireTrace
 from verifiers.v1.types import SamplingConfig

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -443,6 +443,10 @@ class Trace(StrictBaseModel, Generic[DataT, StateT, AgentConfigT]):
         and on traces with no agent info (the legacy bridge)."""
         return self.agent.runtime if self.agent is not None else None
 
+    def _last_assistant(self) -> MessageNode | None:
+        """Most recent model-produced node, ignoring prompt-supplied assistant messages."""
+        return next((n for n in reversed(self.nodes) if n.sampled), None)
+
     @property
     def num_input_tokens(self) -> int:
         """Fed-in tokens (system + user + tool), counted once, summed across branches."""

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -443,10 +443,6 @@ class Trace(StrictBaseModel, Generic[DataT, StateT, AgentConfigT]):
         and on traces with no agent info (the legacy bridge)."""
         return self.agent.runtime if self.agent is not None else None
 
-    def _last_assistant(self) -> MessageNode | None:
-        """Most recent model-produced node, ignoring prompt-supplied assistant messages."""
-        return next((n for n in reversed(self.nodes) if n.sampled), None)
-
     @property
     def num_input_tokens(self) -> int:
         """Fed-in tokens (system + user + tool), counted once, summed across branches."""


### PR DESCRIPTION
## Overview

Remove a small set of unused v1 imports, logger declarations, parameters, and temporary bindings.

## Details

- Delete the stale task-data import from the serving request types.
- Simplify the legacy eval client helper to accept only the configuration it consumes.
- Remove inactive module logger setup from client, runtime, and serving modules.
- Return ACP program results and episode agents directly.

These changes reduce the v1 maintenance surface without changing runtime behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import and signature cleanup only; eval still passes `config.model` into `run_rollout` separately.
> 
> **Overview**
> **Dead-code cleanup** across `verifiers/v1` with no intended behavior change.
> 
> Unused `logging` setup is removed from `clients/client.py`, `runtimes/base.py`, and `serve/client.py` (those modules never logged). The stale `WireTaskData` import is dropped from `serve/types.py`. Legacy in-process eval’s `_eval_client` no longer takes an unused `model` argument; `run_legacy_eval` calls it with only `config.client`.
> 
> Minor style tweaks: `ACP.run` and `Env._episode_agents` return the constructed value directly instead of via a temporary variable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9438b7461225de479cc8e7d0a239d8c0a7eb7a4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused imports, variables, and parameters from v1 code
> Cleans up dead code across several files in the `verifiers/v1` module with no behavior changes.
>
> - Removes unused `logging` imports and logger initialization from [clients/client.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2145/files#diff-03d8d18cf21766007d7efc7af13862dcd1d58ab1a1374aef2efdd4ba59c69e2e), [runtimes/base.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2145/files#diff-0811c040a163eb5a3212208f1e3a6c6388d7690fcc4780c081cc7754036232b9), and [serve/client.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2145/files#diff-ef98a21052536967b8f8723e36022f69e539f4e8b13794791e8254434ac4696e)
> - Removes the unused `model` parameter from `_eval_client` in [legacy.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2145/files#diff-96c5091f7d2968ddfbe984f433163f21cab745ea95174158e924984d55abbfed) and updates the call site accordingly
> - Inlines intermediate return variables in [acp/__init__.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2145/files#diff-4a98e09e3584605f8da12349ce8fa454922c607127e29c836edfae5094b41ccf) and [env.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2145/files#diff-69be10bd5960e88d88f219d4f261d0bdd16586857f9126451b04d05bac4c2cbb)
> - Removes an unused `WireTaskData` import from [serve/types.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2145/files#diff-8e290c0dfc583c92b20ee9f20fa2ecd0df82459ad63f8e819e87aa856de97cf4)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9438b74.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->