### PR TITLE
feat: self-healing prime tunnels and typed tunnel failures

### DIFF
--- a/verifiers/v1/errors.py
+++ b/verifiers/v1/errors.py
@@ -79,7 +79,8 @@ class InterceptionError(RolloutError):
 
 
 class TunnelError(InterceptionError):
-    """The `prime_tunnel` tunnel to the host interception server couldn't be established."""
+    """The `prime_tunnel` tunnel to the host interception server couldn't be established,
+    or was found dead after a harness failure (its calls hit a gone tunnel)."""
 
 
 @contextlib.asynccontextmanager

--- a/verifiers/v1/interception/pool.py
+++ b/verifiers/v1/interception/pool.py
@@ -138,6 +138,6 @@ class ElasticInterceptionPool(Interception):
             server = await self._server()
             secret = server.register(session)
         try:
-            yield server.base_url, secret
+            yield await server.url(), secret
         finally:
             server.unregister(secret)

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -169,11 +169,12 @@ class InterceptionServer(Interception):
         assert self.endpoint is not None, "server not started"
         return await self.endpoint.url()
 
-    async def healthy(self) -> bool:
-        """Whether the server is reachable at its published URL — i.e. its endpoint is up
-        (trivially yes without a tunnel). A fresh probe: the failure-attribution hook for
-        a rollout whose harness just failed."""
-        return self.endpoint is None or await self.endpoint.healthy()
+    async def healthy(self, url: str) -> bool:
+        """Whether the server is still reachable at `url` — the base URL a rollout's slot
+        handed out (trivially yes without a tunnel). A fresh probe, anchored to that
+        rollout's tunnel rather than the current one so a concurrent heal can't mask its
+        death: the failure-attribution hook for a rollout whose harness just failed."""
+        return self.endpoint is None or await self.endpoint.healthy(url)
 
     @asynccontextmanager
     async def acquire(self, session: RolloutSession) -> AsyncIterator[Slot]:

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -44,6 +44,8 @@ from verifiers.v1.errors import (
 )
 from verifiers.v1.interception.base import BaseInterceptionConfig, Interception, Slot
 from verifiers.v1.interception.tunnel import (
+    Endpoint,
+    FixedEndpoint,
     PrimeTunnelConfig,
     Tunnel,
     TunnelConfig,
@@ -135,7 +137,7 @@ class InterceptionServer(Interception):
         )
         self.host = "127.0.0.1"
         self.port = 0
-        self.base_url = ""  # set by `start`
+        self.endpoint: Endpoint | None = None  # set by `start`
         self.runner: web.AppRunner | None = None
 
     @property
@@ -148,6 +150,8 @@ class InterceptionServer(Interception):
         return it."""
         secret = secrets.token_urlsafe(16)
         self.sessions[secret] = session
+        # So the rollout can ask `healthy()` after a harness failure.
+        session.server = self
         return secret
 
     def unregister(self, secret: str) -> None:
@@ -158,11 +162,24 @@ class InterceptionServer(Interception):
             # can't commit a late turn onto the concluded trace.
             session.release()
 
+    async def url(self) -> str:
+        """The server's reachable base URL right now — asked per acquire rather than
+        cached, because a healing tunnel re-minted since the last acquire answers with a
+        new URL. Raises `TunnelError` when the tunnel is dead and can't be re-established."""
+        assert self.endpoint is not None, "server not started"
+        return await self.endpoint.url()
+
+    async def healthy(self) -> bool:
+        """Whether the server is reachable at its published URL — i.e. its endpoint is up
+        (trivially yes without a tunnel). A fresh probe: the failure-attribution hook for
+        a rollout whose harness just failed."""
+        return self.endpoint is None or await self.endpoint.healthy()
+
     @asynccontextmanager
     async def acquire(self, session: RolloutSession) -> AsyncIterator[Slot]:
         secret = self.register(session)
         try:
-            yield self.base_url, secret
+            yield await self.url(), secret
         finally:
             self.unregister(secret)
 
@@ -212,9 +229,9 @@ class InterceptionServer(Interception):
             logger.info, "interception down: url=http://%s:%d", self.host, self.port
         )
         if self.tunnel is None:
-            self.base_url = f"http://127.0.0.1:{self.port}"
+            self.endpoint = FixedEndpoint(f"http://127.0.0.1:{self.port}")
         else:
-            self.base_url = await self.stack.enter_async_context(
+            self.endpoint = await self.stack.enter_async_context(
                 self.tunnel.expose(self.port)
             )
 

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -164,16 +164,15 @@ class InterceptionServer(Interception):
 
     async def url(self) -> str:
         """The server's reachable base URL right now — asked per acquire rather than
-        cached, because a healing tunnel re-minted since the last acquire answers with a
-        new URL. Raises `TunnelError` when the tunnel is dead and can't be re-established."""
+        cached, because a healing tunnel may have re-minted at a new URL. Raises
+        `TunnelError` when the tunnel is dead and can't be re-established."""
         assert self.endpoint is not None, "server not started"
         return await self.endpoint.url()
 
     async def healthy(self, url: str) -> bool:
-        """Whether the server is still reachable at `url` — the base URL a rollout's slot
-        handed out (trivially yes without a tunnel). A fresh probe, anchored to that
-        rollout's tunnel rather than the current one so a concurrent heal can't mask its
-        death: the failure-attribution hook for a rollout whose harness just failed."""
+        """Whether the server is still reachable at `url`, the base URL a rollout's slot
+        handed out (trivially yes without a tunnel) — the failure-attribution hook for a
+        rollout whose harness just failed."""
         return self.endpoint is None or await self.endpoint.healthy(url)
 
     @asynccontextmanager

--- a/verifiers/v1/interception/tunnel/__init__.py
+++ b/verifiers/v1/interception/tunnel/__init__.py
@@ -2,7 +2,12 @@ from typing import Annotated
 
 from pydantic import Field
 
-from verifiers.v1.interception.tunnel.base import BaseTunnelConfig, Tunnel
+from verifiers.v1.interception.tunnel.base import (
+    BaseTunnelConfig,
+    Endpoint,
+    FixedEndpoint,
+    Tunnel,
+)
 from verifiers.v1.interception.tunnel.custom import CustomTunnel, CustomTunnelConfig
 from verifiers.v1.interception.tunnel.prime import PrimeTunnel, PrimeTunnelConfig
 
@@ -23,6 +28,8 @@ __all__ = [
     "BaseTunnelConfig",
     "CustomTunnel",
     "CustomTunnelConfig",
+    "Endpoint",
+    "FixedEndpoint",
     "PrimeTunnel",
     "PrimeTunnelConfig",
     "Tunnel",

--- a/verifiers/v1/interception/tunnel/base.py
+++ b/verifiers/v1/interception/tunnel/base.py
@@ -22,25 +22,22 @@ ConfigT = TypeVar("ConfigT", bound=BaseTunnelConfig)
 
 
 class Endpoint(Protocol):
-    """A live exposed endpoint, valid while its `Tunnel.expose` is entered. A tunnel's URL
-    is not a constant: a healing tunnel (prime) re-establishes itself when it finds its
-    underlying tunnel dead — and comes back at a NEW public URL. So consumers ask `url()`
-    per acquire instead of caching a snapshot."""
+    """A live exposed endpoint, valid while its `Tunnel.expose` is entered. A healing
+    tunnel re-mints at a NEW URL when it finds itself dead, so consumers ask `url()` per
+    acquire instead of caching a snapshot."""
 
     async def url(self) -> str:
-        """The current public URL — healing the tunnel first if it has died (so it may
-        differ across calls). Raises `TunnelError` when the tunnel is dead and can't be
-        re-established."""
+        """The current public URL, healing a dead tunnel first (so it may differ across
+        calls). Raises `TunnelError` when it can't be re-established."""
         ...
 
     async def healthy(self, url: str) -> bool:
-        """Whether the endpoint a consumer reached at `url` is still the live one — the
+        """Whether the endpoint a consumer reached at `url` is still up — the
         failure-attribution hook: `False` means that tunnel died, so the consumer's
-        concurrent failure was the tunnel's fault, not its own. `url` anchors the answer
-        to the consumer's tunnel, not the current one: a heal re-mints at a NEW URL, so a
-        stale `url` proves its tunnel died even when a replacement is already up (probing
-        bare liveness would race the heal and mask the death). Must not raise; an
-        inconclusive probe reads as healthy."""
+        concurrent failure was the tunnel's fault. Anchored to `url` rather than bare
+        liveness because a heal re-mints at a new URL: a stale `url` proves its tunnel
+        died even when a replacement is already up. Must not raise; an inconclusive
+        probe reads as healthy."""
         ...
 
 

--- a/verifiers/v1/interception/tunnel/base.py
+++ b/verifiers/v1/interception/tunnel/base.py
@@ -8,7 +8,7 @@ host-side counterpart to `Runtime.expose`, which publishes a port inside a sandb
 
 import contextlib
 from abc import ABC, abstractmethod
-from typing import ClassVar, Generic, TypeVar
+from typing import ClassVar, Generic, Protocol, TypeVar
 
 from pydantic_config import BaseConfig
 
@@ -19,6 +19,39 @@ class BaseTunnelConfig(BaseConfig):
 
 
 ConfigT = TypeVar("ConfigT", bound=BaseTunnelConfig)
+
+
+class Endpoint(Protocol):
+    """A live exposed endpoint, valid while its `Tunnel.expose` is entered. A tunnel's URL
+    is not a constant: a healing tunnel (prime) re-establishes itself when it finds its
+    underlying tunnel dead — and comes back at a NEW public URL. So consumers ask `url()`
+    per acquire instead of caching a snapshot."""
+
+    async def url(self) -> str:
+        """The current public URL — healing the tunnel first if it has died (so it may
+        differ across calls). Raises `TunnelError` when the tunnel is dead and can't be
+        re-established."""
+        ...
+
+    async def healthy(self) -> bool:
+        """Probe liveness without healing — the failure-attribution hook: `False` means
+        the endpoint was down, so a consumer's concurrent failure was the tunnel's fault,
+        not its own. Must not raise; an inconclusive probe reads as healthy."""
+        ...
+
+
+class FixedEndpoint:
+    """An `Endpoint` at a URL the framework doesn't manage: nothing to probe or heal —
+    the operator owns it."""
+
+    def __init__(self, url: str) -> None:
+        self._url = url
+
+    async def url(self) -> str:
+        return self._url
+
+    async def healthy(self) -> bool:
+        return True
 
 
 class Tunnel(ABC, Generic[ConfigT]):
@@ -40,8 +73,8 @@ class Tunnel(ABC, Generic[ConfigT]):
         return 0
 
     @abstractmethod
-    def expose(self, port: int) -> contextlib.AbstractAsyncContextManager[str]:
-        """An async context manager yielding a public URL that reaches the host's `port`
-        from a remote runtime. Entered only when a consumer is remote; torn down on exit.
-        A setup failure raises `TunnelError`; an error raised while the URL is held (the
-        caller's body) propagates unchanged."""
+    def expose(self, port: int) -> contextlib.AbstractAsyncContextManager[Endpoint]:
+        """An async context manager yielding an `Endpoint` whose `url()` reaches the
+        host's `port` from a remote runtime. Entered only when a consumer is remote; torn
+        down on exit. A setup failure raises `TunnelError`; an error raised while the
+        endpoint is held (the caller's body) propagates unchanged."""

--- a/verifiers/v1/interception/tunnel/base.py
+++ b/verifiers/v1/interception/tunnel/base.py
@@ -33,10 +33,14 @@ class Endpoint(Protocol):
         re-established."""
         ...
 
-    async def healthy(self) -> bool:
-        """Probe liveness without healing — the failure-attribution hook: `False` means
-        the endpoint was down, so a consumer's concurrent failure was the tunnel's fault,
-        not its own. Must not raise; an inconclusive probe reads as healthy."""
+    async def healthy(self, url: str) -> bool:
+        """Whether the endpoint a consumer reached at `url` is still the live one — the
+        failure-attribution hook: `False` means that tunnel died, so the consumer's
+        concurrent failure was the tunnel's fault, not its own. `url` anchors the answer
+        to the consumer's tunnel, not the current one: a heal re-mints at a NEW URL, so a
+        stale `url` proves its tunnel died even when a replacement is already up (probing
+        bare liveness would race the heal and mask the death). Must not raise; an
+        inconclusive probe reads as healthy."""
         ...
 
 
@@ -50,7 +54,7 @@ class FixedEndpoint:
     async def url(self) -> str:
         return self._url
 
-    async def healthy(self) -> bool:
+    async def healthy(self, url: str) -> bool:
         return True
 
 

--- a/verifiers/v1/interception/tunnel/custom.py
+++ b/verifiers/v1/interception/tunnel/custom.py
@@ -9,7 +9,12 @@ from typing import ClassVar, Literal
 
 from pydantic import Field
 
-from verifiers.v1.interception.tunnel.base import BaseTunnelConfig, Tunnel
+from verifiers.v1.interception.tunnel.base import (
+    BaseTunnelConfig,
+    Endpoint,
+    FixedEndpoint,
+    Tunnel,
+)
 
 
 class CustomTunnelConfig(BaseTunnelConfig):
@@ -38,5 +43,5 @@ class CustomTunnel(Tunnel[CustomTunnelConfig]):
         return self.config.port
 
     @contextlib.asynccontextmanager
-    async def expose(self, port: int) -> AsyncIterator[str]:
-        yield self.config.url
+    async def expose(self, port: int) -> AsyncIterator[Endpoint]:
+        yield FixedEndpoint(self.config.url)

--- a/verifiers/v1/interception/tunnel/prime.py
+++ b/verifiers/v1/interception/tunnel/prime.py
@@ -123,7 +123,12 @@ class PrimeEndpoint:
                     client = TunnelClient(local_port=self.port)
                     async with TUNNEL_LIMITER:
                         self._url = str(await client.start()).rstrip("/")
-                    self._client = client
+                        # Record the client with no await in between: a cancellation
+                        # landing on the limiter's exit would otherwise orphan the
+                        # started frpc/registration — `close()` only stops what's
+                        # recorded. (A cancellation inside `start()` is the SDK's to
+                        # clean up, and it does.)
+                        self._client = client
         except Exception as e:
             raise TunnelError(f"{label} failed: {e}") from e
         logger.info("prime tunnel up: %s -> 127.0.0.1:%d", self._url, self.port)

--- a/verifiers/v1/interception/tunnel/prime.py
+++ b/verifiers/v1/interception/tunnel/prime.py
@@ -5,18 +5,30 @@ pool scales with."""
 
 import asyncio
 import contextlib
+import logging
+import time
 from collections.abc import AsyncIterator
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
-from verifiers.v1.interception.tunnel.base import BaseTunnelConfig, Tunnel
+from verifiers.v1.interception.tunnel.base import BaseTunnelConfig, Endpoint, Tunnel
 from verifiers.v1.runtimes.limiters import creation_limiter
 from verifiers.v1.utils.aio import run_shielded
+
+if TYPE_CHECKING:
+    from prime_tunnel import Tunnel as TunnelClient
+
+logger = logging.getLogger(__name__)
 
 # The prime_tunnel service caps tunnel starts at 512/min per API token — a property of the
 # tunnel service, shared by every process on the host that opens one. One host-global
 # limiter, not a per-runtime config knob.
-_TUNNELS_PER_MIN = 512
-TUNNEL_LIMITER = creation_limiter(_TUNNELS_PER_MIN / 60, "prime-tunnel")
+TUNNELS_PER_MIN = 512
+TUNNEL_LIMITER = creation_limiter(TUNNELS_PER_MIN / 60, "prime-tunnel")
+
+# A registration can lapse server-side while frpc is still running locally, so `url()`
+# also probes the tunnel service — but that's a network call, so at most this often.
+# (`is_running`, a local process poll, guards every call.)
+REGISTRATION_CHECK_INTERVAL = 60.0
 
 
 class PrimeTunnelConfig(BaseTunnelConfig):
@@ -26,31 +38,110 @@ class PrimeTunnelConfig(BaseTunnelConfig):
     type: Literal["prime"] = "prime"
 
 
-class PrimeTunnel(Tunnel[PrimeTunnelConfig]):
-    @contextlib.asynccontextmanager
-    async def expose(self, port: int) -> AsyncIterator[str]:
-        """Bridge the host `port` to a public URL via prime_tunnel (frpc). Tunnel creation
-        is network-bound and globally rate-capped (512/min, host-wide via the shared
-        `TUNNEL_LIMITER`), so transient failures are retried; a terminal one raises
-        `TunnelError`. The tunnel is torn down on exit."""
+class PrimeEndpoint:
+    """A self-healing prime tunnel: `url()` verifies the frpc process (and, throttled, the
+    server-side registration) and re-mints the tunnel when either is gone — at a NEW public
+    URL. Healing serves the *next* acquire; a consumer holding the old URL isn't saved (its
+    URL is baked in) — `healthy()` is how its failure gets attributed to the tunnel."""
+
+    def __init__(self, port: int) -> None:
+        self.port = port
+        self._client: TunnelClient | None = None
+        self._url = ""
+        self._lock = asyncio.Lock()
+        self._last_registration_check = 0.0
+
+    async def url(self) -> str:
+        async with self._lock:
+            if self._client is not None and not await self._alive():
+                await self.close()
+            if self._client is None:
+                await self._mint()
+            return self._url
+
+    async def healthy(self) -> bool:
+        async with self._lock:
+            # Torn down (or a heal already failed): it was dead.
+            if self._client is None:
+                return False
+            if await self._alive(fresh=True):
+                return True
+            await self.close()  # observed dead: tear down so the next `url()` re-mints
+            return False
+
+    async def _alive(self, fresh: bool = False) -> bool:
+        """Whether the tunnel is up: frpc running locally and (throttled — or forced with
+        `fresh`, the attribution path) still registered server-side. An unreachable tunnel
+        API is not a dead tunnel: the probe reads as alive."""
+        assert self._client is not None
+        client = self._client
+        if not client.is_running:
+            output = await asyncio.to_thread(lambda: "\n".join(client.recent_output))
+            logger.warning("prime tunnel %s: frpc died\n%s", self._url, output)
+            return False
+        now = time.monotonic()
+        if fresh or now - self._last_registration_check > REGISTRATION_CHECK_INTERVAL:
+            self._last_registration_check = now
+            try:
+                # Not `client.check_registered()`: deletion is soft server-side (the
+                # record survives as `status="terminated"`, and GET keeps returning it),
+                # so existence alone reads a terminated tunnel as registered.
+                info = await client._client.get_tunnel(client.tunnel_id)
+                if info is None or info.status == "terminated":
+                    logger.warning(
+                        "prime tunnel %s: registration %s server-side",
+                        self._url,
+                        "terminated" if info else "gone",
+                    )
+                    return False
+            except Exception as e:  # noqa: BLE001 - API unreachable is not a dead tunnel
+                logger.warning(
+                    "prime tunnel %s: liveness probe failed (%s), assuming alive",
+                    self._url,
+                    e,
+                )
+        return True
+
+    async def _mint(self) -> None:
+        """Register a fresh tunnel (network-bound and globally rate-capped — 512/min,
+        host-wide via the shared `TUNNEL_LIMITER` — so transient failures are retried);
+        a terminal one raises `TunnelError`."""
         from prime_tunnel import Tunnel as TunnelClient
 
         from verifiers.v1.errors import TunnelError
         from verifiers.v1.retries import retrying
 
-        label = f"host tunnel (port {port})"
+        label = f"host tunnel (port {self.port})"
         try:
             async for attempt in retrying(retries=3, label=label):
                 with attempt:
-                    client = TunnelClient(local_port=port)
+                    client = TunnelClient(local_port=self.port)
                     async with TUNNEL_LIMITER:
-                        url = str(await client.start()).rstrip("/")
+                        self._url = str(await client.start()).rstrip("/")
+                    self._client = client
         except Exception as e:
             raise TunnelError(f"{label} failed: {e}") from e
-        try:
-            yield url
-        finally:
-            # Run the synchronous stop to completion even under cancellation (`run_shielded`
-            # re-raises the cancellation after); tunnel-stop failures are best-effort.
+        logger.info("prime tunnel up: %s -> 127.0.0.1:%d", self._url, self.port)
+
+    async def close(self) -> None:
+        """Stop the *current* frpc client (it changes across heals). Runs the synchronous
+        stop to completion even under cancellation (`run_shielded` re-raises the
+        cancellation after); tunnel-stop failures are best-effort."""
+        client, self._client = self._client, None
+        if client is not None:
             with contextlib.suppress(Exception):
                 await run_shielded(asyncio.to_thread(client.sync_stop))
+
+
+class PrimeTunnel(Tunnel[PrimeTunnelConfig]):
+    @contextlib.asynccontextmanager
+    async def expose(self, port: int) -> AsyncIterator[Endpoint]:
+        """Bridge the host `port` to a public URL via prime_tunnel (frpc), self-healing
+        for the lifetime of the context: each `url()` re-mints a dead tunnel. The tunnel
+        is torn down on exit."""
+        endpoint = PrimeEndpoint(port)
+        try:
+            await endpoint.url()  # mint eagerly so a setup failure raises here, typed
+            yield endpoint
+        finally:
+            await endpoint.close()

--- a/verifiers/v1/interception/tunnel/prime.py
+++ b/verifiers/v1/interception/tunnel/prime.py
@@ -26,8 +26,7 @@ TUNNELS_PER_MIN = 512
 TUNNEL_LIMITER = creation_limiter(TUNNELS_PER_MIN / 60, "prime-tunnel")
 
 # A registration can lapse server-side while frpc is still running locally, so `url()`
-# also probes the tunnel service — but that's a network call, so at most this often.
-# (`is_running`, a local process poll, guards every call.)
+# also probes the tunnel service — a network call, so at most this often.
 REGISTRATION_CHECK_INTERVAL = 60.0
 
 
@@ -39,10 +38,10 @@ class PrimeTunnelConfig(BaseTunnelConfig):
 
 
 class PrimeEndpoint:
-    """A self-healing prime tunnel: `url()` verifies the frpc process (and, throttled, the
-    server-side registration) and re-mints the tunnel when either is gone — at a NEW public
-    URL. Healing serves the *next* acquire; a consumer holding the old URL isn't saved (its
-    URL is baked in) — `healthy()` is how its failure gets attributed to the tunnel."""
+    """A self-healing prime tunnel: `url()` re-mints when the frpc process or the
+    server-side registration is gone — at a NEW public URL. Healing serves the *next*
+    acquire; a consumer holding the old URL isn't saved, `healthy()` attributes its
+    failure to the tunnel."""
 
     def __init__(self, port: int) -> None:
         self.port = port
@@ -61,9 +60,8 @@ class PrimeEndpoint:
 
     async def healthy(self, url: str) -> bool:
         async with self._lock:
-            # A re-mint changes the URL, so a stale `url` proves the consumer's tunnel
-            # died — even when a concurrent acquire already healed past it. (Without the
-            # anchor, probing the replacement would mask the death.)
+            # A stale `url` means the consumer's tunnel died, even if a concurrent
+            # acquire already healed past it.
             if url != self._url:
                 return False
             # Torn down (or a heal already failed): it was dead.
@@ -75,9 +73,8 @@ class PrimeEndpoint:
             return False
 
     async def _alive(self, fresh: bool = False) -> bool:
-        """Whether the tunnel is up: frpc running locally and (throttled — or forced with
-        `fresh`, the attribution path) still registered server-side. An unreachable tunnel
-        API is not a dead tunnel: the probe reads as alive."""
+        """Whether the tunnel is up: frpc running locally and (throttled, or forced with
+        `fresh`) still registered server-side. An unreachable tunnel API reads as alive."""
         assert self._client is not None
         client = self._client
         if not client.is_running:
@@ -88,9 +85,8 @@ class PrimeEndpoint:
         if fresh or now - self._last_registration_check > REGISTRATION_CHECK_INTERVAL:
             self._last_registration_check = now
             try:
-                # Not `client.check_registered()`: deletion is soft server-side (the
-                # record survives as `status="terminated"`, and GET keeps returning it),
-                # so existence alone reads a terminated tunnel as registered.
+                # Deletion is soft server-side (`status="terminated"`, GET still 200),
+                # so probe status rather than `check_registered()`'s existence check.
                 info = await client._client.get_tunnel(client.tunnel_id)
                 if info is None or info.status == "terminated":
                     logger.warning(
@@ -108,9 +104,8 @@ class PrimeEndpoint:
         return True
 
     async def _mint(self) -> None:
-        """Register a fresh tunnel (network-bound and globally rate-capped — 512/min,
-        host-wide via the shared `TUNNEL_LIMITER` — so transient failures are retried);
-        a terminal one raises `TunnelError`."""
+        """Register a fresh tunnel; transient failures are retried, a terminal one
+        raises `TunnelError`."""
         from prime_tunnel import Tunnel as TunnelClient
 
         from verifiers.v1.errors import TunnelError
@@ -123,20 +118,14 @@ class PrimeEndpoint:
                     client = TunnelClient(local_port=self.port)
                     async with TUNNEL_LIMITER:
                         self._url = str(await client.start()).rstrip("/")
-                        # Record the client with no await in between: a cancellation
-                        # landing on the limiter's exit would otherwise orphan the
-                        # started frpc/registration — `close()` only stops what's
-                        # recorded. (A cancellation inside `start()` is the SDK's to
-                        # clean up, and it does.)
-                        self._client = client
+                        self._client = client  # no await in between, or a cancellation orphans the tunnel
         except Exception as e:
             raise TunnelError(f"{label} failed: {e}") from e
         logger.info("prime tunnel up: %s -> 127.0.0.1:%d", self._url, self.port)
 
     async def close(self) -> None:
-        """Stop the *current* frpc client (it changes across heals). Runs the synchronous
-        stop to completion even under cancellation (`run_shielded` re-raises the
-        cancellation after); tunnel-stop failures are best-effort."""
+        """Stop the *current* frpc client (it changes across heals); best-effort and
+        shielded from cancellation."""
         client, self._client = self._client, None
         if client is not None:
             with contextlib.suppress(Exception):

--- a/verifiers/v1/interception/tunnel/prime.py
+++ b/verifiers/v1/interception/tunnel/prime.py
@@ -59,8 +59,13 @@ class PrimeEndpoint:
                 await self._mint()
             return self._url
 
-    async def healthy(self) -> bool:
+    async def healthy(self, url: str) -> bool:
         async with self._lock:
+            # A re-mint changes the URL, so a stale `url` proves the consumer's tunnel
+            # died — even when a concurrent acquire already healed past it. (Without the
+            # anchor, probing the replacement would mask the death.)
+            if url != self._url:
+                return False
             # Torn down (or a heal already failed): it was dead.
             if self._client is None:
                 return False

--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -236,8 +236,8 @@ async def reachable_url(
     elif consumer_is_local:  # local consumer → localhost, no public tunnel
         yield f"http://127.0.0.1:{port}"
     else:  # remote consumer → a host tunnel publishes the port outward
-        async with PrimeTunnel().expose(port) as url:
-            yield url
+        async with PrimeTunnel().expose(port) as endpoint:
+            yield await endpoint.url()
 
 
 @contextlib.asynccontextmanager

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -163,6 +163,7 @@ class RolloutRun:
         self._opened = False
         self._closed = False
         self._endpoint: str | None = None
+        self._base_url: str | None = None
         self._urls: dict[str, str] = {}
         self.deadline_at: float | None = None
         """The active harness segment's absolute deadline (event-loop clock), or
@@ -275,6 +276,7 @@ class RolloutRun:
                     self._shared_tools,
                 )
             )
+            self._base_url = base_url
             self._endpoint = f"{runtime.host_url(base_url)}/v1"
             self._secret = secret
             self._urls = await self._stack.enter_async_context(
@@ -372,12 +374,14 @@ class RolloutRun:
         """The real cause behind a harness exit when the interception tunnel was down:
         the harness's model calls hit a dead tunnel (e.g. the gateway's 404 page) and the
         program died on them — infra, not the agent. Probe the server this rollout is
-        registered on and type it `TunnelError`; an inconclusive probe blames nothing."""
+        registered on, anchored to THIS rollout's slot URL (a concurrent acquire may
+        already have healed the tunnel — at a new URL — and a bare liveness probe would
+        mask the death); an inconclusive probe blames nothing."""
         server = self._session.server
-        if server is None:
+        if server is None or self._base_url is None:
             return None
         with contextlib.suppress(Exception):
-            if not await server.healthy():
+            if not await server.healthy(self._base_url):
                 return TunnelError("interception tunnel was down while the harness ran")
         return None
 

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -372,11 +372,9 @@ class RolloutRun:
 
     async def _tunnel_failure(self) -> RolloutError | None:
         """The real cause behind a harness exit when the interception tunnel was down:
-        the harness's model calls hit a dead tunnel (e.g. the gateway's 404 page) and the
-        program died on them — infra, not the agent. Probe the server this rollout is
-        registered on, anchored to THIS rollout's slot URL (a concurrent acquire may
-        already have healed the tunnel — at a new URL — and a bare liveness probe would
-        mask the death); an inconclusive probe blames nothing."""
+        its model calls hit a dead tunnel — infra, not the agent. Probed against THIS
+        rollout's slot URL (a concurrent acquire may already have healed at a new URL);
+        an inconclusive probe blames nothing."""
         server = self._session.server
         if server is None or self._base_url is None:
             return None

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -34,6 +34,7 @@ from verifiers.v1.errors import (
     RolloutError,
     TaskError,
     ToolsetError,
+    TunnelError,
     boundary,
 )
 from verifiers.v1.harness import Harness
@@ -345,6 +346,8 @@ class RolloutRun:
             return False
         except Exception as e:  # noqa: BLE001 - harness boundary records every rollout failure
             real = self._session.error
+            if real is None and isinstance(e, HarnessError):
+                real = await self._tunnel_failure()
             if real is not None and isinstance(e, RolloutError):
                 real.__cause__ = e
                 self.fail(real)
@@ -364,6 +367,19 @@ class RolloutRun:
         # it as continuable would consult the user against a conversation that
         # never moved, forever.
         return self.ok and trace.num_turns > turns_before
+
+    async def _tunnel_failure(self) -> RolloutError | None:
+        """The real cause behind a harness exit when the interception tunnel was down:
+        the harness's model calls hit a dead tunnel (e.g. the gateway's 404 page) and the
+        program died on them — infra, not the agent. Probe the server this rollout is
+        registered on and type it `TunnelError`; an inconclusive probe blames nothing."""
+        server = self._session.server
+        if server is None:
+            return None
+        with contextlib.suppress(Exception):
+            if not await server.healthy():
+                return TunnelError("interception tunnel was down while the harness ran")
+        return None
 
     async def abort(self) -> None:
         """Free everything this run holds — the entered servers and an owned

--- a/verifiers/v1/session.py
+++ b/verifiers/v1/session.py
@@ -7,6 +7,8 @@ and stashes the real failure on `error`. `RolloutLimits` is the framework's per-
 budget (turns / tokens), checked between turns.
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable
@@ -65,12 +67,12 @@ class RolloutSession:
     trace: Trace
     stops: list[Callable[[Trace], Awaitable[bool]]] = field(default_factory=list)
     limits: RolloutLimits = field(default_factory=RolloutLimits)
-    error: "RolloutError | None" = None
+    error: RolloutError | None = None
     """The latest unresolved model-call failure. The harness only sees it as an HTTP error
     (and may swallow it, or exit non-zero), so the rollout re-raises this original error once the
     harness returns — recording the real `ProviderError` instead of a secondary `HarnessError`.
     Reset before each model turn, so a successful retry clears it."""
-    server: "InterceptionServer | None" = None
+    server: InterceptionServer | None = None
     """The interception server this session is registered on (set by `register`). How the
     rollout, after a harness failure, asks whether the server's tunnel was down
     (`healthy()`) — attributing the failure to the tunnel rather than the harness."""
@@ -84,7 +86,7 @@ class RolloutSession:
     is always of the most recent request — keeping only the last one is sufficient and bounded."""
     last_response: dict | None = None
     """The response returned for `last_request`, replayed verbatim on a retry."""
-    inflight: dict[bytes, "asyncio.Future[dict | None]"] = field(default_factory=dict)
+    inflight: dict[bytes, asyncio.Future[dict | None]] = field(default_factory=dict)
     """Body digest -> the future of the attempt currently computing it. A retry that arrives
     while the first attempt is still in flight (a slow turn) awaits this future instead of
     starting a second inference — the other half of retry atomicity (with `last_response`, which
@@ -95,12 +97,12 @@ class RolloutSession:
     """Set when the rollout unregisters the session: the trace is sealed (its conclusion is
     what scored and persisted), so a handler still in flight must not commit turns, record
     calls, or write state onto it — the in-memory trace must stay what the run produced."""
-    tasks: set["asyncio.Task"] = field(default_factory=set)
+    tasks: set[asyncio.Task] = field(default_factory=set)
     """Handler tasks currently serving this session. aiohttp does not cancel a handler when
     its client disconnects, so a request whose program died at teardown would keep driving
     the exchange (upstream call, simulator turn) — unregistering cancels these instead."""
 
-    def adopt(self, task: "asyncio.Task | None") -> None:
+    def adopt(self, task: asyncio.Task | None) -> None:
         """Track a handler task serving this session, for cancellation at release.
         Callers adopt in the same synchronous stretch that fetched the session, so
         `release()` can't interleave; the released check keeps the seal even if a

--- a/verifiers/v1/session.py
+++ b/verifiers/v1/session.py
@@ -18,6 +18,7 @@ from verifiers.v1.trace import Trace
 
 if TYPE_CHECKING:
     from verifiers.v1.errors import RolloutError
+    from verifiers.v1.interception.server import InterceptionServer
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +70,10 @@ class RolloutSession:
     (and may swallow it, or exit non-zero), so the rollout re-raises this original error once the
     harness returns — recording the real `ProviderError` instead of a secondary `HarnessError`.
     Reset before each model turn, so a successful retry clears it."""
+    server: "InterceptionServer | None" = None
+    """The interception server this session is registered on (set by `register`). How the
+    rollout, after a harness failure, asks whether the server's tunnel was down
+    (`healthy()`) — attributing the failure to the tunnel rather than the harness."""
     last_request: bytes | None = None
     """Digest of the most recently served request body; with `last_response`, the replay cache
     that keeps the message graph atomic under harness-SDK retries. A retry re-sends the

--- a/verifiers/v1/session.py
+++ b/verifiers/v1/session.py
@@ -73,9 +73,8 @@ class RolloutSession:
     harness returns — recording the real `ProviderError` instead of a secondary `HarnessError`.
     Reset before each model turn, so a successful retry clears it."""
     server: InterceptionServer | None = None
-    """The interception server this session is registered on (set by `register`). How the
-    rollout, after a harness failure, asks whether the server's tunnel was down
-    (`healthy()`) — attributing the failure to the tunnel rather than the harness."""
+    """The interception server this session is registered on (set by `register`) — how
+    the rollout attributes a harness failure to a dead tunnel (`healthy()`)."""
     last_request: bytes | None = None
     """Digest of the most recently served request body; with `last_response`, the replay cache
     that keeps the message graph atomic under harness-SDK retries. A retry re-sends the


### PR DESCRIPTION
## Summary
- `Tunnel.expose()` now yields an `Endpoint` handle (`url()` / `healthy(url)`) instead of a URL string — a tunnel's URL is not a constant, so the interception server asks per acquire instead of caching a start-time snapshot.
- `PrimeTunnel`'s endpoint self-heals: `url()` verifies the frpc process on every call and the server-side registration behind a 60s TTL, and re-mints a dead tunnel (through the existing retry + rate-limiter path) at a new public URL before the next rollout gets its slot. The probe reads `get_tunnel().status` rather than `check_registered()` — deletion is soft server-side (`status="terminated"`, GET keeps returning 200), so existence alone reads a terminated tunnel as registered.
- Mid-rollout tunnel death is now typed: on a harness failure the rollout probes the interception server's endpoint, and if the tunnel was down, fails with `TunnelError` — the `HarnessError` (with the gateway's 404 body) chained as cause. Infra drops become retryable and distinguishable from agent failures instead of counting as `HarnessError: bash exited 1: <404 HTML>`.
- The probe is anchored to the failing rollout's own slot URL (`healthy(url)`): a re-mint always changes the URL, so a stale slot URL proves that rollout's tunnel died even when a concurrent acquire has already healed past it — a bare liveness probe would race the heal and misattribute the failure.
- `CustomTunnel` yields a `FixedEndpoint` (always healthy — the operator owns that endpoint); no behavior change.

## Breaking
- `Tunnel.expose()` yields an `Endpoint` instead of `str` — custom `Tunnel` implementations must yield an object with `async url() -> str` / `async healthy(url: str) -> bool` (or a `FixedEndpoint`).
- `InterceptionServer.base_url` is removed; use `await server.url()`.

## Verification
Live evals (`echo-agentic-v1`, bash harness, prime runtime, `-c 1` so rollouts run back-to-back on one shared elastic-pool tunnel), interrupting at a rollout's first intercepted model turn:

- **frpc killed mid-rollout 2** — before: every later rollout on the server would keep failing at its first model call as `HarnessError` with the 404 HTML body. After: rollout 2 fails typed (`stop=TunnelError`, trace records `type: TunnelError` with the 404-HTML `HarnessError` as chained cause), the next acquire re-mints a new tunnel on the same local port, and the remaining rollouts all score `reward=1.000`. Re-run after the anchored-probe fix with the same result.
- **registration terminated server-side mid-rollout 2 of 4** — the gateway routes by the live frpc session, so the data plane survives the soft delete; at the first acquire past the TTL: `registration terminated server-side` → re-mint → `reward=1.000`.
- The heal-vs-probe race (tunnel dies, a concurrent acquire re-mints, the failed rollout probes last) is covered deterministically with a mocked `prime_tunnel` SDK: the stale slot URL reads dead while the replacement reads healthy.

`uv run pytest tests/v1` (64 passed, 63 key-gated skips), `ruff check`, and `pre-commit` green on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add self-healing prime tunnels and typed `TunnelError` failures to rollout
> - Introduces an `Endpoint` protocol in [base.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2158/files#diff-9b479ab70aa7454176615d329f633f68331e6b2d870e2797bf4ef08d85caaa3d) with async `url()` and `healthy()` methods, replacing raw URL strings yielded by `Tunnel.expose()`.
> - Adds `PrimeEndpoint` in [prime.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2158/files#diff-a70cc8fc1aab57c92b0c051b7523f1fa78ca04920046a9b2de1036ca1409dc3e) that auto-heals dead tunnels by reminting a new frpc connection when the existing one is unhealthy, with rate limiting and registration health checks.
> - `InterceptionServer` now stores an `Endpoint` abstraction instead of a static `base_url`, and resolves the public URL dynamically at acquisition time.
> - `RolloutRun` in [rollout.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2158/files#diff-f886b7f4717cf8fce9270bd4ff4790f3182aa1016abb9efb7f6e57efe18d1bf2) detects tunnel outages during harness failures via the new `_tunnel_failure()` method and surfaces them as `TunnelError` instead of generic `HarnessError`.
> - `RolloutSession` gains a `server` field to hold a back-reference to its `InterceptionServer`, enabling post-execution health checks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 34b1b64.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote-eval networking (tunnel lifecycle, error classification on harness failures) and breaks custom `Tunnel` / callers that cached `base_url`, though healing and attribution are scoped to prime tunnels and explicit health probes.
> 
> **Overview**
> **Self-healing prime tunnels and typed infra failures** replace cached tunnel URLs with per-acquire `Endpoint` handles (`url()` / `healthy(url)`). `PrimeEndpoint` re-mints when frpc dies or server-side registration is terminated (status probe, not bare existence), so later rollouts on a shared elastic pool get a fresh public URL without manual restart.
> 
> **Interception and rollouts** resolve `await server.url()` on each slot acquire instead of caching `base_url` at server start. When a harness exits with `HarnessError` and no stashed model error, the rollout probes `healthy()` against **that rollout's** slot URL (stale URL ⇒ dead tunnel even if another acquire already healed), and records **`TunnelError`** with the harness error chained—so 404 HTML from a gone tunnel is retryable infra, not agent failure.
> 
> **Breaking:** `Tunnel.expose()` yields `Endpoint` (custom tunnels need `url()` / `healthy()` or `FixedEndpoint`); `InterceptionServer.base_url` is removed in favor of `await server.url()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34b1b642e96175c6f22b8b31ffd98176cb2091ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


