### PR TITLE
refactor(v1)!: make serving its own config block

### DIFF
--- a/docs/v1/evaluation.md
+++ b/docs/v1/evaluation.md
@@ -40,7 +40,9 @@ The output from evaluations are written into `outputs/<env>--<model>--<harness>/
 - `num_tasks` — how many tasks to evaluate. Not setting a value means all tasks; an
   infinite taskset (a procedural generator, e.g. `wordle-v1`) requires it
 - `num_rollouts` — rollouts per task
-- `max_concurrent` — caps how many episodes are in flight at once (per worker under `--server`); `env.max_concurrent_agents` caps the agent runs inside one episode (1 by default — see [The Env § Concurrency](env.md#concurrency))
+- `max_concurrent` — caps how many episodes are in flight at once; `env.max_concurrent_agents` caps the agent runs inside one episode (1 by default — see [The Env § Concurrency](env.md#concurrency))
+- `[serve]` — how the env is hosted under `--server`: `serve.pool` (worker pool), `serve.address`, and `serve.max_concurrent` (a per-worker episode bound; unset takes `max_concurrent`)
+- `[legacy]` — run a classic (v0) environment through the bridge instead of `[env]`: `legacy.id`, `legacy.args`
 - `verbose` — log at debug instead of info
 - `shuffle` — randomizes the order of tasks (fixed seed); a no-op on an infinite taskset
 

--- a/skills/evaluate-environments/SKILL.md
+++ b/skills/evaluate-environments/SKILL.md
@@ -204,7 +204,7 @@ Do not average these categories together without reporting failure rate.
 For a real v0 package only:
 
 ```bash
-prime eval run --id legacy-env --args.split test -n 5
+prime eval run --legacy.id legacy-env --legacy.args.split test -n 5
 ```
 
-Label the result as bridged v0. Do not present `args` as the v1 config contract.
+Label the result as bridged v0. Do not present `legacy.args` as the v1 config contract.

--- a/skills/evaluate-environments/references/REFERENCE.md
+++ b/skills/evaluate-environments/references/REFERENCE.md
@@ -2,7 +2,7 @@
 
 A complete reference of every settable config field for **evaluating tasksets in `verifiers.v1`**. The config tree is parsed from CLI flags (dotted, e.g. `--env.agent.runtime.type docker`) and/or `@ file.toml` by `prime-pydantic-config`; every field below is settable either way unless noted.
 
-The root config the eval CLI parses is [`EvalConfig`](#evalconfig--the-run). It composes the environment (`env` — the whole `[env]` block: taskset, agents, limits) with the run knobs (model, sampling, counts) and the worker pool. The tree:
+The root config the eval CLI parses is [`EvalConfig`](#evalconfig--the-run). It composes three orthogonal blocks — the environment (`env`: taskset, agents, limits), how it's hosted (`serve`: worker pool, address, per-worker bound), and the classic v0 bridge (`legacy`) — with its own run knobs (model, sampling, counts). The tree:
 
 ```text
 EvalConfig                          (the run)
@@ -20,11 +20,17 @@ EvalConfig                          (the run)
 │  │  └─ max_turns / max_input_tokens / max_output_tokens / max_total_tokens
 │  ├─ timeout: TimeoutConfig        (episode / finalize — the env's own hooks)
 │  ├─ retries: RetryConfig          (whole-episode fallback for faults no agent owns)
+│  ├─ max_concurrent_agents          (agent runs inside one episode — 1 by default)
 │  └─ interception
-└─ pool: PoolConfig                 (static | elastic) — env-server only
+├─ serve: ServingConfig             (how it's hosted — the `--server` path)
+│  ├─ pool: PoolConfig              (static | elastic)
+│  ├─ address                       (where the ROUTER binds)
+│  └─ max_concurrent                (episodes per worker; unset = the run's `-c`)
+└─ legacy: LegacyEnvConfig          (a classic v0 env instead of `env`)
+   └─ id / args / extra_env_kwargs
 ```
 
-There is no run-level harness: each agent pins its own (`--env.agent.harness.*` on the single-agent env), an unpinned agent runs the taskset's default harness (its bundled one, else `bash`), and a declared pin is the env author's default. The retired flat axes error with a pointer: `--taskset.*` → `--env.taskset.*`, `--harness.*` → `--env.<agent>.harness.*`.
+There is no run-level harness: each agent pins its own (`--env.agent.harness.*` on the single-agent env), an unpinned agent runs the taskset's default harness (its bundled one, else `bash`), and a declared pin is the env author's default. The retired flat axes error with a pointer: `--taskset.*` → `--env.taskset.*`, `--harness.*` → `--env.<agent>.harness.*`, `--pool.*` → `--serve.pool.*`, `--address` → `--serve.address`, `--id` / `--args` / `--extra-env-kwargs` → `--legacy.*`.
 
 Sibling entrypoints reuse the same tree: [`ServeConfig`](#serveconfig--the-env-server-cli) (env server) and [`ValidateConfig`](#validateconfig--the-validate-cli) (per-task validation). All three live in `verifiers/v1/configs/cli/`.
 
@@ -32,7 +38,7 @@ Sibling entrypoints reuse the same tree: [`ServeConfig`](#serveconfig--the-env-s
 
 ## EvalConfig — the run
 
-`verifiers/v1/configs/cli/eval.py` — `EvalConfig(EnvServerConfig)`. The single config object the eval CLI parses. Inherits [`EnvServerConfig`](#envserverconfig--the-pool) (the `env` block + `--pool.*` + the legacy v0 fields) and adds the run knobs. Everything environment-shaped lives under `--env.*` / `[env]`.
+`verifiers/v1/configs/cli/eval.py` — `EvalConfig(BaseConfig)`. The single config object the eval CLI parses: it declares [`env`](#envconfig--the-environment), [`serve`](#servingconfig--how-its-hosted) and [`legacy`](#legacy-v0-envs) as blocks and adds the run knobs. Nothing is inherited — the `serve` CLI and a trainer declare the same blocks. Everything environment-shaped lives under `--env.*` / `[env]`.
 
 | Field | Type | Default | Aliases | Notes |
 | --- | --- | --- | --- | --- |
@@ -43,18 +49,18 @@ Sibling entrypoints reuse the same tree: [`ServeConfig`](#serveconfig--the-env-s
 | `num_tasks` | `int \| None` | `None` | `batch_size`, `num_examples`, `num_tasks`, `n` | How many tasks to evaluate (None = all). |
 | `num_rollouts` | `int` | `1` | `group_size`, `rollouts_per_example`, `num_rollouts`, `r` | Independent episodes per task — the trainer's group size. Env-internal fan-out (e.g. best-of-n attempts) is the env's own knob, not `-r`. |
 | `shuffle` | `bool` | `False` | `shuffle`, `s` | Shuffle tasks before taking the first `num_tasks`. |
-| `max_concurrent` | `int \| None` | `128` | `max_concurrent`, `c` | Max rollouts in flight at once. |
+| `max_concurrent` | `int \| None` | `128` (≥1) | `max_concurrent`, `c` | Episodes in flight at once (`None` = no limit). An episode plays its agents one at a time, so this is the live agent runs too — until `--env.max-concurrent-agents` says otherwise. Under `--server` it seeds each worker's bound unless `--serve.max-concurrent` pins one. |
 | `verbose` | `bool` | `False` | `verbose`, `v` | Log at debug level instead of info. |
 | `dry_run` | `bool` | `False` | — | Resolve + validate the config and dump it, then exit. |
 | `rich` | `bool` | `True` | — | Live dashboard instead of per-rollout logs (in-process only). |
-| `server` | `bool` | `False` | — | Drive rollouts through the env-server worker pool (sized by `pool`) instead of in-process — the path prime-rl trains through. Incompatible with `--rich`. |
+| `server` | `bool` | `False` | — | Drive rollouts through the env-server worker pool (sized by `[serve]`) instead of in-process — the path prime-rl trains through. Incompatible with `--rich`. |
 | `push` | `bool` | `True` | — | Upload the finished run to the private Evaluations tab. Disable with `--no-push`. |
 | `output_dir` | `Path \| None` | `None` | `output_dir`, `o` | Where to write the run (`config.toml` + `traces.jsonl`). None = a fresh per-run dir under `outputs/<env>--<model>--<harness>/<uuid>`. |
 | `resume` | `Path \| None` | `None` | — | Set by `--resume <dir>`: re-run missing/errored rollouts, episode-atomically (a multi-trace rollout is kept or redone as a unit; `Env.complete` is the keep verdict). Excluded from the saved config; takes no other args. |
 
 Validator: `--rich` + `--server` together is rejected (the dashboard is in-process only).
 
-Inherited from `EnvServerConfig`: [`env`](#envconfig--the-environment), [`pool`](#pool-config), and the legacy `id` / `args` / `extra_env_kwargs`.
+Blocks: [`env`](#envconfig--the-environment), [`serve`](#servingconfig--how-its-hosted), [`legacy`](#legacy-v0-envs). Derived: `is_legacy` (a `legacy.id` and no v1 taskset), `env_id` (the env's id, else the v0 one), `worker_max_concurrent` (`serve.max_concurrent`, else `max_concurrent`).
 
 ---
 
@@ -137,9 +143,9 @@ Per-run caps (turns, tokens, stage timeouts, retries) are agent fields, not env 
 
 Trainability is not a config field: it is env truth, set in place by the env's `setup(agents)` hook (default: every agent trains) and stamped on each trace. An env that wants the flip run-configurable exposes its own switch (e.g. proposer-solver's `--env.train_solver false`).
 
-### Legacy (v0) backwards-compat fields
+### Legacy (v0) envs
 
-On `EnvServerConfig` (below): set `id` (leave `env.taskset` unset) to run a classic `verifiers.load_environment` env through the legacy bridge.
+`verifiers/v1/configs/legacy.py` — `LegacyEnvConfig(BaseConfig)`, the `[legacy]` block. Set `legacy.id` (and leave `env.taskset` unset) to run a classic `verifiers.load_environment` env through the bridge. A v0 id next to a v1 taskset is refused, not silently ignored.
 
 | Field | Type | Default | Notes |
 | --- | --- | --- | --- |
@@ -147,16 +153,17 @@ On `EnvServerConfig` (below): set `id` (leave `env.taskset` unset) to run a clas
 | `args` | `dict` | `{}` | Construction kwargs forwarded to `load_environment(id, **args)`. |
 | `extra_env_kwargs` | `dict` | `{}` | Post-load kwargs applied via `env.set_kwargs(**...)` (e.g. `max_total_completion_tokens`, `max_seq_len`, `timeout_seconds`). |
 
-`EnvServerConfig.is_legacy` → `id is not None and no v1 taskset`.
+`is_legacy` → a `legacy.id` is set and no v1 taskset.
 
-### EnvServerConfig — the pool
+### ServingConfig — how it's hosted
 
-`EnvServerConfig(BaseConfig)`. The `env` block plus the worker pool sizing and the legacy v0 fields. Shared by the `serve` CLI, server-backed eval, and prime-rl's orchestrator.
+`verifiers/v1/configs/serve.py` — `ServingConfig(BaseConfig)`, the `[serve]` block. Read by whoever hosts the env: the `serve` CLI, a server-backed eval, a trainer's orchestrator. An in-process eval ignores it.
 
 | Field | Type | Default | Notes |
 | --- | --- | --- | --- |
-| `env` | `EnvConfig` | `SingleAgentEnvConfig()` | The environment (above). `SerializeAsAny`, so the resolved subclass's agents and knobs survive `model_dump` onto the wire. |
-| `pool` | `PoolConfig` | `ElasticPoolConfig()` | See [Pool config](#pool-config). |
+| `pool` | `PoolConfig` | `ElasticPoolConfig()` | Worker-pool sizing — see [Pool config](#pool-config). |
+| `address` | `str` | `"tcp://127.0.0.1:5000"` | ZMQ address the ROUTER binds (and clients connect to). |
+| `max_concurrent` | `int \| None` | `None` (≥1) | Episodes in flight per worker. None = take the run's own bound (an eval's `-c`). |
 
 ---
 
@@ -195,7 +202,7 @@ Rerun when the run ends with a captured error. Matching is by the error's **exce
 
 ## Pool config
 
-`verifiers/v1/configs/cli/env.py`. Discriminated on `type`; selected with `--pool.type static|elastic`. Drives the env-server worker pool (the `--server` path).
+`verifiers/v1/configs/serve.py`. Discriminated on `type`; selected with `--serve.pool.type static|elastic`. Drives the env-server worker pool (the `--server` path).
 
 ### `StaticPoolConfig` — `type: "static"`
 
@@ -212,7 +219,7 @@ Elastic pool: start at one worker and scale up on demand.
 | Field | Type | Default | Notes |
 | --- | --- | --- | --- |
 | `max_workers` | `int \| None` | `None` | Upper bound on workers (None = unbounded). |
-| `multiplex` | `int` | `128` (≥1) | Rollouts per worker for the scale-up trigger: add a worker once in-flight rollouts reach 90% of `workers * multiplex`. |
+| `multiplex` | `int` | `128` (≥1) | Episodes per worker for the scale-up trigger: add a worker once in-flight episodes reach 90% of `workers * multiplex`. |
 
 ---
 
@@ -534,15 +541,14 @@ A judge class may define:
 
 ## ServeConfig — the env-server CLI
 
-`verifiers/v1/configs/serve.py` — `ServeConfig(EnvServerConfig)`. The env-server CLI. Inherits the `env` block + pool, so `--env.*` / `--pool.*` are the same flags as eval. Adds only CLI-specific serving knobs.
+`verifiers/v1/configs/cli/serve.py` — `ServeConfig(BaseConfig)`. The env-server CLI. Declares the same blocks as eval — [`env`](#envconfig--the-environment), [`serve`](#servingconfig--how-its-hosted), [`legacy`](#legacy-v0-envs) — so `--env.*` / `--serve.*` are the same flags there, and adds only its own two.
 
 | Field | Type | Default | Aliases | Notes |
 | --- | --- | --- | --- | --- |
-| `address` | `str` | `"tcp://127.0.0.1:5000"` | `address`, `a` | ZMQ address the ROUTER binds. |
 | `verbose` | `bool` | `False` | `verbose`, `v` | Log at debug level. |
 | `dry_run` | `bool` | `False` | — | Resolve + validate and dump, then exit. |
 
-Plus all inherited `EnvServerConfig` fields (`env`, `pool`, legacy).
+Where it binds is `--serve.address`; how many workers is `--serve.pool.*`.
 
 ---
 
@@ -584,7 +590,7 @@ Use `only_gold` or `only_setup` to select one mode; setting both is rejected. Th
 - **Plugin resolution.** The run's `env` field narrows to the selected env's config class
   (`--env.id`, else the taskset's exported env, else `SingleAgentEnvConfig`) *before* validation; inside it, `taskset` narrows by its id and each pinned agent `harness` by its id. Entries in `TaskConfig.judges` are similarly narrowed by each judge `id`. This is why local and Hub plugin fields remain typed and appear in CLI validation instead of living in an untyped arguments dictionary.
 - **Dotted flags.** Every nested field is part of the same CLI tree
-  (`--env.agent.runtime.type docker`, `--env.taskset.split test`, `--pool.max_workers 8`, `--env.agent.retries.max_retries 2`). An `@ file.toml` describes the identical tree; explicit CLI values layer over values loaded from the file.
+  (`--env.agent.runtime.type docker`, `--env.taskset.split test`, `--serve.pool.max-workers 8`, `--env.agent.retries.max_retries 2`). An `@ file.toml` describes the identical tree; explicit CLI values layer over values loaded from the file.
 - **Runtime precedence.** An explicit, non-default CLI/TOML `workdir` or resource field wins over
   `TaskData`; otherwise a non-`None` row value fills it, and otherwise the runtime/provider default remains. `TaskData.image` is the required image for that row and replaces the runtime's base image. Unsupported resource fields are ignored; evaluation warns once per runtime/field.
 - **Timeout precedence.** For eval stages, a non-`None` agent-level `TimeoutConfig` value

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -14,16 +14,17 @@ from verifiers.v1.clients import (
     resolve_client,
 )
 from verifiers.v1.configs.agent import AgentConfig
-from verifiers.v1.configs.cli.env import (
-    ElasticPoolConfig,
-    EnvServerConfig,
-    StaticPoolConfig,
-    pool_serve_kwargs,
-)
 from verifiers.v1.configs.env import EnvConfig, default_agent_harness
 from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.configs.judge import JudgeConfig, Judges
+from verifiers.v1.configs.legacy import LegacyEnvConfig
 from verifiers.v1.configs.retries import RetryConfig
+from verifiers.v1.configs.serve import (
+    ElasticPoolConfig,
+    ServingConfig,
+    StaticPoolConfig,
+    pool_serve_kwargs,
+)
 from verifiers.v1.configs.task import TaskConfig
 from verifiers.v1.configs.taskset import TasksetConfig
 from verifiers.v1.decorators import metric, reward, stop, tool
@@ -248,7 +249,8 @@ __all__ = [  # noqa: RUF022 - grouped by public API area
     "Env",
     "SingleAgentEnv",
     "EnvConfig",
-    "EnvServerConfig",
+    "ServingConfig",
+    "LegacyEnvConfig",
     "SingleAgentEnvConfig",
     "AgentConfig",
     "StaticPoolConfig",

--- a/verifiers/v1/cli/eval/main.py
+++ b/verifiers/v1/cli/eval/main.py
@@ -24,7 +24,7 @@ from verifiers.v1.utils.logging import setup_logging
 logger = logging.getLogger(__name__)
 
 USAGE = (
-    "usage: uv run eval [<taskset-id>] [--env.id <id>] [--id <env-id> (legacy)] [options] [@ file.toml]\n"
+    "usage: uv run eval [<taskset-id>] [--env.id <id>] [--legacy.id <env-id> (v0)] [options] [@ file.toml]\n"
     "       uv run eval --resume <output-dir>   (re-run a previous run's missing/errored rollouts)"
 )
 
@@ -49,12 +49,15 @@ def main(argv: list[str] | None = None) -> None:
             )
         config = load_resume_config(resume_dir)
     else:
-        legacy_id = any(a == "--id" or a.startswith("--id=") for a in argv)  # v0 env id
+        legacy_id = any(
+            a == "--legacy.id" or a.startswith("--legacy.id=") for a in argv
+        )
         # An env-block flag (or a retired flat axis) skips the usage gate so the
         # typed parse renders its did-you-mean / pointer to the new flags instead
         # of a bare usage line.
         typed_axis = any(
-            a.startswith(("--env.", "--taskset.", "--harness.")) for a in argv
+            a.startswith(("--env.", "--taskset.", "--harness.", "--serve."))
+            for a in argv
         )
         if (
             not extract_id(argv, "env.taskset")
@@ -64,7 +67,7 @@ def main(argv: list[str] | None = None) -> None:
         ):
             raise SystemExit(
                 USAGE
-            )  # need a taskset (positional / --env.taskset.id), a legacy --id, or a @ file.toml
+            )  # need a taskset (positional / --env.taskset.id), a v0 --legacy.id, or a @ file.toml
 
         with plugin_errors():
             config_type = narrow_config(EvalConfig, argv)

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -107,23 +107,23 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
     import multiprocessing as mp
     from functools import partial
 
-    from verifiers.v1.configs.cli.env import pool_serve_kwargs
+    from verifiers.v1.configs.serve import pool_serve_kwargs
     from verifiers.v1.serve import EnvClient, env_config_data, serve_env
     from verifiers.v1.utils.logging import setup_logging
 
     legacy = config.is_legacy
     server_kwargs = (
         {
-            "env_id": config.id,
-            "env_args": config.args,
-            "extra_env_kwargs": config.extra_env_kwargs,
+            "env_id": config.legacy.id,
+            "env_args": config.legacy.args,
+            "extra_env_kwargs": config.legacy.extra_env_kwargs,
         }
         if legacy
         else {
             "config_data": env_config_data(config.env),  # picklable across the spawn
-            # `-c` is the episode bound here too, per worker — so a pool carries
-            # `workers * max_concurrent` episodes, as the pool's `multiplex` implies.
-            "max_concurrent": config.max_concurrent,
+            # `-c` seeds each worker's episode bound unless `[serve]` pins one — so a
+            # pool carries `workers * bound` episodes, as `multiplex` implies.
+            "max_concurrent": config.worker_max_concurrent,
         }
     )
     tasks = []
@@ -147,7 +147,7 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
     proc = mpctx.Process(
         target=serve_env,
         kwargs=dict(
-            **pool_serve_kwargs(config.pool),
+            **pool_serve_kwargs(config.serve.pool),
             legacy=legacy,
             address="tcp://127.0.0.1:0",
             address_queue=address_queue,
@@ -215,7 +215,7 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
                 "running %dx%d rollouts via the env-server %s pool on %s",
                 len(plan),
                 config.num_rollouts,
-                config.pool.type,
+                config.serve.pool.type,
                 config.model,
             )
         logger.info("results: %s", out)

--- a/verifiers/v1/cli/serve.py
+++ b/verifiers/v1/cli/serve.py
@@ -12,12 +12,12 @@ from verifiers.v1.cli.resolve import (
     references_config_file,
     with_positional_taskset,
 )
-from verifiers.v1.configs.cli.env import pool_serve_kwargs
 from verifiers.v1.configs.cli.serve import ServeConfig
+from verifiers.v1.configs.serve import pool_serve_kwargs
 from verifiers.v1.serve import serve_env
 from verifiers.v1.utils.logging import setup_logging
 
-USAGE = "usage: uv run serve [<taskset-id>] [--env.id <id>] [--id <env-id> (legacy)] [options] [@ file.toml]"
+USAGE = "usage: uv run serve [<taskset-id>] [--env.id <id>] [--legacy.id <env-id> (v0)] [options] [@ file.toml]"
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -29,11 +29,13 @@ def main(argv: list[str] | None = None) -> None:
         with plugin_errors():
             cli(narrow_config(ServeConfig, argv))
         return
-    legacy_id = any(a == "--id" or a.startswith("--id=") for a in argv)  # v0 env id
+    legacy_id = any(a == "--legacy.id" or a.startswith("--legacy.id=") for a in argv)
     # An env-block flag (or a retired flat axis) skips the usage gate so the typed
     # parse renders its did-you-mean / pointer to the new flags instead of a bare
     # usage line.
-    typed_axis = any(a.startswith(("--env.", "--taskset.", "--harness.")) for a in argv)
+    typed_axis = any(
+        a.startswith(("--env.", "--taskset.", "--harness.", "--serve.")) for a in argv
+    )
     if (
         not extract_id(argv, "env.taskset")
         and not legacy_id
@@ -42,7 +44,7 @@ def main(argv: list[str] | None = None) -> None:
     ):
         raise SystemExit(
             USAGE
-        )  # need a taskset (positional / --env.taskset.id), a legacy --id, or @ file.toml
+        )  # need a taskset (positional / --env.taskset.id), a v0 --legacy.id, or @ file.toml
 
     with plugin_errors():
         config_type = narrow_config(ServeConfig, argv)
@@ -60,19 +62,19 @@ def main(argv: list[str] | None = None) -> None:
     # in each one.
     server_kwargs = (
         {
-            "env_id": config.id,
-            "env_args": config.args,
-            "extra_env_kwargs": config.extra_env_kwargs,
+            "env_id": config.legacy.id,
+            "env_args": config.legacy.args,
+            "extra_env_kwargs": config.legacy.extra_env_kwargs,
         }
         if config.is_legacy
-        # `--max-concurrent` is each v1 worker's episode bound; the legacy bridge
-        # has never had one.
-        else {"config": config.env, "max_concurrent": config.max_concurrent}
+        # `--serve.max-concurrent` is each v1 worker's episode bound; the legacy
+        # bridge has never had one.
+        else {"config": config.env, "max_concurrent": config.serve.max_concurrent}
     )
     serve_env(
-        **pool_serve_kwargs(config.pool),
+        **pool_serve_kwargs(config.serve.pool),
         legacy=config.is_legacy,
-        address=config.address,
+        address=config.serve.address,
         log_setup=partial(setup_logging, level),
         **server_kwargs,
     )

--- a/verifiers/v1/configs/cli/env.py
+++ b/verifiers/v1/configs/cli/env.py
@@ -1,41 +1,54 @@
-"""Run-config plumbing around the `[env]` block: narrowing the `env` field of the
-configs that own one, and how a served env sizes its worker pool."""
+"""Run-config plumbing around the `[env]` block: narrowing the `env` field of every
+config that owns one, and the retired keys such a config refuses.
 
-from typing import Annotated, Literal
+A run composes the blocks it needs — `[env]` (what runs, `configs/env.py`),
+`[serve]` (how it's hosted, `configs/serve.py`), `[legacy]` (the v0 bridge,
+`configs/legacy.py`) — plus its own fields. Nothing here is a base class: the eval
+CLI, the `serve` CLI, GEPA and a trainer each declare their blocks and call these."""
 
-from pydantic import (
-    AliasChoices,
-    Field,
-    SerializeAsAny,
-    ValidationError,
-    model_validator,
-)
+from pydantic import Field, SerializeAsAny, ValidationError
 from pydantic_config import BaseConfig
 
 from verifiers.v1.configs.env import EnvConfig
-from verifiers.v1.types import ID
 from verifiers.v1.utils.generic import prefix_validation_error
+
+RETIRED = {
+    "taskset": "the taskset lives on the env: --env.taskset.id <id> (TOML: "
+    "[env.taskset]), or the positional `eval <taskset-id>`",
+    "harness": "a harness belongs to an agent: --env.agent.harness.* on the "
+    "single-agent env, --env.<agent>.harness.* on a multi-agent one (TOML: "
+    "[env.agent.harness])",
+    "pool": "the worker pool is serving, not the env: --serve.pool.type "
+    "elastic|static (TOML: [serve.pool])",
+    "address": "the bind address is serving, not the env: --serve.address "
+    "(TOML: address under [serve])",
+    "id": "a classic (v0) env is its own block: --legacy.id <env-id>; pairing a "
+    "reusable v1 env with a taskset is --env.id",
+    "args": "v0 construction kwargs live with the v0 env: --legacy.args",
+    "extra_env_kwargs": "v0 post-load kwargs live with the v0 env: "
+    "--legacy.extra-env-kwargs",
+}
+"""Top-level keys a run config no longer owns, each pointing at its home. Every one
+would otherwise fail as a bare `extra_forbidden`, saying nothing about where it went."""
+
+
+def env_field() -> Field:  # type: ignore[valid-type]
+    """The `env` field every run config declares: the single-agent shape by default,
+    `SerializeAsAny` so a narrowed subclass's agents and knobs survive `model_dump()`
+    (see `EnvConfig.taskset`)."""
+    return Field(default_factory=_single_agent_env_config)
 
 
 def resolve_env_field(data: dict, narrowed: "type[EnvConfig] | None" = None) -> dict:
-    """Shared `mode="before"` body for every run config owning an `env` field
-    (`EnvServerConfig`, `GEPAConfig`): refuse the retired top-level axes with a
-    pointer home, and narrow `env` to the concrete env's config class. `narrowed`
-    is the annotation the CLI pre-resolved (`narrow_config`) — its id is
-    authoritative, so validate against it directly."""
+    """Shared `mode="before"` body for every run config owning an `env` field: refuse
+    the retired top-level keys with a pointer home, and narrow `env` to the concrete
+    env's config class. `narrowed` is the annotation the CLI pre-resolved
+    (`narrow_config`) — its id is authoritative, so validate against it directly."""
     if not isinstance(data, dict):
         return data
-    if "taskset" in data:
-        raise ValueError(
-            "the taskset lives on the env now: --env.taskset.id <id> "
-            "(TOML: [env.taskset]), or the positional `eval <taskset-id>`"
-        )
-    if "harness" in data:
-        raise ValueError(
-            "a harness belongs to an agent now: --env.agent.harness.* on the "
-            "single-agent env, --env.<agent>.harness.* on a multi-agent one "
-            "(TOML: [env.agent.harness])"
-        )
+    for key, pointer in RETIRED.items():
+        if key in data:
+            raise ValueError(pointer)
     raw = data.get("env")
     if raw is None:
         return data
@@ -71,42 +84,6 @@ def narrowed_env_annotation(cls) -> "type[EnvConfig] | None":
     return None
 
 
-class StaticPoolConfig(BaseConfig):
-    """Fixed env-server pool: pre-spawn `num_workers` workers up front."""
-
-    type: Literal["static"] = "static"
-    num_workers: int = Field(4, ge=1)
-    """Worker processes to pre-spawn (1 = a single in-process server, no pool)."""
-
-
-class ElasticPoolConfig(BaseConfig):
-    """Elastic env-server pool: start at one worker and scale up on demand."""
-
-    type: Literal["elastic"] = "elastic"
-    max_workers: int | None = None
-    """Upper bound on workers (None = unbounded)."""
-    multiplex: int = Field(128, ge=1)
-    """Episodes per worker for the scale-up trigger: add a worker once in-flight episodes
-    reach 90% of `workers * multiplex`."""
-
-
-# Discriminated on `type` so the CLI selects with `--pool.type static|elastic`.
-PoolConfig = Annotated[
-    StaticPoolConfig | ElasticPoolConfig, Field(discriminator="type")
-]
-
-
-def pool_serve_kwargs(pool: StaticPoolConfig | ElasticPoolConfig) -> dict:
-    """Unpack a pool config into `serve_env` kwargs (`max_workers` / `multiplex` / `elastic`)."""
-    if isinstance(pool, ElasticPoolConfig):
-        return {
-            "max_workers": pool.max_workers,
-            "multiplex": pool.multiplex,
-            "elastic": True,
-        }
-    return {"max_workers": pool.num_workers, "elastic": False}
-
-
 def _single_agent_env_config() -> EnvConfig:
     """The default `env` block: the single-agent shape. Lazy — the concrete env
     lives in `envs/`, which imports `env.py`."""
@@ -115,67 +92,5 @@ def _single_agent_env_config() -> EnvConfig:
     return SingleAgentEnvConfig()
 
 
-class EnvServerConfig(BaseConfig):
-    """A run's environment plus how it's *served*: the `env` block and the worker-pool
-    sizing. Shared by the `serve` CLI, server-backed eval, and prime-rl's orchestrator, so
-    they all configure the pool the same way (`--pool.type elastic|static`)."""
-
-    # SerializeAsAny: see EnvConfig.taskset — model_dump() must keep the subclass's
-    # agent fields and knobs.
-    env: SerializeAsAny[EnvConfig] = Field(default_factory=_single_agent_env_config)
-    """The environment — the run's `[env]` block: which env, its seed taskset, each
-    agent, its knobs, and the run limits. Narrowed to the selected env's config
-    class by the env id, else the taskset id."""
-    pool: PoolConfig = Field(default_factory=ElasticPoolConfig)
-    """Worker-pool sizing for the env server. `elastic` (default) starts at one worker and
-    scales up on demand; `static` pre-spawns a fixed `num_workers`."""
-    max_concurrent: int | None = Field(
-        None,
-        ge=1,
-        validation_alias=AliasChoices("max_concurrent", "max_concurrent_episodes"),
-    )
-    """Episodes in flight at once, per worker (None = no limit). The episode is the unit
-    here; how many agent runs one episode carries is the env's own
-    (`--env.max-concurrent-agents`, one at a time by default)."""
-    # --- legacy (v0) backwards-compat -----------------------------------------
-    id: ID | None = None
-    """Classic (v0) env id (`name`, `org/name`, or `org/name@version` — installed from the
-    hub on demand), loaded via `verifiers.load_environment` and run through the legacy
-    bridge. Set this *instead of* `env.taskset` to run a v0 environment."""
-    args: dict = Field(default_factory=dict)
-    """Construction kwargs forwarded to `load_environment(id, **args)`."""
-    extra_env_kwargs: dict = Field(default_factory=dict)
-    """Post-load kwargs applied to the v0 env via `env.set_kwargs(**extra_env_kwargs)` (e.g.
-    `max_total_completion_tokens`, `max_seq_len`, `timeout_seconds`) — typically
-    auto-populated by the orchestrator, distinct from the `args` passed at construction."""
-
-    @property
-    def is_legacy(self) -> bool:
-        """A v0/legacy env (run via the bridge): a legacy `id` is set and no v1 taskset."""
-        return self.id is not None and not self.env.taskset.id
-
-    @property
-    def env_id(self) -> str:
-        """The run's identifier: the v1 env's (`EnvConfig.env_id`), else the legacy
-        v0 env id."""
-        return self.env.env_id or self.id or ""
-
-    @model_validator(mode="after")
-    def _refuse_legacy_id_with_taskset(self):
-        """A legacy `id` next to a v1 `env.taskset` would be silently inert
-        (`is_legacy` is False and the v0 env never loads); refuse the mix."""
-        if self.id is not None and self.env.taskset.id:
-            raise ValueError(
-                f"--id {self.id!r} is the legacy (v0) env id and can't combine with "
-                f"the v1 taskset {self.env.taskset.id!r}. Pairing an env with a "
-                f"taskset is --env.id {self.id!r} (TOML: id under [env]); to run the "
-                "v0 env instead, drop the taskset."
-            )
-        return self
-
-    # --- end legacy -----------------------------------------------------------
-
-    @model_validator(mode="before")
-    @classmethod
-    def _resolve_env(cls, data):
-        return resolve_env_field(data, narrowed_env_annotation(cls))
+EnvField = SerializeAsAny[EnvConfig]
+"""Annotation for a run config's `env` field: `env: EnvField = env_field()`."""

--- a/verifiers/v1/configs/cli/eval.py
+++ b/verifiers/v1/configs/cli/eval.py
@@ -4,13 +4,34 @@ from pathlib import Path
 from uuid import uuid4
 
 from pydantic import AliasChoices, Field, model_validator
+from pydantic_config import BaseConfig
 
 from verifiers.v1.clients import ClientConfig, EvalClientConfig
-from verifiers.v1.configs.cli.env import EnvServerConfig
+from verifiers.v1.configs.cli.env import (
+    EnvField,
+    env_field,
+    narrowed_env_annotation,
+    resolve_env_field,
+)
+from verifiers.v1.configs.legacy import (
+    LegacyEnvConfig,
+    is_legacy,
+    refuse_mixed_run,
+    run_env_id,
+)
+from verifiers.v1.configs.serve import ServingConfig
 from verifiers.v1.types import SamplingConfig
 
 
-class EvalConfig(EnvServerConfig):
+class EvalConfig(BaseConfig):
+    env: EnvField = env_field()
+    """The environment — which env, its seed taskset, each agent, its knobs. Narrowed to
+    the selected env's config class by the env id, else the taskset id."""
+    serve: ServingConfig = ServingConfig()
+    """How the env is hosted under `--server`: the worker pool, each worker's episode
+    bound. Ignored by an in-process run."""
+    legacy: LegacyEnvConfig = LegacyEnvConfig()
+    """A classic (v0) environment to evaluate through the bridge instead of `[env]`."""
     uuid: str = Field(default_factory=lambda: str(uuid4()), exclude=True)
     """Auto-generated run id — the leaf of the output dir, so runs never overwrite.
     Excluded from the saved config so re-running `@ config.toml` lands in a fresh dir."""
@@ -39,9 +60,10 @@ class EvalConfig(EnvServerConfig):
     max_concurrent: int | None = Field(
         128, ge=1, validation_alias=AliasChoices("max_concurrent", "c")
     )
-    """Episodes in flight at once (per worker under `--server`), `None` for no limit. An
-    episode plays its agents one at a time, so this is the live agent runs too — until
-    `--env.max-concurrent-agents` says otherwise."""
+    """Episodes in flight at once, `None` for no limit. An episode plays its agents one
+    at a time, so this is the live agent runs too — until `--env.max-concurrent-agents`
+    says otherwise. Under `--server` it seeds each worker's bound, unless
+    `--serve.max-concurrent` pins one."""
     verbose: bool = Field(False, validation_alias=AliasChoices("verbose", "v"))
     """Log at debug level instead of the default info."""
     dry_run: bool = Field(False, exclude=True)
@@ -51,7 +73,7 @@ class EvalConfig(EnvServerConfig):
     """Show a live dashboard instead of per-rollout logs (in-process only; an unset
     `rich` defaults off under `--server`)."""
     server: bool = False
-    """Drive rollouts through the env-server worker pool (sized by `--pool.*`) instead of
+    """Drive rollouts through the env-server worker pool (sized by `[serve]`) instead of
     in-process — the path prime-rl trains through. Incompatible with `--rich`."""
     push: bool = True
     """Upload the finished run to the Prime Intellect platform (the private Evaluations
@@ -82,3 +104,30 @@ class EvalConfig(EnvServerConfig):
                 "`--server`; drop `--rich`."
             )
         return self
+
+    @property
+    def is_legacy(self) -> bool:
+        return is_legacy(self.env, self.legacy)
+
+    @property
+    def env_id(self) -> str:
+        return run_env_id(self.env, self.legacy)
+
+    @property
+    def worker_max_concurrent(self) -> int | None:
+        """A served worker's episode bound: its own pin, else the run's `--max-concurrent`."""
+        return (
+            self.serve.max_concurrent
+            if self.serve.max_concurrent is not None
+            else self.max_concurrent
+        )
+
+    @model_validator(mode="after")
+    def _refuse_mixed_run(self):
+        refuse_mixed_run(self.env, self.legacy)
+        return self
+
+    @model_validator(mode="before")
+    @classmethod
+    def _resolve_env(cls, data):
+        return resolve_env_field(data, narrowed_env_annotation(cls))

--- a/verifiers/v1/configs/cli/serve.py
+++ b/verifiers/v1/configs/cli/serve.py
@@ -1,16 +1,53 @@
 """Environment-server CLI configuration."""
 
-from pydantic import AliasChoices, Field
+from pydantic import AliasChoices, Field, model_validator
+from pydantic_config import BaseConfig
 
-from verifiers.v1.configs.cli.env import EnvServerConfig
+from verifiers.v1.configs.cli.env import (
+    EnvField,
+    env_field,
+    narrowed_env_annotation,
+    resolve_env_field,
+)
+from verifiers.v1.configs.legacy import (
+    LegacyEnvConfig,
+    is_legacy,
+    refuse_mixed_run,
+    run_env_id,
+)
+from verifiers.v1.configs.serve import ServingConfig
 
 
-class ServeConfig(EnvServerConfig):
-    address: str = Field(
-        "tcp://127.0.0.1:5000", validation_alias=AliasChoices("address", "a")
-    )
-    """ZMQ address the ROUTER binds (and clients connect to)."""
+class ServeConfig(BaseConfig):
+    """`uv run serve`: what to serve (`[env]`, or `[legacy]` for a classic v0 env) and
+    how it's hosted (`[serve]`)."""
+
+    env: EnvField = env_field()
+    """The environment — which env, its seed taskset, each agent, its knobs. Narrowed to
+    the selected env's config class by the env id, else the taskset id."""
+    serve: ServingConfig = ServingConfig()
+    """How it's served: the worker pool, the bind address, each worker's episode bound."""
+    legacy: LegacyEnvConfig = LegacyEnvConfig()
+    """A classic (v0) environment to serve through the bridge instead of `[env]`."""
     verbose: bool = Field(False, validation_alias=AliasChoices("verbose", "v"))
     """Log at debug level instead of info."""
     dry_run: bool = False
     """Resolve + validate the config and dump it, then exit."""
+
+    @property
+    def is_legacy(self) -> bool:
+        return is_legacy(self.env, self.legacy)
+
+    @property
+    def env_id(self) -> str:
+        return run_env_id(self.env, self.legacy)
+
+    @model_validator(mode="after")
+    def _refuse_mixed_run(self):
+        refuse_mixed_run(self.env, self.legacy)
+        return self
+
+    @model_validator(mode="before")
+    @classmethod
+    def _resolve_env(cls, data):
+        return resolve_env_field(data, narrowed_env_annotation(cls))

--- a/verifiers/v1/configs/legacy.py
+++ b/verifiers/v1/configs/legacy.py
@@ -1,0 +1,47 @@
+"""The `[legacy]` block: running a classic (v0) environment through the bridge.
+
+Quarantined in its own block, not mixed into `[env]` — a v0 env is a different
+thing to run, not a variant of a v1 env's config."""
+
+from pydantic import Field
+from pydantic_config import BaseConfig
+
+from verifiers.v1.configs.env import EnvConfig
+from verifiers.v1.types import ID
+
+
+class LegacyEnvConfig(BaseConfig):
+    """A classic (v0) `verifiers` environment, loaded via `verifiers.load_environment`
+    and run through the legacy bridge. Set `id` *instead of* a v1 `env.taskset`."""
+
+    id: ID | None = None
+    """v0 env id: `name`, `org/name`, or `org/name@version` — installed from the hub on
+    demand."""
+    args: dict = Field(default_factory=dict)
+    """Construction kwargs forwarded to `load_environment(id, **args)`."""
+    extra_env_kwargs: dict = Field(default_factory=dict)
+    """Post-load kwargs applied via `env.set_kwargs(**extra_env_kwargs)` (e.g.
+    `max_total_completion_tokens`, `max_seq_len`, `timeout_seconds`) — typically
+    auto-populated by a trainer, distinct from the `args` passed at construction."""
+
+
+def is_legacy(env: EnvConfig, legacy: LegacyEnvConfig) -> bool:
+    """Whether this run goes through the v0 bridge: a legacy id is set and no v1 taskset."""
+    return legacy.id is not None and not env.taskset.id
+
+
+def run_env_id(env: EnvConfig, legacy: LegacyEnvConfig) -> str:
+    """The run's identifier: the v1 env's (`EnvConfig.env_id`), else the v0 env id."""
+    return env.env_id or legacy.id or ""
+
+
+def refuse_mixed_run(env: EnvConfig, legacy: LegacyEnvConfig) -> None:
+    """Refuse a v0 id next to a v1 taskset: `is_legacy` would be False and the v0 env
+    would never load, so the id would sit there silently inert."""
+    if legacy.id is not None and env.taskset.id:
+        raise ValueError(
+            f"--legacy.id {legacy.id!r} is a classic (v0) env and can't combine with "
+            f"the v1 taskset {env.taskset.id!r}. Pairing a reusable env with a taskset "
+            f"is --env.id {legacy.id!r} (TOML: id under [env]); to run the v0 env "
+            "instead, drop the taskset."
+        )

--- a/verifiers/v1/configs/serve.py
+++ b/verifiers/v1/configs/serve.py
@@ -1,0 +1,63 @@
+"""How an env is served: the worker pool, where it binds, and each worker's bound.
+
+Serving is its own axis. `[env]` says what runs; this says how it's hosted, so an
+eval, a `serve` process, and a trainer configure it identically instead of each
+flattening pool knobs onto its own config."""
+
+from typing import Annotated, Literal
+
+from pydantic import Field
+from pydantic_config import BaseConfig
+
+
+class StaticPoolConfig(BaseConfig):
+    """Fixed env-server pool: pre-spawn `num_workers` workers up front."""
+
+    type: Literal["static"] = "static"
+    num_workers: int = Field(4, ge=1)
+    """Worker processes to pre-spawn (1 = a single in-process server, no pool)."""
+
+
+class ElasticPoolConfig(BaseConfig):
+    """Elastic env-server pool: start at one worker and scale up on demand."""
+
+    type: Literal["elastic"] = "elastic"
+    max_workers: int | None = None
+    """Upper bound on workers (None = unbounded)."""
+    multiplex: int = Field(128, ge=1)
+    """Episodes per worker for the scale-up trigger: add a worker once in-flight episodes
+    reach 90% of `workers * multiplex`."""
+
+
+# Discriminated on `type` so the CLI selects with `--serve.pool.type static|elastic`.
+PoolConfig = Annotated[
+    StaticPoolConfig | ElasticPoolConfig, Field(discriminator="type")
+]
+
+
+class ServingConfig(BaseConfig):
+    """The `[serve]` block: the worker pool, the ZMQ address, and each worker's
+    episode bound. Read by whoever hosts the env — the `serve` CLI, a server-backed
+    eval, a trainer's orchestrator."""
+
+    pool: PoolConfig = Field(default_factory=ElasticPoolConfig)
+    """Worker-pool sizing. `elastic` (default) starts at one worker and scales up on
+    demand; `static` pre-spawns a fixed `num_workers`."""
+    address: str = "tcp://127.0.0.1:5000"
+    """ZMQ address the ROUTER binds (and clients connect to)."""
+    max_concurrent: int | None = Field(None, ge=1)
+    """Episodes in flight per worker (None = take the run's own bound, e.g. an eval's
+    `--max-concurrent`). Pin it to hold a worker below what the run asks for; how many
+    agent runs one episode carries is the env's own
+    (`--env.max-concurrent-agents`, one at a time by default)."""
+
+
+def pool_serve_kwargs(pool: StaticPoolConfig | ElasticPoolConfig) -> dict:
+    """Unpack a pool config into `serve_env` kwargs (`max_workers` / `multiplex` / `elastic`)."""
+    if isinstance(pool, ElasticPoolConfig):
+        return {
+            "max_workers": pool.max_workers,
+            "multiplex": pool.multiplex,
+            "elastic": True,
+        }
+    return {"max_workers": pool.num_workers, "elastic": False}

--- a/verifiers/v1/gepa/config.py
+++ b/verifiers/v1/gepa/config.py
@@ -4,9 +4,9 @@ GEPA optimizes one taskset's `Task.system_prompt` by alternating rollouts (`eval
 teacher LM reflecting on the reflective dataset (`make_reflective_dataset`) — see
 `verifiers.v1.gepa.adapter.GEPAAdapter`. Like `EvalConfig`, it owns an `env` field (the
 environment: its taskset, seats, limits) and adds the optimization loop's own knobs (model,
-reflection model, train/val split, budget). There is no worker pool here (`EnvServerConfig`
-is not a base) — GEPA always runs in-process, since its adapter protocol is itself
-synchronous (see `GEPAAdapter`)."""
+reflection model, train/val split, budget). There is no `[serve]` block here — GEPA
+always runs in-process, since its adapter protocol is itself synchronous (see
+`GEPAAdapter`)."""
 
 from pathlib import Path
 from uuid import uuid4

--- a/verifiers/v1/legacy.py
+++ b/verifiers/v1/legacy.py
@@ -495,7 +495,7 @@ def _legacy_output_dir(config) -> Path:
 
     if config.output_dir is not None:
         return config.output_dir
-    name = f"{env_name(config.id)}--{config.model.replace('/', '--')}--legacy"
+    name = f"{env_name(config.legacy.id)}--{config.model.replace('/', '--')}--legacy"
     return Path("outputs") / name / config.uuid
 
 
@@ -510,15 +510,21 @@ async def run_legacy_eval(config) -> list[Episode]:
 
     # Install from the env hub on demand for an `org/name[@version]` id (a local id is
     # already importable), then load by module name.
-    env = load_environment(ensure_installed(config.id), **(config.args or {}))
-    if config.extra_env_kwargs:  # post-load knobs (max_total_completion_tokens, …)
-        env.set_kwargs(**config.extra_env_kwargs)
+    env = load_environment(
+        ensure_installed(config.legacy.id), **(config.legacy.args or {})
+    )
+    if (
+        config.legacy.extra_env_kwargs
+    ):  # post-load knobs (max_total_completion_tokens, …)
+        env.set_kwargs(**config.legacy.extra_env_kwargs)
     dataset = env.get_eval_dataset()  # the eval split (falls back to train when unset)
     idxs = sample(list(range(len(dataset))), config.shuffle, config.num_tasks)
 
     client = _eval_client(config.client, config.model)
     sampling_args = config.sampling.model_dump(exclude_none=True)
-    taskset_id = env_name(config.id)  # the same identity the served bridge stamps
+    taskset_id = env_name(
+        config.legacy.id
+    )  # the same identity the served bridge stamps
     out_dir = _legacy_output_dir(config)
     save_config(config, out_dir)
     logger.info("results: %s", out_dir)


### PR DESCRIPTION
Follows @mikasenghaas's review on #2157: a per-worker bound is a serving knob, not part of describing the env. Pulling that thread all the way — `EnvServerConfig` was three things at once (the env, how it's served, the v0 bridge) and `EvalConfig` / the serve CLI / prime-rl's env entry all *inherited* it, so pool knobs sat flattened on an eval config and on a trainer's source entry.

Three blocks now, composed rather than inherited:

```toml
[env]      # what runs — unchanged
[serve]    # how it's hosted: pool, address, per-worker episode bound
[legacy]   # the v0 bridge: id, args, extra_env_kwargs
```

A run config declares the blocks it needs and adds its own fields, sharing only the narrowing helpers — `GEPAConfig` already worked exactly this way, and has no `[serve]` at all since it runs in-process. `EnvServerConfig` is gone.

**The run keeps owning its concurrency.** `-c` bounds episodes in flight and seeds each worker's bound under `--server`; `serve.max_concurrent` pins a worker *below* the run when you want that (`EvalConfig.worker_max_concurrent`). So an in-process eval never has to reach into a block named `serve`, and one number stays honest when a run spawns workers.

```bash
uv run eval gsm8k-v1 --server -c 128                          # 128 episodes, per worker
uv run eval gsm8k-v1 --server -c 128 --serve.max-concurrent 32  # ... but hold each worker at 32
uv run serve gsm8k-v1 --serve.pool.type static --serve.pool.num-workers 4 --serve.address tcp://0.0.0.0:7000
```

**Breaking:** `--pool.*` → `--serve.pool.*`, `--address` → `--serve.address`, `--id` / `--args` / `--extra-env-kwargs` → `--legacy.*`. Every retired top-level key raises with a pointer home rather than a bare `extra_forbidden`, the way the retired `--taskset.*` / `--harness.*` axes already do:

```
--pool.type
  Value error, the worker pool is serving, not the env: --serve.pool.type elastic|static (TOML: [serve.pool])
```

Nothing in this repo set the moved keys, and the `configs/gepa/*.toml` `max_concurrent` entries are GEPA's own run-level bound, untouched.

**Downstream:** prime-rl's `EnvConfig` subclasses `vf.EnvServerConfig`, so it needs the matching composition change — that lands with the `deps/verifiers` bump, not here.

### Stacked

On #2157 (episode/agent concurrency), which introduced the per-worker bound this moves. Review that one first; this branch is the follow-up Mika's comment asked for.

### Verified

- `pytest tests/v1 -m "not e2e"` (64) and the v0 config/serve/gepa/env-server/display tests (94), `ruff check`, `ruff format --check`, `ty check verifiers` — all clean. Live E2Es not run here (no endpoint in this environment).
- Throwaway probe over the parsed configs: blocks compose (`-c 64` + `--serve.pool.type static --serve.pool.num-workers 4` → worker bound 64; `--serve.max-concurrent 16` → 16); `--legacy.id` + `--legacy.args '{"a": 1}'` resolves with `is_legacy`/`env_id` intact; a v0 id next to a v1 taskset is refused; all five retired keys point home.
- The concurrency probe from #2157 still holds on this branch: default 1 agent run per episode, turn-taking interactions still alternate, `-c 2` over 6 episodes peaks at 2 episodes / 2 runs, `max_concurrent_agents=None` at `-c 3` peaks at 3 episodes / 6 runs.
- Docs + the `evaluate-environments` skill reference updated for the new tree (that reference documented `EnvServerConfig` field by field).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor v1 eval/serve config to use dedicated `[serve]` and `[legacy]` blocks
> - Introduces `ServingConfig` (pool, address, max_concurrent) and `LegacyEnvConfig` (id, args, extra_env_kwargs) as explicit config blocks, replacing the flat `EnvServerConfig` base class on `EvalConfig` and `ServeConfig`.
> - The `[serve]` block now owns all pool and address settings; `serve.max_concurrent` is used as the per-worker episode bound, falling back to run-level `max_concurrent`.
> - Legacy (v0) environment bridge parameters are read from the `[legacy]` block; mixed v0/v1 configurations are rejected at validation time.
> - CLI flags shift from `--id`/`--args` to `--legacy.id`/`--legacy.args` and from top-level pool flags to `--serve.*`.
> - Behavioral Change: `EnvServerConfig` is removed from the public API; callers must migrate to `ServingConfig` and `LegacyEnvConfig`. Deprecated top-level keys (`pool`, `address`, `id`, `args`, etc.) now raise targeted errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 8ba0afe. 13 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->