### PR TITLE
fix(v1): cache Codex binaries by version

### DIFF
--- a/verifiers/v1/harnesses/codex/harness.py
+++ b/verifiers/v1/harnesses/codex/harness.py
@@ -11,6 +11,8 @@ import re
 import shlex
 from collections import Counter
 
+from pydantic import Field
+
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.harness import Harness
@@ -26,7 +28,7 @@ PROVIDER = "intercept"
 # The env var codex reads the provider api key (its bearer = the session secret) from.
 KEY_VAR = "CODEX_INTERCEPT_KEY"
 
-CODEX_DIR = "/tmp/vf-codex"
+CODEX_DIR = "/tmp/vf-codex-{version}"
 CODEX_BIN = f"{CODEX_DIR}/bin/codex"
 SKILLS_DIR = ".agents/skills"
 INSTALL = r"""
@@ -42,7 +44,7 @@ chmod +x {bin}
 
 
 class CodexHarnessConfig(HarnessConfig):
-    version: str = "0.144.5"
+    version: str = Field(default="0.144.5", pattern=r"^[A-Za-z0-9._+-]+$")
     """Codex release to install (the `rust-v<version>` GitHub release); pinned for reproducibility."""
     multi_agent: bool = False
     """Enable Codex's native multi-agent v2 tools."""
@@ -57,15 +59,17 @@ class CodexHarness(Harness[CodexHarnessConfig]):
     async def setup(self, runtime: Runtime) -> None:
         await self.install_skills(runtime, SKILLS_DIR)
         logger.info("codex: ensuring codex %s is installed", self.config.version)
+        directory = CODEX_DIR.format(version=self.config.version)
+        binary = CODEX_BIN.format(version=self.config.version)
         script = (
             INSTALL.replace("{version}", self.config.version)
-            .replace("{dir}", CODEX_DIR)
-            .replace("{bin}", CODEX_BIN)
+            .replace("{dir}", directory)
+            .replace("{bin}", binary)
         )
-        ensure = shlex.quote(f"[ -x {CODEX_BIN} ] || ({script})")
-        # Shared local runtimes may provision concurrently; only the first downloads.
+        ensure = shlex.quote(f"[ -x {binary} ] || ({script})")
+        # Shared local runtimes may provision one release concurrently; only the first downloads.
         guarded = (
-            f"mkdir -p {CODEX_DIR} && flock {CODEX_DIR}/install.lock sh -c {ensure}"
+            f"mkdir -p {directory} && flock {directory}/install.lock sh -c {ensure}"
         )
         install = await runtime.run(["sh", "-c", guarded], {})
         if install.exit_code != 0:
@@ -129,7 +133,7 @@ class CodexHarness(Harness[CodexHarnessConfig]):
                     image_index += 1
             prompt = "\n\n".join(texts)
         argv = [
-            CODEX_BIN,
+            CODEX_BIN.format(version=self.config.version),
             "exec",
             *self._config_args(ctx, endpoint, mcp_urls),
             *image_args,
@@ -195,7 +199,7 @@ class CodexHarness(Harness[CodexHarnessConfig]):
                 data.model_copy(update={"prompt": messages}),
             )
         argv = [
-            CODEX_BIN,
+            CODEX_BIN.format(version=self.config.version),
             "exec",
             "resume",
             "--last",


### PR DESCRIPTION
## Summary

`CodexHarnessConfig.version` is pinned for reproducibility, but every release
currently shares `/tmp/vf-codex/bin/codex`. `SubprocessRuntime` leaves that
cache in place between rollouts and eval processes, so a later run can silently
execute an older release than the one in its config. The repository's own
default pin changed from `0.137.0` to `0.144.5` in #2064 without changing the
cache path.

This change scopes the cache and install lock by version, uses that binary for
launch and resume, and restricts version strings to path-safe release names. It
matches the versioned cache already used by `PoolHarness`.

## Reproduction

Against `origin/main` (`106e9eb9`), I started one clean Linux arm64
`SubprocessRuntime`, ran `CodexHarness.setup()`'s normal installer for both
official releases, and checked the executable with `--version` after each
setup:

| Configured version | Reported executable |
| --- | --- |
| `0.143.0` | `codex-cli 0.143.0` |
| `0.144.5` | `codex-cli 0.143.0` |

With this change, the same sequence reports `codex-cli 0.143.0` and
`codex-cli 0.144.5` from their version-specific paths.

## Scope

This affects persistent Linux subprocess hosts and unrestricted shared runtimes.
Fresh Docker, Prime, and Modal runtimes do not retain the cache between
provisions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized harness install/launch path changes with validation on version strings; no auth or data-handling impact.
> 
> **Overview**
> Fixes a bug where **all Codex releases shared one install path** (`/tmp/vf-codex`), so on persistent subprocess hosts a newer configured pin could still run an older cached binary.
> 
> The harness now **scopes the install directory, flock lock, and executable path by `config.version`** (e.g. `/tmp/vf-codex-0.144.5/...`), and **`launch` / `resume` invoke that version-specific binary**. **`CodexHarnessConfig.version`** gains a Pydantic **`Field` pattern** so only path-safe release names are accepted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd5de8742372dfded994dc61552c2268382140d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache Codex binaries by version in `CodexHarness`
> - Changes `CODEX_DIR` and `CODEX_BIN` from fixed paths to version-scoped templates (e.g. `/tmp/vf-codex-{version}`), so each Codex version installs to its own directory.
> - Updates `setup`, `launch`, and `resume` in [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2168/files#diff-904c37fe437bb3b42e0238258ed85a8c6cede02461216bcf9c7417c5f3b72b7b) to resolve paths using `self.config.version` at runtime.
> - Installation locking (`flock`) is now per-version, preventing contention when multiple versions install concurrently.
> - Adds a regex pattern constraint (`^[A-Za-z0-9._+-]+$`) to `CodexHarnessConfig.version` to reject malformed version strings early.
> - Behavioral Change: existing installs at `/tmp/vf-codex` are no longer used; Codex will re-download into the versioned path on first run.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd5de87.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->