### PR TITLE
refactor(v1): address isolated grading review feedback

### DIFF
--- a/docs/v1/env.md
+++ b/docs/v1/env.md
@@ -63,6 +63,11 @@ class MyData(vf.TaskData):
     artifacts: list[vf.Artifact] = [
         vf.Artifact(source="/work/report", exclude=[".git"])
     ]
+
+
+class MyTask(vf.Task[MyData]):
+    async def finalize(self, trace: vf.Trace, runtime: vf.Runtime) -> None:
+        trace.state.artifacts = await vf.collect(runtime, self.data.artifacts)
 ```
 
 Declared paths must exist when collected. The implicit directory is optional.

--- a/docs/v1/env.md
+++ b/docs/v1/env.md
@@ -52,3 +52,17 @@ Just like tasksets and harnesses, an `Env` can be user-defined for full expressi
 | `single-agent` | `agent` | (default) one `agent` plays the taskset |
 | `best-of-n` | `agent` | `n` independent attempts per episode; its metrics mark the argmax-reward sibling (`best`) and whether any reached `--env.threshold` (`pass_at_n`) — rejection sampling and pass@k. |
 | `agentic-judge` | `solver`, `judge` | the solver plays the task; a code-executing judge agent verifies the finished attempt with real execution. |
+
+## Grading artifacts
+
+Use artifacts to carry files between runtimes. Files written to
+`/logs/artifacts/` are collected implicitly; declare other paths on the task data:
+
+```python
+class MyData(vf.TaskData):
+    artifacts: list[vf.Artifact] = [
+        vf.Artifact(source="/work/report", exclude=[".git"])
+    ]
+```
+
+Declared paths must exist when collected. The implicit directory is optional.

--- a/docs/v1/harbor.md
+++ b/docs/v1/harbor.md
@@ -105,7 +105,7 @@ accepts host-level entries and rejects combinations that need both policy modes.
 Two deliberate differences from `harbor run`:
 
 - **A failing collect hook fails the rollout.** Harbor logs it and carries on, because there the output is observability; here it is a grading input, and a silently absent file makes the verifier score a stale state.
-- **`destination` has no effect.** It positions a file in Harbor's host trial directory; verifiers has no trial directory (the trace is the record), and Harbor never lets `destination` affect verifier-side placement.
+- **`destination` is ignored.** Artifacts are restored to their source paths.
 
 ## Shortcomings
 

--- a/docs/v1/harbor.md
+++ b/docs/v1/harbor.md
@@ -112,5 +112,4 @@ Two deliberate differences from `harbor run`:
 verifiers does not have parity with Harbor yet, so some features are missing and currently being worked on. The most notable missing features right now are:
 
 - Switching to a different verifier-phase network policy ([Harbor Docs](https://www.harborframework.com/docs/tasks/network-policy))
-- Sidecar services, and the sidecar artifacts and collect hooks that go with them ([Harbor Docs](https://www.harborframework.com/docs/tasks#sidecar-artifacts-and-collect-hooks))
 - Multi-step tasks ([Harbor Docs](https://www.harborframework.com/docs/tasks/multi-step))

--- a/docs/v1/harbor.md
+++ b/docs/v1/harbor.md
@@ -102,11 +102,6 @@ accepts host-level entries and rejects combinations that need both policy modes.
 
 `artifacts = [...]` and `[[verifier.collect]]` are read from `task.toml` ([Harbor Docs](https://www.harborframework.com/docs/run-jobs/results-and-artifacts)). Collect hooks run in the agent's box from the task's `finalize`, which is Harbor's own ordering — after the agent phase, before collection — and declared paths plus the `/logs/artifacts/` convention dir are then carried into the grading box and restored at their original paths ("no translation", as in Harbor).
 
-Two deliberate differences from `harbor run`:
-
-- **A failing collect hook fails the rollout.** Harbor logs it and carries on, because there the output is observability; here it is a grading input, and a silently absent file makes the verifier score a stale state.
-- **`destination` is ignored.** Artifacts are restored to their source paths.
-
 ## Shortcomings
 
 verifiers does not have parity with Harbor yet, so some features are missing and currently being worked on. The most notable missing features right now are:

--- a/docs/v1/tasksets.md
+++ b/docs/v1/tasksets.md
@@ -231,20 +231,6 @@ class JudgeTraceTaskset(vf.Taskset[JudgedTask, SetConfig]):
 
 To override the judge model, set `env.taskset.task.judge.model` in your config (it is a string).
 
-## Grading artifacts
-
-Use artifacts to carry files between runtimes. Files written to
-`/logs/artifacts/` are collected implicitly; declare other paths on the task data:
-
-```python
-class MyData(vf.TaskData):
-    artifacts: list[vf.Artifact] = [
-        vf.Artifact(source="/work/report", exclude=[".git"])
-    ]
-```
-
-Declared paths must exist when collected. The implicit directory is optional.
-
 ## Beyond one agent
 
 One episode doesn't have to be one agent run: agents, the control flow between agents, and cross-agent rewards are the environment's job — see [The Env](env.md).

--- a/docs/v1/tasksets.md
+++ b/docs/v1/tasksets.md
@@ -233,27 +233,8 @@ To override the judge model, set `env.taskset.task.judge.model` in your config (
 
 ## Grading artifacts
 
-An environment can grade in a second sandbox rather than the one the agent worked in, so nothing the agent did to its environment can reach the grader. Only what the task declares crosses over.
-
-Two channels, and they do different jobs:
-
-- **`trace.info` is the record.** `capture_patch` puts the diff in `trace.info["patch"]`, a judge puts its verdict there, and both ride `traces.jsonl`. It is not a transport channel — nothing you put there is placed in the grading sandbox as a file. An agentic judge is the exception: it receives the whole serialized trace, `info` included, at `/tmp/trace.json`, so treat anything you leave there as visible to the grader.
-- **`/logs/artifacts/` is transport.** Anything written there is collected with no declaration at all, carried to the host, and restored in the grading sandbox at the same path.
-
-Produce artifacts in `finalize`, while the runtime is live and before scoring mutates anything:
-
-```python
-class MySweTask(vf.Task[MyData]):
-    async def finalize(self, trace: vf.Trace, runtime: vf.Runtime) -> None:
-        await vf.capture_patch(
-            trace,
-            runtime,
-            self.data.base_commit,
-            write_path=f"{vf.CONVENTION_DIR}/patch.diff",  # record + transport, one call
-        )
-```
-
-Declare paths outside the convention dir on the task row:
+Use artifacts to carry files between runtimes. Files written to
+`/logs/artifacts/` are collected implicitly; declare other paths on the task data:
 
 ```python
 class MyData(vf.TaskData):
@@ -262,9 +243,7 @@ class MyData(vf.TaskData):
     ]
 ```
 
-A declared path that is missing at collection time fails the rollout: it was declared because grading needs it, and grading a partial state scores the rollout wrong rather than loudly failing it. The convention dir is exempt — it is collected for every task, and most never write to it.
-
-The grading sandbox boots from the same image as the agent's, so the repo and its dependencies are already present. Only the agent's delta has to travel, which is why the collection cap (`vf.artifacts.MAX_ARTIFACT_BYTES`) is sized for a patch rather than a tree.
+Declared paths must exist when collected. The implicit directory is optional.
 
 ## Beyond one agent
 

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -392,25 +392,12 @@ async def test_env_id_best_of_n(run_v1, tmp_path):
 
 @pytest.mark.e2e
 async def test_env_id_agentic_judge(run_v1, tmp_path):
-    """The agentic judge over the echo taskset (needs docker), on the default
-    `shared` topology: the box is provisioned once from the solver's runtime
-    policy, the solver plays the task in it, the judge lands in the SAME box with
-    the graded trace uploaded, investigates with real execution, and its parsed
-    verdict lands on the solver's trace under the spec's reward key. Wiring, not
-    taste: the judge followed the verdict-file contract — the grade itself is the
-    model's call. Exercises the config surface too: an unpinned judge runtime
-    (inherits the solver's), a policy-only prompt override (the verdict contract
-    is appended regardless), and reward-composition weights."""
     traces = await run_v1(
         "echo-v1",
-        harness=None,  # seats pin their own harness; there is no run-level one
+        harness=None,
         env={
             "id": "agentic-judge",
-            # The solver owns the shared box, so the container is pinned here; the
-            # judge's runtime is left unset to exercise the inheritance.
             "solver": {"harness": {"id": "bash"}, "runtime": {"type": "docker"}},
-            # The judge reads the trace and reasons before it writes the
-            # verdict file; the shared 2048-token run cap truncates it mid-audit.
             "judge": {
                 "harness": {"id": "bash"},
                 "max_output_tokens": 8192,
@@ -429,10 +416,9 @@ async def test_env_id_agentic_judge(run_v1, tmp_path):
     (judge,) = [t for t in traces if t.agent_name == "judge"]
     assert solver.ok and judge.ok
     assert judge.trainable is False
-    # The task's own reward keeps its raw score; the rescale lands on the weight.
     assert solver.rewards["echoed"].score == 1.0
     assert solver.rewards["echoed"].weight == 0.5
-    assert isinstance(judge.info.get("verdict"), dict)  # scraped off the box
+    assert isinstance(judge.info.get("verdict"), dict)
     assert 0.0 <= solver.rewards["judge"].score <= 1.0
 
 

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -5,7 +5,7 @@ from pydantic_config import BaseConfig
 from verifiers.v1.acp import ACP
 from verifiers.v1.agent import Agent, Agents, Interaction, Segment, make_agent
 from verifiers.v1.artifacts import (
-    CONVENTION_DIR,
+    ARTIFACTS_DIR,
     Artifact,
     collect,
     restore,
@@ -305,7 +305,7 @@ __all__ = [  # noqa: RUF022 - grouped by public API area
     "resolve_head",
     "snapshot_untracked",
     # grading artifacts
-    "CONVENTION_DIR",
+    "ARTIFACTS_DIR",
     "Artifact",
     "collect",
     "restore",

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -37,7 +37,6 @@ from verifiers.v1.env import Env
 from verifiers.v1.envs.single_agent import SingleAgentEnv, SingleAgentEnvConfig
 from verifiers.v1.episode import Episode, WireEpisode
 from verifiers.v1.errors import (
-    ArtifactError,
     EnvError,
     HarnessError,
     InterceptionError,
@@ -230,7 +229,6 @@ __all__ = [  # noqa: RUF022 - grouped by public API area
     "ToolsetError",
     "SandboxError",
     "TaskError",
-    "ArtifactError",
     "InterceptionError",
     "TunnelError",
     # clients

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -161,9 +161,6 @@ from verifiers.v1.utils.git import (
 from verifiers.v1.utils.git import (
     resolve_head as resolve_head,
 )
-from verifiers.v1.utils.git import (
-    snapshot_untracked as snapshot_untracked,
-)
 
 __all__ = [  # noqa: RUF022 - grouped by public API area
     # types
@@ -301,7 +298,6 @@ __all__ = [  # noqa: RUF022 - grouped by public API area
     "PATCH_CAP_BYTES",
     "capture_patch",
     "resolve_head",
-    "snapshot_untracked",
     # grading artifacts
     "ARTIFACTS_DIR",
     "Artifact",

--- a/verifiers/v1/artifacts.py
+++ b/verifiers/v1/artifacts.py
@@ -79,8 +79,7 @@ async def collect(
             if sweep and source == ARTIFACTS_DIR:
                 continue
             raise ArtifactError(
-                f"declared artifact {source!r} does not exist in the box; the task must "
-                "produce it in finalize() (or a [[verifier.collect]] hook)"
+                f"declared artifact {source!r} does not exist in the runtime"
             )
         archive = await _tar_out(runtime, artifact, budget)
         budget -= len(archive)

--- a/verifiers/v1/artifacts.py
+++ b/verifiers/v1/artifacts.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING
 
 from pydantic import Field
 
-from verifiers.v1.errors import ArtifactError
 from verifiers.v1.types import StrictBaseModel
 
 if TYPE_CHECKING:
@@ -78,7 +77,7 @@ async def collect(
         if (await runtime.run(["test", "-e", source], {})).exit_code != 0:
             if sweep and source == ARTIFACTS_DIR:
                 continue
-            raise ArtifactError(
+            raise RuntimeError(
                 f"declared artifact {source!r} does not exist in the runtime"
             )
         archive = await _tar_out(runtime, artifact, budget)
@@ -96,7 +95,7 @@ async def restore(runtime: Runtime, collected: dict[str, bytes]) -> None:
     # Extraction writes to absolute paths. In a container that is the point; under the
     # subprocess runtime it is the developer's own filesystem.
     if getattr(runtime.config, "type", None) == "subprocess":
-        raise ArtifactError(
+        raise RuntimeError(
             "refusing to restore artifacts into the subprocess runtime: extraction "
             "writes to absolute paths on the host. Grade in a container."
         )
@@ -129,7 +128,7 @@ async def _tar_out(runtime: Runtime, artifact: Artifact, budget: int) -> bytes:
         # memory, not after.
         sized = await runtime.run(["sh", "-c", f"wc -c < {shlex.quote(path)}"], {})
         if (raw := sized.stdout.strip()).isdigit() and int(raw) > budget:
-            raise ArtifactError(
+            raise RuntimeError(
                 f"artifact {artifact.source!r} takes the collection over the "
                 f"{MAX_ARTIFACT_BYTES} byte limit. The grading box boots from the "
                 "agent's image, so only the delta needs to travel — narrow the source "
@@ -148,4 +147,4 @@ async def _run(runtime: Runtime, command: str, action: str) -> None:
     result = await runtime.run(["sh", "-c", command], {})
     if result.exit_code:
         detail = (result.stderr or result.stdout).strip()[-500:]
-        raise ArtifactError(f"failed to {action}: {detail}")
+        raise RuntimeError(f"failed to {action}: {detail}")

--- a/verifiers/v1/artifacts.py
+++ b/verifiers/v1/artifacts.py
@@ -1,4 +1,4 @@
-"""Carry a task's declared files out of the agent's box and into a grading box.
+"""Artifact collection and restoration across runtimes.
 
 Grading in the box the agent worked in leaves a seam a policy under RL pressure will
 find. Grading in a second box removes it — only what the task declares crosses over.

--- a/verifiers/v1/artifacts.py
+++ b/verifiers/v1/artifacts.py
@@ -1,17 +1,4 @@
-"""Artifact collection and restoration across runtimes.
-
-Grading in the box the agent worked in leaves a seam a policy under RL pressure will
-find. Grading in a second box removes it — only what the task declares crosses over.
-
-Two channels, non-overlapping: `Trace.info` is the durable record (`capture_patch` puts
-the diff there, a judge puts its verdict there) and never travels; `/logs/artifacts/` is
-transport, Harbor's in-sandbox convention, collected with no declaration and restored at
-the same path in the grading box ("no translation", as in Harbor).
-
-`collect` runs while the agent's box is alive, right after `Task.finalize` produced the
-files. It is the barrier: once it returns, nothing downstream needs the agent's box and
-it can be torn down.
-"""
+"""Artifact collection and restoration across runtimes."""
 
 from __future__ import annotations
 

--- a/verifiers/v1/artifacts.py
+++ b/verifiers/v1/artifacts.py
@@ -18,8 +18,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 ARTIFACTS_DIR = "/logs/artifacts"
-"""Harbor's in-sandbox publish directory, swept implicitly so a task that writes here
-needs no declaration."""
+"""Implicit artifact directory; tasks that write here need no declaration."""
 
 MAX_ARTIFACT_BYTES = 32 * 1024 * 1024
 """Ceiling per collection. Sized for a delta, not a tree: the grading box boots from the
@@ -27,11 +26,7 @@ agent's image, so the repo is already there and only its output has to travel.""
 
 
 class Artifact(StrictBaseModel):
-    """One path to carry into the grading box, where it lands at this same path.
-
-    Harbor's `ArtifactConfig` minus `destination` (host trial-directory placement, which
-    verifiers has no equivalent for) and `service` (compose sidecars, unsupported).
-    """
+    """One path to restore at the same location in another runtime."""
 
     source: str
     exclude: list[str] = Field(default_factory=list)
@@ -52,10 +47,9 @@ async def collect(
 
     Each source is archived separately so its exclude patterns stay local.
     """
-    # Harbor permits a relative source, and the probe below resolves one against the
-    # runtime's workdir — so the tar, which runs `-C /`, has to agree or it archives a
-    # different file. Joining also normalises `/work/` to `/work`, so one tree cannot
-    # key two entries (the source is both the dict key and `restore`'s rm -rf target).
+    # Resolve relative sources against the runtime workdir. Joining also normalises
+    # `/work/` to `/work`, so one tree cannot key two entries (the source is both the
+    # dict key and `restore`'s rm -rf target).
     workdir = PurePosixPath(getattr(runtime.config, "workdir", "") or "/")
     declared = [
         a.model_copy(update={"source": str(workdir / a.source)})

--- a/verifiers/v1/artifacts.py
+++ b/verifiers/v1/artifacts.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-CONVENTION_DIR = "/logs/artifacts"
+ARTIFACTS_DIR = "/logs/artifacts"
 """Harbor's in-sandbox publish directory, swept implicitly so a task that writes here
 needs no declaration."""
 
@@ -62,21 +62,21 @@ async def collect(
         a.model_copy(update={"source": str(workdir / a.source)})
         for a in artifacts or []
     ]
-    convention = PurePosixPath(CONVENTION_DIR)
+    convention = PurePosixPath(ARTIFACTS_DIR)
     sweep = not any(
         (p := PurePosixPath(a.source)) == convention
         or p.is_relative_to(convention)
         or convention.is_relative_to(p)
         for a in declared
     )
-    entries = ([Artifact(source=CONVENTION_DIR)] if sweep else []) + declared
+    entries = ([Artifact(source=ARTIFACTS_DIR)] if sweep else []) + declared
 
     collected: dict[str, bytes] = {}
     budget = MAX_ARTIFACT_BYTES
     for artifact in entries:
         source = artifact.source
         if (await runtime.run(["test", "-e", source], {})).exit_code != 0:
-            if sweep and source == CONVENTION_DIR:
+            if sweep and source == ARTIFACTS_DIR:
                 continue
             raise ArtifactError(
                 f"declared artifact {source!r} does not exist in the box; the task must "

--- a/verifiers/v1/artifacts.py
+++ b/verifiers/v1/artifacts.py
@@ -51,8 +51,7 @@ async def collect(
     and grading a partial state scores the rollout wrong rather than failing it. The
     implicit convention sweep is exempt — most tasks never write there.
 
-    One archive per source: BusyBox `tar` (every alpine-based image) implements only
-    `c`/`x`/`t` with no `-r` to append, and each source carries its own excludes anyway.
+    Each source is archived separately so its exclude patterns stay local.
     """
     # Harbor permits a relative source, and the probe below resolves one against the
     # runtime's workdir — so the tar, which runs `-C /`, has to agree or it archives a

--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -1,4 +1,4 @@
-"""agentic-judge: a solver plays the task, a code-executing judge verifies the work.
+"""agentic-judge: a solver plays the task, then a judge verifies the work.
 
 A reusable env (`--env.id agentic-judge` over any taskset). The solver plays the
 task in a container provisioned from its runtime policy; the judge then grades

--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -358,9 +358,6 @@ class AgenticJudgeEnv(vf.Env[AgenticJudgeEnvConfig]):
                 await agents.judge.run(judge_task, runtime=box)
             return
 
-        # Collection is the barrier: once it returns, nothing downstream needs the
-        # solver's box. Letting the context manager tear it down normally keeps an
-        # episode at one box rather than two, which is what costs on a paid runtime.
         async with agents.solver.provision(task) as box:
             solution = await agents.solver.run(task, runtime=box)
             if not solution.ok:

--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -315,14 +315,6 @@ class AgenticJudgeEnvConfig(vf.EnvConfig):
 
 class AgenticJudgeEnv(vf.Env[AgenticJudgeEnvConfig]):
     def __init__(self, config: AgenticJudgeEnvConfig) -> None:
-        # The judge inherits the solver's runtime policy unless it pins a container of
-        # its own. Under `shared` that is definitional — its effective runtime IS the
-        # solver's box, and aligning the config keeps the base env's subprocess warning
-        # and the runtime stamped on its trace truthful. Under `isolated` it is the
-        # fallback every other unpinned `AgentConfig` field already gets (harness,
-        # model, sampling): `runtime` defaults to `SubprocessConfig` with no `None` to
-        # distinguish unset from chosen, and a code-executing judge can never run on the
-        # host anyway, so subprocess here always means "not specified".
         if config.sandbox_mode == "shared" or isinstance(
             config.judge.runtime, vf.SubprocessConfig
         ):

--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -337,12 +337,16 @@ class AgenticJudgeEnv(vf.Env[AgenticJudgeEnvConfig]):
             return
 
         solution = await agents.solver.run(task)
+        if not solution.ok:
+            return
         await agents.judge.run(
             JudgeTask.from_trace(solution, self.config.task, share_runtime=False)
         )
 
     async def finalize(self, task: vf.Task, episode: vf.Episode) -> None:
         by_agent = {t.agent_name: t for t in episode.traces}
+        if "judge" not in by_agent:
+            return
         solution, verdict = by_agent["solver"], by_agent["judge"]
         data = verdict.info.get("verdict")
         if not isinstance(data, dict) or not isinstance(data.get("verdicts"), list):

--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -312,15 +312,15 @@ class AgenticJudgeEnv(vf.Env[AgenticJudgeEnvConfig]):
         judge = self._harnesses["judge"]
         if not judge.EXECUTES_CODE:
             raise ValueError(
-                "agentic-judge plays a code-executing judge in its own sandbox, but "
+                "agentic-judge requires a judge harness that can execute code, but "
                 f"harness {judge.config.id!r} is a tool-less chat loop — a verdict "
                 "that needs no execution is a plugged judge "
                 "(--env.taskset.task.judges), not an agent."
             )
         if isinstance(self.config.solver.runtime, vf.SubprocessConfig):
             raise TypeError(
-                "agentic-judge runs a code-executing solver in a container, but the "
-                "solver resolves to the subprocess runtime; use "
+                "agentic-judge requires the solver to run in a container, but it "
+                "resolves to the subprocess runtime; use "
                 "--env.solver.runtime.type docker or prime"
             )
 

--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -8,12 +8,9 @@ verdicts to `/tmp/verdict.json`, with the solver's full trace record uploaded at
 `judge/<name>` metrics plus a weighted-mean `judge` reward, composed with the
 taskset's own rewards via `[env.score]` (judge-only by default).
 
-`--env.sandbox-mode` decides where the judge stands. Under `shared` (the default) it
-plays in the box the agent worked in, seeing that environment directly and every
-seam in it. Under `isolated` it gets its own box from the same image, holding only
-what the task declared as artifacts, so nothing the agent did to its environment
-can reach the grader — worth opting into once a taskset publishes its evidence
-somewhere that travels.
+`--env.share-runtime` controls whether the judge uses the solver's runtime. It is
+enabled by default. When disabled, the judge gets a fresh runtime containing the
+task's collected artifacts.
 """
 
 import json
@@ -21,7 +18,6 @@ import math
 import re
 import tomllib
 from pathlib import Path
-from typing import Literal
 
 from pydantic import Field, field_validator
 
@@ -30,7 +26,6 @@ from verifiers.v1.types import StrictBaseModel
 
 VERDICT_FILE = "/tmp/verdict.json"
 TRACE_FILE = "/tmp/trace.json"
-SandboxMode = Literal["shared", "isolated"]
 
 GRADE_PROMPT = """\
 You are grading another agent's attempt at a task. Verify the work EMPIRICALLY:
@@ -149,11 +144,11 @@ class JudgeTask(vf.Task):
         cls,
         solution: vf.Trace,
         config: "JudgeTaskConfig",
-        sandbox_mode: SandboxMode = "shared",
+        share_runtime: bool = True,
     ) -> "JudgeTask":
         """Mint the judge's task from the solver's finished trace.
 
-        `sandbox_mode` selects the workspace note. It has to match how the judge is
+        `share_runtime` selects the workspace note. It has to match how the judge is
         actually placed: the note is the judge's only account of what its box
         contains, and a judge told it is standing in the agent's workspace when it
         is standing in a fresh one will read an unmodified tree as a failed attempt.
@@ -165,9 +160,7 @@ class JudgeTask(vf.Task):
         if "{prompt}" not in template:
             # A policy that doesn't place the task statement itself still needs it.
             body += "\n\n" + _render(TASK_SECTION, prompt=solved.prompt_text)
-        note = (
-            SHARED_SANDBOX_NOTE if sandbox_mode == "shared" else ISOLATED_SANDBOX_NOTE
-        )
+        note = SHARED_SANDBOX_NOTE if share_runtime else ISOLATED_SANDBOX_NOTE
         sections = [body, _verdict_section(config.criteria()), note]
         if (hint := config.build_hint()) is not None:
             sections.insert(1, _render(HINT_SECTION, hint=hint))
@@ -283,30 +276,16 @@ class AgenticJudgeEnvConfig(vf.EnvConfig):
     """The solver agent. Its runtime must be a container:
     `--env.solver.runtime.type docker|prime`."""
     judge: vf.AgentConfig = vf.AgentConfig()
-    """The judge agent. Under `isolated` it provisions its own box from this policy;
-    under `shared` it plays in the solver's box and this policy is ignored."""
-    sandbox_mode: SandboxMode = "shared"
-    """Whether the judge grades in the solver's box or its own.
-
-    `shared` places the judge in the box the agent worked in, so it can inspect that
-    environment directly — at the cost of leaving every seam in it reachable. It is the
-    default because it is what has been measured, and because a judge only gains from
-    isolation once the task publishes what the judge needs.
-
-    `isolated` boots a second box from the same image, carries the task's declared
-    artifacts across, and grades there, so nothing the agent did to its environment can
-    reach the grader. Opt in per taskset, and only once that taskset puts its evidence
-    somewhere that travels: an artifact under `vf.ARTIFACTS_DIR` (see
-    `capture_patch(write_path=...)`), a declared `TaskData.artifacts` path, or the trace
-    record itself. A task whose judge hint says to run `git diff` in the box will find
-    a pristine checkout here and grade every attempt as untouched."""
+    """The judge agent. Its runtime is ignored when `share_runtime` is enabled."""
+    share_runtime: bool = True
+    """Whether the judge grades in the solver's runtime."""
     task: JudgeTaskConfig = JudgeTaskConfig()
     score: ScoreConfig = ScoreConfig()
 
 
 class AgenticJudgeEnv(vf.Env[AgenticJudgeEnvConfig]):
     def __init__(self, config: AgenticJudgeEnvConfig) -> None:
-        if config.sandbox_mode == "shared" or isinstance(
+        if config.share_runtime or isinstance(
             config.judge.runtime, vf.SubprocessConfig
         ):
             config.judge = config.judge.model_copy(
@@ -342,10 +321,10 @@ class AgenticJudgeEnv(vf.Env[AgenticJudgeEnvConfig]):
         agents.judge.trainable = False
 
     async def run(self, task: vf.Task, agents: vf.Agents) -> None:
-        if self.config.sandbox_mode == "shared":
+        if self.config.share_runtime:
             async with agents.solver.provision(task) as box:
                 solution = await agents.solver.run(task, runtime=box)
-                judge_task = JudgeTask.from_trace(solution, self.config.task, "shared")
+                judge_task = JudgeTask.from_trace(solution, self.config.task)
                 await agents.judge.run(judge_task, runtime=box)
             return
 
@@ -362,7 +341,9 @@ class AgenticJudgeEnv(vf.Env[AgenticJudgeEnvConfig]):
 
         async with agents.judge.provision(task) as judge_box:
             await vf.restore(judge_box, collected)
-            judge_task = JudgeTask.from_trace(solution, self.config.task, "isolated")
+            judge_task = JudgeTask.from_trace(
+                solution, self.config.task, share_runtime=False
+            )
             await agents.judge.run(judge_task, runtime=judge_box)
 
     async def finalize(self, task: vf.Task, episode: vf.Episode) -> None:

--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -8,7 +8,7 @@ verdicts to `/tmp/verdict.json`, with the solver's full trace record uploaded at
 `judge/<name>` metrics plus a weighted-mean `judge` reward, composed with the
 taskset's own rewards via `[env.score]` (judge-only by default).
 
-`--env.topology` decides where the judge stands. Under `shared` (the default) it
+`--env.sandbox-mode` decides where the judge stands. Under `shared` (the default) it
 plays in the box the agent worked in, seeing that environment directly and every
 seam in it. Under `isolated` it gets its own box from the same image, holding only
 what the task declared as artifacts, so nothing the agent did to its environment
@@ -291,7 +291,7 @@ class AgenticJudgeEnvConfig(vf.EnvConfig):
     judge: vf.AgentConfig = vf.AgentConfig()
     """The judge agent. Under `isolated` it provisions its own box from this policy;
     under `shared` it plays in the solver's box and this policy is ignored."""
-    topology: Literal["shared", "isolated"] = "shared"
+    sandbox_mode: Literal["shared", "isolated"] = "shared"
     """Whether the judge grades in the solver's box or its own.
 
     `shared` places the judge in the box the agent worked in, so it can inspect that
@@ -320,7 +320,7 @@ class AgenticJudgeEnv(vf.Env[AgenticJudgeEnvConfig]):
         # model, sampling): `runtime` defaults to `SubprocessConfig` with no `None` to
         # distinguish unset from chosen, and a code-executing judge can never run on the
         # host anyway, so subprocess here always means "not specified".
-        if config.topology == "shared" or isinstance(
+        if config.sandbox_mode == "shared" or isinstance(
             config.judge.runtime, vf.SubprocessConfig
         ):
             config.judge = config.judge.model_copy(
@@ -356,7 +356,7 @@ class AgenticJudgeEnv(vf.Env[AgenticJudgeEnvConfig]):
         agents.judge.trainable = False
 
     async def run(self, task: vf.Task, agents: vf.Agents) -> None:
-        if self.config.topology == "shared":
+        if self.config.sandbox_mode == "shared":
             async with agents.solver.provision(task) as box:
                 solution = await agents.solver.run(task, runtime=box)
                 judge_task = JudgeTask.from_trace(solution, self.config.task, "shared")

--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -31,6 +31,7 @@ from verifiers.v1.types import StrictBaseModel
 
 VERDICT_FILE = "/tmp/verdict.json"
 TRACE_FILE = "/tmp/trace.json"
+SandboxMode = Literal["shared", "isolated"]
 
 GRADE_PROMPT = """\
 You are grading another agent's attempt at a task. Verify the work EMPIRICALLY:
@@ -157,11 +158,11 @@ class JudgeTask(vf.Task):
         cls,
         solution: vf.Trace,
         config: "JudgeTaskConfig",
-        topology: str = "shared",
+        sandbox_mode: SandboxMode = "shared",
     ) -> "JudgeTask":
         """Mint the judge's task from the solver's finished trace.
 
-        `topology` selects the workspace note. It has to match how the judge is
+        `sandbox_mode` selects the workspace note. It has to match how the judge is
         actually placed: the note is the judge's only account of what its box
         contains, and a judge told it is standing in the agent's workspace when it
         is standing in a fresh one will read an unmodified tree as a failed attempt.
@@ -173,7 +174,9 @@ class JudgeTask(vf.Task):
         if "{prompt}" not in template:
             # A policy that doesn't place the task statement itself still needs it.
             body += "\n\n" + _render(TASK_SECTION, prompt=solved.prompt_text)
-        note = SHARED_SANDBOX_NOTE if topology == "shared" else ISOLATED_SANDBOX_NOTE
+        note = (
+            SHARED_SANDBOX_NOTE if sandbox_mode == "shared" else ISOLATED_SANDBOX_NOTE
+        )
         sections = [body, _verdict_section(config.criteria()), note]
         if (hint := config.build_hint()) is not None:
             sections.insert(1, _render(HINT_SECTION, hint=hint))

--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -119,8 +119,7 @@ reference solves it. Your verdict is what YOU verified by execution."""
 SHARED_SANDBOX_NOTE = f"""\
 ## Your workspace
 
-Your sandbox is the SAME box the graded agent worked in, in the state the agent
-left it — its edits (and any scoring side effects) are applied. {_RECORD_NOTE}"""
+The graded agent worked in this sandbox. {_RECORD_NOTE}"""
 
 ISOLATED_SANDBOX_NOTE = f"""\
 ## Your workspace

--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -135,9 +135,15 @@ class JudgeTask(vf.Task):
 
     NEEDS_CONTAINER = True
 
-    def __init__(self, data: vf.TaskData, files: dict[str, bytes]) -> None:
+    def __init__(
+        self,
+        data: vf.TaskData,
+        files: dict[str, bytes],
+        artifacts: dict[str, bytes],
+    ) -> None:
         super().__init__(data)
         self.files = files
+        self.artifacts = artifacts
 
     @classmethod
     def from_trace(
@@ -174,9 +180,11 @@ class JudgeTask(vf.Task):
                 resources=solved.resources,
             ),
             files=files,
+            artifacts={} if share_runtime else solution.state.artifacts,
         )
 
     async def setup(self, trace: vf.Trace, runtime: vf.Runtime) -> None:
+        await vf.restore(runtime, self.artifacts)
         # The solver had this box first: a pre-seeded verdict must never read as
         # the judge's own, and a file (or planted symlink) at an upload path must
         # never survive it — a symlinked TRACE_FILE would redirect the write onto
@@ -328,28 +336,13 @@ class AgenticJudgeEnv(vf.Env[AgenticJudgeEnvConfig]):
                 await agents.judge.run(judge_task, runtime=box)
             return
 
-        async with agents.solver.provision(task) as box:
-            solution = await agents.solver.run(task, runtime=box)
-            if not solution.ok:
-                # The rollout errored, so its own scoring never ran either; grading it
-                # would spend a second sandbox to reproduce a failure the trace already
-                # records. Return rather than raise: `episode.ok` follows the failed
-                # trace, and `episode_should_retry` classifies off that trace's own
-                # error — an exception raised here would bury the real type.
-                return
-            collected = await vf.collect(box, task.data.artifacts)
-
-        async with agents.judge.provision(task) as judge_box:
-            await vf.restore(judge_box, collected)
-            judge_task = JudgeTask.from_trace(
-                solution, self.config.task, share_runtime=False
-            )
-            await agents.judge.run(judge_task, runtime=judge_box)
+        solution = await agents.solver.run(task)
+        await agents.judge.run(
+            JudgeTask.from_trace(solution, self.config.task, share_runtime=False)
+        )
 
     async def finalize(self, task: vf.Task, episode: vf.Episode) -> None:
         by_agent = {t.agent_name: t for t in episode.traces}
-        if "judge" not in by_agent:
-            return  # solver errored; `run` skipped grading and the trace says why
         solution, verdict = by_agent["solver"], by_agent["judge"]
         data = verdict.info.get("verdict")
         if not isinstance(data, dict) or not isinstance(data.get("verdicts"), list):

--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -296,7 +296,7 @@ class AgenticJudgeEnvConfig(vf.EnvConfig):
     `isolated` boots a second box from the same image, carries the task's declared
     artifacts across, and grades there, so nothing the agent did to its environment can
     reach the grader. Opt in per taskset, and only once that taskset puts its evidence
-    somewhere that travels: an artifact under `vf.CONVENTION_DIR` (see
+    somewhere that travels: an artifact under `vf.ARTIFACTS_DIR` (see
     `capture_patch(write_path=...)`), a declared `TaskData.artifacts` path, or the trace
     record itself. A task whose judge hint says to run `git diff` in the box will find
     a pristine checkout here and grade every attempt as untouched."""

--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -26,7 +26,6 @@ from typing import Literal
 from pydantic import Field, field_validator
 
 import verifiers.v1 as vf
-from verifiers.v1.artifacts import CONVENTION_DIR
 from verifiers.v1.types import StrictBaseModel
 
 VERDICT_FILE = "/tmp/verdict.json"
@@ -124,15 +123,8 @@ The graded agent worked in this sandbox. {_RECORD_NOTE}"""
 ISOLATED_SANDBOX_NOTE = f"""\
 ## Your workspace
 
-Your sandbox is a FRESH box, built from the same image the graded agent started
-from — so it holds the task's original state, NOT the state the agent left. The
-agent's environment is gone; you cannot inspect it, and nothing it changed is
-here except what the task declared as an artifact. Those artifacts have been
-restored at their original paths (a patch under `{CONVENTION_DIR}/` is the usual
-one for code tasks), so to see the agent's work you generally have to apply or
-read them rather than looking at the working tree. If something you need to
-check was never declared as an artifact, say so in your reason rather than
-assuming its absence means the agent failed. {_RECORD_NOTE}"""
+This is a fresh sandbox. The task's artifacts were restored at their original
+paths; other changes made by the graded agent are not present. {_RECORD_NOTE}"""
 
 HINT_SECTION = """\
 ## Hints

--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -294,7 +294,7 @@ class AgenticJudgeEnvConfig(vf.EnvConfig):
     judge: vf.AgentConfig = vf.AgentConfig()
     """The judge agent. Under `isolated` it provisions its own box from this policy;
     under `shared` it plays in the solver's box and this policy is ignored."""
-    sandbox_mode: Literal["shared", "isolated"] = "shared"
+    sandbox_mode: SandboxMode = "shared"
     """Whether the judge grades in the solver's box or its own.
 
     `shared` places the judge in the box the agent worked in, so it can inspect that

--- a/verifiers/v1/errors.py
+++ b/verifiers/v1/errors.py
@@ -74,13 +74,6 @@ class TaskError(RolloutError):
     """Task-authored code raised — `setup`, `finalize`, or a `@reward`/`@metric`."""
 
 
-class ArtifactError(RolloutError):
-    """A grading artifact could not be carried between boxes — a declared source was
-    missing, the collection exceeded its limits, or the archive was unsafe to extract.
-    Strict on purpose: an incompletely restored grading box scores the rollout wrong,
-    which is worse than failing it."""
-
-
 class InterceptionError(RolloutError):
     """The host interception server (model calls + `/state` + `/task` channels) couldn't be reached."""
 

--- a/verifiers/v1/state.py
+++ b/verifiers/v1/state.py
@@ -1,12 +1,10 @@
 """Mutable state shared within one rollout.
 
 Tool servers synchronize it through the interception state channel. It is excluded
-from serialized traces; persist artifacts in `Trace.info` instead. `Trace.info` is the
-durable record and never leaves the host — files a grader needs in a second box travel
-separately, through `verifiers.v1.artifacts`.
+from serialized traces.
 """
 
-from pydantic import ConfigDict
+from pydantic import ConfigDict, Field
 from typing_extensions import TypeVar
 
 from verifiers.v1.types import StrictBaseModel
@@ -15,6 +13,7 @@ from verifiers.v1.utils.generic import generic_type
 
 class State(StrictBaseModel):
     model_config = ConfigDict(ser_json_inf_nan="constants")
+    artifacts: dict[str, bytes] = Field(default_factory=dict)
 
 
 StateT = TypeVar("StateT", bound=State, default=State)

--- a/verifiers/v1/tasksets/harbor/taskset.py
+++ b/verifiers/v1/tasksets/harbor/taskset.py
@@ -83,7 +83,7 @@ class CollectHook(StrictBaseModel):
     """One `[[verifier.collect]]` command, run in the agent's box by `finalize`."""
 
     command: str
-    timeout_sec: float = 60.0
+    timeout_sec: float = 600.0
 
 
 class HarborData(TaskData):

--- a/verifiers/v1/tasksets/harbor/taskset.py
+++ b/verifiers/v1/tasksets/harbor/taskset.py
@@ -400,8 +400,9 @@ def parse_verifier_extras(
     for entry in normalize_artifact_entries(parsed.artifacts):
         if effective_artifact_service(entry) != MAIN_SERVICE_NAME:
             raise ValueError(
-                f"{task_dir.name}: artifact {entry.source!r} targets service "
-                f"{entry.service!r}; only the main task service is supported"
+                f"{task_dir.name}: artifact {entry.source!r} targets additional "
+                f"service {entry.service!r}; verifiers currently supports artifacts "
+                "from the main service only"
             )
         # `destination` positions a file in Harbor's host trial directory. Verifiers has
         # no such directory (the trace is the record) and Harbor never lets destination
@@ -414,8 +415,9 @@ def parse_verifier_extras(
     for hook in verifier.collect:
         if hook.service != MAIN_SERVICE_NAME:
             raise ValueError(
-                f"{task_dir.name}: collect hook targets service {hook.service!r}; "
-                "only the main task service is supported"
+                f"{task_dir.name}: collect hook targets additional service "
+                f"{hook.service!r}; verifiers currently supports collect hooks for "
+                "the main service only"
             )
         if hook.user is not None:
             raise ValueError(

--- a/verifiers/v1/tasksets/harbor/taskset.py
+++ b/verifiers/v1/tasksets/harbor/taskset.py
@@ -28,7 +28,7 @@ from pydantic import Field
 from verifiers.v1.artifacts import Artifact, collect
 from verifiers.v1.configs.taskset import TasksetConfig
 from verifiers.v1.decorators import reward
-from verifiers.v1.errors import SandboxError, TaskError
+from verifiers.v1.errors import SandboxError
 from verifiers.v1.runtimes import Runtime
 from verifiers.v1.task import Task, TaskData, TaskResources, TaskTimeout
 from verifiers.v1.taskset import Taskset
@@ -130,12 +130,12 @@ class HarborTask(Task[HarborData]):
                     hook.timeout_sec,
                 )
             except TimeoutError as exc:
-                raise TaskError(
+                raise RuntimeError(
                     f"collect hook timed out after {hook.timeout_sec}s: {hook.command}"
                 ) from exc
             if result.exit_code:
                 detail = (result.stderr or result.stdout).strip()[-500:]
-                raise TaskError(
+                raise RuntimeError(
                     f"collect hook failed (exit {result.exit_code}): "
                     f"{hook.command}\n{detail}"
                 )

--- a/verifiers/v1/tasksets/harbor/taskset.py
+++ b/verifiers/v1/tasksets/harbor/taskset.py
@@ -400,7 +400,7 @@ def parse_verifier_extras(
         if effective_artifact_service(entry) != MAIN_SERVICE_NAME:
             raise ValueError(
                 f"{task_dir.name}: artifact {entry.source!r} targets service "
-                f"{entry.service!r}; sidecars need a compose-capable runtime"
+                f"{entry.service!r}; only the main task service is supported"
             )
         # `destination` positions a file in Harbor's host trial directory. Verifiers has
         # no such directory (the trace is the record) and Harbor never lets destination
@@ -414,7 +414,7 @@ def parse_verifier_extras(
         if hook.service != MAIN_SERVICE_NAME:
             raise ValueError(
                 f"{task_dir.name}: collect hook targets service {hook.service!r}; "
-                "sidecars need a compose-capable runtime"
+                "only the main task service is supported"
             )
         if hook.user is not None:
             raise ValueError(

--- a/verifiers/v1/tasksets/harbor/taskset.py
+++ b/verifiers/v1/tasksets/harbor/taskset.py
@@ -377,14 +377,7 @@ def parse_task(task_dir: Path, idx: int, harbor_config: HarborConfig) -> HarborD
 def parse_verifier_extras(
     task_dir: Path, parsed
 ) -> tuple[list[Artifact], list[CollectHook]]:
-    """Harbor's `artifacts` and `[[verifier.collect]]` blocks, narrowed to what a
-    single-container runtime can honor.
-
-    The convention dir is deliberately not prepended here (Harbor's
-    `with_convention_entry` would): collection injects it itself, as an optional sweep.
-    Prepending it would make it an explicitly declared entry, and declared entries are
-    required — which would fail every task that never writes there.
-    """
+    """Parse supported artifact and collect-hook settings."""
     from harbor.constants import MAIN_SERVICE_NAME
     from harbor.models.task.artifacts import (
         effective_artifact_service,

--- a/verifiers/v1/tasksets/harbor/taskset.py
+++ b/verifiers/v1/tasksets/harbor/taskset.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 from pydantic import Field
 
-from verifiers.v1.artifacts import Artifact
+from verifiers.v1.artifacts import Artifact, collect
 from verifiers.v1.configs.taskset import TasksetConfig
 from verifiers.v1.decorators import reward
 from verifiers.v1.errors import SandboxError, TaskError
@@ -139,6 +139,7 @@ class HarborTask(Task[HarborData]):
                     f"collect hook failed (exit {result.exit_code}): "
                     f"{hook.command}\n{detail}"
                 )
+        trace.state.artifacts = await collect(runtime, self.data.artifacts)
 
     @reward(weight=1.0)
     async def solved(self, runtime: Runtime) -> float:

--- a/verifiers/v1/utils/git.py
+++ b/verifiers/v1/utils/git.py
@@ -173,12 +173,6 @@ async def capture_patch(
         trace.info["patch_truncated"] = True
     trace.info["patch"] = raw.decode("utf-8", errors="replace")
     if write_path is not None:
-        try:
-            parent = str(PurePosixPath(write_path).parent)
-            await runtime.run(["mkdir", "-p", parent], env or {})
-            await runtime.write(write_path, raw)
-        except Exception as exc:
-            # Transport again, not the policy: the patch exists, we could not place it.
-            raise SandboxError(
-                f"patch capture could not write {write_path!r}: {exc}"
-            ) from exc
+        parent = str(PurePosixPath(write_path).parent)
+        await runtime.run(["mkdir", "-p", parent], env or {})
+        await runtime.write(write_path, raw)

--- a/verifiers/v1/utils/git.py
+++ b/verifiers/v1/utils/git.py
@@ -161,8 +161,6 @@ async def capture_patch(
             )
             return
         raw = await runtime.read(capped)
-    except Exception as exc:
-        raise SandboxError(f"patch capture could not reach the box: {exc}") from exc
     finally:
         # Unique names don't overwrite each other, so leftovers would accumulate
         # on shared-filesystem runtimes; removal is best-effort by design.

--- a/verifiers/v1/utils/git.py
+++ b/verifiers/v1/utils/git.py
@@ -133,7 +133,7 @@ async def capture_patch(
     infrastructure failed.
 
     `write_path` additionally writes the patch to that path inside the box, for tasks
-    graded in a second sandbox. Point it at `vf.CONVENTION_DIR` (e.g.
+    graded in a second sandbox. Point it at `vf.ARTIFACTS_DIR` (e.g.
     `/logs/artifacts/patch.diff`) and collection picks it up with no declaration. Leave
     it on the convention sweep rather than declaring it as an `Artifact`: a declared
     path is collected strictly, which would turn an agent-broken repo into a rollout


### PR DESCRIPTION
Stacks on #2144 and addresses each of its 30 open human review threads with one corresponding commit. Every commit body records the review-thread ID it addresses.

## What changed

- replaces the shared/isolated string mode with `share_runtime: bool = True`
- moves artifact collection into solver task finalization and restoration into judge task setup, so the separate-runtime path uses normal `Agent.run(...)` calls
- removes the custom artifact error type and redundant sandbox-error wrapping in favor of existing framework boundaries
- renames `CONVENTION_DIR` to `ARTIFACTS_DIR`
- trims or relocates the flagged documentation, comments, workspace notes, and test narration
- raises the Harbor collect-hook default timeout and makes unsupported-service errors explicit
- keeps `snapshot_untracked` internal

The runtime-liveness concern was explicitly marked unrelated and ticketed during review; its corresponding commit is intentionally empty rather than introducing unrelated churn.

## Impact

The default remains a shared runtime. With sharing disabled, solver artifacts travel through transient `Trace.state`, are excluded from serialized trace records, and are restored by `JudgeTask.setup()` in the judge's fresh runtime.

## Validation

- `uv run ruff check .`
- `uv run ty check verifiers`
- `uv run pytest tests/ -m 'not e2e'` — 909 passed, 63 deselected
- `uv run pre-commit run --all-files`
- temporary artifact lifecycle smoke: transient state exclusion and judge-setup restoration

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor isolated grading to use `State.artifacts` and replace `ArtifactError` with `RuntimeError`
> - Adds an `artifacts: dict[str, bytes]` field to `State` so solver traces carry collected artifacts for later restoration in judge runtimes.
> - Replaces the `topology` config with a `share_runtime: bool` flag in `AgenticJudgeEnvConfig`; isolated judge runs now restore artifacts via `JudgeTask.setup` instead of ad-hoc collect/restore in the env.
> - Renames `CONVENTION_DIR` to `ARTIFACTS_DIR` and removes `ArtifactError` entirely — all artifact errors now raise `RuntimeError`.
> - Removes `ArtifactError`, `snapshot_untracked`, and `CONVENTION_DIR` from the `verifiers.v1` public API; `ARTIFACTS_DIR` is exported instead.
> - Increases the default `CollectHook` timeout from 60s to 600s and stores collected artifacts into `trace.state.artifacts` after hooks run.
> - Behavioral Change: code catching `ArtifactError` will break; `capture_patch` failures now surface as underlying exceptions instead of `SandboxError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b1daff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking rename/removals (`topology`, `CONVENTION_DIR`, `ArtifactError`) and changed error types affect integrators; isolated grading now depends on tasks populating `trace.state.artifacts` during finalize rather than env-managed collection.
> 
> **Overview**
> Refactors **isolated grading** so artifact handoff follows normal task/agent lifecycle instead of custom env orchestration.
> 
> **`AgenticJudgeEnv`** replaces `topology: "shared" | "isolated"` with **`share_runtime: bool = True`**. When sharing is off, the env runs sequential `Agent.run` calls; the solver’s **`finalize`** is expected to populate **`trace.state.artifacts`**, and **`JudgeTask.setup`** calls **`vf.restore`** with archives from **`solution.state.artifacts`** (not env-level collect/restore).
> 
> **Artifacts API:** **`CONVENTION_DIR` → `ARTIFACTS_DIR`**, public **`ArtifactError`** removed ( **`RuntimeError`** in **`artifacts.py`** ), **`snapshot_untracked`** dropped from **`verifiers.v1` exports**. **`State`** gains **`artifacts: dict[str, bytes]`** (transient, not serialized on traces).
> 
> **Harbor:** **`HarborTask.finalize`** runs collect hooks then **`collect(...)`** into **`trace.state.artifacts`**; collect-hook default timeout **60s → 600s**; hook/collect failures use **`RuntimeError`** instead of **`TaskError`**.
> 
> **Docs:** grading-artifacts guidance moves from **`tasksets.md`** to **`env.md`**; Harbor doc trims duplicate artifact/collect prose.
> 
> **`capture_patch`:** optional **`write_path`** no longer wraps host write failures in **`SandboxError`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b1daff6bda9e8d9cd3f5ea4da207b180a854169. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->