### PR TITLE
fix(v1): retire dead-tunnel servers from the elastic interception pool

### DIFF
--- a/verifiers/v1/interception/pool.py
+++ b/verifiers/v1/interception/pool.py
@@ -31,6 +31,12 @@ from verifiers.v1.session import RolloutSession
 
 logger = logging.getLogger(__name__)
 
+# How often the elastic pool polls its servers' tunnels. A dead tunnel keeps absorbing
+# rollout assignments until the next poll (fast-failing ones drain and re-land on it), so
+# the interval bounds how long that black hole lives; per-server checks are one GET to the
+# tunnel service, so polling even a large pool this often is cheap.
+_HEALTH_CHECK_INTERVAL = 60.0
+
 
 class StaticInterceptionPoolConfig(BaseInterceptionConfig):
     """A fixed set of interception servers, each configured like a `server` type; rollouts
@@ -47,14 +53,10 @@ class StaticInterceptionPool(Interception):
     a slot on the least-loaded one. No capacity cap — sizing the set to the load is the
     operator's call (it's the shape for pre-provisioned/bring-your-own endpoints)."""
 
-    def __init__(
-        self, config: StaticInterceptionPoolConfig, requires_tunnel: bool = False
-    ) -> None:
+    def __init__(self, config: StaticInterceptionPoolConfig, requires_tunnel: bool = False) -> None:
         super().__init__()
         self.config = config
-        self.servers = [
-            InterceptionServer(server, requires_tunnel) for server in config.servers
-        ]
+        self.servers = [InterceptionServer(server, requires_tunnel) for server in config.servers]
 
     async def start(self) -> None:
         for server in self.servers:
@@ -83,7 +85,9 @@ class ElasticInterceptionPoolConfig(BaseInterceptionConfig):
 class ElasticInterceptionPool(Interception):
     """Warm the first interception server on start, then grow on demand: `multiplex`
     rollouts share one server (one prime tunnel behind a remote consumer); `acquire` hands
-    a rollout a slot on one, bringing up a new server when all are at capacity."""
+    a rollout a slot on one, bringing up a new server when all are at capacity. A health
+    loop retires servers whose tunnel has died (see `Tunnel.is_alive`), so the pool grows
+    back with fresh tunnels instead of black-holing rollouts on dead URLs."""
 
     def __init__(
         self,
@@ -94,18 +98,66 @@ class ElasticInterceptionPool(Interception):
         self.config = config or ElasticInterceptionPoolConfig()
         self.requires_tunnel = requires_tunnel
         self.servers: list[InterceptionServer] = []
+        self._draining: list[InterceptionServer] = []
         self._lock = asyncio.Lock()
         self._warm_task: asyncio.Task[InterceptionServer] | None = None
+        self._health_task: asyncio.Task[None] | None = None
 
     async def start(self) -> None:
         self._warm_task = asyncio.create_task(self._server())
+        if self.requires_tunnel:
+            self._health_task = asyncio.create_task(self._health_loop())
 
     async def stop(self) -> None:
-        if self._warm_task is not None:
-            self._warm_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError, Exception):
-                await self._warm_task
+        for task in (self._warm_task, self._health_task):
+            if task is not None:
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await task
+        self._warm_task = None
+        self._health_task = None
         await super().stop()
+
+    async def _health_loop(self) -> None:
+        """Retire servers whose tunnel has died, so rollouts stop landing on dead URLs.
+
+        A dead server otherwise poisons the pool forever: its rollouts fail instantly, its
+        load drops back to 0, and `_server` hands it out again — while healthy servers work
+        real (slow) rollouts, so the dead one absorbs most assignments. Retiring also covers
+        tunnels in a terminal status that still route on a surviving frpc connection: they
+        die for good on the next connection drop, so they're replaced proactively."""
+        while True:
+            await asyncio.sleep(_HEALTH_CHECK_INTERVAL)
+            try:
+                await self._retire_dead_servers()
+            except Exception:
+                logger.exception("interception pool: health check failed")
+
+    async def _retire_dead_servers(self) -> None:
+        # Liveness checks call the tunnel service — keep them off the acquire lock.
+        for server in list(self.servers):
+            if server.tunnel is None or await server.tunnel.is_alive():
+                continue
+            async with self._lock:
+                if server in self.servers:
+                    self.servers.remove(server)
+                    self._draining.append(server)
+                    logger.warning(
+                        "interception pool: retired server with dead tunnel %s (%d rollouts draining)",
+                        server.base_url,
+                        server.load,
+                    )
+        # Tear a retired server down only once its in-flight rollouts have drained; until
+        # then its interception server keeps serving whatever still reaches it. The pool's
+        # exit stack still holds every retired server, so this early stop is an optimization
+        # (frees the frpc process and registration) and the double-stop at pool shutdown is
+        # a no-op.
+        for server in list(self._draining):
+            if server.load > 0:
+                continue
+            self._draining.remove(server)
+            with contextlib.suppress(Exception):
+                await server.stop()
 
     async def _server(self) -> InterceptionServer:
         """A server with spare capacity — reuse one under `multiplex`, else bring up a new
@@ -115,9 +167,7 @@ class ElasticInterceptionPool(Interception):
             if server.load < self.config.multiplex:
                 return server
         # Pin prime explicitly — the only tunnel kind that can be minted on demand.
-        server = InterceptionServer(
-            InterceptionServerConfig(tunnel=PrimeTunnelConfig()), self.requires_tunnel
-        )
+        server = InterceptionServer(InterceptionServerConfig(tunnel=PrimeTunnelConfig()), self.requires_tunnel)
         await self.stack.enter_async_context(server)
         self.servers.append(server)
         logger.info(

--- a/verifiers/v1/interception/pool.py
+++ b/verifiers/v1/interception/pool.py
@@ -28,6 +28,7 @@ from verifiers.v1.interception.server import (
 )
 from verifiers.v1.interception.tunnel import PrimeTunnelConfig
 from verifiers.v1.session import RolloutSession
+from verifiers.v1.utils.aio import run_shielded
 
 logger = logging.getLogger(__name__)
 
@@ -155,13 +156,16 @@ class ElasticInterceptionPool(Interception):
         # then its interception server keeps serving whatever still reaches it. The pool's
         # exit stack still holds every retired server, so this early stop is an optimization
         # (frees the frpc process and registration) and the double-stop at pool shutdown is
-        # a no-op.
+        # a no-op — but only if it runs to completion. `stop` unwinds an `AsyncExitStack`,
+        # which pops each callback before awaiting it, so a cancellation landing mid-teardown
+        # (pool shutdown cancels this task) would drop the popped callback for good and the
+        # later stop would find it already gone. Shield it so the unwind always finishes.
         for server in list(self._draining):
             if server.load > 0:
                 continue
             self._draining.remove(server)
             with contextlib.suppress(Exception):
-                await server.stop()
+                await run_shielded(server.stop())
 
     async def _server(self) -> InterceptionServer:
         """A server with spare capacity — reuse one under `multiplex`, else bring up a new

--- a/verifiers/v1/interception/pool.py
+++ b/verifiers/v1/interception/pool.py
@@ -53,10 +53,14 @@ class StaticInterceptionPool(Interception):
     a slot on the least-loaded one. No capacity cap — sizing the set to the load is the
     operator's call (it's the shape for pre-provisioned/bring-your-own endpoints)."""
 
-    def __init__(self, config: StaticInterceptionPoolConfig, requires_tunnel: bool = False) -> None:
+    def __init__(
+        self, config: StaticInterceptionPoolConfig, requires_tunnel: bool = False
+    ) -> None:
         super().__init__()
         self.config = config
-        self.servers = [InterceptionServer(server, requires_tunnel) for server in config.servers]
+        self.servers = [
+            InterceptionServer(server, requires_tunnel) for server in config.servers
+        ]
 
     async def start(self) -> None:
         for server in self.servers:
@@ -167,7 +171,9 @@ class ElasticInterceptionPool(Interception):
             if server.load < self.config.multiplex:
                 return server
         # Pin prime explicitly — the only tunnel kind that can be minted on demand.
-        server = InterceptionServer(InterceptionServerConfig(tunnel=PrimeTunnelConfig()), self.requires_tunnel)
+        server = InterceptionServer(
+            InterceptionServerConfig(tunnel=PrimeTunnelConfig()), self.requires_tunnel
+        )
         await self.stack.enter_async_context(server)
         self.servers.append(server)
         logger.info(

--- a/verifiers/v1/interception/tunnel/base.py
+++ b/verifiers/v1/interception/tunnel/base.py
@@ -45,3 +45,11 @@ class Tunnel(ABC, Generic[ConfigT]):
         from a remote runtime. Entered only when a consumer is remote; torn down on exit.
         A setup failure raises `TunnelError`; an error raised while the URL is held (the
         caller's body) propagates unchanged."""
+
+    async def is_alive(self) -> bool:
+        """Whether the exposed URL is still expected to route. True by default — a custom
+        tunnel has no registration that can be revoked out from under it. `PrimeTunnel`
+        overrides this: the tunnel service can terminate a registration server-side (e.g.
+        reaping one whose frpc connection dropped too long), after which the URL 404s
+        forever. Pools poll this to retire servers whose tunnel has died."""
+        return True

--- a/verifiers/v1/interception/tunnel/prime.py
+++ b/verifiers/v1/interception/tunnel/prime.py
@@ -6,17 +6,24 @@ pool scales with."""
 import asyncio
 import contextlib
 from collections.abc import AsyncIterator
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from verifiers.v1.interception.tunnel.base import BaseTunnelConfig, Tunnel
 from verifiers.v1.runtimes.limiters import creation_limiter
 from verifiers.v1.utils.aio import run_shielded
+
+if TYPE_CHECKING:
+    from prime_tunnel import Tunnel as TunnelClient
 
 # The prime_tunnel service caps tunnel starts at 512/min per API token — a property of the
 # tunnel service, shared by every process on the host that opens one. One host-global
 # limiter, not a per-runtime config knob.
 _TUNNELS_PER_MIN = 512
 TUNNEL_LIMITER = creation_limiter(_TUNNELS_PER_MIN / 60, "prime-tunnel")
+
+# Registration statuses after which the tunnel service never routes the URL again (frps
+# rejects every reconnect). Matches the platform's terminal tunnel statuses.
+_TERMINAL_STATUSES = frozenset({"expired", "terminated"})
 
 
 class PrimeTunnelConfig(BaseTunnelConfig):
@@ -27,6 +34,10 @@ class PrimeTunnelConfig(BaseTunnelConfig):
 
 
 class PrimeTunnel(Tunnel[PrimeTunnelConfig]):
+    def __init__(self, config: PrimeTunnelConfig | None = None) -> None:
+        super().__init__(config)
+        self._client: "TunnelClient | None" = None  # held while expose() is active
+
     @contextlib.asynccontextmanager
     async def expose(self, port: int) -> AsyncIterator[str]:
         """Bridge the host `port` to a public URL via prime_tunnel (frpc). Tunnel creation
@@ -47,10 +58,34 @@ class PrimeTunnel(Tunnel[PrimeTunnelConfig]):
                         url = str(await client.start()).rstrip("/")
         except Exception as e:
             raise TunnelError(f"{label} failed: {e}") from e
+        self._client = client
         try:
             yield url
         finally:
+            self._client = None
             # Run the synchronous stop to completion even under cancellation (`run_shielded`
             # re-raises the cancellation after); tunnel-stop failures are best-effort.
             with contextlib.suppress(Exception):
                 await run_shielded(asyncio.to_thread(client.sync_stop))
+
+    async def is_alive(self) -> bool:
+        """Whether the exposed URL still routes (or ever will again).
+
+        Dead means dead for good: frpc exited (nothing restarts it), or the service put the
+        registration in a terminal status — after which frps rejects every reconnect, so
+        even a tunnel that still routes on its surviving connection dies permanently on the
+        next drop. The status must be read explicitly: a terminal registration still exists
+        (the SDK's `check_registered` existence probe stays True), and a transient check
+        failure reports alive so a flaky control plane can't mass-retire healthy servers."""
+        client = self._client
+        if client is None:
+            return True  # not exposed — nothing to have died
+        if not client.is_running:
+            return False
+        try:
+            info = await client._client.get_tunnel(client.tunnel_id)
+        except Exception:
+            return True
+        if info is None:
+            return False  # registration deleted
+        return (info.status or "").lower() not in _TERMINAL_STATUSES

--- a/verifiers/v1/interception/tunnel/prime.py
+++ b/verifiers/v1/interception/tunnel/prime.py
@@ -36,7 +36,7 @@ class PrimeTunnelConfig(BaseTunnelConfig):
 class PrimeTunnel(Tunnel[PrimeTunnelConfig]):
     def __init__(self, config: PrimeTunnelConfig | None = None) -> None:
         super().__init__(config)
-        self._client: "TunnelClient | None" = None  # held while expose() is active
+        self._client: TunnelClient | None = None  # held while expose() is active
 
     @contextlib.asynccontextmanager
     async def expose(self, port: int) -> AsyncIterator[str]:
@@ -77,6 +77,8 @@ class PrimeTunnel(Tunnel[PrimeTunnelConfig]):
         next drop. The status must be read explicitly: a terminal registration still exists
         (the SDK's `check_registered` existence probe stays True), and a transient check
         failure reports alive so a flaky control plane can't mass-retire healthy servers."""
+        from prime_tunnel.exceptions import TunnelError as SDKTunnelError
+
         client = self._client
         if client is None:
             return True  # not exposed — nothing to have died
@@ -84,7 +86,7 @@ class PrimeTunnel(Tunnel[PrimeTunnelConfig]):
             return False
         try:
             info = await client._client.get_tunnel(client.tunnel_id)
-        except Exception:
+        except SDKTunnelError:  # timeouts and connection errors both subclass it
             return True
         if info is None:
             return False  # registration deleted


### PR DESCRIPTION
The elastic pool never notices when a server's prime tunnel dies. The tunnel service reaps registrations whose frpc connection stayed down >60min (terminal status, frps rejects every reconnect), after which the server's URL 404s forever — but it stays in the pool with load 0 and keeps absorbing rollout assignments. Hit this in prod on a long GLM-4.5-Air SWE run: a network flap killed a third of the tunnels and ~80% of rollouts fast-failed on dead URLs for hours.

- `PrimeTunnel.is_alive()`: frpc alive + registration not in a terminal status. Status-based on purpose — a terminal registration still exists, so the SDK's `check_registered` existence probe stays True; transient API failures report alive so a flaky control plane can't mass-retire healthy servers.
- `ElasticInterceptionPool` health loop (60s): retires dead servers so new rollouts land elsewhere and the pool grows back with fresh tunnels; retired servers drain in-flight rollouts before teardown.
- Also retires zombies (terminal status but still routing on a surviving connection) proactively — they die for good on the next drop.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout routing and long-running background teardown in the elastic pool; behavior is scoped to tunnel-required pools but affects remote eval reliability under tunnel failures.
> 
> **Overview**
> Fixes the elastic interception pool **keeping servers whose prime tunnel has died**, which caused rollouts to fast-fail on dead URLs while those servers kept getting picked (load 0, instant failures).
> 
> Adds **`Tunnel.is_alive()`** (default true for custom tunnels) and **`PrimeTunnel.is_alive()`**, which treats frpc as dead when it is not running, the registration is gone, or status is terminal (`expired` / `terminated`). Transient tunnel API errors count as alive so a flaky control plane does not mass-retire healthy servers.
> 
> **`ElasticInterceptionPool`** starts a **60s health loop** when tunnels are required: dead servers are removed from the active pool into a **draining** list, new acquires get healthy servers (and the pool can grow fresh tunnels), and drained servers are torn down with **`run_shielded`** only after in-flight rollouts finish. **`PrimeTunnel.expose()`** now holds the SDK client on the instance so liveness checks can query registration status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 274217383057f3485c266799e758530d7dbabf93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->