### PR TITLE
feat(v1)!: two-level concurrency, and serving as its own config block

### DIFF
--- a/docs/v1/env.md
+++ b/docs/v1/env.md
@@ -43,25 +43,6 @@ class DebateEnv(vf.Env[DebateConfig]):
 
 An `Episode` holds all agents' traces from a single invocation of `Env.run`. A good mental model is: the `Trace` is an agent's local view of a rollout, while the `Episode` is the global view.
 
-## Concurrency
-
-Concurrency is bounded at two levels, and the **episode is the unit** at the outer one:
-
-| knob | bounds |
-| --- | --- |
-| `max_concurrent` / `-c` | episodes in flight (per worker when served) |
-| `env.max_concurrent_agents` | agent runs inside one episode — **1** by default |
-
-So an episode plays its agents one at a time, and `-c 128` is 128 live agent runs whatever the env does internally. Write independent agents as independent (`asyncio.gather`, a `TaskGroup`) — how many actually run at once is the run's call, not the env's. Without the inner bound an env's fan-out would multiply the outer one invisibly: `-c 128` on a 16-attempt `best-of-n` would be 2048 live agent runs, each with its own sandbox and in-flight completions.
-
-Raise `max_concurrent_agents` (or set it to `None` for no limit) when you want that multiplication — an eval fanning `best-of-n`'s attempts out is the case for it, since `-c` still caps the episodes carrying them:
-
-```bash
-uv run eval gsm8k-v1 --env.id best-of-n --env.n 16 --env.max-concurrent-agents None -c 128
-```
-
-An episode holds its permit for as long as it lives — its agent runs, their boxes, `finalize()` — and an interaction holds an agent permit only around an active segment, never while awaiting its caller, so two-sided conversations (`user-sim`, turn-taking games) interleave turn by turn at any setting.
-
 ## Pluggability
 
 Just like tasksets and harnesses, an `Env` can be user-defined for full expressiveness over multi-agent interaction patterns — export an `Env` subclass via `__all__`. Otherwise, verifiers ships with a handful of built-ins.
@@ -71,3 +52,20 @@ Just like tasksets and harnesses, an `Env` can be user-defined for full expressi
 | `single-agent` | `agent` | (default) one `agent` plays the taskset |
 | `best-of-n` | `agent` | `n` independent attempts per episode; its metrics mark the argmax-reward sibling (`best`) and whether any reached `--env.threshold` (`pass_at_n`) — rejection sampling and pass@k. |
 | `agentic-judge` | `solver`, `judge` | the solver plays the task; a code-executing judge agent verifies the finished attempt with real execution. |
+
+## Concurrency
+
+Write independent agents as independent (`asyncio.gather`, a `TaskGroup`) — how many actually run at once is the run's call, not the env's. Two knobs bound it, and the **episode is the unit** at the outer one:
+
+| knob | bounds |
+| --- | --- |
+| `max_concurrent` / `-c` | episodes in flight (per worker when served) |
+| `env.max_concurrent_agents` | agent runs inside one episode — **1** by default |
+
+At the default, `-c 128` is 128 live agent runs whatever the env does internally. Set `max_concurrent_agents` higher (or `None` for no limit) when you want an episode's fan-out to run together — `-c` still caps the episodes carrying it:
+
+```bash
+uv run eval gsm8k-v1 --env.id best-of-n --env.n 16 --env.max-concurrent-agents None -c 128
+```
+
+Turn-taking envs are unaffected: an interaction holds its agent permit only around an active segment, never while awaiting its caller, so `user-sim` and games alternate at any setting.

--- a/docs/v1/env.md
+++ b/docs/v1/env.md
@@ -43,6 +43,25 @@ class DebateEnv(vf.Env[DebateConfig]):
 
 An `Episode` holds all agents' traces from a single invocation of `Env.run`. A good mental model is: the `Trace` is an agent's local view of a rollout, while the `Episode` is the global view.
 
+## Concurrency
+
+Concurrency is bounded at two levels, and the **episode is the unit** at the outer one:
+
+| knob | bounds |
+| --- | --- |
+| `max_concurrent` / `-c` | episodes in flight (per worker when served) |
+| `env.max_concurrent_agents` | agent runs inside one episode — **1** by default |
+
+So an episode plays its agents one at a time, and `-c 128` is 128 live agent runs whatever the env does internally. Write independent agents as independent (`asyncio.gather`, a `TaskGroup`) — how many actually run at once is the run's call, not the env's. Without the inner bound an env's fan-out would multiply the outer one invisibly: `-c 128` on a 16-attempt `best-of-n` would be 2048 live agent runs, each with its own sandbox and in-flight completions.
+
+Raise `max_concurrent_agents` (or set it to `None` for no limit) when you want that multiplication — an eval fanning `best-of-n`'s attempts out is the case for it, since `-c` still caps the episodes carrying them:
+
+```bash
+uv run eval gsm8k-v1 --env.id best-of-n --env.n 16 --env.max-concurrent-agents None -c 128
+```
+
+An episode holds its permit for as long as it lives — its agent runs, their boxes, `finalize()` — and an interaction holds an agent permit only around an active segment, never while awaiting its caller, so two-sided conversations (`user-sim`, turn-taking games) interleave turn by turn at any setting.
+
 ## Pluggability
 
 Just like tasksets and harnesses, an `Env` can be user-defined for full expressiveness over multi-agent interaction patterns — export an `Env` subclass via `__all__`. Otherwise, verifiers ships with a handful of built-ins.

--- a/docs/v1/evaluation.md
+++ b/docs/v1/evaluation.md
@@ -40,7 +40,9 @@ The output from evaluations are written into `outputs/<env>--<model>--<harness>/
 - `num_tasks` — how many tasks to evaluate. Not setting a value means all tasks; an
   infinite taskset (a procedural generator, e.g. `wordle-v1`) requires it
 - `num_rollouts` — rollouts per task
-- `max_concurrent` — caps how many episodes are in flight at once (per worker under `--server`); `env.max_concurrent_agents` caps the agent runs inside one episode (1 by default — see [The Env § Concurrency](env.md#concurrency))
+- `max_concurrent` — caps how many episodes are in flight at once; `env.max_concurrent_agents` caps the agent runs inside one episode (1 by default — see [The Env § Concurrency](env.md#concurrency))
+- `[serve]` — how the env is hosted under `--server`: `serve.pool` (worker pool), `serve.address`, and `serve.max_concurrent` (a per-worker episode bound; unset takes `max_concurrent`)
+- `[legacy]` — run a classic (v0) environment through the bridge instead of `[env]`: `legacy.id`, `legacy.args`
 - `verbose` — log at debug instead of info
 - `shuffle` — randomizes the order of tasks (fixed seed); a no-op on an infinite taskset
 

--- a/docs/v1/evaluation.md
+++ b/docs/v1/evaluation.md
@@ -40,7 +40,7 @@ The output from evaluations are written into `outputs/<env>--<model>--<harness>/
 - `num_tasks` — how many tasks to evaluate. Not setting a value means all tasks; an
   infinite taskset (a procedural generator, e.g. `wordle-v1`) requires it
 - `num_rollouts` — rollouts per task
-- `max_concurrent` — caps how many rollouts are in flight at once
+- `max_concurrent` — caps how many episodes are in flight at once (per worker under `--server`); `env.max_concurrent_agents` caps the agent runs inside one episode (1 by default — see [The Env § Concurrency](env.md#concurrency))
 - `verbose` — log at debug instead of info
 - `shuffle` — randomizes the order of tasks (fixed seed); a no-op on an infinite taskset
 

--- a/docs/v1/gepa.md
+++ b/docs/v1/gepa.md
@@ -31,7 +31,7 @@ Validate the config by using `uv run gepa @ config.toml --dry-run`. To run GEPA,
 - `reflection_model` / `reflection_client` — model/endpoint that proposes new prompts (default: reuse `model` / `client`)
 - `num_train` / `num_val` — train tasks for reflection minibatches and held-out val tasks for the pareto frontier (defaults: 100 / 50)
 - `max_total_rollouts` — total rollouts the run may spend (default: 500)
-- `max_concurrent` / `-c` — caps how many rollouts are in flight at once (default: 128)
+- `max_concurrent` / `-c` — caps how many episodes are in flight at once (default: 128)
 
 ## Output
 

--- a/skills/evaluate-environments/SKILL.md
+++ b/skills/evaluate-environments/SKILL.md
@@ -204,7 +204,7 @@ Do not average these categories together without reporting failure rate.
 For a real v0 package only:
 
 ```bash
-prime eval run --id legacy-env --args.split test -n 5
+prime eval run --legacy.id legacy-env --legacy.args.split test -n 5
 ```
 
-Label the result as bridged v0. Do not present `args` as the v1 config contract.
+Label the result as bridged v0. Do not present `legacy.args` as the v1 config contract.

--- a/skills/evaluate-environments/references/REFERENCE.md
+++ b/skills/evaluate-environments/references/REFERENCE.md
@@ -21,7 +21,6 @@ EvalConfig                          (the run)
 │  ├─ timeout: TimeoutConfig        (episode / finalize — the env's own hooks)
 │  ├─ retries: RetryConfig          (whole-episode fallback for faults no agent owns)
 │  ├─ max_concurrent_agents          (agent runs inside one episode — 1 by default)
-│  │                                 (alias: max_concurrent)
 │  └─ interception
 ├─ serve: ServingConfig             (how it's hosted — the `--server` path)
 │  ├─ pool: PoolConfig              (static | elastic)

--- a/skills/evaluate-environments/references/REFERENCE.md
+++ b/skills/evaluate-environments/references/REFERENCE.md
@@ -31,7 +31,7 @@ EvalConfig                          (the run)
    └─ id / args / extra_env_kwargs
 ```
 
-There is no run-level harness: each agent pins its own (`--env.agent.harness.*` on the single-agent env), an unpinned agent runs the taskset's default harness (its bundled one, else `bash`), and a declared pin is the env author's default. The retired flat axes error with a pointer: `--taskset.*` → `--env.taskset.*`, `--harness.*` → `--env.<agent>.harness.*`, `--pool.*` → `--serve.pool.*`, `--address` → `--serve.address`, `--id` / `--args` / `--extra-env-kwargs` → `--legacy.*`.
+There is no run-level harness: each agent pins its own (`--env.agent.harness.*` on the single-agent env), an unpinned agent runs the taskset's default harness (its bundled one, else `bash`), and a declared pin is the env author's default. Nothing is flat on the run config — a taskset is `--env.taskset.*`, a harness `--env.<agent>.harness.*`, the pool and bind address `--serve.*`, and a v0 env's id/args `--legacy.*`.
 
 Sibling entrypoints reuse the same tree: [`ServeConfig`](#serveconfig--the-env-server-cli) (env server) and [`ValidateConfig`](#validateconfig--the-validate-cli) (per-task validation). All three live in `verifiers/v1/configs/cli/`.
 

--- a/skills/evaluate-environments/references/REFERENCE.md
+++ b/skills/evaluate-environments/references/REFERENCE.md
@@ -2,7 +2,7 @@
 
 A complete reference of every settable config field for **evaluating tasksets in `verifiers.v1`**. The config tree is parsed from CLI flags (dotted, e.g. `--env.agent.runtime.type docker`) and/or `@ file.toml` by `prime-pydantic-config`; every field below is settable either way unless noted.
 
-The root config the eval CLI parses is [`EvalConfig`](#evalconfig--the-run). It composes the environment (`env` — the whole `[env]` block: taskset, agents, limits) with the run knobs (model, sampling, counts) and the worker pool. The tree:
+The root config the eval CLI parses is [`EvalConfig`](#evalconfig--the-run). It composes three orthogonal blocks — the environment (`env`: taskset, agents, limits), how it's hosted (`serve`: worker pool, address, per-worker bound), and the classic v0 bridge (`legacy`) — with its own run knobs (model, sampling, counts). The tree:
 
 ```text
 EvalConfig                          (the run)
@@ -20,11 +20,17 @@ EvalConfig                          (the run)
 │  │  └─ max_turns / max_input_tokens / max_output_tokens / max_total_tokens
 │  ├─ timeout: TimeoutConfig        (episode / finalize — the env's own hooks)
 │  ├─ retries: RetryConfig          (whole-episode fallback for faults no agent owns)
+│  ├─ max_concurrent_agents          (agent runs inside one episode — 1 by default)
 │  └─ interception
-└─ pool: PoolConfig                 (static | elastic) — env-server only
+├─ serve: ServingConfig             (how it's hosted — the `--server` path)
+│  ├─ pool: PoolConfig              (static | elastic)
+│  ├─ address                       (where the ROUTER binds)
+│  └─ max_concurrent                (episodes per worker; unset = the run's `-c`)
+└─ legacy: LegacyEnvConfig          (a classic v0 env instead of `env`)
+   └─ id / args / extra_env_kwargs
 ```
 
-There is no run-level harness: each agent pins its own (`--env.agent.harness.*` on the single-agent env), an unpinned agent runs the taskset's default harness (its bundled one, else `bash`), and a declared pin is the env author's default. The retired flat axes error with a pointer: `--taskset.*` → `--env.taskset.*`, `--harness.*` → `--env.<agent>.harness.*`.
+There is no run-level harness: each agent pins its own (`--env.agent.harness.*` on the single-agent env), an unpinned agent runs the taskset's default harness (its bundled one, else `bash`), and a declared pin is the env author's default. The retired flat axes error with a pointer: `--taskset.*` → `--env.taskset.*`, `--harness.*` → `--env.<agent>.harness.*`, `--pool.*` → `--serve.pool.*`, `--address` → `--serve.address`, `--id` / `--args` / `--extra-env-kwargs` → `--legacy.*`.
 
 Sibling entrypoints reuse the same tree: [`ServeConfig`](#serveconfig--the-env-server-cli) (env server) and [`ValidateConfig`](#validateconfig--the-validate-cli) (per-task validation). All three live in `verifiers/v1/configs/cli/`.
 
@@ -32,7 +38,7 @@ Sibling entrypoints reuse the same tree: [`ServeConfig`](#serveconfig--the-env-s
 
 ## EvalConfig — the run
 
-`verifiers/v1/configs/cli/eval.py` — `EvalConfig(EnvServerConfig)`. The single config object the eval CLI parses. Inherits [`EnvServerConfig`](#envserverconfig--the-pool) (the `env` block + `--pool.*` + the legacy v0 fields) and adds the run knobs. Everything environment-shaped lives under `--env.*` / `[env]`.
+`verifiers/v1/configs/cli/eval.py` — `EvalConfig(BaseConfig)`. The single config object the eval CLI parses: it declares [`env`](#envconfig--the-environment), [`serve`](#servingconfig--how-its-hosted) and [`legacy`](#legacy-v0-envs) as blocks and adds the run knobs. Nothing is inherited — the `serve` CLI and a trainer declare the same blocks. Everything environment-shaped lives under `--env.*` / `[env]`.
 
 | Field | Type | Default | Aliases | Notes |
 | --- | --- | --- | --- | --- |
@@ -43,18 +49,18 @@ Sibling entrypoints reuse the same tree: [`ServeConfig`](#serveconfig--the-env-s
 | `num_tasks` | `int \| None` | `None` | `batch_size`, `num_examples`, `num_tasks`, `n` | How many tasks to evaluate (None = all). |
 | `num_rollouts` | `int` | `1` | `group_size`, `rollouts_per_example`, `num_rollouts`, `r` | Independent episodes per task — the trainer's group size. Env-internal fan-out (e.g. best-of-n attempts) is the env's own knob, not `-r`. |
 | `shuffle` | `bool` | `False` | `shuffle`, `s` | Shuffle tasks before taking the first `num_tasks`. |
-| `max_concurrent` | `int \| None` | `128` | `max_concurrent`, `c` | Max rollouts in flight at once. |
+| `max_concurrent` | `int \| None` | `128` (≥1) | `max_concurrent`, `c` | Episodes in flight at once (`None` = no limit). An episode plays its agents one at a time, so this is the live agent runs too — until `--env.max-concurrent-agents` says otherwise. Under `--server` it seeds each worker's bound unless `--serve.max-concurrent` pins one. |
 | `verbose` | `bool` | `False` | `verbose`, `v` | Log at debug level instead of info. |
 | `dry_run` | `bool` | `False` | — | Resolve + validate the config and dump it, then exit. |
 | `rich` | `bool` | `True` | — | Live dashboard instead of per-rollout logs (in-process only). |
-| `server` | `bool` | `False` | — | Drive rollouts through the env-server worker pool (sized by `pool`) instead of in-process — the path prime-rl trains through. Incompatible with `--rich`. |
+| `server` | `bool` | `False` | — | Drive rollouts through the env-server worker pool (sized by `[serve]`) instead of in-process — the path prime-rl trains through. Incompatible with `--rich`. |
 | `push` | `bool` | `True` | — | Upload the finished run to the private Evaluations tab. Disable with `--no-push`. |
 | `output_dir` | `Path \| None` | `None` | `output_dir`, `o` | Where to write the run (`config.toml` + `traces.jsonl`). None = a fresh per-run dir under `outputs/<env>--<model>--<harness>/<uuid>`. |
 | `resume` | `Path \| None` | `None` | — | Set by `--resume <dir>`: re-run missing/errored rollouts, episode-atomically (a multi-trace rollout is kept or redone as a unit; `Env.complete` is the keep verdict). Excluded from the saved config; takes no other args. |
 
 Validator: `--rich` + `--server` together is rejected (the dashboard is in-process only).
 
-Inherited from `EnvServerConfig`: [`env`](#envconfig--the-environment), [`pool`](#pool-config), and the legacy `id` / `args` / `extra_env_kwargs`.
+Blocks: [`env`](#envconfig--the-environment), [`serve`](#servingconfig--how-its-hosted), [`legacy`](#legacy-v0-envs). Derived: `is_legacy` (a `legacy.id` and no v1 taskset), `env_id` (the env's id, else the v0 one), `worker_max_concurrent` (`serve.max_concurrent`, else `max_concurrent`).
 
 ---
 
@@ -137,9 +143,9 @@ Per-run caps (turns, tokens, stage timeouts, retries) are agent fields, not env 
 
 Trainability is not a config field: it is env truth, set in place by the env's `setup(agents)` hook (default: every agent trains) and stamped on each trace. An env that wants the flip run-configurable exposes its own switch (e.g. proposer-solver's `--env.train_solver false`).
 
-### Legacy (v0) backwards-compat fields
+### Legacy (v0) envs
 
-On `EnvServerConfig` (below): set `id` (leave `env.taskset` unset) to run a classic `verifiers.load_environment` env through the legacy bridge.
+`verifiers/v1/configs/legacy.py` — `LegacyEnvConfig(BaseConfig)`, the `[legacy]` block. Set `legacy.id` (and leave `env.taskset` unset) to run a classic `verifiers.load_environment` env through the bridge. A v0 id next to a v1 taskset is refused, not silently ignored.
 
 | Field | Type | Default | Notes |
 | --- | --- | --- | --- |
@@ -147,16 +153,17 @@ On `EnvServerConfig` (below): set `id` (leave `env.taskset` unset) to run a clas
 | `args` | `dict` | `{}` | Construction kwargs forwarded to `load_environment(id, **args)`. |
 | `extra_env_kwargs` | `dict` | `{}` | Post-load kwargs applied via `env.set_kwargs(**...)` (e.g. `max_total_completion_tokens`, `max_seq_len`, `timeout_seconds`). |
 
-`EnvServerConfig.is_legacy` → `id is not None and no v1 taskset`.
+`is_legacy` → a `legacy.id` is set and no v1 taskset.
 
-### EnvServerConfig — the pool
+### ServingConfig — how it's hosted
 
-`EnvServerConfig(BaseConfig)`. The `env` block plus the worker pool sizing and the legacy v0 fields. Shared by the `serve` CLI, server-backed eval, and prime-rl's orchestrator.
+`verifiers/v1/configs/serve.py` — `ServingConfig(BaseConfig)`, the `[serve]` block. Read by whoever hosts the env: the `serve` CLI, a server-backed eval, a trainer's orchestrator. An in-process eval ignores it.
 
 | Field | Type | Default | Notes |
 | --- | --- | --- | --- |
-| `env` | `EnvConfig` | `SingleAgentEnvConfig()` | The environment (above). `SerializeAsAny`, so the resolved subclass's agents and knobs survive `model_dump` onto the wire. |
-| `pool` | `PoolConfig` | `ElasticPoolConfig()` | See [Pool config](#pool-config). |
+| `pool` | `PoolConfig` | `ElasticPoolConfig()` | Worker-pool sizing — see [Pool config](#pool-config). |
+| `address` | `str` | `"tcp://127.0.0.1:5000"` | ZMQ address the ROUTER binds (and clients connect to). |
+| `max_concurrent` | `int \| None` | `None` (≥1) | Episodes in flight per worker. None = take the run's own bound (an eval's `-c`). |
 
 ---
 
@@ -195,7 +202,7 @@ Rerun when the run ends with a captured error. Matching is by the error's **exce
 
 ## Pool config
 
-`verifiers/v1/configs/cli/env.py`. Discriminated on `type`; selected with `--pool.type static|elastic`. Drives the env-server worker pool (the `--server` path).
+`verifiers/v1/configs/serve.py`. Discriminated on `type`; selected with `--serve.pool.type static|elastic`. Drives the env-server worker pool (the `--server` path).
 
 ### `StaticPoolConfig` — `type: "static"`
 
@@ -212,7 +219,7 @@ Elastic pool: start at one worker and scale up on demand.
 | Field | Type | Default | Notes |
 | --- | --- | --- | --- |
 | `max_workers` | `int \| None` | `None` | Upper bound on workers (None = unbounded). |
-| `multiplex` | `int` | `128` (≥1) | Rollouts per worker for the scale-up trigger: add a worker once in-flight rollouts reach 90% of `workers * multiplex`. |
+| `multiplex` | `int` | `128` (≥1) | Episodes per worker for the scale-up trigger: add a worker once in-flight episodes reach 90% of `workers * multiplex`. |
 
 ---
 
@@ -534,15 +541,14 @@ A judge class may define:
 
 ## ServeConfig — the env-server CLI
 
-`verifiers/v1/configs/serve.py` — `ServeConfig(EnvServerConfig)`. The env-server CLI. Inherits the `env` block + pool, so `--env.*` / `--pool.*` are the same flags as eval. Adds only CLI-specific serving knobs.
+`verifiers/v1/configs/cli/serve.py` — `ServeConfig(BaseConfig)`. The env-server CLI. Declares the same blocks as eval — [`env`](#envconfig--the-environment), [`serve`](#servingconfig--how-its-hosted), [`legacy`](#legacy-v0-envs) — so `--env.*` / `--serve.*` are the same flags there, and adds only its own two.
 
 | Field | Type | Default | Aliases | Notes |
 | --- | --- | --- | --- | --- |
-| `address` | `str` | `"tcp://127.0.0.1:5000"` | `address`, `a` | ZMQ address the ROUTER binds. |
 | `verbose` | `bool` | `False` | `verbose`, `v` | Log at debug level. |
 | `dry_run` | `bool` | `False` | — | Resolve + validate and dump, then exit. |
 
-Plus all inherited `EnvServerConfig` fields (`env`, `pool`, legacy).
+Where it binds is `--serve.address`; how many workers is `--serve.pool.*`.
 
 ---
 
@@ -584,7 +590,7 @@ Use `only_gold` or `only_setup` to select one mode; setting both is rejected. Th
 - **Plugin resolution.** The run's `env` field narrows to the selected env's config class
   (`--env.id`, else the taskset's exported env, else `SingleAgentEnvConfig`) *before* validation; inside it, `taskset` narrows by its id and each pinned agent `harness` by its id. Entries in `TaskConfig.judges` are similarly narrowed by each judge `id`. This is why local and Hub plugin fields remain typed and appear in CLI validation instead of living in an untyped arguments dictionary.
 - **Dotted flags.** Every nested field is part of the same CLI tree
-  (`--env.agent.runtime.type docker`, `--env.taskset.split test`, `--pool.max_workers 8`, `--env.agent.retries.max_retries 2`). An `@ file.toml` describes the identical tree; explicit CLI values layer over values loaded from the file.
+  (`--env.agent.runtime.type docker`, `--env.taskset.split test`, `--serve.pool.max-workers 8`, `--env.agent.retries.max_retries 2`). An `@ file.toml` describes the identical tree; explicit CLI values layer over values loaded from the file.
 - **Runtime precedence.** An explicit, non-default CLI/TOML `workdir` or resource field wins over
   `TaskData`; otherwise a non-`None` row value fills it, and otherwise the runtime/provider default remains. `TaskData.image` is the required image for that row and replaces the runtime's base image. Unsupported resource fields are ignored; evaluation warns once per runtime/field.
 - **Timeout precedence.** For eval stages, a non-`None` agent-level `TimeoutConfig` value

--- a/skills/evaluate-environments/references/REFERENCE.md
+++ b/skills/evaluate-environments/references/REFERENCE.md
@@ -21,6 +21,7 @@ EvalConfig                          (the run)
 │  ├─ timeout: TimeoutConfig        (episode / finalize — the env's own hooks)
 │  ├─ retries: RetryConfig          (whole-episode fallback for faults no agent owns)
 │  ├─ max_concurrent_agents          (agent runs inside one episode — 1 by default)
+│  │                                 (alias: max_concurrent)
 │  └─ interception
 ├─ serve: ServingConfig             (how it's hosted — the `--server` path)
 │  ├─ pool: PoolConfig              (static | elastic)
@@ -49,7 +50,7 @@ Sibling entrypoints reuse the same tree: [`ServeConfig`](#serveconfig--the-env-s
 | `num_tasks` | `int \| None` | `None` | `batch_size`, `num_examples`, `num_tasks`, `n` | How many tasks to evaluate (None = all). |
 | `num_rollouts` | `int` | `1` | `group_size`, `rollouts_per_example`, `num_rollouts`, `r` | Independent episodes per task — the trainer's group size. Env-internal fan-out (e.g. best-of-n attempts) is the env's own knob, not `-r`. |
 | `shuffle` | `bool` | `False` | `shuffle`, `s` | Shuffle tasks before taking the first `num_tasks`. |
-| `max_concurrent` | `int \| None` | `128` (≥1) | `max_concurrent`, `c` | Episodes in flight at once (`None` = no limit). An episode plays its agents one at a time, so this is the live agent runs too — until `--env.max-concurrent-agents` says otherwise. Under `--server` it seeds each worker's bound unless `--serve.max-concurrent` pins one. |
+| `max_concurrent` | `int \| None` | `128` (≥1) | `max_concurrent`, `c` | Episodes in flight at once (`None` = no limit); under `--server` it seeds each worker's bound unless `--serve.max-concurrent` pins one. Agent runs inside one episode are `--env.max-concurrent-agents`. |
 | `verbose` | `bool` | `False` | `verbose`, `v` | Log at debug level instead of info. |
 | `dry_run` | `bool` | `False` | — | Resolve + validate the config and dump it, then exit. |
 | `rich` | `bool` | `True` | — | Live dashboard instead of per-rollout logs (in-process only). |

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -180,7 +180,7 @@ def _eval_config(
         },
         rich=False,
         output_dir=output_dir,
-        **({"pool": pool} if pool else {}),
+        **({"serve": {"pool": pool}} if pool else {}),
         **({"model": model} if model else {}),
     )
 
@@ -237,7 +237,7 @@ async def live_ctx():
 
 @pytest.fixture
 def run_v0():
-    """Run a legacy v0 env through the v1 bridge (the eval CLI's `--id` path)."""
+    """Run a legacy v0 env through the v1 bridge (the eval CLI's `--legacy.id` path)."""
     from verifiers.v1.legacy import run_legacy_eval
 
     async def _run(
@@ -249,8 +249,7 @@ def run_v0():
         args: dict | None = None,
     ) -> list[Trace]:
         config = EvalConfig(
-            id=env_id,
-            args=args or {},
+            legacy={"id": env_id, "args": args or {}},
             num_tasks=1,
             num_rollouts=n,
             sampling={"max_tokens": max_tokens, "temperature": 0},

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -14,6 +14,12 @@ from verifiers.v1.clients import (
     resolve_client,
 )
 from verifiers.v1.configs.agent import AgentConfig
+from verifiers.v1.configs.cli.env import (
+    EnvField,
+    env_field,
+    narrowed_env_annotation,
+    resolve_env_field,
+)
 from verifiers.v1.configs.env import EnvConfig, default_agent_harness
 from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.configs.judge import JudgeConfig, Judges
@@ -251,6 +257,10 @@ __all__ = [  # noqa: RUF022 - grouped by public API area
     "EnvConfig",
     "ServingConfig",
     "LegacyEnvConfig",
+    "EnvField",
+    "env_field",
+    "resolve_env_field",
+    "narrowed_env_annotation",
     "SingleAgentEnvConfig",
     "AgentConfig",
     "StaticPoolConfig",

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -14,11 +14,7 @@ from verifiers.v1.clients import (
     resolve_client,
 )
 from verifiers.v1.configs.agent import AgentConfig
-from verifiers.v1.configs.cli.env import (
-    narrowed_env_annotation,
-    resolve_env_field,
-    single_agent_env_config,
-)
+from verifiers.v1.configs.cli.env import narrowed_env_annotation, resolve_env_field
 from verifiers.v1.configs.env import EnvConfig, default_agent_harness
 from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.configs.judge import JudgeConfig, Judges
@@ -256,7 +252,6 @@ __all__ = [  # noqa: RUF022 - grouped by public API area
     "EnvConfig",
     "ServingConfig",
     "LegacyEnvConfig",
-    "single_agent_env_config",
     "resolve_env_field",
     "narrowed_env_annotation",
     "SingleAgentEnvConfig",

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -15,7 +15,6 @@ from verifiers.v1.clients import (
 )
 from verifiers.v1.configs.agent import AgentConfig
 from verifiers.v1.configs.cli.env import (
-    EnvField,
     env_field,
     narrowed_env_annotation,
     resolve_env_field,
@@ -257,7 +256,6 @@ __all__ = [  # noqa: RUF022 - grouped by public API area
     "EnvConfig",
     "ServingConfig",
     "LegacyEnvConfig",
-    "EnvField",
     "env_field",
     "resolve_env_field",
     "narrowed_env_annotation",

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -15,9 +15,9 @@ from verifiers.v1.clients import (
 )
 from verifiers.v1.configs.agent import AgentConfig
 from verifiers.v1.configs.cli.env import (
-    env_field,
     narrowed_env_annotation,
     resolve_env_field,
+    single_agent_env_config,
 )
 from verifiers.v1.configs.env import EnvConfig, default_agent_harness
 from verifiers.v1.configs.harness import HarnessConfig
@@ -256,7 +256,7 @@ __all__ = [  # noqa: RUF022 - grouped by public API area
     "EnvConfig",
     "ServingConfig",
     "LegacyEnvConfig",
-    "env_field",
+    "single_agent_env_config",
     "resolve_env_field",
     "narrowed_env_annotation",
     "SingleAgentEnvConfig",

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -14,16 +14,17 @@ from verifiers.v1.clients import (
     resolve_client,
 )
 from verifiers.v1.configs.agent import AgentConfig
-from verifiers.v1.configs.cli.env import (
-    ElasticPoolConfig,
-    EnvServerConfig,
-    StaticPoolConfig,
-    pool_serve_kwargs,
-)
 from verifiers.v1.configs.env import EnvConfig, default_agent_harness
 from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.configs.judge import JudgeConfig, Judges
+from verifiers.v1.configs.legacy import LegacyEnvConfig
 from verifiers.v1.configs.retries import RetryConfig
+from verifiers.v1.configs.serve import (
+    ElasticPoolConfig,
+    ServingConfig,
+    StaticPoolConfig,
+    pool_serve_kwargs,
+)
 from verifiers.v1.configs.task import TaskConfig
 from verifiers.v1.configs.taskset import TasksetConfig
 from verifiers.v1.decorators import metric, reward, stop, tool
@@ -248,7 +249,8 @@ __all__ = [  # noqa: RUF022 - grouped by public API area
     "Env",
     "SingleAgentEnv",
     "EnvConfig",
-    "EnvServerConfig",
+    "ServingConfig",
+    "LegacyEnvConfig",
     "SingleAgentEnvConfig",
     "AgentConfig",
     "StaticPoolConfig",

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -276,9 +276,9 @@ class Agent:
             max_total_tokens=config.max_total_tokens,
         )
         self.timeout = config.timeout
-        # Env episode agents replace this with the eval concurrency semaphore.
-        # Interactions acquire it only around active lifecycle work, never while
-        # awaiting the caller between segments.
+        # Env episode agents replace this with the episode's agent semaphore
+        # (`--env.max-concurrent-agents`). Interactions acquire it only around active
+        # lifecycle work, never while awaiting the caller between segments.
         self._gate: asyncio.Semaphore | None = None
         # Env-owned standing, not config: `Env.setup` marks fixed agents
         # untrainable and traces are stamped from here; inert outside an env.
@@ -578,9 +578,9 @@ class _EpisodeAgent(Agent):
     bundle of references — expensive resources are env-owned and borrowed, so no
     state spans concurrent episodes): traces get their agent standing the moment
     they're created, finished ones land in `completed` (the episode's traces),
-    each run takes the eval's gate. The taskset's shared tool servers ride only
-    its own tasks — on an env-minted task they'd wrongly put MCP in play
-    (`tools=` overrides)."""
+    each run takes one of the episode's agent permits. The taskset's shared tool
+    servers ride only its own tasks — on an env-minted task they'd wrongly put MCP
+    in play (`tools=` overrides)."""
 
     def __init__(
         self,
@@ -664,8 +664,9 @@ class _EpisodeAgent(Agent):
         """The agent's `interaction`, with every trace stamped with its standing
         at mint and captured in `completed` at close — an interaction driven from
         `Env.run` stays crash-safe. Setup, each active segment, and close acquire
-        the eval gate independently; the interaction holds no permit while awaiting
-        its caller, so peer interactions can interleave even at concurrency one."""
+        an agent permit independently; the interaction holds no permit while awaiting
+        its caller, so peer interactions still interleave where an episode plays one
+        agent at a time."""
         trace: Trace | None = None
 
         def remember(current: Trace) -> None:

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -95,7 +95,7 @@ def _limits(config: EvalConfig) -> list[str]:
             toks.append(f"{label}≤{v}")
     turns = _seat_value(config, lambda spec: spec.max_turns)
     return [
-        f"≤{config.max_concurrent} concurrent"
+        f"≤{config.max_concurrent} episodes"
         if config.max_concurrent
         else "no concurrency cap",
         "per-seat turn caps"

--- a/verifiers/v1/cli/eval/main.py
+++ b/verifiers/v1/cli/eval/main.py
@@ -24,7 +24,7 @@ from verifiers.v1.utils.logging import setup_logging
 logger = logging.getLogger(__name__)
 
 USAGE = (
-    "usage: uv run eval [<taskset-id>] [--env.id <id>] [--id <env-id> (legacy)] [options] [@ file.toml]\n"
+    "usage: uv run eval [<taskset-id>] [--env.id <id>] [--legacy.id <env-id> (v0)] [options] [@ file.toml]\n"
     "       uv run eval --resume <output-dir>   (re-run a previous run's missing/errored rollouts)"
 )
 
@@ -49,12 +49,15 @@ def main(argv: list[str] | None = None) -> None:
             )
         config = load_resume_config(resume_dir)
     else:
-        legacy_id = any(a == "--id" or a.startswith("--id=") for a in argv)  # v0 env id
+        legacy_id = any(
+            a == "--legacy.id" or a.startswith("--legacy.id=") for a in argv
+        )
         # An env-block flag (or a retired flat axis) skips the usage gate so the
         # typed parse renders its did-you-mean / pointer to the new flags instead
         # of a bare usage line.
         typed_axis = any(
-            a.startswith(("--env.", "--taskset.", "--harness.")) for a in argv
+            a.startswith(("--env.", "--taskset.", "--harness.", "--serve."))
+            for a in argv
         )
         if (
             not extract_id(argv, "env.taskset")
@@ -64,7 +67,7 @@ def main(argv: list[str] | None = None) -> None:
         ):
             raise SystemExit(
                 USAGE
-            )  # need a taskset (positional / --env.taskset.id), a legacy --id, or a @ file.toml
+            )  # need a taskset (positional / --env.taskset.id), a v0 --legacy.id, or a @ file.toml
 
         with plugin_errors():
             config_type = narrow_config(EvalConfig, argv)

--- a/verifiers/v1/cli/eval/main.py
+++ b/verifiers/v1/cli/eval/main.py
@@ -52,9 +52,8 @@ def main(argv: list[str] | None = None) -> None:
         legacy_id = any(
             a == "--legacy.id" or a.startswith("--legacy.id=") for a in argv
         )
-        # An env-block flag (or a retired flat axis) skips the usage gate so the
-        # typed parse renders its did-you-mean / pointer to the new flags instead
-        # of a bare usage line.
+        # An env-block flag (or a since-moved flat axis) skips the usage gate so the
+        # typed parse renders its did-you-mean instead of a bare usage line.
         typed_axis = any(
             a.startswith(("--env.", "--taskset.", "--harness.", "--serve."))
             for a in argv

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -107,23 +107,23 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
     import multiprocessing as mp
     from functools import partial
 
-    from verifiers.v1.configs.cli.env import pool_serve_kwargs
+    from verifiers.v1.configs.serve import pool_serve_kwargs
     from verifiers.v1.serve import EnvClient, env_config_data, serve_env
     from verifiers.v1.utils.logging import setup_logging
 
     legacy = config.is_legacy
     server_kwargs = (
         {
-            "env_id": config.id,
-            "env_args": config.args,
-            "extra_env_kwargs": config.extra_env_kwargs,
+            "env_id": config.legacy.id,
+            "env_args": config.legacy.args,
+            "extra_env_kwargs": config.legacy.extra_env_kwargs,
         }
         if legacy
         else {
             "config_data": env_config_data(config.env),  # picklable across the spawn
-            # `-c` is the episode bound here too, per worker — so a pool carries
-            # `workers * max_concurrent` episodes, as the pool's `multiplex` implies.
-            "max_concurrent": config.max_concurrent,
+            # `-c` seeds each worker's episode bound unless `[serve]` pins one — so a
+            # pool carries `workers * bound` episodes, as `multiplex` implies.
+            "max_concurrent": config.worker_max_concurrent,
         }
     )
     tasks = []
@@ -147,7 +147,7 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
     proc = mpctx.Process(
         target=serve_env,
         kwargs=dict(
-            **pool_serve_kwargs(config.pool),
+            **pool_serve_kwargs(config.serve.pool),
             legacy=legacy,
             address="tcp://127.0.0.1:0",
             address_queue=address_queue,
@@ -215,7 +215,7 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
                 "running %dx%d rollouts via the env-server %s pool on %s",
                 len(plan),
                 config.num_rollouts,
-                config.pool.type,
+                config.serve.pool.type,
                 config.model,
             )
         logger.info("results: %s", out)

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -119,7 +119,12 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
             "extra_env_kwargs": config.extra_env_kwargs,
         }
         if legacy
-        else {"config_data": env_config_data(config.env)}  # picklable across the spawn
+        else {
+            "config_data": env_config_data(config.env),  # picklable across the spawn
+            # `-c` is the episode bound here too, per worker — so a pool carries
+            # `workers * max_concurrent` episodes, as the pool's `multiplex` implies.
+            "max_concurrent": config.max_concurrent,
+        }
     )
     tasks = []
     if not legacy:

--- a/verifiers/v1/cli/serve.py
+++ b/verifiers/v1/cli/serve.py
@@ -65,7 +65,9 @@ def main(argv: list[str] | None = None) -> None:
             "extra_env_kwargs": config.extra_env_kwargs,
         }
         if config.is_legacy
-        else {"config": config.env}
+        # `--max-concurrent` is each v1 worker's episode bound; the legacy bridge
+        # has never had one.
+        else {"config": config.env, "max_concurrent": config.max_concurrent}
     )
     serve_env(
         **pool_serve_kwargs(config.pool),

--- a/verifiers/v1/cli/serve.py
+++ b/verifiers/v1/cli/serve.py
@@ -12,12 +12,12 @@ from verifiers.v1.cli.resolve import (
     references_config_file,
     with_positional_taskset,
 )
-from verifiers.v1.configs.cli.env import pool_serve_kwargs
 from verifiers.v1.configs.cli.serve import ServeConfig
+from verifiers.v1.configs.serve import pool_serve_kwargs
 from verifiers.v1.serve import serve_env
 from verifiers.v1.utils.logging import setup_logging
 
-USAGE = "usage: uv run serve [<taskset-id>] [--env.id <id>] [--id <env-id> (legacy)] [options] [@ file.toml]"
+USAGE = "usage: uv run serve [<taskset-id>] [--env.id <id>] [--legacy.id <env-id> (v0)] [options] [@ file.toml]"
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -29,11 +29,13 @@ def main(argv: list[str] | None = None) -> None:
         with plugin_errors():
             cli(narrow_config(ServeConfig, argv))
         return
-    legacy_id = any(a == "--id" or a.startswith("--id=") for a in argv)  # v0 env id
+    legacy_id = any(a == "--legacy.id" or a.startswith("--legacy.id=") for a in argv)
     # An env-block flag (or a retired flat axis) skips the usage gate so the typed
     # parse renders its did-you-mean / pointer to the new flags instead of a bare
     # usage line.
-    typed_axis = any(a.startswith(("--env.", "--taskset.", "--harness.")) for a in argv)
+    typed_axis = any(
+        a.startswith(("--env.", "--taskset.", "--harness.", "--serve.")) for a in argv
+    )
     if (
         not extract_id(argv, "env.taskset")
         and not legacy_id
@@ -42,7 +44,7 @@ def main(argv: list[str] | None = None) -> None:
     ):
         raise SystemExit(
             USAGE
-        )  # need a taskset (positional / --env.taskset.id), a legacy --id, or @ file.toml
+        )  # need a taskset (positional / --env.taskset.id), a v0 --legacy.id, or @ file.toml
 
     with plugin_errors():
         config_type = narrow_config(ServeConfig, argv)
@@ -60,19 +62,19 @@ def main(argv: list[str] | None = None) -> None:
     # in each one.
     server_kwargs = (
         {
-            "env_id": config.id,
-            "env_args": config.args,
-            "extra_env_kwargs": config.extra_env_kwargs,
+            "env_id": config.legacy.id,
+            "env_args": config.legacy.args,
+            "extra_env_kwargs": config.legacy.extra_env_kwargs,
         }
         if config.is_legacy
-        # `--max-concurrent` is each v1 worker's episode bound; the legacy bridge
-        # has never had one.
-        else {"config": config.env, "max_concurrent": config.max_concurrent}
+        # `--serve.max-concurrent` is each v1 worker's episode bound; the legacy
+        # bridge has never had one.
+        else {"config": config.env, "max_concurrent": config.serve.max_concurrent}
     )
     serve_env(
-        **pool_serve_kwargs(config.pool),
+        **pool_serve_kwargs(config.serve.pool),
         legacy=config.is_legacy,
-        address=config.address,
+        address=config.serve.address,
         log_setup=partial(setup_logging, level),
         **server_kwargs,
     )

--- a/verifiers/v1/cli/serve.py
+++ b/verifiers/v1/cli/serve.py
@@ -30,9 +30,8 @@ def main(argv: list[str] | None = None) -> None:
             cli(narrow_config(ServeConfig, argv))
         return
     legacy_id = any(a == "--legacy.id" or a.startswith("--legacy.id=") for a in argv)
-    # An env-block flag (or a retired flat axis) skips the usage gate so the typed
-    # parse renders its did-you-mean / pointer to the new flags instead of a bare
-    # usage line.
+    # An env-block flag (or a since-moved flat axis) skips the usage gate so the typed
+    # parse renders its did-you-mean instead of a bare usage line.
     typed_axis = any(
         a.startswith(("--env.", "--taskset.", "--harness.", "--serve.")) for a in argv
     )

--- a/verifiers/v1/configs/cli/env.py
+++ b/verifiers/v1/configs/cli/env.py
@@ -17,36 +17,14 @@ from pydantic_config import BaseConfig
 from verifiers.v1.configs.env import EnvConfig
 from verifiers.v1.utils.generic import prefix_validation_error
 
-RETIRED = {
-    "taskset": "the taskset lives on the env: --env.taskset.id <id> (TOML: "
-    "[env.taskset]), or the positional `eval <taskset-id>`",
-    "harness": "a harness belongs to an agent: --env.agent.harness.* on the "
-    "single-agent env, --env.<agent>.harness.* on a multi-agent one (TOML: "
-    "[env.agent.harness])",
-    "pool": "the worker pool is serving, not the env: --serve.pool.type "
-    "elastic|static (TOML: [serve.pool])",
-    "address": "the bind address is serving, not the env: --serve.address "
-    "(TOML: address under [serve])",
-    "id": "a classic (v0) env is its own block: --legacy.id <env-id>; pairing a "
-    "reusable v1 env with a taskset is --env.id",
-    "args": "v0 construction kwargs live with the v0 env: --legacy.args",
-    "extra_env_kwargs": "v0 post-load kwargs live with the v0 env: "
-    "--legacy.extra-env-kwargs",
-}
-"""Top-level keys a run config no longer owns, each pointing at its home. Every one
-would otherwise fail as a bare `extra_forbidden`, saying nothing about where it went."""
-
 
 def resolve_env_field(data: dict, narrowed: "type[EnvConfig] | None" = None) -> dict:
-    """Shared `mode="before"` body for every run config owning an `env` field: refuse
-    the retired top-level keys with a pointer home, and narrow `env` to the concrete
-    env's config class. `narrowed` is the annotation the CLI pre-resolved
-    (`narrow_config`) — its id is authoritative, so validate against it directly."""
+    """Shared `mode="before"` body for every run config owning an `env` field: narrow
+    `env` to the concrete env's config class. `narrowed` is the annotation the CLI
+    pre-resolved (`narrow_config`) — its id is authoritative, so validate against it
+    directly."""
     if not isinstance(data, dict):
         return data
-    for key, pointer in RETIRED.items():
-        if key in data:
-            raise ValueError(pointer)
     raw = data.get("env")
     if raw is None:
         return data

--- a/verifiers/v1/configs/cli/env.py
+++ b/verifiers/v1/configs/cli/env.py
@@ -1,41 +1,54 @@
-"""Run-config plumbing around the `[env]` block: narrowing the `env` field of the
-configs that own one, and how a served env sizes its worker pool."""
+"""Run-config plumbing around the `[env]` block: narrowing the `env` field of every
+config that owns one, and the retired keys such a config refuses.
 
-from typing import Annotated, Literal
+A run composes the blocks it needs — `[env]` (what runs, `configs/env.py`),
+`[serve]` (how it's hosted, `configs/serve.py`), `[legacy]` (the v0 bridge,
+`configs/legacy.py`) — plus its own fields. Nothing here is a base class: the eval
+CLI, the `serve` CLI, GEPA and a trainer each declare their blocks and call these."""
 
-from pydantic import (
-    AliasChoices,
-    Field,
-    SerializeAsAny,
-    ValidationError,
-    model_validator,
-)
+from pydantic import Field, SerializeAsAny, ValidationError
 from pydantic_config import BaseConfig
 
 from verifiers.v1.configs.env import EnvConfig
-from verifiers.v1.types import ID
 from verifiers.v1.utils.generic import prefix_validation_error
+
+RETIRED = {
+    "taskset": "the taskset lives on the env: --env.taskset.id <id> (TOML: "
+    "[env.taskset]), or the positional `eval <taskset-id>`",
+    "harness": "a harness belongs to an agent: --env.agent.harness.* on the "
+    "single-agent env, --env.<agent>.harness.* on a multi-agent one (TOML: "
+    "[env.agent.harness])",
+    "pool": "the worker pool is serving, not the env: --serve.pool.type "
+    "elastic|static (TOML: [serve.pool])",
+    "address": "the bind address is serving, not the env: --serve.address "
+    "(TOML: address under [serve])",
+    "id": "a classic (v0) env is its own block: --legacy.id <env-id>; pairing a "
+    "reusable v1 env with a taskset is --env.id",
+    "args": "v0 construction kwargs live with the v0 env: --legacy.args",
+    "extra_env_kwargs": "v0 post-load kwargs live with the v0 env: "
+    "--legacy.extra-env-kwargs",
+}
+"""Top-level keys a run config no longer owns, each pointing at its home. Every one
+would otherwise fail as a bare `extra_forbidden`, saying nothing about where it went."""
+
+
+def env_field() -> Field:  # type: ignore[valid-type]
+    """The `env` field every run config declares: the single-agent shape by default,
+    `SerializeAsAny` so a narrowed subclass's agents and knobs survive `model_dump()`
+    (see `EnvConfig.taskset`)."""
+    return Field(default_factory=_single_agent_env_config)
 
 
 def resolve_env_field(data: dict, narrowed: "type[EnvConfig] | None" = None) -> dict:
-    """Shared `mode="before"` body for every run config owning an `env` field
-    (`EnvServerConfig`, `GEPAConfig`): refuse the retired top-level axes with a
-    pointer home, and narrow `env` to the concrete env's config class. `narrowed`
-    is the annotation the CLI pre-resolved (`narrow_config`) — its id is
-    authoritative, so validate against it directly."""
+    """Shared `mode="before"` body for every run config owning an `env` field: refuse
+    the retired top-level keys with a pointer home, and narrow `env` to the concrete
+    env's config class. `narrowed` is the annotation the CLI pre-resolved
+    (`narrow_config`) — its id is authoritative, so validate against it directly."""
     if not isinstance(data, dict):
         return data
-    if "taskset" in data:
-        raise ValueError(
-            "the taskset lives on the env now: --env.taskset.id <id> "
-            "(TOML: [env.taskset]), or the positional `eval <taskset-id>`"
-        )
-    if "harness" in data:
-        raise ValueError(
-            "a harness belongs to an agent now: --env.agent.harness.* on the "
-            "single-agent env, --env.<agent>.harness.* on a multi-agent one "
-            "(TOML: [env.agent.harness])"
-        )
+    for key, pointer in RETIRED.items():
+        if key in data:
+            raise ValueError(pointer)
     raw = data.get("env")
     if raw is None:
         return data
@@ -71,42 +84,6 @@ def narrowed_env_annotation(cls) -> "type[EnvConfig] | None":
     return None
 
 
-class StaticPoolConfig(BaseConfig):
-    """Fixed env-server pool: pre-spawn `num_workers` workers up front."""
-
-    type: Literal["static"] = "static"
-    num_workers: int = Field(4, ge=1)
-    """Worker processes to pre-spawn (1 = a single in-process server, no pool)."""
-
-
-class ElasticPoolConfig(BaseConfig):
-    """Elastic env-server pool: start at one worker and scale up on demand."""
-
-    type: Literal["elastic"] = "elastic"
-    max_workers: int | None = None
-    """Upper bound on workers (None = unbounded)."""
-    multiplex: int = Field(128, ge=1)
-    """Episodes per worker for the scale-up trigger: add a worker once in-flight episodes
-    reach 90% of `workers * multiplex`."""
-
-
-# Discriminated on `type` so the CLI selects with `--pool.type static|elastic`.
-PoolConfig = Annotated[
-    StaticPoolConfig | ElasticPoolConfig, Field(discriminator="type")
-]
-
-
-def pool_serve_kwargs(pool: StaticPoolConfig | ElasticPoolConfig) -> dict:
-    """Unpack a pool config into `serve_env` kwargs (`max_workers` / `multiplex` / `elastic`)."""
-    if isinstance(pool, ElasticPoolConfig):
-        return {
-            "max_workers": pool.max_workers,
-            "multiplex": pool.multiplex,
-            "elastic": True,
-        }
-    return {"max_workers": pool.num_workers, "elastic": False}
-
-
 def _single_agent_env_config() -> EnvConfig:
     """The default `env` block: the single-agent shape. Lazy — the concrete env
     lives in `envs/`, which imports `env.py`."""
@@ -115,67 +92,5 @@ def _single_agent_env_config() -> EnvConfig:
     return SingleAgentEnvConfig()
 
 
-class EnvServerConfig(BaseConfig):
-    """A run's environment plus how it's *served*: the `env` block and the worker-pool
-    sizing. Shared by the `serve` CLI, server-backed eval, and prime-rl's orchestrator, so
-    they all configure the pool the same way (`--pool.type elastic|static`)."""
-
-    # SerializeAsAny: see EnvConfig.taskset — model_dump() must keep the subclass's
-    # agent fields and knobs.
-    env: SerializeAsAny[EnvConfig] = Field(default_factory=_single_agent_env_config)
-    """The environment — the run's `[env]` block: which env, its seed taskset, each
-    agent, its knobs, and the run limits. Narrowed to the selected env's config
-    class by the env id, else the taskset id."""
-    pool: PoolConfig = Field(default_factory=ElasticPoolConfig)
-    """Worker-pool sizing for the env server. `elastic` (default) starts at one worker and
-    scales up on demand; `static` pre-spawns a fixed `num_workers`."""
-    max_concurrent: int | None = Field(
-        None,
-        ge=1,
-        validation_alias=AliasChoices("max_concurrent", "max_concurrent_episodes"),
-    )
-    """Episodes in flight at once, per worker (None = no limit). The episode is the unit
-    here; how many agent runs one episode carries is the env's own
-    (`--env.max-concurrent-agents`, one at a time by default)."""
-    # --- legacy (v0) backwards-compat -----------------------------------------
-    id: ID | None = None
-    """Classic (v0) env id (`name`, `org/name`, or `org/name@version` — installed from the
-    hub on demand), loaded via `verifiers.load_environment` and run through the legacy
-    bridge. Set this *instead of* `env.taskset` to run a v0 environment."""
-    args: dict = Field(default_factory=dict)
-    """Construction kwargs forwarded to `load_environment(id, **args)`."""
-    extra_env_kwargs: dict = Field(default_factory=dict)
-    """Post-load kwargs applied to the v0 env via `env.set_kwargs(**extra_env_kwargs)` (e.g.
-    `max_total_completion_tokens`, `max_seq_len`, `timeout_seconds`) — typically
-    auto-populated by the orchestrator, distinct from the `args` passed at construction."""
-
-    @property
-    def is_legacy(self) -> bool:
-        """A v0/legacy env (run via the bridge): a legacy `id` is set and no v1 taskset."""
-        return self.id is not None and not self.env.taskset.id
-
-    @property
-    def env_id(self) -> str:
-        """The run's identifier: the v1 env's (`EnvConfig.env_id`), else the legacy
-        v0 env id."""
-        return self.env.env_id or self.id or ""
-
-    @model_validator(mode="after")
-    def _refuse_legacy_id_with_taskset(self):
-        """A legacy `id` next to a v1 `env.taskset` would be silently inert
-        (`is_legacy` is False and the v0 env never loads); refuse the mix."""
-        if self.id is not None and self.env.taskset.id:
-            raise ValueError(
-                f"--id {self.id!r} is the legacy (v0) env id and can't combine with "
-                f"the v1 taskset {self.env.taskset.id!r}. Pairing an env with a "
-                f"taskset is --env.id {self.id!r} (TOML: id under [env]); to run the "
-                "v0 env instead, drop the taskset."
-            )
-        return self
-
-    # --- end legacy -----------------------------------------------------------
-
-    @model_validator(mode="before")
-    @classmethod
-    def _resolve_env(cls, data):
-        return resolve_env_field(data, narrowed_env_annotation(cls))
+EnvField = SerializeAsAny[EnvConfig]
+"""Annotation for a run config's `env` field: `env: EnvField = env_field()`."""

--- a/verifiers/v1/configs/cli/env.py
+++ b/verifiers/v1/configs/cli/env.py
@@ -4,9 +4,14 @@ config that owns one, and the retired keys such a config refuses.
 A run composes the blocks it needs — `[env]` (what runs, `configs/env.py`),
 `[serve]` (how it's hosted, `configs/serve.py`), `[legacy]` (the v0 bridge,
 `configs/legacy.py`) — plus its own fields. Nothing here is a base class: the eval
-CLI, the `serve` CLI, GEPA and a trainer each declare their blocks and call these."""
+CLI, the `serve` CLI, GEPA and a trainer each declare their blocks and call these.
 
-from pydantic import Field, ValidationError
+Declare the env field as `SerializeAsAny[EnvConfig] = Field(default_factory=
+single_agent_env_config)`. The `SerializeAsAny` is load-bearing: pydantic serializes
+by declared type, so a plain `EnvConfig` silently drops a narrowed subclass's agents
+and knobs from `model_dump()` — the env-server wire's payload."""
+
+from pydantic import ValidationError
 from pydantic_config import BaseConfig
 
 from verifiers.v1.configs.env import EnvConfig
@@ -30,14 +35,6 @@ RETIRED = {
 }
 """Top-level keys a run config no longer owns, each pointing at its home. Every one
 would otherwise fail as a bare `extra_forbidden`, saying nothing about where it went."""
-
-
-def env_field() -> Field:  # type: ignore[valid-type]
-    """The default for the `env` field every run config declares: the single-agent
-    shape. Annotate the field `SerializeAsAny[EnvConfig]` — pydantic serializes by
-    declared type, so a plain `EnvConfig` silently drops a narrowed subclass's agents
-    and knobs from `model_dump()`, which is the env-server wire's payload."""
-    return Field(default_factory=_single_agent_env_config)
 
 
 def resolve_env_field(data: dict, narrowed: "type[EnvConfig] | None" = None) -> dict:
@@ -85,9 +82,10 @@ def narrowed_env_annotation(cls) -> "type[EnvConfig] | None":
     return None
 
 
-def _single_agent_env_config() -> EnvConfig:
-    """The default `env` block: the single-agent shape. Lazy — the concrete env
-    lives in `envs/`, which imports `env.py`."""
+def single_agent_env_config() -> EnvConfig:
+    """The default `env` block: the single-agent shape. Imported inside the body to
+    keep the env runtime (`envs/` pulls in `env.py`, `agent.py`, `task.py`) out of a
+    module that only describes configs."""
     from verifiers.v1.envs.single_agent import SingleAgentEnvConfig
 
     return SingleAgentEnvConfig()

--- a/verifiers/v1/configs/cli/env.py
+++ b/verifiers/v1/configs/cli/env.py
@@ -130,7 +130,9 @@ class EnvServerConfig(BaseConfig):
     """Worker-pool sizing for the env server. `elastic` (default) starts at one worker and
     scales up on demand; `static` pre-spawns a fixed `num_workers`."""
     max_concurrent: int | None = Field(
-        None, validation_alias=AliasChoices("max_concurrent", "max_concurrent_episodes")
+        None,
+        ge=1,
+        validation_alias=AliasChoices("max_concurrent", "max_concurrent_episodes"),
     )
     """Episodes in flight at once, per worker (None = no limit). The episode is the unit
     here; how many agent runs one episode carries is the env's own

--- a/verifiers/v1/configs/cli/env.py
+++ b/verifiers/v1/configs/cli/env.py
@@ -80,12 +80,3 @@ def narrowed_env_annotation(cls) -> "type[EnvConfig] | None":
     ):
         return annotation
     return None
-
-
-def single_agent_env_config() -> EnvConfig:
-    """The default `env` block: the single-agent shape. Imported inside the body to
-    keep the env runtime (`envs/` pulls in `env.py`, `agent.py`, `task.py`) out of a
-    module that only describes configs."""
-    from verifiers.v1.envs.single_agent import SingleAgentEnvConfig
-
-    return SingleAgentEnvConfig()

--- a/verifiers/v1/configs/cli/env.py
+++ b/verifiers/v1/configs/cli/env.py
@@ -3,7 +3,13 @@ configs that own one, and how a served env sizes its worker pool."""
 
 from typing import Annotated, Literal
 
-from pydantic import Field, SerializeAsAny, ValidationError, model_validator
+from pydantic import (
+    AliasChoices,
+    Field,
+    SerializeAsAny,
+    ValidationError,
+    model_validator,
+)
 from pydantic_config import BaseConfig
 
 from verifiers.v1.configs.env import EnvConfig
@@ -80,7 +86,7 @@ class ElasticPoolConfig(BaseConfig):
     max_workers: int | None = None
     """Upper bound on workers (None = unbounded)."""
     multiplex: int = Field(128, ge=1)
-    """Rollouts per worker for the scale-up trigger: add a worker once in-flight rollouts
+    """Episodes per worker for the scale-up trigger: add a worker once in-flight episodes
     reach 90% of `workers * multiplex`."""
 
 
@@ -123,6 +129,12 @@ class EnvServerConfig(BaseConfig):
     pool: PoolConfig = Field(default_factory=ElasticPoolConfig)
     """Worker-pool sizing for the env server. `elastic` (default) starts at one worker and
     scales up on demand; `static` pre-spawns a fixed `num_workers`."""
+    max_concurrent: int | None = Field(
+        None, validation_alias=AliasChoices("max_concurrent", "max_concurrent_episodes")
+    )
+    """Episodes in flight at once, per worker (None = no limit). The episode is the unit
+    here; how many agent runs one episode carries is the env's own
+    (`--env.max-concurrent-agents`, one at a time by default)."""
     # --- legacy (v0) backwards-compat -----------------------------------------
     id: ID | None = None
     """Classic (v0) env id (`name`, `org/name`, or `org/name@version` — installed from the

--- a/verifiers/v1/configs/cli/env.py
+++ b/verifiers/v1/configs/cli/env.py
@@ -6,7 +6,7 @@ A run composes the blocks it needs — `[env]` (what runs, `configs/env.py`),
 `configs/legacy.py`) — plus its own fields. Nothing here is a base class: the eval
 CLI, the `serve` CLI, GEPA and a trainer each declare their blocks and call these."""
 
-from pydantic import Field, SerializeAsAny, ValidationError
+from pydantic import Field, ValidationError
 from pydantic_config import BaseConfig
 
 from verifiers.v1.configs.env import EnvConfig
@@ -33,9 +33,10 @@ would otherwise fail as a bare `extra_forbidden`, saying nothing about where it 
 
 
 def env_field() -> Field:  # type: ignore[valid-type]
-    """The `env` field every run config declares: the single-agent shape by default,
-    `SerializeAsAny` so a narrowed subclass's agents and knobs survive `model_dump()`
-    (see `EnvConfig.taskset`)."""
+    """The default for the `env` field every run config declares: the single-agent
+    shape. Annotate the field `SerializeAsAny[EnvConfig]` — pydantic serializes by
+    declared type, so a plain `EnvConfig` silently drops a narrowed subclass's agents
+    and knobs from `model_dump()`, which is the env-server wire's payload."""
     return Field(default_factory=_single_agent_env_config)
 
 
@@ -90,7 +91,3 @@ def _single_agent_env_config() -> EnvConfig:
     from verifiers.v1.envs.single_agent import SingleAgentEnvConfig
 
     return SingleAgentEnvConfig()
-
-
-EnvField = SerializeAsAny[EnvConfig]
-"""Annotation for a run config's `env` field: `env: EnvField = env_field()`."""

--- a/verifiers/v1/configs/cli/eval.py
+++ b/verifiers/v1/configs/cli/eval.py
@@ -4,13 +4,34 @@ from pathlib import Path
 from uuid import uuid4
 
 from pydantic import AliasChoices, Field, model_validator
+from pydantic_config import BaseConfig
 
 from verifiers.v1.clients import ClientConfig, EvalClientConfig
-from verifiers.v1.configs.cli.env import EnvServerConfig
+from verifiers.v1.configs.cli.env import (
+    EnvField,
+    env_field,
+    narrowed_env_annotation,
+    resolve_env_field,
+)
+from verifiers.v1.configs.legacy import (
+    LegacyEnvConfig,
+    is_legacy,
+    refuse_mixed_run,
+    run_env_id,
+)
+from verifiers.v1.configs.serve import ServingConfig
 from verifiers.v1.types import SamplingConfig
 
 
-class EvalConfig(EnvServerConfig):
+class EvalConfig(BaseConfig):
+    env: EnvField = env_field()
+    """The environment — which env, its seed taskset, each agent, its knobs. Narrowed to
+    the selected env's config class by the env id, else the taskset id."""
+    serve: ServingConfig = ServingConfig()
+    """How the env is hosted under `--server`: the worker pool, each worker's episode
+    bound. Ignored by an in-process run."""
+    legacy: LegacyEnvConfig = LegacyEnvConfig()
+    """A classic (v0) environment to evaluate through the bridge instead of `[env]`."""
     uuid: str = Field(default_factory=lambda: str(uuid4()), exclude=True)
     """Auto-generated run id — the leaf of the output dir, so runs never overwrite.
     Excluded from the saved config so re-running `@ config.toml` lands in a fresh dir."""
@@ -39,9 +60,10 @@ class EvalConfig(EnvServerConfig):
     max_concurrent: int | None = Field(
         128, ge=1, validation_alias=AliasChoices("max_concurrent", "c")
     )
-    """Episodes in flight at once (per worker under `--server`), `None` for no limit. An
-    episode plays its agents one at a time, so this is the live agent runs too — until
-    `--env.max-concurrent-agents` says otherwise."""
+    """Episodes in flight at once, `None` for no limit. An episode plays its agents one
+    at a time, so this is the live agent runs too — until `--env.max-concurrent-agents`
+    says otherwise. Under `--server` it seeds each worker's bound, unless
+    `--serve.max-concurrent` pins one."""
     verbose: bool = Field(False, validation_alias=AliasChoices("verbose", "v"))
     """Log at debug level instead of the default info."""
     dry_run: bool = Field(False, exclude=True)
@@ -51,7 +73,7 @@ class EvalConfig(EnvServerConfig):
     """Show a live dashboard instead of per-rollout logs (in-process only; an unset
     `rich` defaults off under `--server`)."""
     server: bool = False
-    """Drive rollouts through the env-server worker pool (sized by `--pool.*`) instead of
+    """Drive rollouts through the env-server worker pool (sized by `[serve]`) instead of
     in-process — the path prime-rl trains through. Incompatible with `--rich`."""
     push: bool = True
     """Upload the finished run to the Prime Intellect platform (the private Evaluations
@@ -82,3 +104,30 @@ class EvalConfig(EnvServerConfig):
                 "`--server`; drop `--rich`."
             )
         return self
+
+    @property
+    def is_legacy(self) -> bool:
+        return is_legacy(self.env, self.legacy)
+
+    @property
+    def env_id(self) -> str:
+        return run_env_id(self.env, self.legacy)
+
+    @property
+    def worker_max_concurrent(self) -> int | None:
+        """A served worker's episode bound: its own pin, else the run's `--max-concurrent`."""
+        return (
+            self.serve.max_concurrent
+            if self.serve.max_concurrent is not None
+            else self.max_concurrent
+        )
+
+    @model_validator(mode="after")
+    def _refuse_mixed_run(self):
+        refuse_mixed_run(self.env, self.legacy)
+        return self
+
+    @model_validator(mode="before")
+    @classmethod
+    def _resolve_env(cls, data):
+        return resolve_env_field(data, narrowed_env_annotation(cls))

--- a/verifiers/v1/configs/cli/eval.py
+++ b/verifiers/v1/configs/cli/eval.py
@@ -39,7 +39,9 @@ class EvalConfig(EnvServerConfig):
     max_concurrent: int | None = Field(
         128, validation_alias=AliasChoices("max_concurrent", "c")
     )
-    """Max rollouts in flight at once."""
+    """Episodes in flight at once (per worker under `--server`). An episode plays its
+    agents one at a time, so this is the live agent runs too — until
+    `--env.max-concurrent-agents` says otherwise."""
     verbose: bool = Field(False, validation_alias=AliasChoices("verbose", "v"))
     """Log at debug level instead of the default info."""
     dry_run: bool = Field(False, exclude=True)

--- a/verifiers/v1/configs/cli/eval.py
+++ b/verifiers/v1/configs/cli/eval.py
@@ -37,10 +37,10 @@ class EvalConfig(EnvServerConfig):
     shuffle: bool = Field(False, validation_alias=AliasChoices("shuffle", "s"))
     """Shuffle tasks before taking the first `num_tasks`."""
     max_concurrent: int | None = Field(
-        128, validation_alias=AliasChoices("max_concurrent", "c")
+        128, ge=1, validation_alias=AliasChoices("max_concurrent", "c")
     )
-    """Episodes in flight at once (per worker under `--server`). An episode plays its
-    agents one at a time, so this is the live agent runs too — until
+    """Episodes in flight at once (per worker under `--server`), `None` for no limit. An
+    episode plays its agents one at a time, so this is the live agent runs too — until
     `--env.max-concurrent-agents` says otherwise."""
     verbose: bool = Field(False, validation_alias=AliasChoices("verbose", "v"))
     """Log at debug level instead of the default info."""

--- a/verifiers/v1/configs/cli/eval.py
+++ b/verifiers/v1/configs/cli/eval.py
@@ -3,16 +3,16 @@
 from pathlib import Path
 from uuid import uuid4
 
-from pydantic import AliasChoices, Field, model_validator
+from pydantic import AliasChoices, Field, SerializeAsAny, model_validator
 from pydantic_config import BaseConfig
 
 from verifiers.v1.clients import ClientConfig, EvalClientConfig
 from verifiers.v1.configs.cli.env import (
-    EnvField,
     env_field,
     narrowed_env_annotation,
     resolve_env_field,
 )
+from verifiers.v1.configs.env import EnvConfig
 from verifiers.v1.configs.legacy import (
     LegacyEnvConfig,
     is_legacy,
@@ -24,7 +24,7 @@ from verifiers.v1.types import SamplingConfig
 
 
 class EvalConfig(BaseConfig):
-    env: EnvField = env_field()
+    env: SerializeAsAny[EnvConfig] = env_field()
     """The environment — which env, its seed taskset, each agent, its knobs. Narrowed to
     the selected env's config class by the env id, else the taskset id."""
     serve: ServingConfig = ServingConfig()

--- a/verifiers/v1/configs/cli/eval.py
+++ b/verifiers/v1/configs/cli/eval.py
@@ -7,24 +7,16 @@ from pydantic import AliasChoices, Field, SerializeAsAny, model_validator
 from pydantic_config import BaseConfig
 
 from verifiers.v1.clients import ClientConfig, EvalClientConfig
-from verifiers.v1.configs.cli.env import (
-    narrowed_env_annotation,
-    resolve_env_field,
-    single_agent_env_config,
-)
+from verifiers.v1.configs.cli.env import narrowed_env_annotation, resolve_env_field
 from verifiers.v1.configs.env import EnvConfig
-from verifiers.v1.configs.legacy import (
-    LegacyEnvConfig,
-    is_legacy,
-    refuse_mixed_run,
-    run_env_id,
-)
+from verifiers.v1.configs.legacy import LegacyEnvConfig
 from verifiers.v1.configs.serve import ServingConfig
+from verifiers.v1.envs.single_agent import SingleAgentEnvConfig
 from verifiers.v1.types import SamplingConfig
 
 
 class EvalConfig(BaseConfig):
-    env: SerializeAsAny[EnvConfig] = Field(default_factory=single_agent_env_config)
+    env: SerializeAsAny[EnvConfig] = SingleAgentEnvConfig()
     """The environment — which env, its seed taskset, each agent, its knobs. Narrowed to
     the selected env's config class by the env id, else the taskset id."""
     serve: ServingConfig = ServingConfig()
@@ -107,11 +99,13 @@ class EvalConfig(BaseConfig):
 
     @property
     def is_legacy(self) -> bool:
-        return is_legacy(self.env, self.legacy)
+        """Whether this run goes through the v0 bridge: a legacy id and no v1 taskset."""
+        return self.legacy.id is not None and not self.env.taskset.id
 
     @property
     def env_id(self) -> str:
-        return run_env_id(self.env, self.legacy)
+        """The run's identifier: the v1 env's, else the v0 env id."""
+        return self.env.env_id or self.legacy.id or ""
 
     @property
     def worker_max_concurrent(self) -> int | None:
@@ -124,8 +118,23 @@ class EvalConfig(BaseConfig):
 
     @model_validator(mode="after")
     def _refuse_mixed_run(self):
-        refuse_mixed_run(self.env, self.legacy)
-        return self
+        # A v0 id next to any v1 env identity leaves one of the two going nowhere, and
+        # which one depends on `is_legacy`: a taskset makes it False, so the v0 env never
+        # loads; a bare `--env.id` leaves it True, so the v0 env runs under the v1 name.
+        if self.legacy.id is None or not self.env.env_id:
+            return self
+        if self.env.taskset.id:
+            raise ValueError(
+                f"--legacy.id {self.legacy.id!r} is a classic (v0) env and can't combine "
+                f"with the v1 taskset {self.env.taskset.id!r}. Pairing a reusable env with "
+                f"a taskset is --env.id {self.legacy.id!r} (TOML: id under [env]); to run "
+                "the v0 env instead, drop the taskset."
+            )
+        raise ValueError(
+            f"--legacy.id {self.legacy.id!r} is a classic (v0) env and can't combine with "
+            f"the v1 env --env.id {self.env.id!r}: the v0 env is what would run, stamped "
+            "with the v1 env's name. Keep whichever one you meant to run."
+        )
 
     @model_validator(mode="before")
     @classmethod

--- a/verifiers/v1/configs/cli/eval.py
+++ b/verifiers/v1/configs/cli/eval.py
@@ -8,9 +8,9 @@ from pydantic_config import BaseConfig
 
 from verifiers.v1.clients import ClientConfig, EvalClientConfig
 from verifiers.v1.configs.cli.env import (
-    env_field,
     narrowed_env_annotation,
     resolve_env_field,
+    single_agent_env_config,
 )
 from verifiers.v1.configs.env import EnvConfig
 from verifiers.v1.configs.legacy import (
@@ -24,7 +24,7 @@ from verifiers.v1.types import SamplingConfig
 
 
 class EvalConfig(BaseConfig):
-    env: SerializeAsAny[EnvConfig] = env_field()
+    env: SerializeAsAny[EnvConfig] = Field(default_factory=single_agent_env_config)
     """The environment — which env, its seed taskset, each agent, its knobs. Narrowed to
     the selected env's config class by the env id, else the taskset id."""
     serve: ServingConfig = ServingConfig()

--- a/verifiers/v1/configs/cli/serve.py
+++ b/verifiers/v1/configs/cli/serve.py
@@ -3,26 +3,18 @@
 from pydantic import AliasChoices, Field, SerializeAsAny, model_validator
 from pydantic_config import BaseConfig
 
-from verifiers.v1.configs.cli.env import (
-    narrowed_env_annotation,
-    resolve_env_field,
-    single_agent_env_config,
-)
+from verifiers.v1.configs.cli.env import narrowed_env_annotation, resolve_env_field
 from verifiers.v1.configs.env import EnvConfig
-from verifiers.v1.configs.legacy import (
-    LegacyEnvConfig,
-    is_legacy,
-    refuse_mixed_run,
-    run_env_id,
-)
+from verifiers.v1.configs.legacy import LegacyEnvConfig
 from verifiers.v1.configs.serve import ServingConfig
+from verifiers.v1.envs.single_agent import SingleAgentEnvConfig
 
 
 class ServeConfig(BaseConfig):
     """`uv run serve`: what to serve (`[env]`, or `[legacy]` for a classic v0 env) and
     how it's hosted (`[serve]`)."""
 
-    env: SerializeAsAny[EnvConfig] = Field(default_factory=single_agent_env_config)
+    env: SerializeAsAny[EnvConfig] = SingleAgentEnvConfig()
     """The environment — which env, its seed taskset, each agent, its knobs. Narrowed to
     the selected env's config class by the env id, else the taskset id."""
     serve: ServingConfig = ServingConfig()
@@ -36,16 +28,33 @@ class ServeConfig(BaseConfig):
 
     @property
     def is_legacy(self) -> bool:
-        return is_legacy(self.env, self.legacy)
+        """Whether this run goes through the v0 bridge: a legacy id and no v1 taskset."""
+        return self.legacy.id is not None and not self.env.taskset.id
 
     @property
     def env_id(self) -> str:
-        return run_env_id(self.env, self.legacy)
+        """The run's identifier: the v1 env's, else the v0 env id."""
+        return self.env.env_id or self.legacy.id or ""
 
     @model_validator(mode="after")
     def _refuse_mixed_run(self):
-        refuse_mixed_run(self.env, self.legacy)
-        return self
+        # A v0 id next to any v1 env identity leaves one of the two going nowhere, and
+        # which one depends on `is_legacy`: a taskset makes it False, so the v0 env never
+        # loads; a bare `--env.id` leaves it True, so the v0 env runs under the v1 name.
+        if self.legacy.id is None or not self.env.env_id:
+            return self
+        if self.env.taskset.id:
+            raise ValueError(
+                f"--legacy.id {self.legacy.id!r} is a classic (v0) env and can't combine "
+                f"with the v1 taskset {self.env.taskset.id!r}. Pairing a reusable env with "
+                f"a taskset is --env.id {self.legacy.id!r} (TOML: id under [env]); to run "
+                "the v0 env instead, drop the taskset."
+            )
+        raise ValueError(
+            f"--legacy.id {self.legacy.id!r} is a classic (v0) env and can't combine with "
+            f"the v1 env --env.id {self.env.id!r}: the v0 env is what would run, stamped "
+            "with the v1 env's name. Keep whichever one you meant to run."
+        )
 
     @model_validator(mode="before")
     @classmethod

--- a/verifiers/v1/configs/cli/serve.py
+++ b/verifiers/v1/configs/cli/serve.py
@@ -4,9 +4,9 @@ from pydantic import AliasChoices, Field, SerializeAsAny, model_validator
 from pydantic_config import BaseConfig
 
 from verifiers.v1.configs.cli.env import (
-    env_field,
     narrowed_env_annotation,
     resolve_env_field,
+    single_agent_env_config,
 )
 from verifiers.v1.configs.env import EnvConfig
 from verifiers.v1.configs.legacy import (
@@ -22,7 +22,7 @@ class ServeConfig(BaseConfig):
     """`uv run serve`: what to serve (`[env]`, or `[legacy]` for a classic v0 env) and
     how it's hosted (`[serve]`)."""
 
-    env: SerializeAsAny[EnvConfig] = env_field()
+    env: SerializeAsAny[EnvConfig] = Field(default_factory=single_agent_env_config)
     """The environment — which env, its seed taskset, each agent, its knobs. Narrowed to
     the selected env's config class by the env id, else the taskset id."""
     serve: ServingConfig = ServingConfig()

--- a/verifiers/v1/configs/cli/serve.py
+++ b/verifiers/v1/configs/cli/serve.py
@@ -1,16 +1,53 @@
 """Environment-server CLI configuration."""
 
-from pydantic import AliasChoices, Field
+from pydantic import AliasChoices, Field, model_validator
+from pydantic_config import BaseConfig
 
-from verifiers.v1.configs.cli.env import EnvServerConfig
+from verifiers.v1.configs.cli.env import (
+    EnvField,
+    env_field,
+    narrowed_env_annotation,
+    resolve_env_field,
+)
+from verifiers.v1.configs.legacy import (
+    LegacyEnvConfig,
+    is_legacy,
+    refuse_mixed_run,
+    run_env_id,
+)
+from verifiers.v1.configs.serve import ServingConfig
 
 
-class ServeConfig(EnvServerConfig):
-    address: str = Field(
-        "tcp://127.0.0.1:5000", validation_alias=AliasChoices("address", "a")
-    )
-    """ZMQ address the ROUTER binds (and clients connect to)."""
+class ServeConfig(BaseConfig):
+    """`uv run serve`: what to serve (`[env]`, or `[legacy]` for a classic v0 env) and
+    how it's hosted (`[serve]`)."""
+
+    env: EnvField = env_field()
+    """The environment — which env, its seed taskset, each agent, its knobs. Narrowed to
+    the selected env's config class by the env id, else the taskset id."""
+    serve: ServingConfig = ServingConfig()
+    """How it's served: the worker pool, the bind address, each worker's episode bound."""
+    legacy: LegacyEnvConfig = LegacyEnvConfig()
+    """A classic (v0) environment to serve through the bridge instead of `[env]`."""
     verbose: bool = Field(False, validation_alias=AliasChoices("verbose", "v"))
     """Log at debug level instead of info."""
     dry_run: bool = False
     """Resolve + validate the config and dump it, then exit."""
+
+    @property
+    def is_legacy(self) -> bool:
+        return is_legacy(self.env, self.legacy)
+
+    @property
+    def env_id(self) -> str:
+        return run_env_id(self.env, self.legacy)
+
+    @model_validator(mode="after")
+    def _refuse_mixed_run(self):
+        refuse_mixed_run(self.env, self.legacy)
+        return self
+
+    @model_validator(mode="before")
+    @classmethod
+    def _resolve_env(cls, data):
+        return resolve_env_field(data, narrowed_env_annotation(cls))

--- a/verifiers/v1/configs/cli/serve.py
+++ b/verifiers/v1/configs/cli/serve.py
@@ -1,14 +1,14 @@
 """Environment-server CLI configuration."""
 
-from pydantic import AliasChoices, Field, model_validator
+from pydantic import AliasChoices, Field, SerializeAsAny, model_validator
 from pydantic_config import BaseConfig
 
 from verifiers.v1.configs.cli.env import (
-    EnvField,
     env_field,
     narrowed_env_annotation,
     resolve_env_field,
 )
+from verifiers.v1.configs.env import EnvConfig
 from verifiers.v1.configs.legacy import (
     LegacyEnvConfig,
     is_legacy,
@@ -22,7 +22,7 @@ class ServeConfig(BaseConfig):
     """`uv run serve`: what to serve (`[env]`, or `[legacy]` for a classic v0 env) and
     how it's hosted (`[serve]`)."""
 
-    env: EnvField = env_field()
+    env: SerializeAsAny[EnvConfig] = env_field()
     """The environment — which env, its seed taskset, each agent, its knobs. Narrowed to
     the selected env's config class by the env id, else the taskset id."""
     serve: ServingConfig = ServingConfig()

--- a/verifiers/v1/configs/env.py
+++ b/verifiers/v1/configs/env.py
@@ -3,7 +3,7 @@ each role as an `AgentConfig` field, and the env-level knobs."""
 
 from typing import get_args
 
-from pydantic import SerializeAsAny, model_validator
+from pydantic import Field, SerializeAsAny, model_validator
 from pydantic_config import BaseConfig
 
 from verifiers.v1.configs.agent import AgentConfig
@@ -48,9 +48,13 @@ class EnvConfig(BaseConfig):
     retries: RetryConfig = RetryConfig()
     """Whole-EPISODE retries — the coarse fallback for faults no agent owns; a
     retried episode reruns whole (a half-played sibling context isn't reproducible)."""
-    max_concurrent: int | None = None
-    """Bounds concurrent agent runs on a SERVED env, per worker (None = no limit);
-    the in-process eval CLI gates with its run-level `--max-concurrent` instead."""
+    max_concurrent_agents: int | None = Field(1, ge=1)
+    """How many of ONE episode's agent runs may be active at once (None = no limit).
+    One at a time by default, so the bound above — `--max-concurrent` episodes, a
+    dispatched training episode — is also one live agent run, whatever `run()` fans
+    out to internally. Raise it where per-episode latency matters and the
+    multiplication is wanted: `--env.max-concurrent-agents None` plays an episode's
+    `best-of-n` attempts together, so `-c` episodes carry `-c * n` live runs."""
     interception: InterceptionConfig = ElasticInterceptionPoolConfig()
     """The interception shape: `elastic` (default), `server`, or `static`."""
 

--- a/verifiers/v1/configs/env.py
+++ b/verifiers/v1/configs/env.py
@@ -3,7 +3,7 @@ each role as an `AgentConfig` field, and the env-level knobs."""
 
 from typing import get_args
 
-from pydantic import AliasChoices, Field, SerializeAsAny, model_validator
+from pydantic import Field, SerializeAsAny, model_validator
 from pydantic_config import BaseConfig
 
 from verifiers.v1.configs.agent import AgentConfig
@@ -48,20 +48,16 @@ class EnvConfig(BaseConfig):
     retries: RetryConfig = RetryConfig()
     """Whole-EPISODE retries — the coarse fallback for faults no agent owns; a
     retried episode reruns whole (a half-played sibling context isn't reproducible)."""
-    max_concurrent_agents: int | None = Field(
-        1,
-        ge=1,
-        validation_alias=AliasChoices("max_concurrent_agents", "max_concurrent"),
-    )
-    """How many of ONE episode's agent runs may be active at once (None = no limit;
-    `--env.max-concurrent` is an alias). One at a time by default, so the bound above —
-    `--max-concurrent` episodes, a dispatched training episode — is also one live agent
-    run, whatever `run()` fans out to internally. Raise it where per-episode latency
-    matters and the multiplication is wanted: `--env.max-concurrent-agents None` plays
-    an episode's `best-of-n` attempts together, so `-c` episodes carry `-c * n` live
-    runs. The unqualified name is `_agents` because two other fields spell
-    `max_concurrent` and both bound episodes, not agents: the run's own `-c` and
-    `serve.max_concurrent`."""
+    max_concurrent_agents: int | None = Field(1, ge=1)
+    """How many of ONE episode's agent runs may be active at once (None = no limit).
+    One at a time by default, so the bound above — `--max-concurrent` episodes, a
+    dispatched training episode — is also one live agent run, whatever `run()` fans
+    out to internally. Raise it where per-episode latency matters and the
+    multiplication is wanted: `--env.max-concurrent-agents None` plays an episode's
+    `best-of-n` attempts together, so `-c` episodes carry `-c * n` live runs. Not
+    spelled `max_concurrent`: that key used to bound a served worker's agent runs
+    across episodes, and taking it as this one silently multiplies it by the episodes
+    in flight."""
     interception: InterceptionConfig = ElasticInterceptionPoolConfig()
     """The interception shape: `elastic` (default), `server`, or `static`."""
 

--- a/verifiers/v1/configs/env.py
+++ b/verifiers/v1/configs/env.py
@@ -3,7 +3,7 @@ each role as an `AgentConfig` field, and the env-level knobs."""
 
 from typing import get_args
 
-from pydantic import Field, SerializeAsAny, model_validator
+from pydantic import AliasChoices, Field, SerializeAsAny, model_validator
 from pydantic_config import BaseConfig
 
 from verifiers.v1.configs.agent import AgentConfig
@@ -48,13 +48,20 @@ class EnvConfig(BaseConfig):
     retries: RetryConfig = RetryConfig()
     """Whole-EPISODE retries — the coarse fallback for faults no agent owns; a
     retried episode reruns whole (a half-played sibling context isn't reproducible)."""
-    max_concurrent_agents: int | None = Field(1, ge=1)
-    """How many of ONE episode's agent runs may be active at once (None = no limit).
-    One at a time by default, so the bound above — `--max-concurrent` episodes, a
-    dispatched training episode — is also one live agent run, whatever `run()` fans
-    out to internally. Raise it where per-episode latency matters and the
-    multiplication is wanted: `--env.max-concurrent-agents None` plays an episode's
-    `best-of-n` attempts together, so `-c` episodes carry `-c * n` live runs."""
+    max_concurrent_agents: int | None = Field(
+        1,
+        ge=1,
+        validation_alias=AliasChoices("max_concurrent_agents", "max_concurrent"),
+    )
+    """How many of ONE episode's agent runs may be active at once (None = no limit;
+    `--env.max-concurrent` is an alias). One at a time by default, so the bound above —
+    `--max-concurrent` episodes, a dispatched training episode — is also one live agent
+    run, whatever `run()` fans out to internally. Raise it where per-episode latency
+    matters and the multiplication is wanted: `--env.max-concurrent-agents None` plays
+    an episode's `best-of-n` attempts together, so `-c` episodes carry `-c * n` live
+    runs. The unqualified name is `_agents` because two other fields spell
+    `max_concurrent` and both bound episodes, not agents: the run's own `-c` and
+    `serve.max_concurrent`."""
     interception: InterceptionConfig = ElasticInterceptionPoolConfig()
     """The interception shape: `elastic` (default), `server`, or `static`."""
 

--- a/verifiers/v1/configs/legacy.py
+++ b/verifiers/v1/configs/legacy.py
@@ -1,0 +1,47 @@
+"""The `[legacy]` block: running a classic (v0) environment through the bridge.
+
+Quarantined in its own block, not mixed into `[env]` — a v0 env is a different
+thing to run, not a variant of a v1 env's config."""
+
+from pydantic import Field
+from pydantic_config import BaseConfig
+
+from verifiers.v1.configs.env import EnvConfig
+from verifiers.v1.types import ID
+
+
+class LegacyEnvConfig(BaseConfig):
+    """A classic (v0) `verifiers` environment, loaded via `verifiers.load_environment`
+    and run through the legacy bridge. Set `id` *instead of* a v1 `env.taskset`."""
+
+    id: ID | None = None
+    """v0 env id: `name`, `org/name`, or `org/name@version` — installed from the hub on
+    demand."""
+    args: dict = Field(default_factory=dict)
+    """Construction kwargs forwarded to `load_environment(id, **args)`."""
+    extra_env_kwargs: dict = Field(default_factory=dict)
+    """Post-load kwargs applied via `env.set_kwargs(**extra_env_kwargs)` (e.g.
+    `max_total_completion_tokens`, `max_seq_len`, `timeout_seconds`) — typically
+    auto-populated by a trainer, distinct from the `args` passed at construction."""
+
+
+def is_legacy(env: EnvConfig, legacy: LegacyEnvConfig) -> bool:
+    """Whether this run goes through the v0 bridge: a legacy id is set and no v1 taskset."""
+    return legacy.id is not None and not env.taskset.id
+
+
+def run_env_id(env: EnvConfig, legacy: LegacyEnvConfig) -> str:
+    """The run's identifier: the v1 env's (`EnvConfig.env_id`), else the v0 env id."""
+    return env.env_id or legacy.id or ""
+
+
+def refuse_mixed_run(env: EnvConfig, legacy: LegacyEnvConfig) -> None:
+    """Refuse a v0 id next to a v1 taskset: `is_legacy` would be False and the v0 env
+    would never load, so the id would sit there silently inert."""
+    if legacy.id is not None and env.taskset.id:
+        raise ValueError(
+            f"--legacy.id {legacy.id!r} is a classic (v0) env and can't combine with "
+            f"the v1 taskset {env.taskset.id!r}. Pairing a reusable env with a taskset "
+            f"is --env.id {legacy.id!r} (TOML: id under [env]); to run the v0 env "
+            "instead, drop the taskset."
+        )

--- a/verifiers/v1/configs/legacy.py
+++ b/verifiers/v1/configs/legacy.py
@@ -6,7 +6,6 @@ thing to run, not a variant of a v1 env's config."""
 from pydantic import Field
 from pydantic_config import BaseConfig
 
-from verifiers.v1.configs.env import EnvConfig
 from verifiers.v1.types import ID
 
 
@@ -23,33 +22,3 @@ class LegacyEnvConfig(BaseConfig):
     """Post-load kwargs applied via `env.set_kwargs(**extra_env_kwargs)` (e.g.
     `max_total_completion_tokens`, `max_seq_len`, `timeout_seconds`) — typically
     auto-populated by a trainer, distinct from the `args` passed at construction."""
-
-
-def is_legacy(env: EnvConfig, legacy: LegacyEnvConfig) -> bool:
-    """Whether this run goes through the v0 bridge: a legacy id is set and no v1 taskset."""
-    return legacy.id is not None and not env.taskset.id
-
-
-def run_env_id(env: EnvConfig, legacy: LegacyEnvConfig) -> str:
-    """The run's identifier: the v1 env's (`EnvConfig.env_id`), else the v0 env id."""
-    return env.env_id or legacy.id or ""
-
-
-def refuse_mixed_run(env: EnvConfig, legacy: LegacyEnvConfig) -> None:
-    """Refuse a v0 id next to any v1 env identity — one of the two would go nowhere,
-    and which one depends on `is_legacy`: a taskset makes it False, so the v0 env never
-    loads; a bare `--env.id` leaves it True, so the v0 env runs under the v1 env's name."""
-    if legacy.id is None or not env.env_id:
-        return
-    if env.taskset.id:
-        raise ValueError(
-            f"--legacy.id {legacy.id!r} is a classic (v0) env and can't combine with "
-            f"the v1 taskset {env.taskset.id!r}. Pairing a reusable env with a taskset "
-            f"is --env.id {legacy.id!r} (TOML: id under [env]); to run the v0 env "
-            "instead, drop the taskset."
-        )
-    raise ValueError(
-        f"--legacy.id {legacy.id!r} is a classic (v0) env and can't combine with the "
-        f"v1 env --env.id {env.id!r}: the v0 env is what would run, stamped with the "
-        "v1 env's name. Keep whichever one you meant to run."
-    )

--- a/verifiers/v1/configs/legacy.py
+++ b/verifiers/v1/configs/legacy.py
@@ -36,12 +36,20 @@ def run_env_id(env: EnvConfig, legacy: LegacyEnvConfig) -> str:
 
 
 def refuse_mixed_run(env: EnvConfig, legacy: LegacyEnvConfig) -> None:
-    """Refuse a v0 id next to a v1 taskset: `is_legacy` would be False and the v0 env
-    would never load, so the id would sit there silently inert."""
-    if legacy.id is not None and env.taskset.id:
+    """Refuse a v0 id next to any v1 env identity — one of the two would go nowhere,
+    and which one depends on `is_legacy`: a taskset makes it False, so the v0 env never
+    loads; a bare `--env.id` leaves it True, so the v0 env runs under the v1 env's name."""
+    if legacy.id is None or not env.env_id:
+        return
+    if env.taskset.id:
         raise ValueError(
             f"--legacy.id {legacy.id!r} is a classic (v0) env and can't combine with "
             f"the v1 taskset {env.taskset.id!r}. Pairing a reusable env with a taskset "
             f"is --env.id {legacy.id!r} (TOML: id under [env]); to run the v0 env "
             "instead, drop the taskset."
         )
+    raise ValueError(
+        f"--legacy.id {legacy.id!r} is a classic (v0) env and can't combine with the "
+        f"v1 env --env.id {env.id!r}: the v0 env is what would run, stamped with the "
+        "v1 env's name. Keep whichever one you meant to run."
+    )

--- a/verifiers/v1/configs/serve.py
+++ b/verifiers/v1/configs/serve.py
@@ -1,0 +1,63 @@
+"""How an env is served: the worker pool, where it binds, and each worker's bound.
+
+Serving is its own axis. `[env]` says what runs; this says how it's hosted, so an
+eval, a `serve` process, and a trainer configure it identically instead of each
+flattening pool knobs onto its own config."""
+
+from typing import Annotated, Literal
+
+from pydantic import Field
+from pydantic_config import BaseConfig
+
+
+class StaticPoolConfig(BaseConfig):
+    """Fixed env-server pool: pre-spawn `num_workers` workers up front."""
+
+    type: Literal["static"] = "static"
+    num_workers: int = Field(4, ge=1)
+    """Worker processes to pre-spawn (1 = a single in-process server, no pool)."""
+
+
+class ElasticPoolConfig(BaseConfig):
+    """Elastic env-server pool: start at one worker and scale up on demand."""
+
+    type: Literal["elastic"] = "elastic"
+    max_workers: int | None = None
+    """Upper bound on workers (None = unbounded)."""
+    multiplex: int = Field(128, ge=1)
+    """Episodes per worker for the scale-up trigger: add a worker once in-flight episodes
+    reach 90% of `workers * multiplex`."""
+
+
+# Discriminated on `type` so the CLI selects with `--serve.pool.type static|elastic`.
+PoolConfig = Annotated[
+    StaticPoolConfig | ElasticPoolConfig, Field(discriminator="type")
+]
+
+
+class ServingConfig(BaseConfig):
+    """The `[serve]` block: the worker pool, the ZMQ address, and each worker's
+    episode bound. Read by whoever hosts the env — the `serve` CLI, a server-backed
+    eval, a trainer's orchestrator."""
+
+    pool: PoolConfig = Field(default_factory=ElasticPoolConfig)
+    """Worker-pool sizing. `elastic` (default) starts at one worker and scales up on
+    demand; `static` pre-spawns a fixed `num_workers`."""
+    address: str = "tcp://127.0.0.1:5000"
+    """ZMQ address the ROUTER binds (and clients connect to)."""
+    max_concurrent: int | None = Field(None, ge=1)
+    """Episodes in flight per worker (None = take the run's own bound, e.g. an eval's
+    `--max-concurrent`). Pin it to hold a worker below what the run asks for; how many
+    agent runs one episode carries is the env's own
+    (`--env.max-concurrent-agents`, one at a time by default)."""
+
+
+def pool_serve_kwargs(pool: StaticPoolConfig | ElasticPoolConfig) -> dict:
+    """Unpack a pool config into `serve_env` kwargs (`max_workers` / `multiplex` / `elastic`)."""
+    if isinstance(pool, ElasticPoolConfig):
+        return {
+            "max_workers": pool.max_workers,
+            "multiplex": pool.multiplex,
+            "elastic": True,
+        }
+    return {"max_workers": pool.num_workers, "elastic": False}

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -154,7 +154,10 @@ class Env(ABC, Generic[ConfigT]):
         """One episode: how the agents interact on `task`, returning nothing —
         every finished run joins the episode automatically, stamped with its seat's
         standing. An agent-run failure is data on its trace (this hook decides what
-        it means); an exception raised here is the episode itself failing."""
+        it means); an exception raised here is the episode itself failing.
+        Independent agents are written as such (`asyncio.gather`); how many of them
+        actually run at once is the run's bound, not this hook's
+        (`--env.max-concurrent-agents`, one at a time by default)."""
 
     async def finalize(self, task: Task, episode: Episode) -> None:
         """Cross-agent judgement — THE programmable judgement surface: plain
@@ -188,13 +191,16 @@ class Env(ABC, Generic[ConfigT]):
     def _episode_agents(
         self,
         ctx: ModelContext,
-        gate: "asyncio.Semaphore | None",
         completed: list[Trace],
         on_trace: Callable[[Trace], None] | None,
         on_discard: Callable[[Trace], None] | None,
     ) -> Agents:
         """One episode's `Agents` — fresh value objects riding the live serving
-        resources (nothing shared across concurrent episodes); `setup()` sees them first."""
+        resources (nothing shared across concurrent episodes), sharing one semaphore
+        so the episode plays `--env.max-concurrent-agents` of them at a time;
+        `setup()` sees them first."""
+        limit = self.config.max_concurrent_agents
+        gate = asyncio.Semaphore(limit) if limit else None
 
         def make(name: str, spec: AgentConfig) -> Agent:
             # Unpinned fields fall back to the run's ctx / the taskset's harness.
@@ -242,17 +248,17 @@ class Env(ABC, Generic[ConfigT]):
         *,
         on_trace: Callable[[Trace], None] | None = None,
         on_discard: Callable[[Trace], None] | None = None,
-        gate: asyncio.Semaphore | None = None,
     ) -> Episode:
         """One episode of `task`, minted as the wire atom: `setup()` then `run()`
-        over fresh agents, then `finalize()`; `gate` bounds
-        the agent runs, so internal fan-out counts against `--max-concurrent` too.
+        over fresh agents, then `finalize()`. Its agents run one at a time
+        (`--env.max-concurrent-agents`), so one live episode is one live agent run
+        however `run()` fans out.
         Traces join the episode as runs complete — a hook raising mid-way yields the
         completed subset, its exception on the episode's `errors`. `on_trace` observes
         each agent-run's trace at mint; `on_discard` its abandonment (a per-agent
         retry mints a replacement)."""
         episode = Episode(env=self.config.env_id)
-        agents = self._episode_agents(ctx, gate, episode.traces, on_trace, on_discard)
+        agents = self._episode_agents(ctx, episode.traces, on_trace, on_discard)
         try:
             async with asyncio.timeout(self.config.timeout.episode):
                 async with boundary(EnvError, f"{type(self).__name__}.setup()"):
@@ -306,8 +312,10 @@ class Env(ABC, Generic[ConfigT]):
         on_complete: Callable[[Episode], Awaitable[None]] | None = None,
     ) -> Episode:
         """Run one planned episode to completion, with whole-episode
-        retries per `--env.retries`; `semaphore` gates the agent RUNS, not the
-        episode; `on_complete` (the runners' persistence hook) fires when final."""
+        retries per `--env.retries`; `semaphore` bounds concurrent EPISODES — one
+        permit for the attempt in flight, held across the whole of it (its agents,
+        their boxes, `finalize()`) and released before a retry's backoff and before
+        `on_complete` (the runners' persistence hook, which fires when final)."""
 
         async def attempt() -> Episode:
             slot.traces = []  # a retry shows the fresh attempt's traces
@@ -318,13 +326,13 @@ class Env(ABC, Generic[ConfigT]):
                 with contextlib.suppress(ValueError):
                     live.remove(trace)
 
-            return await self.run_episode(
-                slot.task,
-                ctx,
-                on_trace=live.append,
-                on_discard=discard,
-                gate=semaphore,
-            )
+            async with semaphore or contextlib.nullcontext():
+                return await self.run_episode(
+                    slot.task,
+                    ctx,
+                    on_trace=live.append,
+                    on_discard=discard,
+                )
 
         episode = await run_episode_with_retry(attempt, self.config.retries)
         slot.traces = list(episode.traces)

--- a/verifiers/v1/gepa/config.py
+++ b/verifiers/v1/gepa/config.py
@@ -4,9 +4,9 @@ GEPA optimizes one taskset's `Task.system_prompt` by alternating rollouts (`eval
 teacher LM reflecting on the reflective dataset (`make_reflective_dataset`) — see
 `verifiers.v1.gepa.adapter.GEPAAdapter`. Like `EvalConfig`, it owns an `env` field (the
 environment: its taskset, seats, limits) and adds the optimization loop's own knobs (model,
-reflection model, train/val split, budget). There is no worker pool here (`EnvServerConfig`
-is not a base) — GEPA always runs in-process, since its adapter protocol is itself
-synchronous (see `GEPAAdapter`)."""
+reflection model, train/val split, budget). There is no `[serve]` block here — GEPA
+always runs in-process, since its adapter protocol is itself synchronous (see
+`GEPAAdapter`)."""
 
 from pathlib import Path
 from uuid import uuid4

--- a/verifiers/v1/legacy.py
+++ b/verifiers/v1/legacy.py
@@ -533,7 +533,7 @@ async def run_legacy_eval(config) -> list[Episode]:
         len(idxs),
         config.num_rollouts,
         config.model,
-        config.id,
+        config.legacy.id,
     )
 
     sem = asyncio.Semaphore(config.max_concurrent) if config.max_concurrent else None

--- a/verifiers/v1/legacy.py
+++ b/verifiers/v1/legacy.py
@@ -495,7 +495,7 @@ def _legacy_output_dir(config) -> Path:
 
     if config.output_dir is not None:
         return config.output_dir
-    name = f"{env_name(config.id)}--{config.model.replace('/', '--')}--legacy"
+    name = f"{env_name(config.legacy.id)}--{config.model.replace('/', '--')}--legacy"
     return Path("outputs") / name / config.uuid
 
 
@@ -510,15 +510,21 @@ async def run_legacy_eval(config) -> list[Episode]:
 
     # Install from the env hub on demand for an `org/name[@version]` id (a local id is
     # already importable), then load by module name.
-    env = load_environment(ensure_installed(config.id), **(config.args or {}))
-    if config.extra_env_kwargs:  # post-load knobs (max_total_completion_tokens, …)
-        env.set_kwargs(**config.extra_env_kwargs)
+    env = load_environment(
+        ensure_installed(config.legacy.id), **(config.legacy.args or {})
+    )
+    if (
+        config.legacy.extra_env_kwargs
+    ):  # post-load knobs (max_total_completion_tokens, …)
+        env.set_kwargs(**config.legacy.extra_env_kwargs)
     dataset = env.get_eval_dataset()  # the eval split (falls back to train when unset)
     idxs = sample(list(range(len(dataset))), config.shuffle, config.num_tasks)
 
     client = _eval_client(config.client, config.model)
     sampling_args = config.sampling.model_dump(exclude_none=True)
-    taskset_id = env_name(config.id)  # the same identity the served bridge stamps
+    taskset_id = env_name(
+        config.legacy.id
+    )  # the same identity the served bridge stamps
     out_dir = _legacy_output_dir(config)
     save_config(config, out_dir)
     logger.info("results: %s", out_dir)

--- a/verifiers/v1/push.py
+++ b/verifiers/v1/push.py
@@ -186,7 +186,7 @@ def push_traces(
         return finish(error="no PRIME_API_KEY (run `prime login`)")
 
     traces = [trace for episode in episodes for trace in episode.traces]
-    env_name = (config.env.taskset.id) or config.id
+    env_name = (config.env.taskset.id) or config.legacy.id
     metrics = _run_metrics(episodes, traces)
     samples = _build_samples(episodes)
     num_examples = len({t.task.data.idx for t in traces})

--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -312,9 +312,10 @@ def serve_env(
             if (
                 "config" in server_kwargs
             ):  # dict-ify for the workers (config_data is picklable)
-                server_kwargs = {
-                    "config_data": env_config_data(server_kwargs["config"])
-                }
+                server_kwargs = {**server_kwargs}
+                server_kwargs["config_data"] = env_config_data(
+                    server_kwargs.pop("config")
+                )
             pool = EnvServerPool(
                 server_kwargs,
                 max_workers,
@@ -335,9 +336,10 @@ def serve_env(
             ):  # rebuild the env config for an in-process server
                 from verifiers.v1.loaders import resolve_env_config
 
-                server_kwargs = {
-                    "config": resolve_env_config(server_kwargs["config_data"])
-                }
+                server_kwargs = {**server_kwargs}
+                server_kwargs["config"] = resolve_env_config(
+                    server_kwargs.pop("config_data")
+                )
             cls = LegacyEnvServer if legacy else EnvServer
             cls.run_server(
                 address=address, address_queue=address_queue, **server_kwargs

--- a/verifiers/v1/serve/server.py
+++ b/verifiers/v1/serve/server.py
@@ -30,7 +30,10 @@ logger = logging.getLogger(__name__)
 
 class EnvServer:
     def __init__(
-        self, config: EnvConfig, address: str = "tcp://127.0.0.1:5000"
+        self,
+        config: EnvConfig,
+        address: str = "tcp://127.0.0.1:5000",
+        max_concurrent: int | None = None,
     ) -> None:
         self.address = address
         self.taskset_id = config.taskset.id
@@ -52,9 +55,8 @@ class EnvServer:
         # v1 envs never group-score (siblings score inside the env's own rollout);
         # only the legacy (v0) bridge sets this.
         self.requires_group_scoring = False
-        self._gate = (
-            asyncio.Semaphore(config.max_concurrent) if config.max_concurrent else None
-        )
+        # This worker's episode bound (`--max-concurrent`), spanning requests.
+        self._gate = asyncio.Semaphore(max_concurrent) if max_concurrent else None
         self._clients: dict[
             tuple[str, str], Client
         ] = {}  # (client_config, model) -> Client
@@ -122,8 +124,8 @@ class EnvServer:
     async def _run(self, req: RunRequest) -> RunResponse:
         ctx = self._context(req.client, req.model, req.sampling)
         (slot,) = self.env.slots(self._build_task(req.task_data))
-        # The gate spans requests: `--env.max-concurrent` bounds this worker's
-        # agent runs the same way the in-process eval's semaphore does.
+        # The gate spans requests: `--max-concurrent` bounds this worker's episodes
+        # in flight the same way the in-process eval's semaphore does.
         episode = await self.env.run_slot(slot, ctx, self._gate)
         # Trust the env-minted episode; serialize it once before client-side re-typing.
         return RunResponse.model_construct(episode=episode)


### PR DESCRIPTION
Concurrency now has two levels, and the **episode is the unit** at the outer one:

| knob | bounds | default |
| --- | --- | --- |
| `max_concurrent` / `-c` | episodes in flight (per worker when served) | 128 (eval), none (serve) |
| `env.max_concurrent_agents` | agent runs inside **one** episode | **1** |

So `-c 128` is 128 live agent runs, whatever the env does internally — and a caller that counts episodes (the eval CLI, a served worker, prime-rl's dispatcher) counts real load. Before, an episode's fan-out multiplied the bound invisibly: `-c 128` on a 16-attempt `best-of-n` is 2048 live agent runs, each with its own sandbox and its own in-flight completions.

Ask for the multiplication when you want it — an eval fanning `best-of-n` out is the case for it, since `-c` still caps the episodes carrying the attempts:

```bash
uv run eval gsm8k-v1 --env.id best-of-n --env.n 16 --env.max-concurrent-agents None -c 128
```

- `run()` keeps expressing independent agents as independent (`asyncio.gather`, a `TaskGroup`) — how many actually run at once is the run's call, not the env's.
- An interaction takes an agent permit per segment and never while awaiting its caller, so two-sided conversations (`user-sim`, turn-taking games like `kuhn-poker-v1`) interleave turn by turn at any setting.
- The episode permit is held for the attempt in flight — its agents, their boxes, `finalize()` — and released before a retry's backoff and before the persistence hook. So what the old agent-run gate left unbounded (env `setup`, `provision()`ed boxes, live `Episode` objects) is bounded now too.

**Breaking:** `[env] max_concurrent` is gone, and nothing takes its place under that name. It bounded a served worker's agent runs *across* episodes — one semaphore built in `EnvServer.__init__` and handed to every `run_slot`. The per-episode gate is minted inside `_episode_agents`, so the same number would now size one semaphore per episode: `max_concurrent = 8` under the default `-c 128` is up to 1024 concurrent agent runs where the config asked for 8. No field reproduces the old meaning — `serve.max_concurrent` bounds a worker's *episodes*, `max_concurrent_agents` bounds one episode's *agents*, and nothing bounds agents worker-wide — so the key errors as an ordinary `extra_forbidden` rather than being aliased to something it didn't mean (thanks @mikasenghaas for the thread that got here; a `validation_alias` was tried and reverted, since it would have accepted the old value from any TOML, not just the CLI). For a single-agent env the migration is exact: `[serve] max_concurrent` — one agent per episode makes capping episodes the same as capping agent runs. Nothing in this repo or in prime-rl's checked-in configs sets it.

Drive-by fix in `serve_env`: converting `config` ⇄ `config_data` replaced `server_kwargs` wholesale, so any sibling kwarg was dropped on the way to a worker — which is how the new cap first went missing.

A global cap on live `Agent.run`s with per-role overrides stays open — #2052.

---

## Serving is its own block

Mika's review asked the obvious next question: a per-worker bound is a serving knob, not part of describing the env. Pulling that thread all the way — `EnvServerConfig` was three things at once (the env, how it's served, the v0 bridge) and `EvalConfig` / the serve CLI / prime-rl's env entry all *inherited* it, so pool knobs sat flattened on an eval config and on a trainer's source entry.

Three blocks now, composed rather than inherited:

```toml
[env]      # what runs — unchanged
[serve]    # how it's hosted: pool, address, per-worker episode bound
[legacy]   # the v0 bridge: id, args, extra_env_kwargs
```

A run config declares the blocks it needs and adds its own fields, sharing only the two narrowing helpers (`resolve_env_field`, `narrowed_env_annotation`) — `GEPAConfig` already worked exactly this way, and has no `[serve]` at all since it runs in-process. `EnvServerConfig` is gone. Everything else a run needs is spelled out where it is used: `is_legacy` and `env_id` are one-liners, the mixed-run refusal lives in each config's validator, and the `env` default is a plain `SingleAgentEnvConfig()` (per @mikasenghaas's review — `configs/legacy.py` is just the config class again).

**The run keeps owning its concurrency.** `-c` bounds episodes in flight and seeds each worker's bound under `--server`; `serve.max_concurrent` pins a worker *below* the run when you want that (`EvalConfig.worker_max_concurrent`). So an in-process eval never has to reach into a block named `serve`, and one number stays honest when a run spawns workers.

```bash
uv run eval gsm8k-v1 --server -c 128                          # 128 episodes, per worker
uv run eval gsm8k-v1 --server -c 128 --serve.max-concurrent 32  # ... but hold each worker at 32
uv run serve gsm8k-v1 --serve.pool.type static --serve.pool.num-workers 4 --serve.address tcp://0.0.0.0:7000
```

**Breaking:** `--pool.*` → `--serve.pool.*`, `--address` → `--serve.address`, `--id` / `--args` / `--extra-env-kwargs` → `--legacy.*`. A moved key fails as an ordinary `extra_forbidden` — no migration table in the config plumbing, per @mikasenghaas, and no back-compat for the old spellings. `--taskset.*` and `--harness.*` still land on pydantic's did-you-mean, since the usage gate lets a typed axis through to validation:

```
--taskset
  Extra inputs are not permitted — did you mean --env.taskset.id?
```

Nothing in this repo set the moved keys, and the `configs/gepa/*.toml` `max_concurrent` entries are GEPA's own run-level bound, untouched.

Two readers kept the flat `config.id` after it moved under `[legacy]` — the legacy eval's startup log line and `push_traces`'s run name — so `eval --legacy.id <env>` raised `AttributeError` after creating its output dir. Fixed, and `refuse_mixed_run` now also catches `--legacy.id` next to a bare `--env.id`: there `is_legacy` stays True, so the v0 env runs stamped with the v1 env's name.

**Downstream:** prime-rl's `EnvConfig` subclasses `vf.EnvServerConfig`, so it needs the matching composition change — that lands with the `deps/verifiers` bump, not here.

### Trade-off

At the default, `best-of-n`'s attempts (and any gathered peers) run sequentially inside an episode, so a single episode's wall clock grows with its fan-out — throughput comes from more episodes, which is what `-c` now counts. Two knock-ons worth knowing: an episode permit is held through non-model work (scoring, plugged judges, box teardown), so at a given `-c` fewer completions are in flight than before — raise `-c` to compensate; and an env with `--env.timeout.episode` set (default: none) may need it raised, or `--env.max-concurrent-agents` raised instead.

### Verified

- `pytest tests/v1 -m "not e2e"` (64) and the v0 config/serve/gepa/env-server/display tests (94), `ruff check`, `ruff format --check`, `ty check verifiers` — all clean. Live E2Es not run here (no endpoint in this environment).
- Throwaway probe over the parsed configs: blocks compose (`-c 64` + `--serve.pool.type static --serve.pool.num-workers 4` → worker bound 64; `--serve.max-concurrent 16` → 16); `--legacy.id` + `--legacy.args '{"a": 1}'` resolves with `is_legacy`/`env_id` intact; a v0 id next to a v1 taskset *or* a bare `--env.id` is refused; `--env.max-concurrent` resolves to `max_concurrent_agents` and the saved config normalizes to the canonical name.
- The concurrency probe from #2157 still holds on this branch: default 1 agent run per episode, turn-taking interactions still alternate, `-c 2` over 6 episodes peaks at 2 episodes / 2 runs, `max_concurrent_agents=None` at `-c 3` peaks at 3 episodes / 6 runs.
- Docs + the `evaluate-environments` skill reference updated for the new tree (that reference documented `EnvServerConfig` field by field).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> Concurrency now has two levels, and the **episode is the unit** at the outer one:
>
> | knob | bounds | default |
> | --- | --- | --- |
> | `max_concurrent` / `-c` | episodes in flight (per worker when served) | 128 (eval), none (serve) |
> | `env.max_concurrent_agents` | agent runs inside **one** episode | **1** |
>
> So `-c 128` is 128 live agent runs, whatever the env does internally — and a caller that counts episodes (the eval CLI, a served worker, prime-rl's dispatcher) counts real load. Before, an episode's fan-out multiplied the bound invisibly: `-c 128` on a 16-attempt `best-of-n` is 2048 live agent runs, each with its own sandbox and its own in-flight completions.
>
> Ask for the multiplication when you want it — an eval fanning `best-of-n` out is the case for it, since `-c` still caps the episodes carrying the attempts:
>
> ```bash
> uv run eval gsm8k-v1 --env.id best-of-n --env.n 16 --env.max-concurrent-agents None -c 128
> ```
>
> - `run()` keeps expressing independent agents as independent (`asyncio.gather`, a `TaskGroup`) — how many actually run at once is the run's call, not the env's.
> - An interaction takes an agent permit per segment and never while awaiting its caller, so two-sided conversations (`user-sim`, turn-taking games like `kuhn-poker-v1`) interleave turn by turn at any setting.
> - The episode permit is held for the attempt in flight — its agents, their boxes, `finalize()` — and released before a retry's backoff and before the persistence hook. So what the old agent-run gate left unbounded (env `setup`, `provision()`ed boxes, live `Episode` objects) is bounded now too.
>
> **Breaking:** `env.max_concurrent` — a served worker's cap — is gone from `[env]`; a per-worker bound is a serving knob, not part of describing the env (thanks @mikasenghaas). That thread is what the second half of this PR pulls on.
>
> Drive-by fix in `serve_env`: converting `config` ⇄ `config_data` replaced `server_kwargs` wholesale, so any sibling kwarg was dropped on the way to a worker — which is how the new cap first went missing.
>
> A global cap on live `Agent.run`s with per-role overrides stays open — #2052.
>
> ---
>
> ## Serving is its own block
>
> Mika's review asked the obvious next question: a per-worker bound is a serving knob, not part of describing the env. Pulling that thread all the way — `EnvServerConfig` was three things at once (the env, how it's served, the v0 bridge) and `EvalConfig` / the serve CLI / prime-rl's env entry all *inherited* it, so pool knobs sat flattened on an eval config and on a trainer's source entry.
>
> Three blocks now, composed rather than inherited:
>
> ```toml
> [env]      # what runs — unchanged
> [serve]    # how it's hosted: pool, address, per-worker episode bound
> [legacy]   # the v0 bridge: id, args, extra_env_kwargs
> ```
>
> A run config declares the blocks it needs and adds its own fields, sharing only the narrowing helpers — `GEPAConfig` already worked exactly this way, and has no `[serve]` at all since it runs in-process. `EnvServerConfig` is gone.
>
> **The run keeps owning its concurrency.** `-c` bounds episodes in flight and seeds each worker's bound under `--server`; `serve.max_concurrent` pins a worker *below* the run when you want that (`EvalConfig.worker_max_concurrent`). So an in-process eval never has to reach into a block named `serve`, and one number stays honest when a run spawns workers.
>
> ```bash
> uv run eval gsm8k-v1 --server -c 128                          # 128 episodes, per worker
> uv run eval gsm8k-v1 --server -c 128 --serve.max-concurrent 32  # ... but hold each worker at 32
> uv run serve gsm8k-v1 --serve.pool.type static --serve.pool.num-workers 4 --serve.address tcp://0.0.0.0:7000
> ```
>
> **Breaking:** `--pool.*` → `--serve.pool.*`, `--address` → `--serve.address`, `--id` / `--args` / `--extra-env-kwargs` → `--legacy.*`. Every retired top-level key raises with a pointer home rather than a bare `extra_forbidden`, the way the retired `--taskset.*` / `--harness.*` axes already do:
>
> ```
> --pool.type
>   Value error, the worker pool is serving, not the env: --serve.pool.type elastic|static (TOML: [serve.pool])
> ```
>
> Nothing in this repo set the moved keys, and the `configs/gepa/*.toml` `max_concurrent` entries are GEPA's own run-level bound, untouched.
>
> **Downstream:** prime-rl's `EnvConfig` subclasses `vf.EnvServerConfig`, so it needs the matching composition change — that lands with the `deps/verifiers` bump, not here.
>
> ### Trade-off
>
> At the default, `best-of-n`'s attempts (and any gathered peers) run sequentially inside an episode, so a single episode's wall clock grows with its fan-out — throughput comes from more episodes, which is what `-c` now counts. Two knock-ons worth knowing: an episode permit is held through non-model work (scoring, plugged judges, box teardown), so at a given `-c` fewer completions are in flight than before — raise `-c` to compensate; and an env with `--env.timeout.episode` set (default: none) may need it raised, or `--env.max-concurrent-agents` raised instead.
>
> ### Verified
>
> - `pytest tests/v1 -m "not e2e"` (64) and the v0 config/serve/gepa/env-server/display tests (94), `ruff check`, `ruff format --check`, `ty check verifiers` — all clean. Live E2Es not run here (no endpoint in this environment).
> - Throwaway probe over the parsed configs: blocks compose (`-c 64` + `--serve.pool.type static --serve.pool.num-workers 4` → worker bound 64; `--serve.max-concurrent 16` → 16); `--legacy.id` + `--legacy.args '{"a": 1}'` resolves with `is_legacy`/`env_id` intact; a v0 id next to a v1 taskset is refused; all five retired keys point home.
> - The concurrency probe from #2157 still holds on this branch: default 1 agent run per episode, turn-taking interactions still alternate, `-c 2` over 6 episodes peaks at 2 episodes / 2 runs, `max_concurrent_agents=None` at `-c 3` peaks at 3 episodes / 6 runs.
> - Docs + the `evaluate-environments` skill reference updated for the new tree (that reference documented `EnvServerConfig` field by field).
> <!-- Macroscope's changelog starts here -->
> #### Changes since #2157 opened
>
> - Refactored `EvalConfig` and `ServeConfig` to compose three separate configuration blocks instead of flat fields [02a0b5e]
> - Removed pool configuration types and `EnvServerConfig` from `configs.cli.env` module and introduced retirement mechanism for obsolete flat axes [02a0b5e]
> - Introduced `configs.serve` module with serving configuration types and `configs.legacy` module with v0 environment bridging configuration [02a0b5e]
> - Updated CLI entrypoints and runner to use new dotted flag paths under `--serve.*` and `--legacy.*` blocks [02a0b5e]
> - Updated `verifiers.v1` package exports to replace `EnvServerConfig` with new serving and legacy configuration types and env field utilities [02a0b5e]
> - Updated legacy evaluation execution to source environment parameters from `legacy` block fields [02a0b5e]
> - Updated documentation to reflect new configuration block structure with separate `env`, `serve`, and `legacy` sections [02a0b5e]
> - Expanded validation in `refuse_mixed_run` function to reject legacy v0 environment IDs when paired with v1 environment identities [7dc42df]
> - Migrated references from `config.id` to `config.legacy.id` for legacy environment identification [7dc42df]
> - Removed `EnvField` type alias and replaced all usages with `SerializeAsAny[EnvConfig]` [4d9d0ed]
> - Replaced `env_field()` helper function with `single_agent_env_config()` factory function and updated environment field declarations to use `Field(default_factory=single_agent_env_config)` with `SerializeAsAny[EnvConfig]` type annotation [51124f1]
> - Removed `single_agent_env_config`, `is_legacy`, `run_env_id`, and `refuse_mixed_run` helper functions from `verifiers.v1.configs.legacy` and `verifiers.v1.configs.cli.env`, stopped exporting `single_agent_env_config` from `verifiers.v1`, and inlined their logic directly into `EvalConfig` and `ServeConfig` classes [ab8e5c8]
> - Added `max_concurrent` as an accepted alias for the `max_concurrent_agents` field in `verifiers.v1.configs.env.EnvConfig` [ab8e5c8]
> - Updated documentation in `docs/v1/env.md` and `skills/evaluate-environments/references/REFERENCE.md` to clarify two-level concurrency model and configuration aliases [ab8e5c8]
> - Removed the `RETIRED` constant and validation logic from `resolve_env_field` function that previously rejected top-level keys (`taskset`, `harness`, `pool`, `address`, `id`, `args`, `extra_env_kwargs`) in the `verifiers.v1.configs.cli.env` module [a0ebc40]
> - Updated CLI flag structure documentation in `REFERENCE.md` to clarify current flag organization [a0ebc40]
> - Reworded inline comments in `verifiers.v1.cli.eval.main.main` and `verifiers.v1.cli.serve.main` CLI entrypoints to reference since-moved flat axes [a0ebc40]
> - Removed alias support for configuration field in verifiers environment config [a0cbdc4]
> - Updated documentation to reflect removed alias support [a0cbdc4]
> - Restructured legacy environment configuration in test fixtures [d4bba3c]
> - Restructured pool configuration parameter in test config builder [d4bba3c]
> <!-- Macroscope's changelog ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking config and CLI renames affect eval, serve, and downstream trainers; concurrency semantics change load and timing for multi-agent envs like best-of-n unless `max_concurrent_agents` is raised.
> 
> **Overview**
> This PR **redefines concurrency** so the outer unit is **episodes**, not agent runs. Run-level `max_concurrent` / `-c` now caps episodes in flight (per worker when served); **`env.max_concurrent_agents`** (default **1**) caps agent runs inside one episode. Episode semaphores gate whole attempts in `run_slot`; per-episode agent gates are minted in `_episode_agents`. **`[env].max_concurrent` is removed** with no alias—old worker-wide agent caps must move to **`serve.max_concurrent`** (episodes per worker).
> 
> **Serving and v0 bridging** stop inheriting from flat `EnvServerConfig`. `EvalConfig` / `ServeConfig` compose **`[env]`**, **`[serve]`** (pool, address, per-worker episode bound), and **`[legacy]`** (`id`, `args`, `extra_env_kwargs`). CLI paths change: **`--pool.*` → `--serve.pool.*`**, **`--address` → `--serve.address`**, **`--id` / `--args` → `--legacy.*`**. Server workers take `max_concurrent` from `worker_max_concurrent`; `serve_env` no longer drops sibling kwargs when converting `config` ↔ `config_data`.
> 
> Docs, skills reference, tests, legacy eval/push, and dashboard copy are updated for episodes vs agents and the new config tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4bba3cd4407925d154572ab3bb0c3b3652f2f46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




