### PR TITLE
Fix repository links in v1 docs

### DIFF
--- a/docs/v1/getting_started.md
+++ b/docs/v1/getting_started.md
@@ -13,4 +13,4 @@ You can now run tasksets directly, e.g. `uv run eval <taskset-id>`, and scaffold
 
 ## Skills
 
-To equip your agent with the necessary knowledge, we highly recommend the skills in this repository's [`skills/`](../../skills/) directory (alongside [`AGENTS.md`](../../AGENTS.md)). They are more comprehensive than these docs, which are meant for human consumption.
+To equip your agent with the necessary knowledge, we highly recommend the skills in this repository's [`skills/`](https://github.com/PrimeIntellect-ai/verifiers/tree/main/skills) directory (alongside [`AGENTS.md`](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)). They are more comprehensive than these docs, which are meant for human consumption.


### PR DESCRIPTION
## Summary

- replace docs-relative links to `skills/` and `AGENTS.md` with absolute GitHub URLs
- prevent the Prime Intellect docs site from resolving repository resources as docs routes and returning 404s

## Validation

- `uv run --locked pre-commit run --all-files`
- `uv run --locked ruff check --fix .`
- `uv run --locked pytest tests/` (896 passed, 63 skipped; the 13 temporary-repository tests were rerun with inherited commit signing disabled and all 27 tests in that file passed)
- verified both target GitHub URLs resolve

Fixes #2150

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix broken repository links in v1 getting started docs
> Updates the 'Skills' section in [getting_started.md](https://github.com/PrimeIntellect-ai/verifiers/pull/2153/files#diff-1faea7577fbf3745cebb90f850079499970dad4e8efa22b0d3a8cf3433bfa415) to use absolute GitHub URLs instead of repository-relative paths, which were broken for external readers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1d5b7b5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link fix with no runtime or security impact.
> 
> **Overview**
> **Fixes broken links** in the v1 getting started **Skills** section for readers on the Prime Intellect docs site.
> 
> Relative paths to `skills/` and `AGENTS.md` are replaced with absolute `github.com/PrimeIntellect-ai/verifiers` URLs so those links no longer resolve as on-site docs routes (404).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d5b7b5906cc464f5ec571e7ebd8239c96d9b184. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->