### PR TITLE
fix: blame the runtime, not the harness, when the box dies mid-rollout

### DIFF
--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.decorators import discover_decorated, invoke_all
-from verifiers.v1.errors import HarnessError, boundary
+from verifiers.v1.errors import HarnessError, SandboxError, boundary
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.types import Messages
@@ -140,6 +140,11 @@ class Harness(ABC, Generic[ConfigT]):
         if result.exit_code != 0:
             # The real cause is at the END of a traceback, so keep the tail.
             detail = (result.stderr or result.stdout).strip()[-2000:] or "<no output>"
+            if not await runtime.alive():
+                raise SandboxError(
+                    f"runtime died under harness {self.config.id!r} "
+                    f"(exit {result.exit_code}): {detail}"
+                )
             raise HarnessError(
                 f"harness {self.config.id!r} exited {result.exit_code}: {detail}"
             )

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -197,6 +197,16 @@ class Runtime(ABC):
     async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
         pass
 
+    async def alive(self) -> bool:
+        """Whether the box still executes anything. Not every runtime raises when
+        the box is gone — some surface it as `exec`'s own non-zero result,
+        indistinguishable from the command failing. One probe on the failure path
+        tells the two apart before we blame anyone."""
+        try:
+            return (await self.run(["true"], {})).exit_code == 0
+        except Exception:  # noqa: BLE001 - failing to exec at all means the box is gone
+            return False
+
     async def run_program(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
         """Run the harness's MAIN program — the rollout itself (a possibly long-lived, stateful,
         agentic run) — as opposed to the short idempotent infra ops (write / mv / install /


### PR DESCRIPTION
## Summary
- Not every runtime raises when the box is gone — some surface it as `exec`'s own non-zero result, indistinguishable from the harness program failing. A sandbox that died mid-rollout was therefore recorded as `HarnessError` ("harness exited 137"), blaming the agent program for an infrastructure death.
- Adds `Runtime.alive()`: one trivial probe exec (`true`) that tells the two apart, and uses it at the single shared blame site — `Harness.run`'s non-zero-exit path. Probe fails → `SandboxError` ("runtime died under harness ..."); probe succeeds → the program genuinely failed and the existing `HarnessError` stands.

Fixes [RES-1195](https://linear.app/primeintellect/issue/RES-1195/distinguish-dead-sandbox-from-command-failure-on-runtime-exec).

## Verification
Real eval rollouts (bash harness, sleeper task whose agent runs `sleep 63`), killing the box manually mid-rollout:

- **docker** (`docker rm -f <container>` mid-rollout)
  - before: `trace.error = HarnessError: harness 'bash' exited 137`
  - after: `trace.error = SandboxError: runtime died under harness 'bash' (exit 137)`
- **subprocess** (workdir removed + harness process group SIGKILLed)
  - before: `trace.error = HarnessError: harness 'bash' exited -9`
  - after: `trace.error = SandboxError: runtime died under harness 'bash' (exit -9)`

Controls: a program exiting non-zero in a live box still records `HarnessError` on both runtimes. `uv run pytest tests/v1 -n auto -m "not e2e"` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow failure-path change with an extra probe exec; genuine program failures in a live runtime still raise HarnessError unchanged.
> 
> **Overview**
> When a harness segment exits non-zero, the framework now **probes the runtime** with `Runtime.alive()` (`true` exec) before assigning blame. If the box no longer runs commands, the trace gets **`SandboxError`** (“runtime died under harness …”) instead of **`HarnessError`** (“harness exited …”), so infra kills (e.g. exit 137 / -9) are not attributed to the agent program.
> 
> `alive()` is a default on the `Runtime` base class (success on exit 0, `False` on exec failure). The only call site is the shared non-zero exit path in **`Harness.run`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de4ada9331e466903d305ed41b3a54bd6353280e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise `SandboxError` instead of `HarnessError` when the runtime dies mid-rollout
> - Adds `Runtime.alive()` in [base.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2156/files#diff-0811c040a163eb5a3212208f1e3a6c6388d7690fcc4780c081cc7754036232b9), an async method that runs `true` and returns `False` if any exception occurs.
> - When a program exits with a non-zero code, the rollout handler in [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2156/files#diff-05e981bb3680a934fbc6865d9dff3b25fc692d0c9970684bf8d41f4aea7ee384) now calls `runtime.alive()` to distinguish a dead sandbox from a program failure, raising `SandboxError` if the runtime is gone and `HarnessError` otherwise.
> - Behavioral Change: callers that previously caught `HarnessError` for all non-zero exits must now also handle `SandboxError` when the runtime has died.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized de4ada9. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->