### PR TITLE
Retry replay-safe MCP tool calls

### DIFF
--- a/verifiers/v1/harnesses/minimal/program.py
+++ b/verifiers/v1/harnesses/minimal/program.py
@@ -254,6 +254,15 @@ async def connect_mcp(
                 raise ValueError(
                     f"duplicate tool name {full!r}; keep MCP tool names qualified"
                 )
+            # Evaluators choose MCP servers, so explicit annotations are their retry contract.
+            annotations = tool.annotations
+            replay_safe = bool(
+                annotations
+                and (
+                    annotations.readOnlyHint is True
+                    or annotations.idempotentHint is True
+                )
+            )
             tool_schemas.append(
                 {
                     "type": "function",
@@ -264,7 +273,7 @@ async def connect_mcp(
                     },
                 }
             )
-            dispatch[full] = (name, tool.name)
+            dispatch[full] = (name, tool.name, replay_safe)
     return tool_schemas, dispatch, servers
 
 
@@ -288,12 +297,12 @@ def mcp_content_to_chat_content(blocks) -> str | list[dict]:
 async def call_mcp(
     servers: dict, dispatch: dict, name: str, arguments: dict
 ) -> tuple[str | list[dict], bool]:
-    """Call once after initialization; a lost response is never replayed in this session."""
-    server, raw = dispatch[name]
+    """Call a tool, retrying it after a lost response only when repetition is safe."""
+    server, raw, replay_safe = dispatch[name]
 
     async def call():
         async with mcp_session(
-            server, servers[server], "call_tool", replay_safe=False
+            server, servers[server], "call_tool", replay_safe=replay_safe
         ) as session:
             return await session.call_tool(raw, arguments)
 

--- a/verifiers/v1/mcp/toolset.py
+++ b/verifiers/v1/mcp/toolset.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from mcp.types import ToolAnnotations
 from pydantic_config import BaseConfig
 
 from verifiers.v1.mcp.server import ConfigT, ServerBase
@@ -27,8 +28,19 @@ class SharedToolsetConfig(BaseConfig):
 class Toolset(ServerBase[ConfigT, StateT]):
     def _register(self, mcp: FastMCP) -> None:
         for fn in discover_decorated(self, "tool"):
+            read_only = getattr(fn, "tool_read_only", False)
+            idempotent = getattr(fn, "tool_idempotent", False)
+            annotations = (
+                ToolAnnotations(
+                    readOnlyHint=read_only,
+                    idempotentHint=idempotent,
+                )
+                if read_only or idempotent
+                else None
+            )
             mcp.add_tool(
                 self._with_state(fn),
                 name=getattr(fn, "tool_name", None) or fn.__name__,
                 description=(fn.__doc__ or "").strip() or None,
+                annotations=annotations,
             )

--- a/verifiers/v1/utils/decorators.py
+++ b/verifiers/v1/utils/decorators.py
@@ -49,13 +49,38 @@ def mark(attr: str, **extra: Any) -> Callable[[F], F]:
 
 
 @overload
-def tool(func: F, name: str | None = None) -> F: ...
+def tool(
+    func: F,
+    name: str | None = None,
+    *,
+    read_only: bool = False,
+    idempotent: bool = False,
+) -> F: ...
 @overload
-def tool(func: None = None, name: str | None = None) -> Callable[[F], F]: ...
-def tool(func: F | None = None, name: str | None = None) -> F | Callable[[F], F]:
+def tool(
+    func: None = None,
+    name: str | None = None,
+    *,
+    read_only: bool = False,
+    idempotent: bool = False,
+) -> Callable[[F], F]: ...
+def tool(
+    func: F | None = None,
+    name: str | None = None,
+    *,
+    read_only: bool = False,
+    idempotent: bool = False,
+) -> F | Callable[[F], F]:
     """Mark a `Toolset` method as an MCP tool exposed to the model. The tool name defaults
-    to the method name (override with `name`); the docstring becomes its description."""
-    decorator = mark("tool", tool_name=name)
+    to the method name (override with `name`); the docstring becomes its description.
+    Set `read_only` or `idempotent` only when repeating identical calls is safe: clients
+    may replay a call after losing its response."""
+    decorator = mark(
+        "tool",
+        tool_name=name,
+        tool_read_only=read_only,
+        tool_idempotent=idempotent,
+    )
     return decorator if func is None else decorator(func)
 
 


### PR DESCRIPTION
## Overview

Teach the shared null/bash MCP client to retry a tool call after response loss only when the evaluator-configured server explicitly declares that repeating it is safe.

## Details

- Add `read_only` and `idempotent` options to `@vf.tool` and publish the corresponding standard MCP tool annotations.
- Carry explicit `readOnlyHint` and `idempotentHint` values into the delivery-aware retry policy introduced by #2134.
- Preserve delivery-unknown handling for unannotated calls and for annotations that do not guarantee safe repetition.

## Scope

This pull request is stacked on #2138, which builds on #2134. It does not claim generic exactly-once execution: non-idempotent actions still need server-owned operation IDs, revisions, and result caching before opting into retry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes retry behavior for MCP tools after transport loss; mis-declared idempotent/read-only tools could be executed twice, though the default remains no replay without explicit hints.
> 
> **Overview**
> **MCP tool retries after a lost response are now gated on explicit server hints**, instead of treating all `call_tool` invocations as non-replayable.
> 
> The shared minimal harness reads each tool’s MCP `readOnlyHint` / `idempotentHint` at enumeration time, stores a per-tool `replay_safe` flag in dispatch metadata, and passes it into `mcp_session` for `call_tool` so the existing delivery-aware retry logic can replay only when repetition is declared safe. Unannotated tools keep the prior conservative behavior (no retry after the operation may have started).
> 
> **Evaluator-authored toolsets** can opt in via `@vf.tool(read_only=…)` / `idempotent=…`, which `Toolset` maps to standard MCP `ToolAnnotations` when registering tools with FastMCP.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ce62818621aff0b5a75496003b25496144119e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry replay-safe MCP tool calls based on `readOnlyHint` and `idempotentHint` annotations
> - Extends the `@tool` decorator in [`decorators.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/2154/files#diff-3d8f7306fa2edfd8c2f1beedb8779c90ace86b13067a16425a9f33f43cf594f9) with `read_only` and `idempotent` keyword parameters that attach metadata to decorated functions.
> - [`Toolset._register`](https://github.com/PrimeIntellect-ai/verifiers/pull/2154/files#diff-1638e398acc8de97e9696063f280512b575057ce9126369ae93434a75b921c99) reads this metadata and advertises matching `ToolAnnotations` (`readOnlyHint`/`idempotentHint`) when registering tools with MCP.
> - [`connect_mcp`](https://github.com/PrimeIntellect-ai/verifiers/pull/2154/files#diff-cfa9a2dff501160af71f3c07beb4c6ca40926e64e93b43f217548811dcc78a36) inspects each tool's annotations to compute a `replay_safe` flag, stored in the dispatch map alongside the server and tool name.
> - [`call_mcp`](https://github.com/PrimeIntellect-ai/verifiers/pull/2154/files#diff-cfa9a2dff501160af71f3c07beb4c6ca40926e64e93b43f217548811dcc78a36) passes the `replay_safe` flag to `mcp_session`, enabling retries on lost responses for read-only or idempotent tools; previously all calls used `replay_safe=False`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5ce6281.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->