### PR TITLE
Add interception transport and replay

### DIFF
--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -342,7 +342,9 @@ class TrainClient(Client):
             prompt = turn.prompt
             tools = parse_tools(body.get("tools"))
         else:
-            prompt, tools = dialect.parse_request(body)
+            request = dialect.parse_request(body)
+            prompt = request.messages
+            tools = request.tools
         from renderers.client import generate
 
         wire_tools = [tool_to_wire(t) for t in tools] if tools else None

--- a/verifiers/v1/dialects/anthropic.py
+++ b/verifiers/v1/dialects/anthropic.py
@@ -30,6 +30,7 @@ from verifiers.v1.types import (
     ImageUrlContentPart,
     ImageUrlSource,
     Messages,
+    Request,
     Response,
     Sampling,
     SamplingConfig,
@@ -196,6 +197,37 @@ def mediate_content(value, path: str):
             continue
         mediated.append(block)
     return mediated, capabilities
+
+
+def content_to_wire(content) -> str | list[dict]:
+    """Typed text/image content in Anthropic's native request shape."""
+    if isinstance(content, str):
+        return content
+    blocks = []
+    for part in content:
+        if isinstance(part, TextContentPart):
+            blocks.append({"type": "text", "text": part.text})
+            continue
+        metadata, separator, data = part.image_url.url.partition(",")
+        if separator and metadata.startswith("data:") and metadata.endswith(";base64"):
+            blocks.append(
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": metadata[5:-7],
+                        "data": data,
+                    },
+                }
+            )
+        else:
+            blocks.append(
+                {
+                    "type": "image",
+                    "source": {"type": "url", "url": part.image_url.url},
+                }
+            )
+    return blocks
 
 
 def parse_messages(body: dict) -> Messages:
@@ -380,7 +412,9 @@ class AnthropicStreamParser(StreamParser):
         for index, parts in self.partial_json.items():
             self.blocks[index]["input"] = json.loads("".join(parts) or "{}")
         self.message["content"] = [self.blocks[index] for index in sorted(self.blocks)]
-        return response_from_wire(self.validate_response(self.message))
+        response = response_from_wire(self.validate_response(self.message))
+        response.raw = self.message
+        return response
 
 
 class ModdedUsage(AnthropicUsage):
@@ -480,6 +514,12 @@ class AnthropicDialect(Dialect[MessageCreateParams, AnthropicMessage]):
         append_user_notice(mediated.setdefault("messages", []))
         return mediated, capabilities
 
+    def is_terminal_event(self, chunk: bytes) -> bool:
+        return any(
+            line.removeprefix(b"event:").strip() == b"message_stop"
+            for line in chunk.splitlines()
+        )
+
     def auth_headers(self, api_key: str) -> dict[str, str]:
         return {"x-api-key": api_key, "anthropic-version": "2023-06-01"}
 
@@ -493,9 +533,7 @@ class AnthropicDialect(Dialect[MessageCreateParams, AnthropicMessage]):
             "error": {"type": "invalid_request_error", "message": message},
         }
 
-    def parse_request(
-        self, body: MessageCreateParams
-    ) -> tuple[Messages, list[Tool] | None]:
+    def parse_request(self, body: MessageCreateParams) -> Request:
         tools = [
             Tool(
                 name=t["name"],
@@ -505,10 +543,103 @@ class AnthropicDialect(Dialect[MessageCreateParams, AnthropicMessage]):
             for t in body.get("tools") or []
             if "input_schema" in t  # skip server tools (web_search etc.)
         ] or None
-        return parse_messages(body), tools
+        return Request(messages=parse_messages(body), tools=tools)
 
     def parse_response(self, response: AnthropicMessage) -> Response:
         return response_from_wire(response)
+
+    def rewrite_request(self, body: dict, before: Request, after: Request) -> None:
+        original = [
+            m for m in before.messages if isinstance(m, (UserMessage, ToolMessage))
+        ]
+        rewritten = [
+            m for m in after.messages if isinstance(m, (UserMessage, ToolMessage))
+        ]
+        targets: list[tuple[dict, dict | None]] = []
+        for native in body.get("messages", []):
+            if native.get("role") == "assistant":
+                continue
+            content = native.get("content")
+            if isinstance(content, str):
+                targets.append((native, None))
+                continue
+            blocks = content or []
+            targets.extend(
+                (native, block)
+                for block in blocks
+                if block.get("type") == "tool_result"
+            )
+            if any(block.get("type") != "tool_result" for block in blocks):
+                targets.append((native, None))
+
+        for (native, block), old, new in zip(targets, original, rewritten, strict=True):
+            if old == new:
+                continue
+            if block is not None:
+                block["content"] = content_to_wire(new.content)
+                continue
+            replacement = content_to_wire(new.content)
+            if isinstance(native.get("content"), str):
+                native["content"] = replacement
+                continue
+            replacement = (
+                [{"type": "text", "text": replacement}]
+                if isinstance(replacement, str)
+                else replacement
+            )
+            blocks = native.get("content") or []
+            updated = []
+            inserted = False
+            for current in blocks:
+                if current.get("type") == "tool_result":
+                    updated.append(current)
+                elif not inserted:
+                    updated.extend(replacement)
+                    inserted = True
+            native["content"] = updated
+
+    def rewrite_response(self, raw: dict, text: str) -> None:
+        raw["content"] = [{"type": "text", "text": text}]
+        raw["stop_reason"] = "end_turn"
+        raw["stop_sequence"] = None
+
+    def stream_events(self, raw: dict) -> list[bytes]:
+        def event(kind: str, payload: dict) -> bytes:
+            return f"event: {kind}\ndata: {json.dumps(payload)}\n\n".encode()
+
+        text = raw["content"][0]["text"]
+        head = {**raw, "content": [], "stop_reason": None, "stop_sequence": None}
+        if isinstance(usage := head.get("usage"), dict):
+            head["usage"] = {**usage, "output_tokens": 0}
+        return [
+            event("message_start", {"type": "message_start", "message": head}),
+            event(
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {"type": "text", "text": ""},
+                },
+            ),
+            event(
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": text},
+                },
+            ),
+            event("content_block_stop", {"type": "content_block_stop", "index": 0}),
+            event(
+                "message_delta",
+                {
+                    "type": "message_delta",
+                    "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+                    "usage": raw.get("usage") or {},
+                },
+            ),
+            event("message_stop", {"type": "message_stop"}),
+        ]
 
     def stream_parser(self) -> StreamParser:
         return AnthropicStreamParser(self.validate_response)

--- a/verifiers/v1/dialects/base.py
+++ b/verifiers/v1/dialects/base.py
@@ -20,7 +20,7 @@ from typing import ClassVar, Generic, TypeVar
 from pydantic import BaseModel
 from pydantic_core import from_json
 
-from verifiers.v1.types import Messages, Response, Sampling, SamplingConfig, Tool
+from verifiers.v1.types import Request, Response, Sampling, SamplingConfig
 
 ReqT = TypeVar("ReqT")
 RespT = TypeVar("RespT", bound=BaseModel)
@@ -193,8 +193,8 @@ class Dialect(ABC, Generic[ReqT, RespT]):
         content. Returned paths never contain request values."""
 
     @abstractmethod
-    def parse_request(self, body: ReqT) -> tuple[Messages, list[Tool] | None]:
-        """The native request -> vf prompt + tools (for the trace)."""
+    def parse_request(self, body: ReqT) -> Request:
+        """The native request -> the typed model request."""
 
     def parse_sampling(self, body: ReqT) -> Sampling:
         """The native request's call settings -> the canonical `Sampling` (for the
@@ -211,6 +211,18 @@ class Dialect(ABC, Generic[ReqT, RespT]):
     def validate_response(self, raw: dict) -> RespT:
         """Validate a native response, normalizing provider-compatible extensions if needed."""
         return self.response_type.model_validate(raw)
+
+    @abstractmethod
+    def rewrite_request(self, body: ReqT, before: Request, after: Request) -> None:
+        """Patch rewritten user/tool messages into the native conversation."""
+
+    @abstractmethod
+    def rewrite_response(self, raw: dict, text: str) -> None:
+        """Replace the native assistant response with inert text."""
+
+    @abstractmethod
+    def stream_events(self, raw: dict) -> list[bytes]:
+        """Serialize a rewritten response as a minimal native SSE stream."""
 
     @abstractmethod
     def stream_parser(self) -> StreamParser:

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -6,6 +6,7 @@ and responses (`parse_response`). Reasoning extraction mirrors the v0 chat clien
 read them in the same precedence (`reasoning` / `reasoning_content` / `reasoning_details`).
 """
 
+import json
 import time
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -28,6 +29,7 @@ from verifiers.v1.types import (
     FinishReason,
     Message,
     Messages,
+    Request,
     Response,
     Sampling,
     SamplingConfig,
@@ -319,7 +321,9 @@ class ChatStreamParser(StreamParser):
             ],
             "usage": self.usage,
         }
-        return response_from_wire(ModdedChatCompletion.model_validate(completion))
+        response = response_from_wire(ModdedChatCompletion.model_validate(completion))
+        response.raw = completion
+        return response
 
 
 class ChatDialect(Dialect[CompletionCreateParams, ChatCompletion]):
@@ -473,9 +477,9 @@ class ChatDialect(Dialect[CompletionCreateParams, ChatCompletion]):
         append_user_notice(mediated.setdefault("messages", []))
         return mediated, capabilities
 
-    def parse_request(
-        self, body: CompletionCreateParams
-    ) -> tuple[Messages, list[Tool] | None]:
+    def parse_request(self, body: CompletionCreateParams) -> Request:
+        if body.get("n", 1) != 1:
+            raise ValueError("chat completions require n=1")
         messages: Messages = []
         tool_names: dict[str, str] = {}
         for raw in body.get("messages", []):
@@ -488,7 +492,7 @@ class ChatDialect(Dialect[CompletionCreateParams, ChatCompletion]):
             if isinstance(message, AssistantMessage):
                 for call in message.tool_calls or []:
                     tool_names[call.id] = call.name
-        return messages, parse_tools(body.get("tools"))
+        return Request(messages=messages, tools=parse_tools(body.get("tools")))
 
     def parse_sampling(self, body: CompletionCreateParams) -> Sampling:
         settings = {k: v for k, v in body.items() if k in self.sampling_fields}
@@ -500,6 +504,41 @@ class ChatDialect(Dialect[CompletionCreateParams, ChatCompletion]):
 
     def parse_response(self, response: ChatCompletion) -> Response:
         return response_from_wire(response)
+
+    def rewrite_request(self, body: dict, before: Request, after: Request) -> None:
+        for native, original, rewritten in zip(
+            body.get("messages", []), before.messages, after.messages, strict=True
+        ):
+            if rewritten != original:
+                native["content"] = message_to_wire(rewritten)["content"]
+                if isinstance(rewritten, ToolMessage):
+                    if rewritten.name is None:
+                        native.pop("name", None)
+                    else:
+                        native["name"] = rewritten.name
+
+    def rewrite_response(self, raw: dict, text: str) -> None:
+        for choice in raw.get("choices") or []:
+            if isinstance(choice.get("message"), dict):
+                choice["message"] = {"role": "assistant", "content": text}
+                choice["finish_reason"] = "stop"
+                choice.pop("logprobs", None)
+
+    def stream_events(self, raw: dict) -> list[bytes]:
+        choice = (raw.get("choices") or [{}])[0]
+        chunk = {
+            **{key: value for key, value in raw.items() if key != "choices"},
+            "object": "chat.completion.chunk",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": choice.get("message")
+                    or {"role": "assistant", "content": ""},
+                    "finish_reason": choice.get("finish_reason"),
+                }
+            ],
+        }
+        return [f"data: {json.dumps(chunk)}\n\n".encode(), b"data: [DONE]\n\n"]
 
     def stream_parser(self) -> StreamParser:
         return ChatStreamParser()

--- a/verifiers/v1/dialects/responses.py
+++ b/verifiers/v1/dialects/responses.py
@@ -32,6 +32,7 @@ from verifiers.v1.types import (
     ImageUrlContentPart,
     ImageUrlSource,
     Messages,
+    Request,
     Response,
     Sampling,
     SamplingConfig,
@@ -386,9 +387,11 @@ class ResponsesStreamParser(StreamParser):
         events = self.terminal_events or self.events
         for event in iter_sse_reverse(b"".join(events)):
             if event.get("type") in FINAL_EVENTS:
-                return response_from_wire(
+                response = response_from_wire(
                     OpenAIResponse.model_validate(event["response"])
                 )
+                response.raw = event["response"]
+                return response
         raise ValueError("Responses stream ended without a terminal event")
 
 
@@ -541,9 +544,7 @@ class ResponsesDialect(Dialect[ResponseCreateParams, OpenAIResponse]):
             settings["max_tokens"] = settings.pop("max_output_tokens")
         return Sampling.model_validate(settings)
 
-    def parse_request(
-        self, body: ResponseCreateParams
-    ) -> tuple[Messages, list[Tool] | None]:
+    def parse_request(self, body: ResponseCreateParams) -> Request:
         prompt: Messages = []
         if instructions := body.get("instructions"):
             prompt.append(SystemMessage(content=instructions))
@@ -596,10 +597,126 @@ class ResponsesDialect(Dialect[ResponseCreateParams, OpenAIResponse]):
             for t in body.get("tools") or []
             if t.get("type") == "function"
         ] or None
-        return prompt, tools
+        return Request(messages=prompt, tools=tools)
 
     def parse_response(self, response: OpenAIResponse) -> Response:
         return response_from_wire(response)
+
+    def rewrite_request(self, body: dict, before: Request, after: Request) -> None:
+        original = [
+            m for m in before.messages if isinstance(m, (UserMessage, ToolMessage))
+        ]
+        rewritten = [
+            m for m in after.messages if isinstance(m, (UserMessage, ToolMessage))
+        ]
+        items = body.get("input")
+        if isinstance(items, str):
+            if original != rewritten:
+                message = rewritten[0]
+                content = (
+                    message.content
+                    if isinstance(message.content, str)
+                    else [
+                        {"type": "input_text", "text": part.text}
+                        if isinstance(part, TextContentPart)
+                        else {
+                            "type": "input_image",
+                            "image_url": part.image_url.url,
+                        }
+                        for part in message.content
+                    ]
+                )
+                body["input"] = (
+                    content
+                    if isinstance(content, str)
+                    else [{"role": "user", "content": content}]
+                )
+            return
+
+        targets = []
+        for item in items or []:
+            role = item.get("role")
+            kind = item.get("type") or ""
+            assistant = role == "assistant" or (
+                role is None and not kind.endswith(("_output", "_response"))
+            )
+            if assistant or role in ("system", "developer"):
+                continue
+            targets.append(item)
+        for item, old, new in zip(targets, original, rewritten, strict=True):
+            if old == new:
+                continue
+            content = (
+                new.content
+                if isinstance(new.content, str)
+                else [
+                    {"type": "input_text", "text": part.text}
+                    if isinstance(part, TextContentPart)
+                    else {
+                        "type": "input_image",
+                        "image_url": part.image_url.url,
+                    }
+                    for part in new.content
+                ]
+            )
+            item["output" if isinstance(new, ToolMessage) else "content"] = content
+
+    def rewrite_response(self, raw: dict, text: str) -> None:
+        original = next(
+            (
+                item
+                for item in raw.get("output") or []
+                if isinstance(item, dict) and item.get("type") == "message"
+            ),
+            {},
+        )
+        raw["output"] = [
+            {
+                "type": "message",
+                "id": original.get("id") or "msg_intercepted",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": text, "annotations": []}],
+            }
+        ]
+        raw.update(status="completed", error=None, incomplete_details=None)
+        raw.pop("required_action", None)
+        if "output_text" in raw:
+            raw["output_text"] = text
+
+    def stream_events(self, raw: dict) -> list[bytes]:
+        item = raw["output"][0]
+        part = item["content"][0]
+        common = {"output_index": 0, "item_id": item["id"], "content_index": 0}
+        head = {
+            **raw,
+            "status": "in_progress",
+            "output": [],
+            "completed_at": None,
+        }
+        events = [
+            ("response.created", {"response": head}),
+            (
+                "response.output_item.added",
+                {"output_index": 0, "item": {**item, "content": []}},
+            ),
+            (
+                "response.content_part.added",
+                {**common, "part": {**part, "text": ""}},
+            ),
+            ("response.output_text.delta", {**common, "delta": part["text"]}),
+            ("response.output_text.done", {**common, "text": part["text"]}),
+            ("response.content_part.done", {**common, "part": part}),
+            ("response.output_item.done", {"output_index": 0, "item": item}),
+            ("response.completed", {"response": raw}),
+        ]
+        return [
+            *(
+                f"data: {json.dumps({'type': kind, 'sequence_number': i, **data})}\n\n".encode()
+                for i, (kind, data) in enumerate(events)
+            ),
+            b"data: [DONE]\n\n",
+        ]
 
     def stream_parser(self) -> StreamParser:
         return ResponsesStreamParser()

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -375,6 +375,18 @@ class PendingTurn:
             self.trace.tools = tools
         return assistant_id
 
+    def commit_prompt(self, tools: list[Tool] | None = None) -> None:
+        """Record an input that terminated before model inference."""
+        parent = self.prefix_node_ids[-1] if self.prefix_node_ids else None
+        index = _head_index(self.trace)
+        for message in self.tail:
+            previous = parent
+            self.trace.nodes.append(MessageNode(parent=parent, message=message))
+            parent = len(self.trace.nodes) - 1
+            index[(previous, message_hash(message))] = parent
+        if tools:
+            self.trace.tools = tools
+
 
 def prepare_turn(trace: Trace, prompt: list[Message]) -> PendingTurn:
     """Resolve `prompt` against the trace graph without mutating it."""

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -29,6 +29,7 @@ import time
 import traceback
 from collections.abc import AsyncIterator, Collection
 from contextlib import asynccontextmanager
+from tempfile import SpooledTemporaryFile
 from typing import Literal
 
 from aiohttp import web
@@ -50,6 +51,7 @@ from verifiers.v1.errors import (
     TaskError,
 )
 from verifiers.v1.interception.base import BaseInterceptionConfig, Interception, Slot
+from verifiers.v1.interception.tool import ToolHookRequest
 from verifiers.v1.interception.tunnel import (
     PrimeTunnelConfig,
     Tunnel,
@@ -58,7 +60,7 @@ from verifiers.v1.interception.tunnel import (
 )
 from verifiers.v1.session import RolloutSession
 from verifiers.v1.trace import Error, ModelCall, PolicyEvent, TimeSpan
-from verifiers.v1.types import FinishReason, Messages, Response, Tool, Usage
+from verifiers.v1.types import FinishReason, Request, Response, Usage
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +72,7 @@ logger = logging.getLogger(__name__)
 _MAX_REQUEST_BODY = 1024**3  # 1 GiB (aiohttp's default is 1 MiB)
 _KEEPALIVE_INTERVAL_SECONDS = 3
 _STREAM_QUEUE_MAXSIZE = 16
+STREAM_MEMORY_BUFFER = 4 * 1024**2
 # blake2b saturates ~1.7 GB/s, so a body up to this size hashes inline in well under a
 # millisecond; a larger one (bodies may reach `_MAX_REQUEST_BODY`) is hashed off the event
 # loop instead — see `_request_digest`.
@@ -221,6 +224,7 @@ class InterceptionServer(Interception):
         # Tool servers use a state-only capability; the model bearer cannot reach these.
         app.router.add_get("/state", self.handle_state_get)
         app.router.add_put("/state", self.handle_state_put)
+        app.router.add_post("/tool", self.handle_tool)
         # A launched tool server fetches its rollout's task here to run `setup_task` — the task
         # is never passed via env, only over this channel, keyed by the state bearer.
         app.router.add_get("/task", self.handle_task_get)
@@ -250,7 +254,7 @@ class InterceptionServer(Interception):
     def _fail(
         self, session: RolloutSession, dialect: Dialect, error: RolloutError
     ) -> web.Response:
-        """Stash a model-turn-adjacent failure (a `@stop` raising) so the rollout
+        """Stash a model-turn-adjacent failure (such as a hook raising) so the rollout
         re-raises it as the real cause, and report it to the harness as an HTTP error."""
         session.error = error
         logger.warning(
@@ -275,6 +279,28 @@ class InterceptionServer(Interception):
                 ",".join(capabilities),
             )
         return mediated, capabilities
+
+    async def handle_tool(self, request: web.Request) -> web.Response:
+        session = self.sessions.get(
+            request.headers.get("Authorization", "").removeprefix("Bearer ")
+        )
+        if session is None:
+            return web.json_response({"error": "unauthorized"}, status=401)
+        session.adopt(asyncio.current_task())
+        if session.released:
+            return web.json_response({"error": "rollout concluded"}, status=409)
+        if session.stopped:
+            return web.json_response(
+                {"action": "stop", "reason": session.trace.stop_condition}
+            )
+        try:
+            hook = ToolHookRequest.model_validate_json(await request.read())
+            return web.json_response(
+                await session.handle_tool(hook.phase, hook.message)
+            )
+        except RolloutError as error:
+            session.error = error
+            return web.json_response({"error": str(error)}, status=400)
 
     def record_call(
         self,
@@ -357,7 +383,6 @@ class InterceptionServer(Interception):
         request._read_bytes = None
         del raw
         body = dialect.apply_overrides(body, session.ctx.model, session.ctx.sampling)
-        body, policy_paths = self.mediate_capabilities(session, dialect, body)
         streaming = dialect.streaming(body)
         logger.debug(
             "intercept %s: id=%s stream=%s",
@@ -377,24 +402,21 @@ class InterceptionServer(Interception):
             logger.debug("intercept replay: id=%s (retried request)", session.trace.id)
             return _completion_response(session.last_response)
 
-        # A streamed response cannot be replayed as a JSON completion without
-        # buffering the full SSE body. Keep streaming outside the non-streaming
-        # coalescing cache, as it was before in-flight retries were introduced.
-        if streaming:
-            prompt, tools = dialect.parse_request(body)
-            return await self._stream(
-                request,
-                session,
-                dialect,
-                body,
-                prompt,
-                tools,
-                policy_paths,
+        try:
+            model_request = dialect.parse_request(body)
+        except ValueError as error:
+            return web.json_response(dialect.error_body(str(error)), status=400)
+        if session.released:
+            return web.json_response(
+                dialect.error_body("rollout concluded"), status=409
+            )
+        if session.stopped:
+            return web.json_response(
+                dialect.error_body(f"rollout stopped: {session.trace.stop_condition}"),
+                status=400,
             )
 
         async def coalesced(inflight: "asyncio.Future[dict | None]") -> web.Response:
-            # Await the first attempt instead of re-sampling. None means it produced no servable
-            # response (it errored/refused), so let the SDK retry afresh.
             logger.debug(
                 "intercept coalesce: id=%s (retry of in-flight turn)", session.trace.id
             )
@@ -405,14 +427,84 @@ class InterceptionServer(Interception):
                 )
             return _completion_response(completion)
 
-        if (inflight := session.inflight.get(req_hash)) is not None:
-            return await coalesced(inflight)
-        # Claim the in-flight slot so a retry arriving mid-flight coalesces onto it (above)
-        # rather than starting a second inference. The get / create / assign run with no
-        # await between them, so two concurrent identical requests can never both become
-        # owner.
-        fut: asyncio.Future[dict | None] = asyncio.get_running_loop().create_future()
-        session.inflight[req_hash] = fut
+        fut: asyncio.Future[dict | None] | None = None
+        if not streaming:
+            if (inflight := session.inflight.get(req_hash)) is not None:
+                return await coalesced(inflight)
+            fut = asyncio.get_running_loop().create_future()
+            session.inflight[req_hash] = fut
+
+        def finish_inflight(completion: dict | None = None) -> None:
+            if fut is None:
+                return
+            if session.inflight.get(req_hash) is fut:
+                session.inflight.pop(req_hash, None)
+            if not fut.done():
+                fut.set_result(completion)
+
+        try:
+            refused = await session.refused()
+            if refused is not None:
+                finish_inflight()
+                return web.json_response(
+                    dialect.error_body(f"rollout stopped: {refused}"), status=400
+                )
+            original_request = model_request
+            model_request, request_rewrites, stopped = await session.rewrite_request(
+                model_request
+            )
+            if request_rewrites:
+                session.trace.request_rewrites.extend(request_rewrites)
+                if stopped is None:
+                    dialect.rewrite_request(body, original_request, model_request)
+        except RolloutError as error:
+            finish_inflight()
+            return self._fail(session, dialect, error)
+        except Exception as error:  # noqa: BLE001 - surface task hook failures
+            finish_inflight()
+            return self._fail(
+                session,
+                dialect,
+                TaskError(
+                    f"model boundary hook failed: {type(error).__name__}: {error}"
+                ),
+            )
+        except BaseException:
+            finish_inflight()
+            raise
+        if stopped is not None:
+            turn = graph.prepare_turn(session.trace, model_request.messages)
+            turn.commit_prompt(model_request.tools)
+            session.trace.stop(stopped)
+            finish_inflight()
+            return web.json_response(
+                dialect.error_body(f"rollout stopped: {stopped}"),
+                status=400,
+            )
+
+        try:
+            body, policy_paths = self.mediate_capabilities(session, dialect, body)
+            model_request = dialect.parse_request(body)
+            turn = graph.prepare_turn(session.trace, model_request.messages)
+        except ValueError as error:
+            finish_inflight()
+            return web.json_response(dialect.error_body(str(error)), status=400)
+        except RolloutError as error:
+            finish_inflight()
+            return self._fail(session, dialect, error)
+
+        inspect_response = bool(session.response_interceptors or session.response_stops)
+        if streaming:
+            return await self._stream(
+                request,
+                session,
+                dialect,
+                body,
+                model_request,
+                turn=turn,
+                inspect_response=inspect_response,
+                policy_paths=policy_paths,
+            )
 
         def serve(response: Response) -> web.Response:
             # Record the served turn and hand it to any coalesced retry, so a retried
@@ -421,42 +513,10 @@ class InterceptionServer(Interception):
             # completion) that the server serializes back to the program.
             session.last_request = req_hash
             session.last_response = response.raw
-            if not fut.done():
-                fut.set_result(response.raw)
+            finish_inflight(response.raw)
             return _completion_response(response.raw)
 
         try:
-            # The proxy preserves native JSON fields except model + sampling. `prompt` is only the
-            # dialect's typed view for building the trace; the renderer re-derives its own from `body`.
-            prompt: Messages
-            # `tools` is recorded onto the trace only when a turn commits (below / in `_stream`):
-            # the request is ground truth for what the model saw, but a refused or failed request
-            # was never seen at all.
-            prompt, tools = dialect.parse_request(body)
-            # The rollout may conclude (deadline, teardown) while this exchange was
-            # upstream: the trace is sealed, so drop the turn instead of mutating it.
-            if session.released:
-                return web.json_response(
-                    dialect.error_body("rollout concluded"), status=409
-                )
-            try:
-                refused = await session.refused()
-            except RolloutError as e:
-                return self._fail(session, dialect, e)
-            except Exception as e:  # noqa: BLE001 - surface any task hook failure
-                return self._fail(
-                    session,
-                    dialect,
-                    TaskError(f"@stop failed: {type(e).__name__}: {e}"),
-                )
-            if refused is not None:
-                # Refuse the model call to halt the harness (it sees an HTTP error;
-                # `HarnessSession.turn` treats a stopped rollout as the clean exit it is).
-                return web.json_response(
-                    dialect.error_body(f"rollout stopped: {refused}"),
-                    status=400,
-                )
-            turn = graph.prepare_turn(session.trace, prompt)
             session.error = None
             call_response: Response | None = None
             node: int | None = None
@@ -483,9 +543,40 @@ class InterceptionServer(Interception):
                         return web.json_response(
                             dialect.error_body("rollout concluded"), status=409
                         )
-                    # One node per new message; branches fall out of walking the
-                    # graph (see Trace.branches / verifiers.v1.graph).
-                    node = turn.commit(call_response, tools)
+                    response_rewrites = []
+                    stopped = None
+                    if session.response_interceptors or session.response_stops:
+                        (
+                            call_response,
+                            response_rewrites,
+                            stopped,
+                        ) = await session.rewrite_response(call_response)
+                        if response_rewrites:
+                            assert call_response.raw is not None
+                            dialect.rewrite_response(
+                                call_response.raw, call_response.message.content or ""
+                            )
+                            raw_response = call_response.raw
+                            call_response = dialect.parse_response(
+                                dialect.validate_response(raw_response)
+                            )
+                            call_response.raw = raw_response
+                    if session.stopped:
+                        return web.json_response(
+                            dialect.error_body(
+                                f"rollout stopped: {session.trace.stop_condition}"
+                            ),
+                            status=400,
+                        )
+                    node = turn.commit(call_response, model_request.tools)
+                    session.consume_prepared(turn.tail)
+                    session.trace.response_rewrites.extend(response_rewrites)
+                    if stopped is not None:
+                        session.trace.stop(stopped)
+                        return web.json_response(
+                            dialect.error_body(f"rollout stopped: {stopped}"),
+                            status=400,
+                        )
                 except OverlongPromptError as e:
                     # An overlong prompt is a budget limit, not a crash: end the rollout
                     # cleanly as a truncation — refuse the call to halt the harness (same
@@ -546,11 +637,7 @@ class InterceptionServer(Interception):
         finally:
             # Free the in-flight slot and unblock any coalesced retry; None signals "no servable
             # response" (an error/refuse return above), so the waiter surfaces a retryable error.
-            # Only clear our own entry — never one a later owner may have installed.
-            if session.inflight.get(req_hash) is fut:
-                session.inflight.pop(req_hash, None)
-            if not fut.done():
-                fut.set_result(None)
+            finish_inflight()
 
     async def _stream(
         self,
@@ -558,35 +645,20 @@ class InterceptionServer(Interception):
         session: RolloutSession,
         dialect: Dialect,
         body: dict,
-        prompt: Messages,
-        tools: list[Tool] | None = None,
+        model_request: Request,
+        *,
+        turn: graph.PendingTurn,
+        inspect_response: bool,
         policy_paths: list[str] | None = None,
     ) -> web.StreamResponse:
         """A streamed (SSE) model turn: relay the provider's stream through to the program,
         incrementally assembling the response to record on the trace (the only client that
         streams is the eval relay)."""
-        if session.released:  # concluded while this request queued — seal holds
-            return web.json_response(
-                dialect.error_body("rollout concluded"), status=409
-            )
-        try:
-            refused = await session.refused()
-        except RolloutError as e:
-            return self._fail(session, dialect, e)
-        except Exception as e:  # noqa: BLE001 - surface any task hook failure
-            return self._fail(
-                session, dialect, TaskError(f"@stop failed: {type(e).__name__}: {e}")
-            )
-        if refused is not None:
-            return web.json_response(
-                dialect.error_body(f"rollout stopped: {refused}"), status=400
-            )
         session.error = None
         reply = None
         response: Response | None = None
         node: int | None = None
         error: Exception | None = None
-        turn = graph.prepare_turn(session.trace, prompt)
         started = time.time()
         try:
             try:
@@ -619,6 +691,97 @@ class InterceptionServer(Interception):
                 error = e
                 logger.warning("model call failed: id=%s %s", session.trace.id, e)
                 return web.json_response(dialect.error_body(str(e)), status=502)
+
+            if inspect_response:
+                buffered = SpooledTemporaryFile(  # noqa: SIM115 - closed before every exit
+                    max_size=STREAM_MEMORY_BUFFER
+                )
+                parser = dialect.stream_parser()
+                saw_terminal = False
+                try:
+                    async for chunk in reply.chunks:
+                        buffered.write(chunk)
+                        saw_terminal |= dialect.is_terminal_event(chunk)
+                        if parser.on_done is not None and is_sse_done_event(chunk):
+                            parser.on_done()
+                        parser.feed(chunk)
+                    if not saw_terminal:
+                        raise ProviderError(
+                            "upstream stream ended before its terminal event"
+                        )
+                    response = parser.finish()
+                    response_rewrites = []
+                    stopped = None
+                    if session.response_interceptors or session.response_stops:
+                        (
+                            response,
+                            response_rewrites,
+                            stopped,
+                        ) = await session.rewrite_response(response)
+                        if response_rewrites:
+                            assert response.raw is not None
+                            dialect.rewrite_response(
+                                response.raw, response.message.content or ""
+                            )
+                            raw_response = response.raw
+                            response = dialect.parse_response(
+                                dialect.validate_response(raw_response)
+                            )
+                            response.raw = raw_response
+                except RolloutError as e:
+                    buffered.close()
+                    error = e
+                    session.error = e
+                    return self._fail(session, dialect, e)
+                except Exception as e:  # noqa: BLE001 - malformed provider stream
+                    buffered.close()
+                    error = ProviderError(str(e))
+                    session.error = error
+                    return self._fail(session, dialect, error)
+                finally:
+                    await reply.close()
+
+                if session.released or session.stopped:
+                    buffered.close()
+                    return web.json_response(
+                        dialect.error_body(
+                            "rollout concluded"
+                            if session.released
+                            else f"rollout stopped: {session.trace.stop_condition}"
+                        ),
+                        status=409 if session.released else 400,
+                    )
+                node = turn.commit(response, model_request.tools)
+                session.consume_prepared(turn.tail)
+                session.trace.response_rewrites.extend(response_rewrites)
+                if stopped is not None:
+                    buffered.close()
+                    session.trace.stop(stopped)
+                    return web.json_response(
+                        dialect.error_body(f"rollout stopped: {stopped}"),
+                        status=400,
+                    )
+
+                resp = web.StreamResponse(
+                    headers={"Cache-Control": "no-cache", "Connection": "keep-alive"}
+                )
+                resp.content_type = reply.content_type.split(";")[0].strip()
+                try:
+                    await resp.prepare(request)
+                    if response_rewrites:
+                        for event in dialect.stream_events(response.raw or {}):
+                            await resp.write(event)
+                    else:
+                        buffered.seek(0)
+                        while chunk := buffered.read(64 * 1024):
+                            await resp.write(chunk)
+                    await resp.write_eof()
+                except ConnectionResetError:
+                    pass
+                finally:
+                    buffered.close()
+                return resp
+
             resp = web.StreamResponse(
                 headers={"Cache-Control": "no-cache", "Connection": "keep-alive"}
             )
@@ -695,9 +858,14 @@ class InterceptionServer(Interception):
                 if parser_error is not None:
                     raise parser_error
                 response = parser.finish()
-                if not session.released:  # concluded mid-stream — seal holds
-                    node = turn.commit(response, tools)
+                if not session.released and not session.stopped:
+                    node = turn.commit(response, model_request.tools)
+                    session.consume_prepared(turn.tail)
                     logger.debug("intercept stream turn: id=%s", session.trace.id)
+                elif session.stopped:
+                    with contextlib.suppress(ConnectionResetError):
+                        await resp.write_eof()
+                    return resp
             finally:
                 # Release the withheld events only now — after the commit — then close.
                 with contextlib.suppress(ConnectionResetError):

--- a/verifiers/v1/interception/tool.py
+++ b/verifiers/v1/interception/tool.py
@@ -1,0 +1,12 @@
+"""Typed wire payload for native harness tool hooks."""
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+from verifiers.v1.types import ToolMessage
+
+
+class ToolHookRequest(BaseModel):
+    phase: Literal["before", "after"]
+    message: ToolMessage

--- a/verifiers/v1/session.py
+++ b/verifiers/v1/session.py
@@ -8,22 +8,54 @@ budget (turns / tokens), checked between turns.
 """
 
 import asyncio
+import inspect
 import logging
+from collections import Counter
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from functools import cached_property
-from typing import TYPE_CHECKING
+from typing import get_origin, get_type_hints
 
 from pydantic import TypeAdapter
 
+from verifiers.v1 import graph
 from verifiers.v1.clients import Client, ModelContext
 from verifiers.v1.configs.runtime import NetworkPolicyConfig
-from verifiers.v1.trace import Trace
-
-if TYPE_CHECKING:
-    from verifiers.v1.errors import RolloutError
+from verifiers.v1.errors import RolloutError, TaskError
+from verifiers.v1.trace import InterceptRecord, Trace
+from verifiers.v1.types import (
+    AssistantMessage,
+    Messages,
+    Request,
+    Response,
+    ToolMessage,
+    UserMessage,
+)
+from verifiers.v1.utils.decorators import invoke
 
 logger = logging.getLogger(__name__)
+
+
+def hook_boundary(handler: Callable, *, allow_trace: bool) -> type:
+    """Select a hook boundary solely from its annotated parameters."""
+    hints = get_type_hints(handler)
+    annotations = [
+        get_origin(hints[name]) or hints[name]
+        for name in inspect.signature(handler).parameters
+        if name in hints
+    ]
+    boundaries = [kind for kind in annotations if kind in (Request, Response)]
+    if len(boundaries) == 1 and annotations.count(Trace) <= 1:
+        return boundaries[0]
+    if not boundaries and allow_trace and annotations.count(Trace) == 1:
+        return Trace
+    expected = "Request, Response, or Trace" if allow_trace else "Request or Response"
+    raise TypeError(f"{handler.__name__} must have exactly one {expected} parameter")
+
+
+async def call_hook(handler: Callable, available: dict[type, object]) -> object:
+    result = invoke(handler, available)
+    return await result if inspect.isawaitable(result) else result
 
 
 @dataclass(frozen=True)
@@ -68,8 +100,12 @@ class RolloutSession:
     trace: Trace
     network_policy: NetworkPolicyConfig = field(default_factory=NetworkPolicyConfig)
     """The resolved execution policy, including task-level restrictions."""
-    stops: list[Callable[[Trace], Awaitable[bool]]] = field(default_factory=list)
+    stops: list[Callable[..., Awaitable[bool] | bool]] = field(default_factory=list)
     limits: RolloutLimits = field(default_factory=RolloutLimits)
+    request_interceptors: list[Callable] = field(default_factory=list)
+    response_interceptors: list[Callable] = field(default_factory=list)
+    request_stops: list[Callable] = field(default_factory=list)
+    response_stops: list[Callable] = field(default_factory=list)
     client: Client | None = None
     """The model client serving this rollout's turns. The interception server assigns it at
     `register` (one server-owned client per distinct endpoint config), so every rollout it
@@ -80,22 +116,12 @@ class RolloutSession:
     harness returns — recording the real `ProviderError` instead of a secondary `HarnessError`.
     Reset before each model turn, so a successful retry clears it."""
     last_request: bytes | None = None
-    """Digest of the most recently served request body; with `last_response`, the replay cache
-    that keeps the message graph atomic under harness-SDK retries. A retry re-sends the
-    byte-identical request; when it matches, the interception server replays the recorded
-    response instead of re-sampling and committing a second turn — which would fork the graph
-    into a dead-end branch. Only a fully served request is cached, so a genuinely failed attempt
-    still re-runs. Turns are issued sequentially (one outstanding request at a time), so a retry
-    is always of the most recent request — keeping only the last one is sufficient and bounded."""
+    """Digest of the most recently served request body. Together with `last_response`, this
+    replays the common SDK retry of the latest completed exchange without re-sampling it."""
     last_response: dict | None = None
     """The response returned for `last_request`, replayed verbatim on a retry."""
     inflight: dict[bytes, "asyncio.Future[dict | None]"] = field(default_factory=dict)
-    """Body digest -> the future of the attempt currently computing it. A retry that arrives
-    while the first attempt is still in flight (a slow turn) awaits this future instead of
-    starting a second inference — the other half of retry atomicity (with `last_response`, which
-    covers a retry after the attempt finished). Because a slow turn is coalesced rather than
-    re-sampled, retries stay safe without an inflated client timeout. The future resolves to the
-    served response, or to None if the attempt produced no servable response (error/refuse)."""
+    """Body digest -> the response currently computing, used to coalesce an in-flight retry."""
     released: bool = False
     """Set when the rollout unregisters the session: the trace is sealed (its conclusion is
     what scored and persisted), so a handler still in flight must not commit turns, record
@@ -104,6 +130,233 @@ class RolloutSession:
     """Handler tasks currently serving this session. aiohttp does not cancel a handler when
     its client disconnects, so a request whose program died at teardown would keep driving
     the exchange (upstream call, simulator turn) — unregistering cancels these instead."""
+    prepared_tool_results: dict[str, ToolMessage] = field(default_factory=dict)
+    prepared_users: Counter[str] = field(default_factory=Counter)
+
+    @property
+    def stopped(self) -> bool:
+        return self.trace.stop_condition is not None
+
+    async def rewrite_request(
+        self, request: Request
+    ) -> tuple[Request, list[InterceptRecord], str | None]:
+        """Run typed request interceptors and stops over one canonical request."""
+        if not self.request_interceptors and not self.request_stops:
+            return request, [], None
+        turn = graph.prepare_turn(self.trace, request.messages)
+        prepared_users = self.prepared_users.copy()
+        prepared: set[int] = set()
+        candidates: set[int] = set()
+        for position in range(turn.tail_start, len(request.messages)):
+            message = request.messages[position]
+            if isinstance(message, UserMessage):
+                candidates.add(position)
+                key = graph.message_hash(message)
+                if prepared_users[key]:
+                    prepared_users[key] -= 1
+                    prepared.add(position)
+            elif isinstance(message, ToolMessage):
+                candidates.add(position)
+                if self.prepared_tool_results.get(message.tool_call_id) == message:
+                    prepared.add(position)
+        if candidates and candidates == prepared:
+            return request, [], None
+
+        current = request
+        records: list[InterceptRecord] = []
+        try:
+            for handler in self.request_interceptors:
+                candidate = current.model_copy(deep=True)
+                result = await call_hook(
+                    handler, {Request: candidate, Trace: self.trace}
+                )
+                if result is None:
+                    continue
+                if not isinstance(result, Request):
+                    raise TypeError(f"expected Request, got {type(result).__name__}")
+                if len(result.messages) != len(current.messages):
+                    raise ValueError(
+                        "request interceptors cannot add or remove messages"
+                    )
+                if result.tools != current.tools:
+                    raise ValueError("request interceptors cannot rewrite tools")
+                for position, (before, after) in enumerate(
+                    zip(current.messages, result.messages, strict=True)
+                ):
+                    if before == after:
+                        continue
+                    if position not in candidates - prepared:
+                        raise ValueError(
+                            "request interceptors can only rewrite new user or tool messages"
+                        )
+                    if type(after) is not type(before):
+                        raise TypeError(
+                            f"expected {type(before).__name__}, got {type(after).__name__}"
+                        )
+                    if (
+                        isinstance(before, ToolMessage)
+                        and after.tool_call_id != before.tool_call_id
+                    ):
+                        raise ValueError(
+                            "request interceptors cannot change a tool-call ID"
+                        )
+                if result != current:
+                    current = result
+                    records.append(InterceptRecord(handler=handler.__name__))
+
+            for stop in self.request_stops:
+                candidate = current.model_copy(deep=True)
+                result = await call_hook(stop, {Request: candidate, Trace: self.trace})
+                if not isinstance(result, bool):
+                    raise TypeError(
+                        f"@stop must return bool, got {type(result).__name__}"
+                    )
+                if result:
+                    return current, records, stop.__name__
+        except RolloutError:
+            raise
+        except Exception as error:
+            raise TaskError(
+                f"request interception failed: {type(error).__name__}: {error}"
+            ) from error
+        return current, records, None
+
+    def consume_prepared(self, messages: Messages) -> None:
+        """Forget pre-harness rewrites only after their model request commits."""
+        for message in messages:
+            if isinstance(message, UserMessage):
+                key = graph.message_hash(message)
+                if self.prepared_users[key]:
+                    self.prepared_users[key] -= 1
+            elif isinstance(message, ToolMessage):
+                self.prepared_tool_results.pop(message.tool_call_id, None)
+
+    async def prepare_users(
+        self, request: Request
+    ) -> tuple[Request, list[InterceptRecord]]:
+        """Intercept caller-owned user turns before the harness stores them."""
+        branch = self.trace.messages
+        rewritten, records, stopped = await self.rewrite_request(
+            Request(messages=[*branch, *request.messages])
+        )
+        tail = rewritten.messages[len(branch) :]
+        if stopped is not None:
+            graph.prepare_turn(self.trace, rewritten.messages).commit_prompt()
+            self.trace.stop(stopped)
+        else:
+            self.prepared_users.update(
+                graph.message_hash(message)
+                for message in tail
+                if isinstance(message, UserMessage)
+            )
+        return Request(messages=tail), records
+
+    async def rewrite_response(
+        self, response: Response
+    ) -> tuple[Response, list[InterceptRecord], str | None]:
+        """Run typed response interceptors and stops before harness delivery."""
+        records: list[InterceptRecord] = []
+        try:
+            for handler in self.response_interceptors:
+                candidate = response.model_copy(deep=True)
+                result = await call_hook(
+                    handler, {Response: candidate, Trace: self.trace}
+                )
+                if result is None:
+                    continue
+                if not isinstance(result, Response):
+                    raise TypeError(f"expected Response, got {type(result).__name__}")
+                if result == response:
+                    continue
+                unchanged = result.model_copy(
+                    update={
+                        "message": response.message,
+                        "finish_reason": response.finish_reason,
+                    }
+                )
+                if unchanged != response:
+                    raise ValueError(
+                        "response interceptors can only replace the assistant message"
+                    )
+                if (
+                    result.message.reasoning_content
+                    or result.message.tool_calls
+                    or result.message.provider_state
+                ):
+                    raise ValueError(
+                        "response interceptors must return an inert text-only message"
+                    )
+                response = result.model_copy(update={"finish_reason": "stop"})
+                records.append(InterceptRecord(handler=handler.__name__))
+
+            for stop in self.response_stops:
+                candidate = response.model_copy(deep=True)
+                result = await call_hook(stop, {Response: candidate, Trace: self.trace})
+                if not isinstance(result, bool):
+                    raise TypeError(
+                        f"@stop must return bool, got {type(result).__name__}"
+                    )
+                if result:
+                    return response, records, stop.__name__
+        except RolloutError:
+            raise
+        except Exception as error:
+            raise TaskError(
+                f"response interception failed: {type(error).__name__}: {error}"
+            ) from error
+        return response, records, None
+
+    async def handle_tool(self, phase: str, message: ToolMessage) -> dict:
+        """Intercept a harness-owned tool result before the harness records it."""
+        branches = [
+            branch
+            for branch in self.trace.branches
+            if branch.nodes
+            and isinstance(branch.nodes[-1].message, AssistantMessage)
+            and any(
+                call.id == message.tool_call_id
+                for call in branch.nodes[-1].message.tool_calls or []
+            )
+        ]
+        if len(branches) != 1:
+            raise TaskError(
+                f"tool call {message.tool_call_id!r} matched {len(branches)} branches"
+            )
+        branch = branches[0]
+        assistant = branch.nodes[-1].message
+        assert isinstance(assistant, AssistantMessage)
+        # Keep earlier results in the hook's trace, but commit them only when the model
+        # request arrives and can supply their token attribution.
+        previous = [
+            self.prepared_tool_results[call.id]
+            for call in assistant.tool_calls or []
+            if call.id in self.prepared_tool_results
+        ]
+        request, records, stopped = await self.rewrite_request(
+            Request(
+                messages=[*branch.messages, *previous, message],
+                tools=self.trace.tools or None,
+            )
+        )
+        candidate = request.messages[-1]
+        assert isinstance(candidate, ToolMessage)
+        self.trace.request_rewrites.extend(records)
+        if stopped is not None:
+            committed = request.messages if phase == "after" else request.messages[:-1]
+            turn = graph.prepare_turn(self.trace, committed)
+            turn.commit_prompt()
+            self.consume_prepared(turn.tail)
+            self.trace.stop(stopped)
+            return {"action": "stop", "reason": stopped}
+        if phase == "before" and candidate == message:
+            return {"action": "allow"}
+        self.prepared_tool_results[candidate.tool_call_id] = candidate
+        if candidate != message:
+            return {
+                "action": "rewrite",
+                "message": candidate.model_dump(exclude_none=True),
+            }
+        return {"action": "allow"}
 
     @cached_property
     def state_adapter(self) -> TypeAdapter:
@@ -140,7 +393,12 @@ class RolloutSession:
             logger.debug("limit %r reached: id=%s", limit, self.trace.id)
             return limit
         for stop in self.stops:
-            if await stop(self.trace):
+            result = stop(self.trace)
+            if inspect.isawaitable(result):
+                result = await result
+            if not isinstance(result, bool):
+                raise TaskError(f"@stop must return bool, got {type(result).__name__}")
+            if result:
                 self.trace.stop(stop.__name__)
                 logger.debug("stop %r fired: id=%s", stop.__name__, self.trace.id)
                 return stop.__name__

--- a/verifiers/v1/tasksets/nemo_gym/taskset.py
+++ b/verifiers/v1/tasksets/nemo_gym/taskset.py
@@ -106,12 +106,12 @@ class NeMoGymTaskset(Taskset[NeMoGymTask, NeMoGymConfig]):
             for idx, line in enumerate(filter(str.strip, lines)):
                 found = True
                 row = json.loads(line)
-                prompt, _ = dialect.parse_request(row["responses_create_params"])
+                request = dialect.parse_request(row["responses_create_params"])
                 yield NeMoGymTask(
                     NeMoGymData(
                         idx=idx,
                         name=f"{path.stem}:{idx}",
-                        prompt=prompt,
+                        prompt=request.messages,
                         row=row,
                     ),
                     self.config.task,

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -25,6 +25,7 @@ from verifiers.v1.types import (
     AssistantMessage,
     FinishReason,
     KeptTokens,
+    Message,
     Messages,
     Sampling,
     Tool,
@@ -123,6 +124,10 @@ class TraceTask(BaseModel, Generic[DataT]):
     """The (immutable) row being solved."""
     hash: str | None = None
     """Content hash of `data` (`Task.hash`) — the task's identity across runs."""
+
+
+class InterceptRecord(BaseModel):
+    handler: str
 
 
 class Reward(BaseModel):
@@ -364,6 +369,10 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
     """The message graph; branches are derived views and storage stays linear in turns."""
     calls: list[ModelCall] = Field(default_factory=list)
     """Every model call; automatically recorded at intercept time + linked into `nodes`."""
+    request_rewrites: list[InterceptRecord] = Field(default_factory=list)
+    """Request changes made by `@intercept`, in execution order."""
+    response_rewrites: list[InterceptRecord] = Field(default_factory=list)
+    """Response changes made by `@intercept`, in execution order."""
 
     rewards: dict[str, Reward | None] = Field(default_factory=dict)
     """Named, weighted rewards; `None` means scoring didn't run (e.g. because of a
@@ -449,6 +458,19 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
                 )
             )
         return branches
+
+    @property
+    def messages(self) -> Messages:
+        """Messages on the final branch."""
+        branches = self.branches
+        return branches[-1].messages if branches else []
+
+    @property
+    def last_message(self) -> Message:
+        """The most recently stored message."""
+        if not self.nodes:
+            raise ValueError("trace has no messages")
+        return self.nodes[-1].message
 
     @property
     def num_branches(self) -> int:

--- a/verifiers/v1/types.py
+++ b/verifiers/v1/types.py
@@ -101,6 +101,13 @@ class Tool(BaseModel):
     strict: bool | None = None
 
 
+class Request(BaseModel):
+    """The typed conversation about to cross a model or harness boundary."""
+
+    messages: Messages
+    tools: list[Tool] | None = None
+
+
 FinishReason = Literal["stop", "length", "tool_calls"] | None
 
 

--- a/verifiers/v1/utils/decorators.py
+++ b/verifiers/v1/utils/decorators.py
@@ -3,7 +3,7 @@
 import asyncio
 import inspect
 from collections.abc import Callable, Iterable
-from typing import Any, TypeVar, overload
+from typing import Any, TypeVar, get_origin, get_type_hints, overload
 
 F = TypeVar("F", bound=Callable[..., Any])
 
@@ -26,9 +26,16 @@ def discover_decorated(obj: object, attr: str) -> list[Callable[..., Any]]:
     return methods
 
 
-def invoke(fn: Callable[..., Any], available: dict[str, Any]) -> Any:
+def invoke(fn: Callable[..., Any], available: dict[str | type, Any]) -> Any:
     params = inspect.signature(fn).parameters
-    return fn(**{name: value for name, value in available.items() if name in params})
+    kwargs = {name: available[name] for name in params if name in available}
+    if any(isinstance(key, type) for key in available):
+        hints = get_type_hints(fn)
+        for name in params:
+            annotation = get_origin(hints.get(name)) or hints.get(name)
+            if name not in kwargs and annotation in available:
+                kwargs[name] = available[annotation]
+    return fn(**kwargs)
 
 
 async def invoke_all(
@@ -80,8 +87,18 @@ def stop(func: F, priority: int = 0) -> F: ...
 @overload
 def stop(func: None = None, priority: int = 0) -> Callable[[F], F]: ...
 def stop(func: F | None = None, priority: int = 0) -> F | Callable[[F], F]:
-    """Mark a stop condition `(self, trace) -> bool`."""
+    """Stop when a typed `Request`, `Response`, or `Trace` predicate returns true."""
     decorator = mark("stop", stop_priority=priority)
+    return decorator if func is None else decorator(func)
+
+
+@overload
+def intercept(func: F, priority: int = 0) -> F: ...
+@overload
+def intercept(func: None = None, priority: int = 0) -> Callable[[F], F]: ...
+def intercept(func: F | None = None, priority: int = 0) -> F | Callable[[F], F]:
+    """Inspect a typed boundary; return its replacement or None to leave it unchanged."""
+    decorator = mark("intercept", intercept_priority=priority)
     return decorator if func is None else decorator(func)
 
 


### PR DESCRIPTION
## Overview

Adds the internal transport and session support for inspecting typed model requests and responses. The normal model path stays unchanged when no response hook needs inspection.

## What this PR adds

- Introduces the Pydantic `vf.Request` boundary with the canonical conversation and advertised function tools.
- Parses Chat Completions, Responses, and Anthropic requests into the same typed form.
- Applies request rewrites only to changed `UserMessage` and `ToolMessage` content in the original native body. Provider-specific fields, message roles, tool-call IDs, and unrelated items stay intact.
- Keeps ordinary streamed responses live. When response inspection is active, the server receives the full upstream stream before sending downstream headers. An unchanged response replays the original bytes; a rewritten response emits a deliberately small text-only response or stream.
- Commits the same canonical messages that the harness receives and records successful rewrites on the trace.
- Adds the internal tool-hook endpoint used by the harness integration later in the stack.
- Replays the latest completed non-streaming retry and coalesces byte-identical non-streaming requests already in flight, without a rollout-wide lock.

## Stack

These PRs are stacked in merge order. Each PR targets the one above it.

| PR | What it adds |
| --- | --- |
| [#2164](https://github.com/PrimeIntellect-ai/verifiers/pull/2164) | Typed transport, native request/response rewriting, buffered inspection, and retry replay |
| [#2165](https://github.com/PrimeIntellect-ai/verifiers/pull/2165) | Public `@vf.intercept` for `vf.Request` and `vf.Response` |
| [#2166](https://github.com/PrimeIntellect-ai/verifiers/pull/2166) | Public `@vf.stop` for `vf.Request`, `vf.Response`, and `vf.Trace` |
| [#2229](https://github.com/PrimeIntellect-ai/verifiers/pull/2229) | Opt-in harness tool hooks, enabled for Bash |
| [#2178](https://github.com/PrimeIntellect-ai/verifiers/pull/2178) | Example environments for response, image, Bash, and native web-search interception |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the core model-call path in the interception server (request ordering, stream buffering, native body patching) across all three dialects; bugs could alter what the harness sees or break streaming/retry semantics.
> 
> **Overview**
> Introduces **`vf.Request`** as the canonical typed boundary (messages + tools) and changes dialect **`parse_request`** to return it instead of a tuple. Chat, Responses, and Anthropic dialects gain **`rewrite_request`**, **`rewrite_response`**, and **`stream_events`**, plus **`response.raw`** on parsed responses so the server can patch native JSON and emit minimal SSE when rewrites occur.
> 
> The **interception server** runs **`session.rewrite_request`** before capability mediation and upstream calls, applies dialect rewrites to the wire body when user/tool messages change, and runs **`rewrite_response`** after inference (non-streaming and, when hooks exist, by **buffering the full SSE stream** first). Unchanged streamed bytes replay as-is; rewritten streams use dialect-generated events. **Request stops** can commit the prompt via **`commit_prompt`** without sampling. Adds **`POST /tool`** for harness tool-hook payloads.
> 
> **`RolloutSession`** implements request/response interceptors and stops, prepared user/tool tracking, **`prepare_users`**, and **`handle_tool`**. The trace records **`request_rewrites`** / **`response_rewrites`**. **`@intercept`** is added in decorators; **`invoke`** resolves parameters by type annotation. Non-streaming **retry replay** and **in-flight coalescing** are preserved; streaming shares the same rewrite path when inspection is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ae08d5216974aede3a05109c7fbd97460d4b6a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add interception transport and replay for request and response boundaries in rollout sessions
> - Introduces an interception layer that allows user-defined handlers (via `@intercept` and `@stop` decorators) to rewrite or halt outbound requests and inbound responses during rollouts.
> - Adds `rewrite_request`, `rewrite_response`, `prepare_users`, and `handle_tool` methods to `RolloutSession` in [session.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2164/files#diff-0eeafa9506eb0d53c459cf476e308ce72a99d147d2f84979affa04baaee79a66), with validated rewriting and provenance tracking via `InterceptRecord`.
> - Extends all three dialects ([anthropic.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2164/files#diff-abc86b3ad07c2d6ab09cd923f50271c4f6c4cb928a9bb82c12f6e97aac17b04d), [chat.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2164/files#diff-5d2fcbf59a03489b63b0626038a853eee89543b591074597161ee29aab901280), [responses.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2164/files#diff-73f89a1b25536fd7a806555e765120f5189cb934eff813f4c7900838efa56b5a)) with `rewrite_request`, `rewrite_response`, and `stream_events` methods to serialize rewritten content back into native wire formats and SSE streams.
> - Changes `Dialect.parse_request` return type from a `(messages, tools)` tuple to a typed `Request` object across all dialects and call sites.
> - Adds a `/tool` endpoint to `InterceptionServer` in [server.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2164/files#diff-84e2f8d027d609e8760ef6d533535ec9d99dfc6384d5ddb6111b4001b2010f35) for harness-owned tool hook handling.
> - Risk: all `Dialect` subclasses must implement the three new abstract methods (`rewrite_request`, `rewrite_response`, `stream_events`) or will raise at instantiation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ae08d5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->