### PR TITLE
Remove redundant v1 structure

### DIFF
--- a/skills/evaluate-environments/references/REFERENCE.md
+++ b/skills/evaluate-environments/references/REFERENCE.md
@@ -60,7 +60,7 @@ Inherited from `EnvServerConfig`: [`env`](#envconfig--the-environment), [`pool`]
 
 ## Sampling config
 
-`verifiers/v1/types.py` — `SamplingConfig(BaseModel)` (alias `Sampling`). Used as `EvalConfig.sampling` and embedded in [`JudgeSamplingConfig`](#judge-config). `extra='allow'`, so provider-specific keys pass through.
+`verifiers/v1/types.py` — `SamplingConfig(BaseModel)` (alias `Sampling`). Used as `EvalConfig.sampling` and `JudgeConfig.sampling`. `extra='allow'`, so provider-specific keys pass through.
 
 | Field | Type | Default | Aliases | Notes |
 | --- | --- | --- | --- | --- |
@@ -500,13 +500,9 @@ Inherits `base_url`, `api_key_var`, and `headers` from [`BaseClientConfig`](#cli
 | `name` | `str` | `""` | Reward-key override for a plugged judge. When empty, the plugin id supplies the key. |
 | `weight` | `float` | `1.0` | Weight applied when the plugged judge records its verdict into aggregate `trace.reward`. |
 | `model` | `str` | `"openai/gpt-5.4-nano"` | Judge model id. |
-| `sampling` | `JudgeSamplingConfig` | `JudgeSamplingConfig()` | Per-call sampling defaults; individual calls may override them. |
+| `sampling` | `SamplingConfig` | `SamplingConfig()` | Per-call sampling defaults; individual calls may override them. |
 | `prompt` | `str \| None` | `None` | Inline prompt-template override for this configured judge instance. |
 | `prompt_file` | `Path \| None` | `None` | Load the prompt template from a UTF-8 text file. Mutually exclusive with `prompt`. |
-
-### `JudgeSamplingConfig(SamplingConfig)`
-
-The same extensible shape as the rollout's [`SamplingConfig`](#sampling-config): `temperature`, `top_p`, `reasoning_effort`, and `max_tokens`, plus provider-specific keys because `extra='allow'`. Values passed directly to `complete()` override these configured defaults.
 
 ### Judge class behavior
 

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -37,7 +37,7 @@ from verifiers.v1.errors import (
 )
 from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.harness import Harness
-from verifiers.v1.configs.judge import JudgeConfig, JudgeSamplingConfig, Judges
+from verifiers.v1.configs.judge import JudgeConfig, Judges
 from verifiers.v1.judge import Judge, JudgeResponse, JudgeView
 from verifiers.v1.judges import (
     ReferenceJudge,
@@ -267,7 +267,6 @@ __all__ = [
     "Judge",
     "JudgeConfig",
     "Judges",
-    "JudgeSamplingConfig",
     "JudgeResponse",
     "JudgeView",
     "ReferenceJudge",

--- a/verifiers/v1/configs/judge.py
+++ b/verifiers/v1/configs/judge.py
@@ -12,10 +12,6 @@ from verifiers.v1.types import ID, SamplingConfig
 from verifiers.v1.utils.install import env_name
 
 
-class JudgeSamplingConfig(SamplingConfig):
-    pass
-
-
 class JudgeConfig(BaseClientConfig):
     id: ID = ""
     """Plugin id; empty for a judge called directly by task code."""
@@ -23,7 +19,7 @@ class JudgeConfig(BaseClientConfig):
     """Reward key override for a plugged judge."""
     weight: float = 1.0
     model: str = "openai/gpt-5.4-nano"
-    sampling: JudgeSamplingConfig = JudgeSamplingConfig()
+    sampling: SamplingConfig = SamplingConfig()
     prompt: str | None = None
     prompt_file: Path | None = None
     """Prompt file override, mutually exclusive with `prompt`."""

--- a/verifiers/v1/gepa/adapter.py
+++ b/verifiers/v1/gepa/adapter.py
@@ -87,7 +87,7 @@ class GEPAAdapter:
 
     def make_reflective_dataset(
         self,
-        candidate: Candidate,  # noqa: ARG002 - required by GEPA's adapter protocol
+        candidate: Candidate,  # Required by GEPA's adapter protocol.
         eval_batch: EvaluationBatch[Episode, Episode],
         components_to_update: list[str],
     ) -> Mapping[str, Sequence[Mapping[str, Any]]]:

--- a/verifiers/v1/utils/git.py
+++ b/verifiers/v1/utils/git.py
@@ -97,7 +97,7 @@ async def capture_patch(
             )
             return
         raw = await runtime.read(capped)
-    except Exception as exc:  # noqa: BLE001 - capture must never fail the rollout.
+    except Exception as exc:  # Capture must never fail the rollout.
         trace.info["patch_error"] = f"{type(exc).__name__}: {exc}"
         return
     finally:
@@ -105,7 +105,7 @@ async def capture_patch(
         # on shared-filesystem runtimes; removal is best-effort by design.
         try:
             await runtime.run(["rm", "-f", full, capped], env or {})
-        except Exception:  # noqa: BLE001,S110 - cleanup must never fail the rollout.
+        except Exception:  # Cleanup must never fail the rollout.
             pass
     if len(raw) > PATCH_CAP_BYTES:
         raw = raw[:PATCH_CAP_BYTES]


### PR DESCRIPTION
## Overview

Simplifies V1 by using the shared sampling configuration directly for judges and removes stale Ruff suppression tokens while preserving their explanatory context.

## Details

- Removes the empty `JudgeSamplingConfig` subclass and its public export, then updates the evaluation reference.
- Keeps the GEPA protocol parameter and best-effort git capture behavior unchanged while removing no-op lint suppressions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8340256a88a0fe7d837b80164075aac628333fc3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `JudgeSamplingConfig` and replace `JudgeConfig.sampling` with `SamplingConfig`
> Removes the redundant `JudgeSamplingConfig` subclass from [`verifiers/v1/configs/judge.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/2146/files#diff-522cedfe610fbf9ddef8449c1629e21266db7e043f7fa310b1961a54cd9d0823) and updates `JudgeConfig.sampling` to use `SamplingConfig` directly. The symbol is also removed from the [`verifiers/v1`](https://github.com/PrimeIntellect-ai/verifiers/pull/2146/files#diff-731a849803c53d001c41b5e0fb1bfcb392eaae7eb4fa4b3ace382768dc40066a) package exports and documentation is updated to reflect the change. Risk: any code importing `JudgeSamplingConfig` from `verifiers.v1` will now fail at import time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8340256.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->