### PR TITLE
Upgrade Harbor to 0.20.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ browser = [
 ]
 harbor = [
     # Harbor currently publishes Python 3.12+ packages; keep core verifiers installable on 3.11.
-    "harbor==0.14.0; python_version >= '3.12'",
+    "harbor==0.20.0; python_version >= '3.12'",
 ]
 modal = [
     "modal>=1.4.0",

--- a/skills/evaluate-environments/references/REFERENCE.md
+++ b/skills/evaluate-environments/references/REFERENCE.md
@@ -309,7 +309,7 @@ Runs Harbor's tmux agent through LiteLLM.
 
 | Field | Type | Default | Notes |
 | --- | --- | --- | --- |
-| `version` | `str` | `"0.14.0"` | Harbor release to install, pinned. |
+| `version` | `str` | `"0.20.0"` | Harbor release to install, pinned. |
 
 #### `KimiCodeHarnessConfig` — `id: "kimi-code"`
 

--- a/uv.lock
+++ b/uv.lock
@@ -679,24 +679,6 @@ wheels = [
 ]
 
 [[package]]
-name = "claude-agent-sdk"
-version = "0.2.116"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "mcp" },
-    { name = "sniffio" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/50/79/b0f01a18bb119e595cc1e66d4adbe39bb09879a570e54793c222a142b662/claude_agent_sdk-0.2.116.tar.gz", hash = "sha256:37d6c9d98960c7ea41d1a7fd3331ad0b1bef68e559ed9cc5ccf9d00ae68adfcd", size = 268648, upload-time = "2026-07-11T01:04:47.192Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/cd/2ed6eaee9e5fa1a13d91d1ccbb9f09a3b53379acd55b3ccb9d6c94378a3f/claude_agent_sdk-0.2.116-py3-none-macosx_11_0_arm64.whl", hash = "sha256:9ea5ababb44afdcc7e33b857ca3ad5008f906c30052aa2d957dacfa7f70ead9f", size = 71529658, upload-time = "2026-07-11T01:04:51.792Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/5a/28cefff3eacb8ba8a2caf2a8e7c944faca8c253157cc5aa207d87964c5cb/claude_agent_sdk-0.2.116-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:93c1f60ed1e4d73dc13f2c714bbe1be43798d9bb4067a6d563358c397b300801", size = 75044679, upload-time = "2026-07-11T01:04:56.414Z" },
-    { url = "https://files.pythonhosted.org/packages/72/e8/6663bd715b1822db87a560aa04ddc51a1e36bbfb076441d96b3af827e572/claude_agent_sdk-0.2.116-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:e130166e5b1054b4e3741d957fd6759546fa657fa765385955a9ef12fdc545f9", size = 80070001, upload-time = "2026-07-11T01:05:01.862Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/a2/305b81ee541ff1323920809803695c0294584f30b7e451a290213f53f4d7/claude_agent_sdk-0.2.116-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:d5e420912378cf66a90cf898bdd4567cc8f994308bd8011d7bd71968066f3894", size = 81082600, upload-time = "2026-07-11T01:05:06.688Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/cb/c492bf6d973837f00894604f2e0ad3b216a03163dc204bff14b3e7e596f0/claude_agent_sdk-0.2.116-py3-none-win_amd64.whl", hash = "sha256:fb8dbc73f52d103e08b30fe865199ea1d89e7b2197652a19a97a15b040cf685b", size = 80616940, upload-time = "2026-07-11T01:05:12.229Z" },
-]
-
-[[package]]
 name = "click"
 version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1572,19 +1554,20 @@ wheels = [
 
 [[package]]
 name = "harbor"
-version = "0.14.0"
+version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "claude-agent-sdk" },
-    { name = "datasets" },
     { name = "dirhash" },
     { name = "fastapi" },
+    { name = "filelock" },
     { name = "httpx" },
     { name = "jinja2" },
     { name = "litellm" },
     { name = "packaging" },
     { name = "pathspec" },
+    { name = "platformdirs" },
     { name = "pydantic" },
+    { name = "pyjwt" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -1596,9 +1579,9 @@ dependencies = [
     { name = "typer" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/f3/cba38a11b0cca01ecd471437869f1cd57d86a3b1e4091b8fd3d112cba8af/harbor-0.14.0.tar.gz", hash = "sha256:0ffffc25a618e4b7bf2b901a8c717c8bc28877f5aa8c37be47f1ec8c301cb0b6", size = 1241271, upload-time = "2026-06-17T16:43:23.495Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/da/5a26998c6e7d9455321ab39bc8e9122993892ece13c3ad4f2b0de986aaf6/harbor-0.20.0.tar.gz", hash = "sha256:e2e5e88f772690fd121553ca34fd5d6dd6b4aaa51c8fae635abc84b112303112", size = 1590870, upload-time = "2026-07-18T21:25:22.578Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/22/cb447121af474cfc7662b9f997be20316eadc692f19fa884608460589020/harbor-0.14.0-py3-none-any.whl", hash = "sha256:171971a008386ce633ef9f53fb4170e7d7807dba15349e930366581dd4c511e2", size = 1412739, upload-time = "2026-06-17T16:43:25.062Z" },
+    { url = "https://files.pythonhosted.org/packages/76/03/b6617f32385295729f3af0ae0d512cf87ba4793b9ce462ea020d776a9025/harbor-0.20.0-py3-none-any.whl", hash = "sha256:4b7e48223aea2384cdb8c9eff35eaebd482fc9b1ec09f8193a121c47356ff19a", size = 1792416, upload-time = "2026-07-18T21:25:19.206Z" },
 ]
 
 [[package]]
@@ -4984,7 +4967,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.78.0" },
     { name = "datasets", specifier = ">=3.3.0,<6.0.0" },
     { name = "gepa", specifier = ">=0.0.6" },
-    { name = "harbor", marker = "python_full_version >= '3.12' and extra == 'harbor'", specifier = "==0.14.0" },
+    { name = "harbor", marker = "python_full_version >= '3.12' and extra == 'harbor'", specifier = "==0.20.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "loguru", specifier = ">=0.7.0" },
     { name = "math-verify", specifier = ">=0.8.0" },

--- a/verifiers/v1/harnesses/terminus_2/harness.py
+++ b/verifiers/v1/harnesses/terminus_2/harness.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 class Terminus2HarnessConfig(HarnessConfig):
-    version: str = "0.14.0"
+    version: str = "0.20.0"
     """Harbor release to install, pinned for reproducibility."""
 
 

--- a/verifiers/v1/tasksets/harbor/taskset.py
+++ b/verifiers/v1/tasksets/harbor/taskset.py
@@ -17,7 +17,6 @@ import subprocess
 import sys
 import tarfile
 import tempfile
-import tomllib
 from collections.abc import Iterator
 from functools import lru_cache
 from pathlib import Path
@@ -214,7 +213,7 @@ def dataset_dir(config: HarborConfig) -> Path:
 
 def resolve_image(
     task_dir: Path,
-    config: dict,
+    image: str | None,
     require_image: bool,
     ignore_dockerfile: bool = False,
 ) -> str | None:
@@ -224,9 +223,8 @@ def resolve_image(
     fallback for tasks with no environment, but would score a Dockerfile task in
     the wrong environment unless the user explicitly opts in.
     """
-    declared = config.get("environment", {}).get("docker_image")
-    if declared:
-        return declared
+    if image:
+        return image
     if (task_dir / "environment" / "Dockerfile").exists():
         if ignore_dockerfile:
             return None
@@ -243,67 +241,41 @@ def resolve_image(
     return None
 
 
-def size_to_mb(size: str | float) -> float:
-    """A Harbor size in MB, from either schema: current integer-MB fields or the
-    legacy schema-1.0 size strings ("8G", "512M", "64K")."""
-    if not isinstance(size, str):
-        return float(size)
-    scale = {"G": 1024.0, "M": 1.0, "K": 1 / 1024}.get(size.strip().upper()[-1:])
-    if scale is None:
-        raise ValueError(
-            f"invalid Harbor size {size!r}: expected a number of MB or a "
-            "'<number>[G|M|K]' string"
-        )
-    return float(size.strip()[:-1]) * scale
-
-
-def parse_resources(env: dict, multiplier: float = 1.0) -> TaskResources:
-    # Harbor's current schema reports memory/storage as integer-MB fields; the
-    # legacy schema 1.0 used size strings under `memory`/`storage`, which Harbor
-    # still migrates (datasets like senior-swe-bench are authored against it).
-    # TaskResources stores GB. A zero GPU count means no GPU request rather than
-    # the string "0".
-    memory = env.get("memory_mb") or env.get("memory")
-    disk = env.get("storage_mb") or env.get("storage")
-    return TaskResources(
-        cpu=env["cpus"] * multiplier if env.get("cpus") else None,
-        memory=size_to_mb(memory) / 1024 * multiplier if memory else None,
-        gpu=str(env["gpus"]) if env.get("gpus") else None,
-        disk=size_to_mb(disk) / 1024 * multiplier if disk else None,
-    )
-
-
 def parse_task(task_dir: Path, idx: int, harbor_config: HarborConfig) -> HarborData:
-    # Harbor is optional, so importing its schema is deferred until a Harbor task loads.
+    # Harbor is optional, so imports stay deferred until a Harbor task loads.
     from harbor.models.task.config import NetworkMode
-    from harbor.models.task.config import TaskConfig as HarborTaskConfig
+    from harbor.models.task.task import Task as HarborModelTask
 
-    config = tomllib.loads((task_dir / "task.toml").read_text())
-    parsed = HarborTaskConfig.model_validate(config)
-    network = (
-        parsed.agent.explicit_phase_policy() or parsed.environment.resolve_baseline()
+    harbor_task = HarborModelTask(task_dir)
+    parsed = harbor_task.config
+    environment = parsed.environment
+    network = parsed.agent.explicit_phase_policy() or environment.resolve_baseline()
+    task, meta = parsed.task, parsed.metadata
+    authors = (
+        [Author(name=author.name, email=author.email) for author in task.authors]
+        if task
+        else []
     )
-    task, meta = config.get("task", {}), config.get("metadata", {})
-    authors = [Author(**a) for a in task.get("authors", [])]
     # Older registry entries stored one author in [metadata].
     if not authors and meta.get("author_name"):
         authors = [Author(name=meta["author_name"], email=meta.get("author_email"))]
     if harbor_config.ignore_timeouts:
         harness_timeout = scoring_timeout = None
     else:
-        harness_timeout = config.get("agent", {}).get("timeout_sec")
-        scoring_timeout = config.get("verifier", {}).get("timeout_sec")
+        harness_timeout = parsed.agent.timeout_sec
+        scoring_timeout = parsed.verifier.timeout_sec
     return HarborData(
         idx=idx,
-        name=task.get("name") or task_dir.name,
-        description=task.get("description"),
-        prompt=(task_dir / "instruction.md").read_text().strip(),
+        name=harbor_task.name,
+        description=task.description if task else None,
+        prompt=harbor_task.instruction.strip(),
         image=resolve_image(
             task_dir,
-            config,
+            environment.docker_image,
             harbor_config.require_image,
             harbor_config.ignore_dockerfile,
         ),
+        workdir=environment.workdir,
         network_allow=(
             ["*"]
             if network.network_mode == NetworkMode.PUBLIC
@@ -317,16 +289,25 @@ def parse_task(task_dir: Path, idx: int, harbor_config: HarborConfig) -> HarborD
             if scoring_timeout is not None
             else None,
         ),
-        resources=parse_resources(
-            config.get("environment", {}), harbor_config.resource_multiplier
+        resources=TaskResources(
+            cpu=environment.cpus * harbor_config.resource_multiplier
+            if environment.cpus
+            else None,
+            memory=environment.memory_mb / 1024 * harbor_config.resource_multiplier
+            if environment.memory_mb
+            else None,
+            gpu=str(environment.gpus) if environment.gpus else None,
+            disk=environment.storage_mb / 1024 * harbor_config.resource_multiplier
+            if environment.storage_mb
+            else None,
         ),
-        keywords=task.get("keywords", []),
+        keywords=task.keywords if task else [],
         authors=authors,
         difficulty=meta.get("difficulty"),
         category=meta.get("category"),
         tags=meta.get("tags", []),
         task_dir=str(task_dir),
-        verifier_env=config.get("verifier", {}).get("env", {}),
+        verifier_env=parsed.verifier.env,
     )
 
 

--- a/verifiers/v1/tasksets/harbor/taskset.py
+++ b/verifiers/v1/tasksets/harbor/taskset.py
@@ -262,8 +262,16 @@ def parse_task(task_dir: Path, idx: int, harbor_config: HarborConfig) -> HarborD
     if harbor_config.ignore_timeouts:
         harness_timeout = scoring_timeout = None
     else:
-        harness_timeout = parsed.agent.timeout_sec
-        scoring_timeout = parsed.verifier.timeout_sec
+        harness_timeout = (
+            parsed.agent.timeout_sec
+            if "timeout_sec" in parsed.agent.model_fields_set
+            else None
+        )
+        scoring_timeout = (
+            parsed.verifier.timeout_sec
+            if "timeout_sec" in parsed.verifier.model_fields_set
+            else None
+        )
     return HarborData(
         idx=idx,
         name=harbor_task.name,


### PR DESCRIPTION
## Overview

Upgrade Harbor and the bundled Terminus 2 harness from 0.14.0 to 0.20.0.

## Details

- synchronize the Harbor optional dependency, lockfile, Terminus 2 default, and reference documentation
- parse Harbor task directories through Harbor's typed `Task` model
- remove duplicate TOML and legacy resource parsing while preserving Verifiers-owned task data and runtime behavior
- propagate Harbor-normalized workdirs, network policy, resources, and timeouts into `HarborData`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Harbor task metadata and resource/timeout mapping now depend on Harbor 0.20’s models, so edge-case task packages or legacy TOML shapes could behave differently than the old manual parser.
> 
> **Overview**
> **Upgrades Harbor** from `0.14.0` to `0.20.0` across the optional extra, `uv.lock`, Terminus 2’s default `version`, and the evaluate-environments reference docs.
> 
> **Harbor task loading** in `taskset.py` no longer reads `task.toml` / `instruction.md` by hand. It constructs Harbor’s `Task` model and maps `HarborData` from typed config (instruction, authors, verifier env, network policy, numeric CPU/memory/storage, timeouts via `model_fields_set`). **`workdir`** is now set from `environment.workdir`. **`resolve_image`** takes `environment.docker_image` directly instead of a raw config dict.
> 
> Removes local **`size_to_mb`** / **`parse_resources`** helpers and legacy string resource parsing; resources assume Harbor’s integer-MB environment fields. The lockfile reflects Harbor’s updated dependency set (e.g. drops `claude-agent-sdk` / `datasets` from the Harbor package closure).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1c21d1cbb6712de13cad7860d22a4affbce7ccd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Upgrade Harbor dependency to 0.20.0 and migrate task parsing to Harbor Python models
> - Bumps the Harbor pin from `0.14.0` to `0.20.0` in [pyproject.toml](https://github.com/PrimeIntellect-ai/verifiers/pull/2161/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711), [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2161/files#diff-d7e62857ee7879dee9d540bae1695d31c9f5e90cb2a8d8a79531b56c71e11c0d), and the reference docs.
> - Rewrites `parse_task` in [taskset.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2161/files#diff-2bff5dabcb9a41f4d830e8bbb890e8cc6f5b8331ef2ac4c3b19ffad0e046fe00) to use Harbor's `HarborModelTask` Python models instead of manually reading `task.toml` via `tomllib`; name, instruction, timeouts, resources, workdir, and verifier env are all derived from the model fields.
> - Removes the `size_to_mb` and `parse_resources` helpers; resources are now built directly from numeric environment fields (`cpus`, `memory_mb`, `storage_mb`, `gpus`).
> - Changes `resolve_image` to accept a plain image string instead of a config dict.
> - Behavioral Change: legacy string-based size values (e.g. `'8G'`, `'512M'`) in task environment fields are no longer supported; all resource fields must now be numeric.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b1c21d1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->