### PR TITLE
feat(v1): config-layer taskset system_prompt for the GEPA handoff

### DIFF
--- a/docs/v1/evaluation.md
+++ b/docs/v1/evaluation.md
@@ -36,7 +36,7 @@ The output from evaluations are written into `outputs/<env>--<model>--<harness>/
 - `model` — the model id to evaluate, e.g. `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B`
 - `sampling` — generation params passed to the model, e.g. `sampling.temperature`
 - `env.taskset.id` — pick the taskset (or the positional `eval <taskset-id>`)
-- `env.taskset.system_prompt` — UTF-8 file whose text overrides each task's
+- `env.taskset.system_prompt` — file whose text overrides each task's
   `TaskData.system_prompt` at select time (e.g. a GEPA `best_system_prompt.txt`)
 - `env.agent.harness.id` — pick the agent's harness (`[env.agent.harness]` in TOML)
 - `num_tasks` — how many tasks to evaluate. Not setting a value means all tasks; an

--- a/docs/v1/evaluation.md
+++ b/docs/v1/evaluation.md
@@ -36,9 +36,8 @@ The output from evaluations are written into `outputs/<env>--<model>--<harness>/
 - `model` — the model id to evaluate, e.g. `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B`
 - `sampling` — generation params passed to the model, e.g. `sampling.temperature`
 - `env.taskset.id` — pick the taskset (or the positional `eval <taskset-id>`)
-- `env.taskset.system_prompt` / `env.taskset.system_prompt_file` — override each task's
-  `TaskData.system_prompt` at select time (mutually exclusive; the file form is read into
-  `system_prompt` at validation — e.g. hand over a GEPA `best_system_prompt.txt`)
+- `env.taskset.system_prompt` — UTF-8 file whose text overrides each task's
+  `TaskData.system_prompt` at select time (e.g. a GEPA `best_system_prompt.txt`)
 - `env.agent.harness.id` — pick the agent's harness (`[env.agent.harness]` in TOML)
 - `num_tasks` — how many tasks to evaluate. Not setting a value means all tasks; an
   infinite taskset (a procedural generator, e.g. `wordle-v1`) requires it

--- a/docs/v1/evaluation.md
+++ b/docs/v1/evaluation.md
@@ -36,6 +36,8 @@ The output from evaluations are written into `outputs/<env>--<model>--<harness>/
 - `model` — the model id to evaluate, e.g. `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B`
 - `sampling` — generation params passed to the model, e.g. `sampling.temperature`
 - `env.taskset.id` — pick the taskset (or the positional `eval <taskset-id>`)
+- `env.taskset.system_prompt` / `env.taskset.system_prompt_file` — override each task's system
+  prompt (mutually exclusive; e.g. hand over a GEPA `best_system_prompt.txt`)
 - `env.agent.harness.id` — pick the agent's harness (`[env.agent.harness]` in TOML)
 - `num_tasks` — how many tasks to evaluate. Not setting a value means all tasks; an
   infinite taskset (a procedural generator, e.g. `wordle-v1`) requires it

--- a/docs/v1/evaluation.md
+++ b/docs/v1/evaluation.md
@@ -36,8 +36,9 @@ The output from evaluations are written into `outputs/<env>--<model>--<harness>/
 - `model` — the model id to evaluate, e.g. `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B`
 - `sampling` — generation params passed to the model, e.g. `sampling.temperature`
 - `env.taskset.id` — pick the taskset (or the positional `eval <taskset-id>`)
-- `env.taskset.system_prompt` / `env.taskset.system_prompt_file` — override each task's system
-  prompt (mutually exclusive; e.g. hand over a GEPA `best_system_prompt.txt`)
+- `env.taskset.system_prompt` / `env.taskset.system_prompt_file` — override each task's
+  `TaskData.system_prompt` at select time (mutually exclusive; the file form is read into
+  `system_prompt` at validation — e.g. hand over a GEPA `best_system_prompt.txt`)
 - `env.agent.harness.id` — pick the agent's harness (`[env.agent.harness]` in TOML)
 - `num_tasks` — how many tasks to evaluate. Not setting a value means all tasks; an
   infinite taskset (a procedural generator, e.g. `wordle-v1`) requires it

--- a/docs/v1/gepa.md
+++ b/docs/v1/gepa.md
@@ -41,7 +41,7 @@ Hand it back to eval or training via the config-layer taskset system prompt:
 
 ```bash
 uv run eval reverse-text-v1 \
-  --env.taskset.system-prompt-file outputs/<run>/best_system_prompt.txt
+  --env.taskset.system-prompt outputs/<run>/best_system_prompt.txt
 ```
 
 ## Limitations

--- a/docs/v1/gepa.md
+++ b/docs/v1/gepa.md
@@ -35,7 +35,14 @@ Validate the config by using `uv run gepa @ config.toml --dry-run`. To run GEPA,
 
 ## Output
 
-Results go under `outputs/<env>--<model>--<harness>/<uuid>/`, matching `eval`. The best system prompt is printed when the run finishes.
+Results go under `outputs/<env>--<model>--<harness>/<uuid>/`, matching `eval`. The best system prompt is printed when the run finishes and written to `best_system_prompt.txt` in that folder.
+
+Hand it back to eval or training via the config-layer taskset system prompt:
+
+```bash
+uv run eval reverse-text-v1 \
+  --env.taskset.system-prompt-file outputs/<run>/best_system_prompt.txt
+```
 
 ## Limitations
 

--- a/environments/wiki_search_v1/wiki_search_v1/__init__.py
+++ b/environments/wiki_search_v1/wiki_search_v1/__init__.py
@@ -1,3 +1,4 @@
+from wiki_search_v1.judge import WikiSearchJudge
 from wiki_search_v1.taskset import WikiSearchTaskset
 
-__all__ = ["WikiSearchTaskset"]
+__all__ = ["WikiSearchJudge", "WikiSearchTaskset"]

--- a/environments/wiki_search_v1/wiki_search_v1/judge.py
+++ b/environments/wiki_search_v1/wiki_search_v1/judge.py
@@ -1,0 +1,20 @@
+"""Wiki-search reference judge: same scoring as `reference`, env-specific prompt."""
+
+from pathlib import Path
+
+import verifiers.v1 as vf
+
+JUDGE_PROMPT = (Path(__file__).parent / "judge_prompt.txt").read_text()
+
+
+class WikiSearchJudgeConfig(vf.ReferenceJudgeConfig):
+    id: vf.ID = "wiki-search-v1"
+    """Local package id — `load_judge` resolves this module's `WikiSearchJudge`."""
+    question_field: str = "question"
+
+
+class WikiSearchJudge(vf.ReferenceJudge):
+    prompt = JUDGE_PROMPT
+
+
+__all__ = ["WikiSearchJudge", "WikiSearchJudgeConfig"]

--- a/environments/wiki_search_v1/wiki_search_v1/judge_prompt.txt
+++ b/environments/wiki_search_v1/wiki_search_v1/judge_prompt.txt
@@ -1,0 +1,18 @@
+Given a ground truth answer and a response, determine if the response is both correct and coherent.
+
+Question:
+```
+{question}
+```
+
+Ground truth answer:
+```
+{answer}
+```
+
+Response:
+```
+{response}
+```
+
+Respond either "yes" or "no" only. If a response contains incoherent text, respond with "no" even if the correct answer is also present.

--- a/environments/wiki_search_v1/wiki_search_v1/taskset.py
+++ b/environments/wiki_search_v1/wiki_search_v1/taskset.py
@@ -2,15 +2,14 @@
 
 The tool server builds an expensive corpus/index in its process-level `setup`, so
 `Taskset.tools` launches one instance per environment worker instead of rebuilding it
-per rollout. The tools are read-only; grading comes from the plugged `reference` judge,
-whose prompt also rejects incoherent answers.
+per rollout. The tools are read-only; grading comes from the plugged wiki-search judge
+(class-level prompt; reject incoherent answers).
 """
-
-from pathlib import Path
 
 from pydantic import Field
 
 import verifiers.v1 as vf
+from wiki_search_v1.judge import WikiSearchJudgeConfig
 from wiki_search_v1.servers.wiki import WikiSearchToolset
 
 SYSTEM = (
@@ -18,8 +17,6 @@ SYSTEM = (
     "`wiki_view_sections` to list a page's sections, and `wiki_read_section` to read "
     "one — to answer the question. When confident, reply with a concise final answer."
 )
-
-JUDGE_PROMPT = Path(__file__).parent / "judge_prompt.txt"
 
 # The question bank and count are fixed properties of this env, not eval-time
 # knobs (the searchable corpus is built in `WikiSearchToolset.setup`).
@@ -29,11 +26,7 @@ NUM_QUESTIONS = 20
 
 class WikiSearchTaskConfig(vf.TaskConfig):
     # Users can replace or reconfigure this judge through --taskset.task.judges.
-    judges: vf.Judges = Field(
-        default_factory=lambda: [
-            vf.ReferenceJudgeConfig(prompt=JUDGE_PROMPT, question_field="question")
-        ]
-    )
+    judges: vf.Judges = Field(default_factory=lambda: [WikiSearchJudgeConfig()])
 
 
 class TriviaTaskData(vf.TaskData):

--- a/environments/wiki_search_v1/wiki_search_v1/taskset.py
+++ b/environments/wiki_search_v1/wiki_search_v1/taskset.py
@@ -6,6 +6,8 @@ per rollout. The tools are read-only; grading comes from the plugged `reference`
 whose prompt also rejects incoherent answers.
 """
 
+from pathlib import Path
+
 from pydantic import Field
 
 import verifiers.v1 as vf
@@ -17,26 +19,7 @@ SYSTEM = (
     "one — to answer the question. When confident, reply with a concise final answer."
 )
 
-JUDGE_PROMPT = """Given a ground truth answer and a response, determine if the response \
-is both correct and coherent.
-
-Question:
-```
-{question}
-```
-
-Ground truth answer:
-```
-{answer}
-```
-
-Response:
-```
-{response}
-```
-
-Respond either "yes" or "no" only. If a response contains incoherent text, respond \
-with "no" even if the correct answer is also present."""
+JUDGE_PROMPT = Path(__file__).parent / "judge_prompt.txt"
 
 # The question bank and count are fixed properties of this env, not eval-time
 # knobs (the searchable corpus is built in `WikiSearchToolset.setup`).

--- a/skills/evaluate-environments/references/REFERENCE.md
+++ b/skills/evaluate-environments/references/REFERENCE.md
@@ -224,6 +224,8 @@ Elastic pool: start at one worker and scale up on demand.
 | --- | --- | --- | --- |
 | `id` | `ID` | `""` | Local package or Hub `org/name[@version]`; selects the taskset and its config type. Set via `--env.taskset.id` or the positional `eval <taskset-id>`. |
 | `task` | `TaskConfig` | `TaskConfig()` | Task-facing config passed to every constructed task. `SerializeAsAny` preserves a narrowed subclass. Set through `--env.taskset.task.*`. |
+| `system_prompt` | `str \| None` | `None` | Run-level override applied in `Taskset.select`, replacing each task's baked-in `TaskData.system_prompt`. Mutually exclusive with `system_prompt_file`. |
+| `system_prompt_file` | `Path \| None` | `None` | UTF-8 file form of `system_prompt`. Mutually exclusive with `system_prompt`; collapsed into `system_prompt` at validation so the runtime only sees the string. |
 
 `.name` → the package name (id with org / version stripped).
 

--- a/skills/evaluate-environments/references/REFERENCE.md
+++ b/skills/evaluate-environments/references/REFERENCE.md
@@ -224,8 +224,7 @@ Elastic pool: start at one worker and scale up on demand.
 | --- | --- | --- | --- |
 | `id` | `ID` | `""` | Local package or Hub `org/name[@version]`; selects the taskset and its config type. Set via `--env.taskset.id` or the positional `eval <taskset-id>`. |
 | `task` | `TaskConfig` | `TaskConfig()` | Task-facing config passed to every constructed task. `SerializeAsAny` preserves a narrowed subclass. Set through `--env.taskset.task.*`. |
-| `system_prompt` | `str \| None` | `None` | Run-level override applied in `Taskset.select`, replacing each task's baked-in `TaskData.system_prompt`. Mutually exclusive with `system_prompt_file`. |
-| `system_prompt_file` | `Path \| None` | `None` | UTF-8 file form of `system_prompt`. Mutually exclusive with `system_prompt`; collapsed into `system_prompt` at validation so the runtime only sees the string. |
+| `system_prompt` | `Path \| None` | `None` | UTF-8 file whose text replaces each task's baked-in `TaskData.system_prompt` in `Taskset.select`. |
 
 `.name` → the package name (id with org / version stripped).
 
@@ -505,15 +504,14 @@ Inherits `base_url`, `api_key_var`, and `headers` from [`BaseClientConfig`](#cli
 | `weight` | `float` | `1.0` | Weight applied when the plugged judge records its verdict into aggregate `trace.reward`. |
 | `model` | `str` | `"openai/gpt-5.4-nano"` | Judge model id. |
 | `sampling` | `SamplingConfig` | `SamplingConfig()` | Per-call sampling defaults; individual calls may override them. |
-| `prompt` | `str \| None` | `None` | Inline prompt-template override for this configured judge instance. |
-| `prompt_file` | `Path \| None` | `None` | Load the prompt template from a UTF-8 text file. Mutually exclusive with `prompt`. |
+| `prompt` | `Path \| None` | `None` | UTF-8 file whose text overrides the judge's default prompt template. |
 
 ### Judge class behavior
 
 A judge class may define:
 
 - `prompt: str | None` — the default template formatted by `build_messages(**fields)`. A configured
-  `prompt` or `prompt_file` overrides it for that instance.
+  `prompt` file overrides it for that instance.
 - `schema: type[BaseModel] | None` — a Pydantic schema for structured output. `evaluate()` sends it
   through the OpenAI-compatible parsed-completion path and places the validated object on `JudgeResponse.parsed`; without a schema, `parse()` receives the text response.
 

--- a/skills/evaluate-environments/references/REFERENCE.md
+++ b/skills/evaluate-environments/references/REFERENCE.md
@@ -224,7 +224,7 @@ Elastic pool: start at one worker and scale up on demand.
 | --- | --- | --- | --- |
 | `id` | `ID` | `""` | Local package or Hub `org/name[@version]`; selects the taskset and its config type. Set via `--env.taskset.id` or the positional `eval <taskset-id>`. |
 | `task` | `TaskConfig` | `TaskConfig()` | Task-facing config passed to every constructed task. `SerializeAsAny` preserves a narrowed subclass. Set through `--env.taskset.task.*`. |
-| `system_prompt` | `Path \| None` | `None` | UTF-8 file whose text replaces each task's baked-in `TaskData.system_prompt` in `Taskset.select`. |
+| `system_prompt` | `Path \| None` | `None` | File whose text replaces each task's baked-in `TaskData.system_prompt` in `Taskset.select`. |
 
 `.name` → the package name (id with org / version stripped).
 
@@ -504,7 +504,7 @@ Inherits `base_url`, `api_key_var`, and `headers` from [`BaseClientConfig`](#cli
 | `weight` | `float` | `1.0` | Weight applied when the plugged judge records its verdict into aggregate `trace.reward`. |
 | `model` | `str` | `"openai/gpt-5.4-nano"` | Judge model id. |
 | `sampling` | `SamplingConfig` | `SamplingConfig()` | Per-call sampling defaults; individual calls may override them. |
-| `prompt` | `Path \| None` | `None` | UTF-8 file whose text overrides the judge's default prompt template. |
+| `prompt` | `Path \| None` | `None` | File whose text overrides the judge's default prompt template. |
 
 ### Judge class behavior
 

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -401,6 +401,8 @@ async def test_env_id_agentic_judge(run_v1, tmp_path):
     model's call. Exercises the config surface too: a policy-only prompt
     override (the verdict contract is appended regardless) and
     reward-composition weights."""
+    policy = tmp_path / "judge_policy.txt"
+    policy.write_text("Check EMPIRICALLY that the agent echoed the word back.")
     traces = await run_v1(
         "echo-v1",
         harness=None,  # seats pin their own harness; there is no run-level one
@@ -414,9 +416,7 @@ async def test_env_id_agentic_judge(run_v1, tmp_path):
                 "harness": {"id": "bash"},
                 "max_output_tokens": 8192,
             },
-            "task": {
-                "prompt": "Check EMPIRICALLY that the agent echoed the word back.",
-            },
+            "task": {"prompt": str(policy)},
             "score": {"task_weight": 0.5},
         },
         output_dir=tmp_path,

--- a/tests/v1/test_judges.py
+++ b/tests/v1/test_judges.py
@@ -368,7 +368,7 @@ async def test_rubric_view_full_trace(tmp_path, fake_judge_model):
 
 
 async def test_config_prompt_overrides_class_template(tmp_path, fake_judge_model):
-    # Config `prompt` is a UTF-8 file; the same {field} placeholders work.
+    # Config `prompt` is a file path; the same {field} placeholders work.
     file = tmp_path / "judge.txt"
     file.write_text("Q:{question} A:{answer} R:{response}")
     judge = vf.ReferenceJudge(vf.ReferenceJudgeConfig(prompt=file))

--- a/tests/v1/test_judges.py
+++ b/tests/v1/test_judges.py
@@ -367,32 +367,20 @@ async def test_rubric_view_full_trace(tmp_path, fake_judge_model):
     assert all("SECRET REASONING" not in prompt for prompt in fake_judge_model)
 
 
-async def test_config_prompt_overrides_class_template(fake_judge_model):
-    judge = vf.ReferenceJudge(
-        vf.ReferenceJudgeConfig(prompt="Q:{question} A:{answer} R:{response}")
-    )
+async def test_config_prompt_overrides_class_template(tmp_path, fake_judge_model):
+    # Config `prompt` is a UTF-8 file; the same {field} placeholders work.
+    file = tmp_path / "judge.txt"
+    file.write_text("Q:{question} A:{answer} R:{response}")
+    judge = vf.ReferenceJudge(vf.ReferenceJudgeConfig(prompt=file))
     assert judge.build_messages(question="q", answer="a", response="r") == "Q:q A:a R:r"
     # A template needn't use every evaluate field: score also passes {positive}/{negative},
     # which str.format ignores when the (custom) prompt doesn't reference them.
     trace = make_trace()
     assert await judge.score(trace.task.data, trace) == 1.0
     assert fake_judge_model[0] == "Q:Capital of France? A:Paris R:It is Paris."
-
-
-async def test_prompt_file(tmp_path, fake_judge_model):
-    # The prompt template can come from a file; the same {field} placeholders work.
-    file = tmp_path / "judge.txt"
-    file.write_text("Q:{question} A:{answer} R:{response}")
-    trace = make_trace()
-    judge = vf.ReferenceJudge(vf.ReferenceJudgeConfig(prompt_file=file))
-    assert await judge.score(trace.task.data, trace) == 1.0
-    assert fake_judge_model[0] == "Q:Capital of France? A:Paris R:It is Paris."
     # a bad path fails at judge construction, not mid-eval at score time
     with pytest.raises(FileNotFoundError):
-        vf.ReferenceJudge(vf.ReferenceJudgeConfig(prompt_file=tmp_path / "missing.txt"))
-    # inline and file prompts are mutually exclusive
-    with pytest.raises(ValueError, match="not both"):
-        vf.ReferenceJudgeConfig(prompt="inline", prompt_file=file)
+        vf.ReferenceJudge(vf.ReferenceJudgeConfig(prompt=tmp_path / "missing.txt"))
 
 
 # --- reference input/verdict knobs ------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 4
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'win32'",
@@ -21,9 +21,9 @@ exclude-newer-span = "P7D"
 prime-tunnel = false
 prime-sandboxes = false
 prime-pydantic-config = false
-ty = "2026-07-27T22:00:00Z"
+ty = "2026-07-28T07:00:00Z"
 renderers = false
-ruff = "2026-07-27T22:00:00Z"
+ruff = "2026-07-28T07:00:00Z"
 
 [[package]]
 name = "aiofile"
@@ -159,12 +159,6 @@ name = "alphabet-sort-v1"
 version = "0.1.0"
 source = { editable = "environments/alphabet_sort_v1" }
 dependencies = [
-    { name = "datasets" },
-    { name = "verifiers" },
-]
-
-[package.metadata]
-requires-dist = [
     { name = "datasets" },
     { name = "verifiers" },
 ]
@@ -698,21 +692,12 @@ dependencies = [
     { name = "verifiers" },
 ]
 
-[package.metadata]
-requires-dist = [{ name = "verifiers" }]
-
 [[package]]
 name = "color-codeword-v1"
 version = "0.1.0"
 source = { editable = "environments/color_codeword_v1" }
 dependencies = [
     { name = "pillow" },
-    { name = "verifiers" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "pillow", specifier = ">=11.0.0" },
     { name = "verifiers" },
 ]
 
@@ -732,9 +717,6 @@ source = { editable = "environments/compact" }
 dependencies = [
     { name = "verifiers" },
 ]
-
-[package.metadata]
-requires-dist = [{ name = "verifiers" }]
 
 [[package]]
 name = "connect-python"
@@ -969,9 +951,6 @@ source = { editable = "environments/deepwiki_v1" }
 dependencies = [
     { name = "verifiers" },
 ]
-
-[package.metadata]
-requires-dist = [{ name = "verifiers" }]
 
 [[package]]
 name = "defusedxml"
@@ -1376,9 +1355,6 @@ dependencies = [
     { name = "verifiers" },
 ]
 
-[package.metadata]
-requires-dist = [{ name = "verifiers" }]
-
 [[package]]
 name = "googleapis-common-protos"
 version = "1.75.0"
@@ -1526,9 +1502,6 @@ source = { editable = "environments/gsm8k_v1" }
 dependencies = [
     { name = "datasets" },
 ]
-
-[package.metadata]
-requires-dist = [{ name = "datasets" }]
 
 [[package]]
 name = "h11"
@@ -2087,9 +2060,6 @@ source = { editable = "environments/kuhn_poker_v1" }
 dependencies = [
     { name = "verifiers" },
 ]
-
-[package.metadata]
-requires-dist = [{ name = "verifiers" }]
 
 [[package]]
 name = "latex2sympy2-extended"
@@ -2840,9 +2810,6 @@ dependencies = [
     { name = "verifiers", extra = ["openenv"] },
 ]
 
-[package.metadata]
-requires-dist = [{ name = "verifiers", extras = ["openenv"] }]
-
 [[package]]
 name = "opentelemetry-api"
 version = "1.43.0"
@@ -3282,9 +3249,6 @@ source = { editable = "environments/proposer_solver_v1" }
 dependencies = [
     { name = "verifiers" },
 ]
-
-[package.metadata]
-requires-dist = [{ name = "verifiers" }]
 
 [[package]]
 name = "protobuf"
@@ -4088,9 +4052,6 @@ dependencies = [
     { name = "datasets" },
 ]
 
-[package.metadata]
-requires-dist = [{ name = "datasets" }]
-
 [[package]]
 name = "rich"
 version = "15.0.0"
@@ -4263,9 +4224,6 @@ source = { editable = "environments/scratchpad_v1" }
 dependencies = [
     { name = "verifiers" },
 ]
-
-[package.metadata]
-requires-dist = [{ name = "verifiers" }]
 
 [[package]]
 name = "secretstorage"
@@ -4960,79 +4918,6 @@ examples = [
     { name = "wordle-v1" },
 ]
 
-[package.metadata]
-requires-dist = [
-    { name = "aiohttp", specifier = ">=3.9.0" },
-    { name = "aiolimiter", specifier = ">=1.2.1" },
-    { name = "anthropic", specifier = ">=0.78.0" },
-    { name = "datasets", specifier = ">=3.3.0,<6.0.0" },
-    { name = "gepa", specifier = ">=0.0.6" },
-    { name = "harbor", marker = "python_full_version >= '3.12' and extra == 'harbor'", specifier = "==0.20.0" },
-    { name = "httpx", specifier = ">=0.27.0" },
-    { name = "loguru", specifier = ">=0.7.0" },
-    { name = "math-verify", specifier = ">=0.8.0" },
-    { name = "mcp", specifier = ">=1.24.0,<2" },
-    { name = "modal", marker = "extra == 'modal'", specifier = ">=1.4.0" },
-    { name = "msgpack", specifier = ">=1.1.2" },
-    { name = "nest-asyncio", marker = "extra == 'notebook'", specifier = ">=1.6.0" },
-    { name = "nltk", marker = "extra == 'ta'", specifier = ">=3.9.2" },
-    { name = "numpy", specifier = ">=2.1.0" },
-    { name = "openai", specifier = ">=2.9.0" },
-    { name = "openai-agents", specifier = ">=0.8.2" },
-    { name = "openenv", marker = "extra == 'openenv'", specifier = ">=0.4.1" },
-    { name = "prime-pydantic-config", extras = ["toml"], specifier = ">=0.4.2" },
-    { name = "prime-sandboxes", specifier = ">=0.2.33" },
-    { name = "prime-tunnel", specifier = ">=0.1.8" },
-    { name = "pydantic", specifier = ">=2.12.3" },
-    { name = "python-dotenv", marker = "extra == 'browser'", specifier = ">=1.0.0" },
-    { name = "pyzmq", specifier = ">=27.1.0" },
-    { name = "reasoning-gym", marker = "extra == 'rg'", specifier = ">=0.1.8" },
-    { name = "renderers", specifier = ">=0.1.8" },
-    { name = "requests" },
-    { name = "rich", specifier = ">=11.0.0" },
-    { name = "setproctitle", specifier = ">=1.3.0" },
-    { name = "stagehand", marker = "extra == 'browser'", specifier = ">=3.4.0" },
-    { name = "tenacity", specifier = ">=8.5.0" },
-    { name = "textarena", marker = "extra == 'ta'", specifier = "==0.7.4" },
-    { name = "tomli-w", specifier = ">=1.0.0" },
-    { name = "typing-extensions", specifier = ">=4.12.2" },
-    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'", specifier = ">=0.21.0" },
-]
-provides-extras = ["browser", "harbor", "modal", "notebook", "openenv", "rg", "ta"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "nest-asyncio", specifier = ">=1.6.0" },
-    { name = "nltk", specifier = ">=3.9.2" },
-    { name = "pre-commit", specifier = ">=2.19.0" },
-    { name = "pytest", specifier = ">=7.0.0,<9.1.0" },
-    { name = "pytest-asyncio", specifier = ">=0.21.0" },
-    { name = "pytest-cov", specifier = ">=4.0.0" },
-    { name = "pytest-xdist", specifier = ">=3.8.0" },
-    { name = "python-dotenv", specifier = ">=1.0.0" },
-    { name = "reasoning-gym", specifier = ">=0.1.8" },
-    { name = "ruff", specifier = ">=0.16.0" },
-    { name = "stagehand", specifier = ">=3.4.0" },
-    { name = "textarena", specifier = "==0.7.4" },
-    { name = "ty", specifier = ">=0.0.63" },
-]
-examples = [
-    { name = "alphabet-sort-v1", editable = "environments/alphabet_sort_v1" },
-    { name = "code-golf-v1", editable = "environments/code_golf_v1" },
-    { name = "color-codeword-v1", editable = "environments/color_codeword_v1" },
-    { name = "compact", editable = "environments/compact" },
-    { name = "deepwiki-v1", editable = "environments/deepwiki_v1" },
-    { name = "glossary-v1", editable = "environments/glossary_v1" },
-    { name = "gsm8k-v1", editable = "environments/gsm8k_v1" },
-    { name = "kuhn-poker-v1", editable = "environments/kuhn_poker_v1" },
-    { name = "openenv-wordle-v1", editable = "environments/openenv_wordle_v1" },
-    { name = "proposer-solver-v1", editable = "environments/proposer_solver_v1" },
-    { name = "reverse-text-v1", editable = "environments/reverse_text_v1" },
-    { name = "scratchpad-v1", editable = "environments/scratchpad_v1" },
-    { name = "wiki-search-v1", editable = "environments/wiki_search_v1" },
-    { name = "wordle-v1", editable = "environments/wordle_v1" },
-]
-
 [[package]]
 name = "virtualenv"
 version = "21.6.1"
@@ -5177,13 +5062,6 @@ dependencies = [
     { name = "verifiers" },
 ]
 
-[package.metadata]
-requires-dist = [
-    { name = "chromadb", specifier = ">=0.4.13" },
-    { name = "datasets" },
-    { name = "verifiers" },
-]
-
 [[package]]
 name = "win32-setctime"
 version = "1.2.0"
@@ -5200,9 +5078,6 @@ source = { editable = "environments/wordle_v1" }
 dependencies = [
     { name = "verifiers", extra = ["ta"] },
 ]
-
-[package.metadata]
-requires-dist = [{ name = "verifiers", extras = ["ta"] }]
 
 [[package]]
 name = "xxhash"

--- a/verifiers/v1/configs/judge.py
+++ b/verifiers/v1/configs/judge.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, SerializeAsAny, model_validator
+from pydantic import BaseModel, SerializeAsAny
 
 from verifiers.v1.clients import BaseClientConfig
 from verifiers.v1.types import ID, SamplingConfig
@@ -20,15 +20,8 @@ class JudgeConfig(BaseClientConfig):
     weight: float = 1.0
     model: str = "openai/gpt-5.4-nano"
     sampling: SamplingConfig = SamplingConfig()
-    prompt: str | None = None
-    prompt_file: Path | None = None
-    """Prompt file override, mutually exclusive with `prompt`."""
-
-    @model_validator(mode="after")
-    def check_prompt_source(self) -> "JudgeConfig":
-        if self.prompt is not None and self.prompt_file is not None:
-            raise ValueError("set `prompt` or `prompt_file`, not both")
-        return self
+    prompt: Path | None = None
+    """UTF-8 file whose text overrides the judge's default prompt template."""
 
 
 Judges = list[SerializeAsAny[JudgeConfig]]

--- a/verifiers/v1/configs/judge.py
+++ b/verifiers/v1/configs/judge.py
@@ -21,7 +21,7 @@ class JudgeConfig(BaseClientConfig):
     model: str = "openai/gpt-5.4-nano"
     sampling: SamplingConfig = SamplingConfig()
     prompt: Path | None = None
-    """UTF-8 file whose text overrides the judge's default prompt template."""
+    """File whose text overrides the judge's default prompt template."""
 
 
 Judges = list[SerializeAsAny[JudgeConfig]]

--- a/verifiers/v1/configs/taskset.py
+++ b/verifiers/v1/configs/taskset.py
@@ -1,6 +1,8 @@
 """The taskset plugin's config: which rows load, under `--env.taskset.*`."""
 
-from pydantic import SerializeAsAny
+from pathlib import Path
+
+from pydantic import SerializeAsAny, model_validator
 from pydantic_config import BaseConfig
 
 from verifiers.v1.configs.task import TaskConfig
@@ -14,6 +16,26 @@ class TasksetConfig(BaseConfig):
     positional `eval <taskset-id>`)."""
     task: SerializeAsAny[TaskConfig] = TaskConfig()
     """Config passed to each task, under `--env.taskset.task.*`."""
+    system_prompt: str | None = None
+    """Config-layer system prompt: replaces each task's baked-in `TaskData.system_prompt`
+    after `load()` (applied in `Taskset.select`). Lets a run set the system prompt without
+    editing the taskset — e.g. hand a GEPA `best_system_prompt.txt` to eval/train via
+    `system_prompt_file`. Mutually exclusive with `system_prompt_file`."""
+    system_prompt_file: Path | None = None
+    """File form of `system_prompt` (read as UTF-8), mutually exclusive with it."""
+
+    @model_validator(mode="after")
+    def check_system_prompt_source(self) -> "TasksetConfig":
+        if self.system_prompt is not None and self.system_prompt_file is not None:
+            raise ValueError("set `system_prompt` or `system_prompt_file`, not both")
+        return self
+
+    def resolve_system_prompt(self) -> str | None:
+        """The effective config-layer system prompt: the file's text if `system_prompt_file`
+        is set, else `system_prompt` (None when neither is)."""
+        if self.system_prompt_file is not None:
+            return self.system_prompt_file.read_text(encoding="utf-8")
+        return self.system_prompt
 
     @property
     def name(self) -> str:

--- a/verifiers/v1/configs/taskset.py
+++ b/verifiers/v1/configs/taskset.py
@@ -26,13 +26,18 @@ class TasksetConfig(BaseConfig):
 
     @model_validator(mode="after")
     def check_system_prompt_source(self) -> "TasksetConfig":
-        if self.system_prompt is not None and self.system_prompt_file is not None:
+        # Reject only when the run explicitly sets *both* — a taskset subclass that defaults
+        # `system_prompt` to a non-None value (e.g. lean) must still accept `system_prompt_file`,
+        # which overrides it (see `resolve_system_prompt`).
+        set_fields = self.model_fields_set
+        if "system_prompt" in set_fields and "system_prompt_file" in set_fields:
             raise ValueError("set `system_prompt` or `system_prompt_file`, not both")
         return self
 
     def resolve_system_prompt(self) -> str | None:
         """The effective config-layer system prompt: the file's text if `system_prompt_file`
-        is set, else `system_prompt` (None when neither is)."""
+        is set (it wins over a taskset's default `system_prompt`), else `system_prompt` (None
+        when neither is)."""
         if self.system_prompt_file is not None:
             return self.system_prompt_file.read_text(encoding="utf-8")
         return self.system_prompt

--- a/verifiers/v1/configs/taskset.py
+++ b/verifiers/v1/configs/taskset.py
@@ -1,13 +1,16 @@
 """The taskset plugin's config: which rows load, under `--env.taskset.*`."""
 
+import logging
 from pathlib import Path
 
-from pydantic import SerializeAsAny, model_validator
+from pydantic import SerializeAsAny
 from pydantic_config import BaseConfig
 
 from verifiers.v1.configs.task import TaskConfig
 from verifiers.v1.types import ID
 from verifiers.v1.utils.install import env_name
+
+logger = logging.getLogger(__name__)
 
 
 class TasksetConfig(BaseConfig):
@@ -20,25 +23,23 @@ class TasksetConfig(BaseConfig):
     """Config-layer system prompt: replaces each task's baked-in `TaskData.system_prompt`
     after `load()` (applied in `Taskset.select`). Lets a run set the system prompt without
     editing the taskset — e.g. hand a GEPA `best_system_prompt.txt` to eval/train via
-    `system_prompt_file`. Mutually exclusive with `system_prompt_file`."""
+    `system_prompt_file`. When both are set, `system_prompt_file` takes precedence."""
     system_prompt_file: Path | None = None
-    """File form of `system_prompt` (read as UTF-8), mutually exclusive with it."""
-
-    @model_validator(mode="after")
-    def check_system_prompt_source(self) -> "TasksetConfig":
-        # Reject only when the run explicitly sets *both* — a taskset subclass that defaults
-        # `system_prompt` to a non-None value (e.g. lean) must still accept `system_prompt_file`,
-        # which overrides it (see `resolve_system_prompt`).
-        set_fields = self.model_fields_set
-        if "system_prompt" in set_fields and "system_prompt_file" in set_fields:
-            raise ValueError("set `system_prompt` or `system_prompt_file`, not both")
-        return self
+    """File form of `system_prompt` (read as UTF-8); takes precedence over `system_prompt`
+    (including a taskset's default) when both are set."""
 
     def resolve_system_prompt(self) -> str | None:
         """The effective config-layer system prompt: the file's text if `system_prompt_file`
-        is set (it wins over a taskset's default `system_prompt`), else `system_prompt` (None
-        when neither is)."""
+        is set, else `system_prompt` (None when neither is). The file wins over `system_prompt`
+        — including a taskset's default — rather than erroring, so it survives a `model_dump` /
+        revalidate round trip across the env-server boundary; a warning flags the shadowed value."""
         if self.system_prompt_file is not None:
+            if self.system_prompt is not None:
+                logger.warning(
+                    "taskset config sets both system_prompt and system_prompt_file; using "
+                    "system_prompt_file (%s) and ignoring system_prompt",
+                    self.system_prompt_file,
+                )
             return self.system_prompt_file.read_text(encoding="utf-8")
         return self.system_prompt
 

--- a/verifiers/v1/configs/taskset.py
+++ b/verifiers/v1/configs/taskset.py
@@ -1,9 +1,8 @@
 """The taskset plugin's config: which rows load, under `--env.taskset.*`."""
 
 from pathlib import Path
-from typing import Any
 
-from pydantic import SerializeAsAny, model_validator
+from pydantic import SerializeAsAny
 from pydantic_config import BaseConfig
 
 from verifiers.v1.configs.task import TaskConfig
@@ -17,30 +16,9 @@ class TasksetConfig(BaseConfig):
     positional `eval <taskset-id>`)."""
     task: SerializeAsAny[TaskConfig] = TaskConfig()
     """Config passed to each task, under `--env.taskset.task.*`."""
-    system_prompt: str | None = None
-    """Config-layer system prompt: replaces each task's baked-in `TaskData.system_prompt`
-    after `load()` (applied in `Taskset.select`). Lets a run set the system prompt without
-    editing the taskset — e.g. hand a GEPA `best_system_prompt.txt` to eval/train via
-    `system_prompt_file`. Mutually exclusive with `system_prompt_file`; the file form is
-    collapsed into this string at validation so the runtime only sees `system_prompt`."""
-    system_prompt_file: Path | None = None
-    """File form of `system_prompt` (read as UTF-8 at validation). Mutually exclusive with
-    `system_prompt`; after validation the text lives on `system_prompt` and this is `None`."""
-
-    @model_validator(mode="before")
-    @classmethod
-    def collapse_system_prompt_file(cls, data: Any) -> Any:
-        if not isinstance(data, dict):
-            return data
-        prompt = data.get("system_prompt")
-        prompt_file = data.get("system_prompt_file")
-        if prompt is not None and prompt_file is not None:
-            raise ValueError("set `system_prompt` or `system_prompt_file`, not both")
-        if prompt_file is not None:
-            path = prompt_file if isinstance(prompt_file, Path) else Path(prompt_file)
-            data["system_prompt"] = path.read_text(encoding="utf-8")
-            data["system_prompt_file"] = None
-        return data
+    system_prompt: Path | None = None
+    """UTF-8 file whose text overrides each task's `TaskData.system_prompt` in
+    `Taskset.select` (e.g. a GEPA `best_system_prompt.txt`)."""
 
     @property
     def name(self) -> str:

--- a/verifiers/v1/configs/taskset.py
+++ b/verifiers/v1/configs/taskset.py
@@ -1,16 +1,14 @@
 """The taskset plugin's config: which rows load, under `--env.taskset.*`."""
 
-import logging
 from pathlib import Path
+from typing import Any
 
-from pydantic import SerializeAsAny
+from pydantic import SerializeAsAny, model_validator
 from pydantic_config import BaseConfig
 
 from verifiers.v1.configs.task import TaskConfig
 from verifiers.v1.types import ID
 from verifiers.v1.utils.install import env_name
-
-logger = logging.getLogger(__name__)
 
 
 class TasksetConfig(BaseConfig):
@@ -23,25 +21,26 @@ class TasksetConfig(BaseConfig):
     """Config-layer system prompt: replaces each task's baked-in `TaskData.system_prompt`
     after `load()` (applied in `Taskset.select`). Lets a run set the system prompt without
     editing the taskset — e.g. hand a GEPA `best_system_prompt.txt` to eval/train via
-    `system_prompt_file`. When both are set, `system_prompt_file` takes precedence."""
+    `system_prompt_file`. Mutually exclusive with `system_prompt_file`; the file form is
+    collapsed into this string at validation so the runtime only sees `system_prompt`."""
     system_prompt_file: Path | None = None
-    """File form of `system_prompt` (read as UTF-8); takes precedence over `system_prompt`
-    (including a taskset's default) when both are set."""
+    """File form of `system_prompt` (read as UTF-8 at validation). Mutually exclusive with
+    `system_prompt`; after validation the text lives on `system_prompt` and this is `None`."""
 
-    def resolve_system_prompt(self) -> str | None:
-        """The effective config-layer system prompt: the file's text if `system_prompt_file`
-        is set, else `system_prompt` (None when neither is). The file wins over `system_prompt`
-        — including a taskset's default — rather than erroring, so it survives a `model_dump` /
-        revalidate round trip across the env-server boundary; a warning flags the shadowed value."""
-        if self.system_prompt_file is not None:
-            if self.system_prompt is not None:
-                logger.warning(
-                    "taskset config sets both system_prompt and system_prompt_file; using "
-                    "system_prompt_file (%s) and ignoring system_prompt",
-                    self.system_prompt_file,
-                )
-            return self.system_prompt_file.read_text(encoding="utf-8")
-        return self.system_prompt
+    @model_validator(mode="before")
+    @classmethod
+    def collapse_system_prompt_file(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        prompt = data.get("system_prompt")
+        prompt_file = data.get("system_prompt_file")
+        if prompt is not None and prompt_file is not None:
+            raise ValueError("set `system_prompt` or `system_prompt_file`, not both")
+        if prompt_file is not None:
+            path = prompt_file if isinstance(prompt_file, Path) else Path(prompt_file)
+            data["system_prompt"] = path.read_text(encoding="utf-8")
+            data["system_prompt_file"] = None
+        return data
 
     @property
     def name(self) -> str:

--- a/verifiers/v1/configs/taskset.py
+++ b/verifiers/v1/configs/taskset.py
@@ -17,7 +17,7 @@ class TasksetConfig(BaseConfig):
     task: SerializeAsAny[TaskConfig] = TaskConfig()
     """Config passed to each task, under `--env.taskset.task.*`."""
     system_prompt: Path | None = None
-    """UTF-8 file whose text overrides each task's `TaskData.system_prompt` in
+    """File whose text overrides each task's `TaskData.system_prompt` in
     `Taskset.select` (e.g. a GEPA `best_system_prompt.txt`)."""
 
     @property

--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -181,13 +181,13 @@ class JudgeTaskConfig(vf.BaseConfig):
     """The judge's minted task: the grading policy and what lands in its box."""
 
     prompt: Path | None = None
-    """UTF-8 grading-policy file. Replaces only the policy body — the verdict
-    contract and workspace note are always appended. May reference `{prompt}` (the
-    solver task's prompt); if it doesn't, the task statement is appended after."""
+    """Grading-policy file. Replaces only the policy body — the verdict contract
+    and workspace note are always appended. May reference `{prompt}` (the solver
+    task's prompt); if it doesn't, the task statement is appended after."""
     hint: Path | None = None
-    """Optional UTF-8 hints file injected as their own section: task-family
-    pointers into the trace or box — e.g. for math, where the reference answer
-    lives in the record; for SWE, to diff the repo or read `info.patch`."""
+    """Optional hints file injected as their own section: task-family pointers
+    into the trace or box — e.g. for math, where the reference answer lives in
+    the record; for SWE, to diff the repo or read `info.patch`."""
     rubric: Path | None = None
     """Criteria the judge grades against: a `.toml`/`.json` file with a
     `criteria` list — the plugged rubric judge's format, so the same rubric
@@ -196,15 +196,15 @@ class JudgeTaskConfig(vf.BaseConfig):
     def build_prompt(self) -> str:
         if self.prompt is None:
             return GRADE_PROMPT + "\n\n" + TASK_SECTION
-        return self.prompt.read_text(encoding="utf-8")
+        return self.prompt.read_text()
 
     def build_hint(self) -> str | None:
-        return self.hint.read_text(encoding="utf-8") if self.hint is not None else None
+        return self.hint.read_text() if self.hint is not None else None
 
     def criteria(self) -> list[Criterion]:
         if self.rubric is None:
             return [SOLVED]
-        text = self.rubric.read_text(encoding="utf-8")
+        text = self.rubric.read_text()
         data = (
             tomllib.loads(text)
             if self.rubric.suffix.lower() == ".toml"

--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -180,36 +180,26 @@ class JudgeTask(vf.Task):
 class JudgeTaskConfig(vf.BaseConfig):
     """The judge's minted task: the grading policy and what lands in its box."""
 
-    prompt: Path | str | None = None
-    """Grading-policy override: inline text, or a policy file (a value ending in
-    `.md`/`.txt` is read from disk). Replaces only the policy body — the verdict
-    contract and workspace note are always appended, so a custom policy cannot
-    break verdict scraping. May reference `{prompt}` (the solver task's prompt);
-    if it doesn't, the task statement is appended after the policy."""
-    hint: Path | str | None = None
-    """Optional hints injected as their own section (inline text or a `.md`/
-    `.txt` file): task-family pointers into the trace or box — e.g. for math,
-    where the reference answer lives in the record; for SWE, to diff the repo
-    or read `info.patch`."""
+    prompt: Path | None = None
+    """UTF-8 grading-policy file. Replaces only the policy body — the verdict
+    contract and workspace note are always appended. May reference `{prompt}` (the
+    solver task's prompt); if it doesn't, the task statement is appended after."""
+    hint: Path | None = None
+    """Optional UTF-8 hints file injected as their own section: task-family
+    pointers into the trace or box — e.g. for math, where the reference answer
+    lives in the record; for SWE, to diff the repo or read `info.patch`."""
     rubric: Path | None = None
     """Criteria the judge grades against: a `.toml`/`.json` file with a
     `criteria` list — the plugged rubric judge's format, so the same rubric
     files work for both. None grades the single built-in `solved` criterion."""
 
-    @staticmethod
-    def _resolve(value: Path | str) -> str:
-        path = Path(value)
-        if isinstance(value, Path) or path.suffix in (".md", ".txt"):
-            return path.read_text(encoding="utf-8")
-        return str(value)
-
     def build_prompt(self) -> str:
         if self.prompt is None:
             return GRADE_PROMPT + "\n\n" + TASK_SECTION
-        return self._resolve(self.prompt)
+        return self.prompt.read_text(encoding="utf-8")
 
     def build_hint(self) -> str | None:
-        return self._resolve(self.hint) if self.hint is not None else None
+        return self.hint.read_text(encoding="utf-8") if self.hint is not None else None
 
     def criteria(self) -> list[Criterion]:
         if self.rubric is None:

--- a/verifiers/v1/gepa/adapter.py
+++ b/verifiers/v1/gepa/adapter.py
@@ -68,14 +68,10 @@ class GEPAAdapter:
         )
 
     async def _run_batch(self, batch: list[int], system_prompt: str) -> list[Episode]:
-        # Inject the candidate by rebuilding each Task around a data row with the new
-        # system_prompt (TaskData is frozen; behavior/config carry over unchanged).
-        tasks = [
-            type(t)(
-                t.data.model_copy(update={"system_prompt": system_prompt}), t.config
-            )
-            for t in (self.tasks[idx] for idx in batch)
-        ]
+        # Inject the candidate as a copy of each base task with its system_prompt overridden
+        # (`with_system_prompt` copies rather than reconstructs, so subclass state survives and
+        # the shared base task in `self.tasks` is left untouched for the next candidate).
+        tasks = [self.tasks[idx].with_system_prompt(system_prompt) for idx in batch]
         slots = [slot for task in tasks for slot in self.env.slots(task)]
         results = await asyncio.gather(
             *(

--- a/verifiers/v1/gepa/runner.py
+++ b/verifiers/v1/gepa/runner.py
@@ -105,7 +105,20 @@ def run_gepa(env: Env, config: GEPAConfig) -> GEPAResult:
                 "skip_perfect_score": False,
                 "logger": _GEPALog(),
             }
-            return optimize(**optimize_kwargs)
+            result = optimize(**optimize_kwargs)
+            if run_dir is not None:
+                # Persist the winning prompt as a plain file so it can be handed straight to
+                # eval/train via `--env.taskset.system-prompt-file` (see TasksetConfig).
+                candidate = result.best_candidate
+                best = (
+                    candidate.get("system_prompt", "")
+                    if isinstance(candidate, dict)
+                    else str(candidate)
+                )
+                best_path = run_dir / "best_system_prompt.txt"
+                best_path.write_text(best, encoding="utf-8")
+                logger.info("best system prompt: %s", best_path)
+            return result
         finally:
             loop.run_until_complete(serving.__aexit__(None, None, None))
     finally:

--- a/verifiers/v1/gepa/runner.py
+++ b/verifiers/v1/gepa/runner.py
@@ -108,7 +108,7 @@ def run_gepa(env: Env, config: GEPAConfig) -> GEPAResult:
             result = optimize(**optimize_kwargs)
             if run_dir is not None:
                 # Persist the winning prompt as a plain file so it can be handed straight to
-                # eval/train via `--env.taskset.system-prompt-file` (see TasksetConfig).
+                # eval/train via `--env.taskset.system-prompt` (see TasksetConfig).
                 candidate = result.best_candidate
                 best = (
                     candidate.get("system_prompt", "")

--- a/verifiers/v1/judge.py
+++ b/verifiers/v1/judge.py
@@ -116,13 +116,13 @@ def judge_config_cls(cls: type) -> type[JudgeConfig]:
 
 class Judge(Generic[ParsedT, ConfigT]):
     prompt: str | None = None
-    """Default prompt template, overridden by config."""
+    """Default prompt template, overridden by a config `prompt` file."""
     schema: type[BaseModel] | None = None
 
     def __init__(self, config: ConfigT | None = None) -> None:
         self.config = cast(ConfigT, config or judge_config_cls(type(self))())
-        if self.config.prompt_file is not None:
-            self.prompt = self.config.prompt_file.read_text(encoding="utf-8")
+        if self.config.prompt is not None:
+            self.prompt = self.config.prompt.read_text(encoding="utf-8")
 
     @property
     def reward_name(self) -> str:
@@ -132,7 +132,7 @@ class Judge(Generic[ParsedT, ConfigT]):
         return judge_key(self.config) or fallback or "judge"
 
     def build_messages(self, **fields: Any) -> str | Messages:
-        template = self.config.prompt or self.prompt
+        template = self.prompt
         if template is None:
             raise ValueError(
                 f"{type(self).__name__} has no `prompt`; set it or override build_messages"

--- a/verifiers/v1/judge.py
+++ b/verifiers/v1/judge.py
@@ -122,7 +122,7 @@ class Judge(Generic[ParsedT, ConfigT]):
     def __init__(self, config: ConfigT | None = None) -> None:
         self.config = cast(ConfigT, config or judge_config_cls(type(self))())
         if self.config.prompt is not None:
-            self.prompt = self.config.prompt.read_text(encoding="utf-8")
+            self.prompt = self.config.prompt.read_text()
 
     @property
     def reward_name(self) -> str:

--- a/verifiers/v1/task.py
+++ b/verifiers/v1/task.py
@@ -24,10 +24,11 @@ wraps it in the declared `Task` — one task type per taskset.
 
 from __future__ import annotations
 
+import copy
 import inspect
 import logging
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, ClassVar, Generic
+from typing import TYPE_CHECKING, ClassVar, Generic, Self
 
 from pydantic import ConfigDict, Field
 from pydantic_config import BaseConfig
@@ -196,6 +197,15 @@ class Task(Generic[DataT, StateT, ConfigT]):
     def __init__(self, data: DataT, config: ConfigT | None = None) -> None:
         self.data = data
         self.config = config if config is not None else task_config_cls(type(self))()
+
+    def with_system_prompt(self, system_prompt: str) -> Self:
+        """A shallow copy of this task with `data.system_prompt` overridden. Copies the
+        instance instead of reconstructing via `type(self)(...)`, so a subclass with a
+        non-`(data, config)` constructor or extra load-time state keeps it. Used to apply the
+        config-layer / GEPA system prompt (see `TasksetConfig` and `verifiers.v1.gepa`)."""
+        clone = copy.copy(self)
+        clone.data = self.data.model_copy(update={"system_prompt": system_prompt})
+        return clone
 
     def plugged_judges(self) -> list[Judge]:
         from verifiers.v1.loaders import load_judge

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -79,10 +79,26 @@ class Taskset(Generic[TaskT, TasksetConfigT]):
                     "taking the first %d generated tasks",
                     num_tasks,
                 )
-            return list(itertools.islice(self.load(), num_tasks))
-        if shuffle:
-            return sample(self.load(), shuffle=True, limit=num_tasks)
-        return list(itertools.islice(self.load(), num_tasks))
+            tasks = list(itertools.islice(self.load(), num_tasks))
+        elif shuffle:
+            tasks = sample(self.load(), shuffle=True, limit=num_tasks)
+        else:
+            tasks = list(itertools.islice(self.load(), num_tasks))
+        return self._apply_system_prompt(tasks)
+
+    def _apply_system_prompt(self, tasks: list[TaskT]) -> list[TaskT]:
+        """Overlay the config-layer `system_prompt` (see `TasksetConfig`) onto the
+        materialized tasks, replacing each task's baked-in `TaskData.system_prompt`. A no-op
+        unless `--env.taskset.system-prompt[-file]` is set — so every entrypoint that selects
+        tasks (eval, validate, debug, GEPA, and the env server's client) picks the override up
+        the same way, e.g. a GEPA `best_system_prompt.txt` handed to eval or training."""
+        override = self.config.resolve_system_prompt()
+        if override is None:
+            return tasks
+        return [
+            type(t)(t.data.model_copy(update={"system_prompt": override}), t.config)
+            for t in tasks
+        ]
 
     def server_config(self, server_cls: type) -> BaseConfig:
         """The config a `tools` entry is built with, resolved off `self.config` (the

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -79,8 +79,8 @@ class Taskset(Generic[TaskT, TasksetConfigT]):
                     "taking the first %d generated tasks",
                     num_tasks,
                 )
-            tasks = list(itertools.islice(self.load(), num_tasks))
-        elif shuffle:
+            shuffle = False  # can't materialize the whole taskset to sample from
+        if shuffle:
             tasks = sample(self.load(), shuffle=True, limit=num_tasks)
         else:
             tasks = list(itertools.islice(self.load(), num_tasks))

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -95,10 +95,7 @@ class Taskset(Generic[TaskT, TasksetConfigT]):
         override = self.config.resolve_system_prompt()
         if override is None:
             return tasks
-        return [
-            type(t)(t.data.model_copy(update={"system_prompt": override}), t.config)
-            for t in tasks
-        ]
+        return [t.with_system_prompt(override) for t in tasks]
 
     def server_config(self, server_cls: type) -> BaseConfig:
         """The config a `tools` entry is built with, resolved off `self.config` (the

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -85,7 +85,7 @@ class Taskset(Generic[TaskT, TasksetConfigT]):
         else:
             tasks = list(itertools.islice(self.load(), num_tasks))
         if self.config.system_prompt is not None:
-            override = self.config.system_prompt.read_text(encoding="utf-8")
+            override = self.config.system_prompt.read_text()
             tasks = [t.with_system_prompt(override) for t in tasks]
         return tasks
 

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -89,10 +89,12 @@ class Taskset(Generic[TaskT, TasksetConfigT]):
     def _apply_system_prompt(self, tasks: list[TaskT]) -> list[TaskT]:
         """Overlay the config-layer `system_prompt` (see `TasksetConfig`) onto the
         materialized tasks, replacing each task's baked-in `TaskData.system_prompt`. A no-op
-        unless `--env.taskset.system-prompt[-file]` is set — so every entrypoint that selects
-        tasks (eval, validate, debug, GEPA, and the env server's client) picks the override up
-        the same way, e.g. a GEPA `best_system_prompt.txt` handed to eval or training."""
-        override = self.config.resolve_system_prompt()
+        unless `--env.taskset.system-prompt` / `system-prompt-file` is set — so every
+        entrypoint that selects tasks (eval, validate, debug, GEPA, and the env server's
+        client) picks the override up the same way, e.g. a GEPA `best_system_prompt.txt`
+        handed to eval or training. The file form is collapsed into `system_prompt` at
+        config validation; this reads the string and materializes it onto `TaskData`."""
+        override = self.config.system_prompt
         if override is None:
             return tasks
         return [t.with_system_prompt(override) for t in tasks]

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -84,20 +84,10 @@ class Taskset(Generic[TaskT, TasksetConfigT]):
             tasks = sample(self.load(), shuffle=True, limit=num_tasks)
         else:
             tasks = list(itertools.islice(self.load(), num_tasks))
-        return self._apply_system_prompt(tasks)
-
-    def _apply_system_prompt(self, tasks: list[TaskT]) -> list[TaskT]:
-        """Overlay the config-layer `system_prompt` (see `TasksetConfig`) onto the
-        materialized tasks, replacing each task's baked-in `TaskData.system_prompt`. A no-op
-        unless `--env.taskset.system-prompt` / `system-prompt-file` is set — so every
-        entrypoint that selects tasks (eval, validate, debug, GEPA, and the env server's
-        client) picks the override up the same way, e.g. a GEPA `best_system_prompt.txt`
-        handed to eval or training. The file form is collapsed into `system_prompt` at
-        config validation; this reads the string and materializes it onto `TaskData`."""
-        override = self.config.system_prompt
-        if override is None:
-            return tasks
-        return [t.with_system_prompt(override) for t in tasks]
+        if self.config.system_prompt is not None:
+            override = self.config.system_prompt.read_text(encoding="utf-8")
+            tasks = [t.with_system_prompt(override) for t in tasks]
+        return tasks
 
     def server_config(self, server_cls: type) -> BaseConfig:
         """The config a `tools` entry is built with, resolved off `self.config` (the

--- a/verifiers/v1/tasksets/lean/taskset.py
+++ b/verifiers/v1/tasksets/lean/taskset.py
@@ -61,7 +61,6 @@ class LeanTaskConfig(TaskConfig):
 class LeanConfig(TasksetConfig):
     dataset: LeanDatasetConfig
     docker_image: str = DEFAULT_DOCKER_IMAGE
-    system_prompt: str = DEFAULT_SYSTEM_PROMPT
     task: LeanTaskConfig = LeanTaskConfig()
 
 
@@ -187,7 +186,7 @@ class LeanTaskset(Taskset[LeanTask, LeanConfig]):
                     idx=index,
                     name=str(name) if name else f"task_{index:05d}",
                     prompt=self._build_prompt(formal_statement, header),
-                    system_prompt=config.system_prompt,
+                    system_prompt=DEFAULT_SYSTEM_PROMPT,
                     image=config.docker_image,
                     workdir=config.task.lean_project_path,
                     resources=resources,


### PR DESCRIPTION
## What

Adds a config-layer system prompt to `TasksetConfig` (`system_prompt` / `system_prompt_file`), applied in `Taskset.select`, and has GEPA write its winning prompt to `best_system_prompt.txt`. Together these close the GEPA → eval/train loop: optimize a system prompt, then hand it straight back to a downstream run.

```bash
uv run gepa reverse-text-v1 --model …            # writes outputs/<run>/best_system_prompt.txt
uv run eval reverse-text-v1 \
  --env.taskset.system-prompt-file outputs/<run>/best_system_prompt.txt
```

## Why

GEPA already optimizes a task's `system_prompt`, but there was no first-class way to (a) set/override a taskset's system prompt from config without editing the taskset, or (b) reuse a GEPA-produced prompt in a downstream eval/train run. This wires that handoff.

## How

- **`TasksetConfig.system_prompt` / `system_prompt_file`** — mutually exclusive (validator); `resolve_system_prompt()` reads the file when set.
- **`Taskset.select()`** overlays the config value onto each task's `TaskData.system_prompt` — a no-op unless set. One chokepoint, so **eval, validate, debug, GEPA, and the env-server client** (the value rides the wire) all honor `--env.taskset.system-prompt[-file]`. No server/harness/adapter changes needed.
- **`gepa/runner.py`** writes `best_system_prompt.txt` to the run dir after `optimize()`.

## Testing

- **End-to-end handoff:** `gepa` wrote `best_system_prompt.txt`; a subsequent `eval --env.taskset.system-prompt-file <that>` put the prompt into the resulting trace (verified with a distinctive marker).
- `select()` unit-checked: applies when set, no-op when unset; mutual exclusion enforced.
- `ruff` clean; `ty` adds no new diagnostics; taskset/gepa/eval/config tests pass.

## Note

Supersedes #2038 — that branch predated main's multi-agent API, client-owned env server, and Episode-based GEPA adapter and had grown unmergeable conflicts across those rewrites. This re-implements the same intent cleanly on current `main`, dropping the now-obsolete `iter_tasks`/server plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Judge and agentic-judge callers must migrate inline prompts to files; task selection now reads an optional system-prompt file for every run that sets it.
> 
> **Overview**
> Closes the **GEPA → eval/train loop**: GEPA now writes the winning prompt to `best_system_prompt.txt`, and **`TasksetConfig.system_prompt`** (a file path) overrides every selected task’s `TaskData.system_prompt` in **`Taskset.select`**, so downstream runs can pass that file via `--env.taskset.system-prompt` without editing the taskset.
> 
> **`Task.with_system_prompt()`** shallow-copies a task with an updated system prompt; GEPA’s adapter uses it instead of reconstructing tasks so subclass state stays intact and the shared task pool is not mutated.
> 
> **Breaking config shape:** judge and agentic-judge prompt overrides are **file paths only** — `JudgeConfig` drops inline `prompt` / `prompt_file` (merged into `prompt: Path`), and agentic-judge `task.prompt` / `task.hint` no longer accept inline strings. Wiki-search moves its judge template into a **`WikiSearchJudge`** plugin with `judge_prompt.txt`. Lean drops taskset-level `system_prompt` in favor of the baked-in default on each row (still overridable via the new taskset file knob).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 304bc24a7341f6686b8c2a988aa33074c7d94d7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add file-based system prompt override to taskset config for GEPA handoff
> - Adds `system_prompt: Path | None` to `TasksetConfig` so a file path can override each selected task's system prompt at selection time via `Taskset.select`.
> - Adds `Task.with_system_prompt()` to clone a task with an updated system prompt, used internally by `Taskset.select`.
> - Consolidates `JudgeConfig` and `JudgeTaskConfig` to accept only file paths for prompt overrides, removing inline string and separate `prompt_file` options.
> - GEPA runs now write the best system prompt to `best_system_prompt.txt` in the run output directory, enabling it to be passed back to eval via `--env.taskset.system-prompt`.
> - Risk: inline string prompt overrides for `Judge`, `JudgeConfig`, and `JudgeTaskConfig` are no longer supported; callers must migrate to file-based paths.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #2171 opened
>
> - Created a judge system for `wiki_search_v1` consisting of `WikiSearchJudge` and `WikiSearchJudgeConfig` classes with prompt loaded from `judge_prompt.txt` [304bc24]
> - Changed default judge configuration in `WikiSearchTaskConfig` from inline `vf.ReferenceJudgeConfig` to `WikiSearchJudgeConfig` instance [304bc24]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e03d653.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->