### PR TITLE
Pin standalone MCP clients to v1

### DIFF
--- a/environments/compact/compact/program.py
+++ b/environments/compact/compact/program.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["openai", "mcp"]
+# dependencies = ["openai", "mcp>=1.24.0,<2"]
 # ///
 """The compacting harness's program: a context-REWRITE loop (so every turn branches).
 

--- a/verifiers/v1/harnesses/bash/program.py
+++ b/verifiers/v1/harnesses/bash/program.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["openai", "mcp", "httpx", "tenacity"]
+# dependencies = ["openai", "mcp>=1.24.0,<2", "httpx", "tenacity"]
 # ///
 """Secrets arrive through argv so local tool subprocesses do not inherit them."""
 

--- a/verifiers/v1/harnesses/null/program.py
+++ b/verifiers/v1/harnesses/null/program.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.11"
-# dependencies = ["openai", "mcp", "httpx", "tenacity"]
+# dependencies = ["openai", "mcp>=1.24.0,<2", "httpx", "tenacity"]
 # ///
 """The interception endpoint and secret arrive through argv rather than the environment."""
 

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -94,6 +94,8 @@ class RLMHarness(Harness[RLMHarnessConfig]):
         ensure = shlex.quote(f"[ -x {RLM_BIN} ] || ({install})")
         guarded = f"mkdir -p {RLM_DIR} && flock {RLM_DIR}/install.lock sh -c {ensure}"
         env = {**self.config.resolved_env, "RLM_HOME": RLM_HOME}
+        extra_uv_args = env.get("RLM_EXTRA_UV_ARGS", "")
+        env["RLM_EXTRA_UV_ARGS"] = f"{extra_uv_args} --with mcp~=1.28".strip()
         result = await runtime.run(["sh", "-c", guarded], env)
         if result.exit_code != 0:
             raise RuntimeError(f"rlm install failed: {result.stderr.strip()[-500:]}")


### PR DESCRIPTION
## Overview

Keep independently resolved MCP clients on the 1.x API until their MCP 2 migration.

## Details

The bash, null, and compact uv scripts now use the same MCP 1.x range as the framework package. These PEP 723 environments resolve independently of the repository lock, so the constraint travels with each script.

The RLM harness passes a compatible MCP 1.x requirement through RLM's existing installer hook while preserving caller-supplied install extras. This keeps RLM's current streamable HTTP import contract available in its isolated tool environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version constraints only; no runtime or auth logic changes.
> 
> **Overview**
> **Pins MCP to the 1.x line** everywhere harness code resolves its own Python environment, so installs cannot silently pick up MCP 2 before those paths are migrated.
> 
> The **compact**, **bash**, and **null** uv script headers now declare `mcp>=1.24.0,<2` instead of an unpinned `mcp`. Those PEP 723 blocks resolve independently of the repo lock, so the constraint has to live on each script.
> 
> The **RLM** harness **appends** `--with mcp~=1.28` to `RLM_EXTRA_UV_ARGS` during `rlm` install, **preserving** any caller-supplied extras so RLM’s isolated tool env still gets a compatible 1.x client for streamable HTTP.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a48304c70d7981d0823fb07e8f085478cdb73ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin standalone MCP clients to `mcp>=1.24.0,<2`
> - Constrains the `mcp` dependency from unpinned to `>=1.24.0,<2` in the script headers for [compact/program.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2155/files#diff-67f3207e6853521a388c3d2c0c34f663db4476c8bdab10acadf0d8b59288fd49), [bash/program.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2155/files#diff-d4cd8c8ecce1607fa0d58ad9d6be1b24a81ace7b7dd85521910d4082319a2400), and [null/program.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2155/files#diff-d4e93ef3c6afb0d7441cceeef2d60bd8618168a7d72b8d1df78f16dbe0289304).
> - Appends `--with mcp~=1.28` to `RLM_EXTRA_UV_ARGS` in [`RLMHarness.setup`](https://github.com/PrimeIntellect-ai/verifiers/pull/2155/files#diff-3955da24b5fd88f62482297bbda7ba0936f633927f15576db27fed6e58f668ec) so the RLM install step also picks up a compatible version.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a48304.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->