### PR TITLE
chore: timezone-stable uv.lock and trace record cleanups

### DIFF
--- a/docs/v1/env.md
+++ b/docs/v1/env.md
@@ -33,7 +33,7 @@ class DebateEnv(vf.Env[DebateConfig]):
         await agents.judge.run(VerdictTask.from_traces(task, pro, con))
 
     async def finalize(self, task: vf.Task, episode: vf.Episode) -> None:
-        by_agent = {t.agent_name: t for t in episode.traces}
+        by_agent = {t.agent.name: t for t in episode.traces}
         winner = (by_agent["judge"].last_reply or "").strip().lower()
         by_agent["pro"].record_reward("won", float(winner == "pro"))
         by_agent["con"].record_reward("won", float(winner == "con"))

--- a/environments/proposer_solver_v1/proposer_solver_v1/taskset.py
+++ b/environments/proposer_solver_v1/proposer_solver_v1/taskset.py
@@ -150,7 +150,7 @@ class ProposerSolverEnv(vf.Env[ProposerSolverEnvConfig]):
 
     @staticmethod
     def _solve_rate(traces: list[vf.Trace]) -> float:
-        solves = [t for t in traces if t.agent_name == "solver"]
+        solves = [t for t in traces if t.agent and t.agent.name == "solver"]
         if not solves:
             return 0.0
         return sum(
@@ -163,7 +163,7 @@ class ProposerSolverEnv(vf.Env[ProposerSolverEnvConfig]):
         the problem, 0 when it's trivial or impossible for them (4p(1-p))."""
         rate = self._solve_rate(episode.traces)
         for trace in episode.traces:
-            if trace.agent_name == "proposer":
+            if trace.agent and trace.agent.name == "proposer":
                 trace.record_metric("solve_rate", rate)
                 trace.record_reward("learnability", 4.0 * rate * (1.0 - rate))
 

--- a/environments/proposer_solver_v1/proposer_solver_v1/taskset.py
+++ b/environments/proposer_solver_v1/proposer_solver_v1/taskset.py
@@ -150,7 +150,7 @@ class ProposerSolverEnv(vf.Env[ProposerSolverEnvConfig]):
 
     @staticmethod
     def _solve_rate(traces: list[vf.Trace]) -> float:
-        solves = [t for t in traces if t.agent and t.agent.name == "solver"]
+        solves = [t for t in traces if t.agent.name == "solver"]
         if not solves:
             return 0.0
         return sum(
@@ -163,7 +163,7 @@ class ProposerSolverEnv(vf.Env[ProposerSolverEnvConfig]):
         the problem, 0 when it's trivial or impossible for them (4p(1-p))."""
         rate = self._solve_rate(episode.traces)
         for trace in episode.traces:
-            if trace.agent and trace.agent.name == "proposer":
+            if trace.agent.name == "proposer":
                 trace.record_metric("solve_rate", rate)
                 trace.record_reward("learnability", 4.0 * rate * (1.0 - rate))
 

--- a/examples/agent.py
+++ b/examples/agent.py
@@ -20,14 +20,13 @@ async def main() -> None:
     async with solver:
         trace = await solver.run(task)
     print("stop:", trace.stop_condition)
-    print("error:", trace.error)
+    print("error:", trace.last_error)
     print("turns:", trace.num_turns)
     print("usage:", trace.usage)
     last = trace.assistant_messages[-1].content if trace.assistant_messages else None
     print("answer:", last)
-    assert trace.agent is not None
     print("agent:", trace.agent.name, trace.agent.config.model)
-    print("runtime:", trace.runtime.type if trace.runtime else None)
+    print("runtime:", trace.agent.runtime.type if trace.agent.runtime else None)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,8 +136,10 @@ kuhn-poker-v1 = { path = "environments/kuhn_poker_v1", editable = true }
 
 [tool.uv.exclude-newer-package]
 # Bounded cutoffs for the explicitly requested tool upgrades.
-ruff = "2026-07-27"
-ty = "2026-07-27"
+# Full UTC timestamps: bare dates resolve to local-tz midnight and churn the
+# lockfile across timezones.
+ruff = "2026-07-28T00:00:00Z"
+ty = "2026-07-28T00:00:00Z"
 # PrimeIntellect-published on PyPI (trusted publisher)
 prime-tunnel = false
 prime-sandboxes = false

--- a/skills/evaluate-environments/references/REFERENCE.md
+++ b/skills/evaluate-environments/references/REFERENCE.md
@@ -173,7 +173,7 @@ On `EnvServerConfig` (below): set `id` (leave `env.taskset` unset) to run a clas
 
 The separate `verifiers/v1/configs/env.py` `TimeoutConfig` (the env's `--env.timeout.*`) keeps only `episode` — the bound on the whole `run()` interaction — and `finalize` — the bound on the env's `finalize()` hook.
 
-> Remote sandboxes cap any harness timeout at 24 hours (provider max lifetime).
+> Remote sandboxes cap any agent timeout at 24 hours (provider max lifetime).
 
 ---
 

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -229,7 +229,7 @@ async def test_tool(run_v1, harness_runtime, tool_runtime, tmp_path):
     assert trace.reward == 1.0
     # The interception server captured the advertised tools onto the trace (for tool-use SFT):
     # the null harness offered the task's MCP tool as `echo_back`, schema included.
-    assert trace.tools is not None
+    assert trace.tools
     (echo_tool,) = [t for t in trace.tools if t.name == "echo_back"]
     assert "message" in echo_tool.parameters.get("properties", {})
 
@@ -495,7 +495,7 @@ async def test_env_id_user_sim_with_tools(run_v1, tmp_path):
     assert user.num_turns >= 1  # the modeled user actually drove the exchange
     assert assistant.rewards["echoed"].score == 1.0  # the tool ran, mid-conversation
     # The tool was advertised to the masked chat exactly as to any run.
-    assert assistant.tools is not None
+    assert assistant.tools
     assert any(tool.name == "echo_back" for tool in assistant.tools)
 
 

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -355,9 +355,9 @@ async def test_multi_agent_env(run_v1, tmp_path):
         max_turns=2,
     )
     assert len(traces) == 2  # one episode, one trace per role
-    assert sorted(t.agent_name for t in traces) == ["a", "b"]
-    (b,) = [t for t in traces if t.agent_name == "b"]
-    assert b.trainable is False
+    assert sorted(t.agent.name for t in traces) == ["a", "b"]
+    (b,) = [t for t in traces if t.agent.name == "b"]
+    assert b.agent.trainable is False
     for trace in traces:
         assert trace.ok
         assert trace.reward == 1.0  # each seat's own task reward
@@ -385,7 +385,7 @@ async def test_env_id_best_of_n(run_v1, tmp_path):
         max_turns=2,
     )
     assert len(traces) == 2  # one episode, two attempts
-    assert all(t.agent_name == "agent" and t.ok for t in traces)
+    assert all(t.agent.name == "agent" and t.ok for t in traces)
     assert any(t.metrics["best"] == 1.0 for t in traces)
     assert all(t.metrics["pass_at_n"] == 1.0 for t in traces)  # echo always passes
 
@@ -423,11 +423,11 @@ async def test_env_id_agentic_judge(run_v1, tmp_path):
         max_turns=10,
         rollout_timeout=600,
     )
-    assert sorted(t.agent_name for t in traces) == ["judge", "solver"]
-    (solver,) = [t for t in traces if t.agent_name == "solver"]
-    (judge,) = [t for t in traces if t.agent_name == "judge"]
+    assert sorted(t.agent.name for t in traces) == ["judge", "solver"]
+    (solver,) = [t for t in traces if t.agent.name == "solver"]
+    (judge,) = [t for t in traces if t.agent.name == "judge"]
     assert solver.ok and judge.ok
-    assert judge.trainable is False
+    assert judge.agent.trainable is False
     # The task's own reward keeps its raw score; the rescale lands on the weight.
     assert solver.rewards["echoed"].score == 1.0
     assert solver.rewards["echoed"].weight == 0.5
@@ -448,11 +448,11 @@ async def test_env_id_user_sim(run_v1, tmp_path):
         max_turns=6,
         rollout_timeout=300,
     )
-    assert sorted(t.agent_name for t in traces) == ["assistant", "user"]
-    (assistant,) = [t for t in traces if t.agent_name == "assistant"]
-    (user,) = [t for t in traces if t.agent_name == "user"]
+    assert sorted(t.agent.name for t in traces) == ["assistant", "user"]
+    (assistant,) = [t for t in traces if t.agent.name == "assistant"]
+    (user,) = [t for t in traces if t.agent.name == "user"]
     assert assistant.ok and user.ok
-    assert user.trainable is False
+    assert user.agent.trainable is False
     assert user.num_turns >= 1  # the modeled user actually spoke
     assert assistant.metrics["user_turns"] >= 1
     # `mask_prompt`: the scenario is hidden from the assistant's harness (the run's
@@ -465,7 +465,7 @@ async def test_env_id_user_sim(run_v1, tmp_path):
     from verifiers.v1.trace import WireTrace
 
     (record,) = read_episodes(tmp_path, WireTrace)
-    assert {t.agent_name for t in record.traces} == {"assistant", "user"}
+    assert {t.agent.name for t in record.traces} == {"assistant", "user"}
     assert record.id  # both traces are persisted under one durable episode identity
 
 
@@ -488,8 +488,8 @@ async def test_env_id_user_sim_with_tools(run_v1, tmp_path):
         max_tokens=8192,
         rollout_timeout=300,
     )
-    (assistant,) = [t for t in traces if t.agent_name == "assistant"]
-    (user,) = [t for t in traces if t.agent_name == "user"]
+    (assistant,) = [t for t in traces if t.agent.name == "assistant"]
+    (user,) = [t for t in traces if t.agent.name == "user"]
     assert assistant.ok and user.ok
     assert assistant.task.data.prompt is None  # the scenario stayed off the wire
     assert user.num_turns >= 1  # the modeled user actually drove the exchange
@@ -514,8 +514,8 @@ async def test_kuhn_poker_self_play(run_v1, tmp_path):
         max_tokens=8192,
         rollout_timeout=300,
     )
-    assert sorted(t.agent_name for t in traces) == ["player0", "player1"]
-    payoffs = {t.agent_name: t.rewards["payoff"].score for t in traces}
+    assert sorted(t.agent.name for t in traces) == ["player0", "player1"]
+    payoffs = {t.agent.name: t.rewards["payoff"].score for t in traces}
     assert payoffs["player0"] + payoffs["player1"] == 0  # zero-sum
     assert abs(payoffs["player0"]) in (1.0, 2.0)
     for trace in traces:
@@ -542,7 +542,7 @@ async def test_multi_agent_env_server(run_v1_server, tmp_path):
         max_turns=2,
     )
     assert len(traces) == 2
-    assert sorted(t.agent_name for t in traces) == ["a", "b"]
+    assert sorted(t.agent.name for t in traces) == ["a", "b"]
     for trace in traces:
         assert trace.ok
         assert trace.metrics["duet"] == 1.0

--- a/tests/v1/test_graph.py
+++ b/tests/v1/test_graph.py
@@ -40,7 +40,8 @@ def test_routed_experts_attributed_and_aligned_across_turns():
     concatenates back to a `[tokens, layers, top_k]` array aligned 1:1 with `branch.token_ids` —
     and survives the base64 wire round-trip."""
     trace = vf.Trace(
-        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="x"))
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
+        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="x")),
     )
     user = vf.UserMessage(content="u1")
     graph.prepare_turn(trace, [user]).commit(
@@ -94,7 +95,8 @@ def test_routed_experts_none_when_absent():
     """No routing captured (engine ran without `enable_return_routed_experts`) -> the branch
     reports None and the trainer simply skips replay."""
     trace = vf.Trace(
-        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="x"))
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
+        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="x")),
     )
     graph.prepare_turn(trace, [vf.UserMessage(content="u1")]).commit(
         vf.Response(
@@ -128,7 +130,10 @@ def test_tool_call_hash_matches_v0_content_and_arguments_normalization():
 
 def test_reasoning_content_participates_in_graph_prefix_matching():
     task = vf.TaskData(idx=0, prompt="use a tool")
-    trace = vf.Trace(task=vf.TraceTask(type="Task", data=task))
+    trace = vf.Trace(
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
+        task=vf.TraceTask(type="Task", data=task),
+    )
     user = vf.UserMessage(content="use a tool")
     call = vf.ToolCall(id="call_0", name="lookup", arguments="{}")
 
@@ -205,7 +210,8 @@ def test_renderer_level_break_forks_by_token_id():
 
     # Control: the prior turn re-renders to the same tokens -> stays one linear branch.
     linear = vf.Trace(
-        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="x"))
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
+        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="x")),
     )
     first_turn(linear)
     second_turn(linear, [1, 2, 3, 4, 5, 6, 7])
@@ -214,7 +220,8 @@ def test_renderer_level_break_forks_by_token_id():
 
     # Break: the assistant turn retokenizes (4 -> 99), so prompt_ids diverge at that node.
     broken = vf.Trace(
-        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="x"))
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
+        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="x")),
     )
     first_turn(broken)
     second_turn(broken, [1, 2, 3, 99, 5, 6, 7])
@@ -227,7 +234,10 @@ def test_renderer_level_break_forks_by_token_id():
 
 def test_prompt_supplied_assistant_messages_are_not_sampled_turns():
     task = vf.TaskData(idx=0, prompt="few-shot")
-    trace = vf.Trace(task=vf.TraceTask(type="Task", data=task))
+    trace = vf.Trace(
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
+        task=vf.TraceTask(type="Task", data=task),
+    )
     fabricated = vf.AssistantMessage(
         content=None,
         tool_calls=[vf.ToolCall(id="call_0", name="lookup", arguments="{}")],

--- a/tests/v1/test_judges.py
+++ b/tests/v1/test_judges.py
@@ -36,6 +36,7 @@ def make_trace(
     task_cls: type[QAData] = QAData,
 ) -> vf.Trace:
     return vf.Trace(
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
         task=vf.TraceTask(
             type="Task",
             data=task_cls(idx=0, prompt="Capital of France?", answer=answer),
@@ -244,6 +245,7 @@ async def test_reference_score_messages_prompt(fake_judge_model):
         answer="Paris",
     )
     trace = vf.Trace(
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
         task=vf.TraceTask(type="Task", data=task),
         nodes=[
             MessageNode(parent=None, message=UserMessage(content="q"), sampled=False),
@@ -269,6 +271,7 @@ async def test_reference_question_field(fake_judge_model):
         answer="Paris",
     )
     trace = vf.Trace(
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
         task=vf.TraceTask(type="Task", data=task),
         nodes=[
             MessageNode(parent=None, message=UserMessage(content="q"), sampled=False),
@@ -293,6 +296,7 @@ def full_trace_fixture() -> vf.Trace:
     from verifiers.v1.types import ToolCall, ToolMessage
 
     return vf.Trace(
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
         task=vf.TraceTask(
             type="Task", data=QAData(idx=0, prompt="Capital of France?", answer="Paris")
         ),

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -21,7 +21,8 @@ class MyState(vf.State):
 def test_bare_trace_round_trip():
     # The minimal trace: a base task, no nodes, no extras — dump and back into a plain Trace.
     tr = vf.Trace(
-        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=3, prompt="hello"))
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
+        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=3, prompt="hello")),
     )
     rt = vf.Trace.model_validate(tr.model_dump())
     assert rt.id == tr.id
@@ -35,6 +36,7 @@ def test_custom_task_state_round_trip():
     # Custom data and state round-trip into the same parameterization. Data fields are
     # typed (not just `model_extra`); `state` is runtime-only and never crosses the wire.
     tr = vf.Trace[MyTask, MyState](
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
         task=vf.TraceTask(type="MyTask", data=MyTask(idx=0, prompt="q", answer="gold")),
         state=MyState(score=7),
         nodes=[
@@ -59,6 +61,7 @@ def test_wire_trace_round_trip():
     # Two leaves off one root → 2 branches (a compaction-shaped trace), so the round-trip has to
     # carry node `parent` links for `num_branches` to survive.
     tr = vf.Trace[MyTask, vf.State](
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
         task=vf.TraceTask(type="MyTask", data=MyTask(idx=0, prompt="q", answer="a")),
         tools=[vf.Tool(name="echo", description="", parameters={"type": "object"})],
         nodes=[

--- a/uv.lock
+++ b/uv.lock
@@ -21,9 +21,9 @@ exclude-newer-span = "P7D"
 prime-tunnel = false
 prime-sandboxes = false
 prime-pydantic-config = false
-ty = "2026-07-27T22:00:00Z"
+ty = "2026-07-28T00:00:00Z"
 renderers = false
-ruff = "2026-07-27T22:00:00Z"
+ruff = "2026-07-28T00:00:00Z"
 
 [[package]]
 name = "aiofile"
@@ -987,7 +987,7 @@ name = "deprecation"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
 wheels = [
@@ -1008,7 +1008,7 @@ name = "dirhash"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "scantree" },
+    { name = "scantree", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/70/49f93897f3a4f7ab5f20a854ebc91aad47854e9fb2cd169e3a4452fa3f5e/dirhash-0.5.0.tar.gz", hash = "sha256:e60760f0ab2e935d8cb088923ea2c6492398dca42cec785df778985fd4cd5386", size = 21377, upload-time = "2024-08-03T22:14:13.322Z" }
 wheels = [
@@ -1557,27 +1557,27 @@ name = "harbor"
 version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dirhash" },
-    { name = "fastapi" },
-    { name = "filelock" },
-    { name = "httpx" },
-    { name = "jinja2" },
-    { name = "litellm" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "platformdirs" },
-    { name = "pydantic" },
-    { name = "pyjwt" },
-    { name = "python-dotenv" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "rich" },
-    { name = "shortuuid" },
-    { name = "supabase" },
-    { name = "tenacity" },
-    { name = "toml" },
-    { name = "typer" },
-    { name = "uvicorn" },
+    { name = "dirhash", marker = "python_full_version >= '3.12'" },
+    { name = "fastapi", marker = "python_full_version >= '3.12'" },
+    { name = "filelock", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", marker = "python_full_version >= '3.12'" },
+    { name = "jinja2", marker = "python_full_version >= '3.12'" },
+    { name = "litellm", marker = "python_full_version >= '3.12'" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
+    { name = "pathspec", marker = "python_full_version >= '3.12'" },
+    { name = "platformdirs", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "pyjwt", marker = "python_full_version >= '3.12'" },
+    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.12'" },
+    { name = "requests", marker = "python_full_version >= '3.12'" },
+    { name = "rich", marker = "python_full_version >= '3.12'" },
+    { name = "shortuuid", marker = "python_full_version >= '3.12'" },
+    { name = "supabase", marker = "python_full_version >= '3.12'" },
+    { name = "tenacity", marker = "python_full_version >= '3.12'" },
+    { name = "toml", marker = "python_full_version >= '3.12'" },
+    { name = "typer", marker = "python_full_version >= '3.12'" },
+    { name = "uvicorn", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1e/da/5a26998c6e7d9455321ab39bc8e9122993892ece13c3ad4f2b0de986aaf6/harbor-0.20.0.tar.gz", hash = "sha256:e2e5e88f772690fd121553ca34fd5d6dd6b4aaa51c8fae635abc84b112303112", size = 1590870, upload-time = "2026-07-18T21:25:22.578Z" }
 wheels = [
@@ -1689,7 +1689,7 @@ wheels = [
 
 [package.optional-dependencies]
 http2 = [
-    { name = "h2" },
+    { name = "h2", marker = "python_full_version >= '3.12'" },
 ]
 
 [[package]]
@@ -2109,18 +2109,18 @@ name = "litellm"
 version = "1.91.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp" },
-    { name = "click" },
-    { name = "fastuuid" },
-    { name = "httpx" },
-    { name = "importlib-metadata" },
-    { name = "jinja2" },
-    { name = "jsonschema" },
-    { name = "openai" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "tiktoken" },
-    { name = "tokenizers" },
+    { name = "aiohttp", marker = "python_full_version >= '3.12'" },
+    { name = "click", marker = "python_full_version >= '3.12'" },
+    { name = "fastuuid", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", marker = "python_full_version >= '3.12'" },
+    { name = "importlib-metadata", marker = "python_full_version >= '3.12'" },
+    { name = "jinja2", marker = "python_full_version >= '3.12'" },
+    { name = "jsonschema", marker = "python_full_version >= '3.12'" },
+    { name = "openai", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
+    { name = "tiktoken", marker = "python_full_version >= '3.12'" },
+    { name = "tokenizers", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6b/5d/2dfda0e057511ba24904c5c9af720512b1fc86893821947fa52f4cc0231b/litellm-1.91.2.tar.gz", hash = "sha256:e9aa292b95f25fa9d127e47a6e7266a2a99f7a1645f41100a411d7a8a77a6a46", size = 14872927, upload-time = "2026-07-11T06:04:18.847Z" }
 wheels = [
@@ -3124,10 +3124,10 @@ name = "postgrest"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "deprecation" },
-    { name = "httpx", extra = ["http2"] },
-    { name = "pydantic" },
-    { name = "yarl" },
+    { name = "deprecation", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", extra = ["http2"], marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "yarl", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e2/22/88c470d8838d2678a44e0172d061630b8837cba3fb7fb492e28f6578c309/postgrest-2.31.0.tar.gz", hash = "sha256:2f395d84b2ee34fc57622ff2f711df603e2ede625f98e5015240741888f7bd0c", size = 14419, upload-time = "2026-06-04T13:37:20.474Z" }
 wheels = [
@@ -3916,9 +3916,9 @@ name = "realtime"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic" },
-    { name = "typing-extensions" },
-    { name = "websockets" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+    { name = "websockets", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/34/54a1eaaefa24db5cb12596fd74792e08efa53ed30dc5bce2c0a68ded6146/realtime-2.31.0.tar.gz", hash = "sha256:9e641cb4d77ca0fe768515f8cf9f83550c79f49ce1550a95afc2dc0e252be8c9", size = 18716, upload-time = "2026-06-04T13:37:22.089Z" }
 wheels = [
@@ -4248,8 +4248,8 @@ name = "scantree"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
-    { name = "pathspec" },
+    { name = "attrs", marker = "python_full_version >= '3.12'" },
+    { name = "pathspec", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/e4/40998faefc72ba1ddeb640a44fba92935353525dba110488806da8339c0b/scantree-0.0.4.tar.gz", hash = "sha256:15bd5cb24483b04db2c70653604e8ea3522e98087db7e38ab8482f053984c0ac", size = 24643, upload-time = "2024-08-03T20:08:59.413Z" }
 wheels = [
@@ -4272,8 +4272,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -4427,10 +4427,10 @@ name = "storage3"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "deprecation" },
-    { name = "httpx", extra = ["http2"] },
-    { name = "pydantic" },
-    { name = "yarl" },
+    { name = "deprecation", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", extra = ["http2"], marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "yarl", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/13/30/fee43d523d3f680a833a4aae5bf8094de0b9031b0c2bddb3e0bc6e829e1b/storage3-2.31.0.tar.gz", hash = "sha256:d2161e2ea650dc115a1787c30e09b118365589ac772f4dd8643e3a503ecfc667", size = 20348, upload-time = "2026-06-04T13:37:23.703Z" }
 wheels = [
@@ -4451,13 +4451,13 @@ name = "supabase"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
-    { name = "postgrest" },
-    { name = "realtime" },
-    { name = "storage3" },
-    { name = "supabase-auth" },
-    { name = "supabase-functions" },
-    { name = "yarl" },
+    { name = "httpx", marker = "python_full_version >= '3.12'" },
+    { name = "postgrest", marker = "python_full_version >= '3.12'" },
+    { name = "realtime", marker = "python_full_version >= '3.12'" },
+    { name = "storage3", marker = "python_full_version >= '3.12'" },
+    { name = "supabase-auth", marker = "python_full_version >= '3.12'" },
+    { name = "supabase-functions", marker = "python_full_version >= '3.12'" },
+    { name = "yarl", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fe/8e/54a2f950629689b1613434a61fc3bff5f92f84ba6b20213f5b2add05c1bb/supabase-2.31.0.tar.gz", hash = "sha256:3467b09d00482b9a0138235bdbde7a350426f93cf2a1342372eaddfc669f1206", size = 9805, upload-time = "2026-06-04T13:37:25.22Z" }
 wheels = [
@@ -4469,9 +4469,9 @@ name = "supabase-auth"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx", extra = ["http2"] },
-    { name = "pydantic" },
-    { name = "pyjwt", extra = ["crypto"] },
+    { name = "httpx", extra = ["http2"], marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "pyjwt", extra = ["crypto"], marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/8a/408689cf39820f0d46d2731d6747ff94dbefc87ae977b4b5c4066da5b070/supabase_auth-2.31.0.tar.gz", hash = "sha256:0945b33fa96239c76dc8eaf96d7d2c94991950d24b4cfe4a5c2da9aa5e909663", size = 39151, upload-time = "2026-06-04T13:37:27.375Z" }
 wheels = [
@@ -4483,9 +4483,9 @@ name = "supabase-functions"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx", extra = ["http2"] },
-    { name = "strenum" },
-    { name = "yarl" },
+    { name = "httpx", extra = ["http2"], marker = "python_full_version >= '3.12'" },
+    { name = "strenum", marker = "python_full_version >= '3.12'" },
+    { name = "yarl", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/5d/61c2446ed26a57fa5543f9c270a731320911569202340d15341f72cdba7c/supabase_functions-2.31.0.tar.gz", hash = "sha256:4ad027b3ae3bd28b31233339f4db1da6965affd3546f655b421baf40cee2690f", size = 4683, upload-time = "2026-06-04T13:37:28.878Z" }
 wheels = [

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -419,7 +419,7 @@ class Agent:
             # close() never runs — free the run's servers and owned runtime first.
             await run.abort()
             raise
-        if trace.agent is not None and trace.agent.runtime is not None:
+        if trace.agent.runtime is not None:
             trace.agent.runtime.borrowed = runtime is not None
         return trace
 

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -482,8 +482,8 @@ class Agent:
             opened = await run.open()
             if not opened:
                 trace = await run.close()
-                if trace.runtime is not None:
-                    trace.runtime.borrowed = runtime is not None
+                if trace.agent.runtime is not None:
+                    trace.agent.runtime.borrowed = runtime is not None
         if not opened:
             failure = run.failure
             if failure is None:  # `open()` returning False always captures one.
@@ -499,8 +499,8 @@ class Agent:
             raise
         finally:
             trace = run.trace if run.closed else await interaction.close()
-            if trace.runtime is not None:
-                trace.runtime.borrowed = runtime is not None
+            if trace.agent.runtime is not None:
+                trace.agent.runtime.borrowed = runtime is not None
 
     def _rollout_params(
         self, task: Task, runtime: Runtime | None, shared_tools: dict

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -45,7 +45,7 @@ from verifiers.v1.types import (
     UserMessage,
 )
 from verifiers.v1.utils.compile import (
-    cap_remote_harness_timeout,
+    cap_remote_agent_timeout,
     resolve_runtime_config,
     validate_pairing,
 )
@@ -390,7 +390,7 @@ class Agent:
                 attempt + 1,
                 retry.max_retries,
                 delay,
-                trace.error.type if trace.error else "?",
+                trace.last_error.type if trace.last_error else "?",
             )
             await asyncio.sleep(delay)
         if history:
@@ -419,8 +419,8 @@ class Agent:
             # close() never runs — free the run's servers and owned runtime first.
             await run.abort()
             raise
-        if trace.runtime is not None:
-            trace.runtime.borrowed = runtime is not None
+        if trace.agent is not None and trace.agent.runtime is not None:
+            trace.agent.runtime.borrowed = runtime is not None
         return trace
 
     @asynccontextmanager
@@ -520,10 +520,10 @@ class Agent:
             self.harness, type(task), runtime_config, shared_tools=shared_tools
         )
         # Timeout precedence: agent-level wins, else the task's, else no limit.
-        harness_timeout = (
+        agent_timeout = (
             self.timeout.rollout
             if self.timeout.rollout is not None
-            else task.data.timeout.harness
+            else task.data.timeout.agent
         )
         return {
             "agent_config": self.config,
@@ -535,8 +535,8 @@ class Agent:
                 if self.timeout.setup is not None
                 else task.data.timeout.setup
             ),
-            "harness_timeout": cap_remote_harness_timeout(
-                harness_timeout, runtime_config, task
+            "agent_timeout": cap_remote_agent_timeout(
+                agent_timeout, runtime_config, task
             ),
             "finalize_timeout": (
                 self.timeout.finalize

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -302,9 +302,7 @@ def Progress(
     # run, a modeled user) are `trainable=False` and carry no rewards, so counting
     # them dilutes every mean with structural zeros. An all-untrainable run (every
     # role frozen) falls back to all traces rather than showing nothing.
-    scored = [
-        t for t in done_traces if t.agent is None or t.agent.trainable
-    ] or done_traces
+    scored = [t for t in done_traces if t.agent.trainable] or done_traces
     total = len(slots)
     # Headline reward = mean over non-errored traces; when any errored, `format_mean` appends
     # the global avg (errored count as 0) in parens. `err` is the share of episodes that
@@ -369,13 +367,13 @@ def _breakdown(scored: list[Trace], done: list[Trace]) -> Table | None:
     # show); usage/time below still cover errored rollouts (their resources were spent regardless).
     has_clean = any(not t.has_error for t in done)
     score_rows = (("rewards", "rewards"), ("metrics", "metrics")) if has_clean else ()
-    by_agent: dict[str | None, list[Trace]] = {}
+    by_agent: dict[str, list[Trace]] = {}
     for trace in done:
-        by_agent.setdefault(trace.agent.name if trace.agent else None, []).append(trace)
+        by_agent.setdefault(trace.agent.name, []).append(trace)
     for label, source in score_rows:
         if len(by_agent) > 1:
             segments = [
-                f"[dim]{name or '—'}:[/dim] {means}"
+                f"[dim]{name}:[/dim] {means}"
                 for name, traces in by_agent.items()
                 if (means := _score_segments(traces, source)) is not None
             ]
@@ -566,7 +564,7 @@ def Rows(groups: list[list[RunSlot]], now: float, runtime_type: str) -> Table:
                     group_rows.append(("pending", [f"task {base}", *[""] * 7], "", ""))
                 continue
             for t in slot.traces:
-                label = f"{base} agent={t.agent.name}" if t.agent else base
+                label = f"{base} agent={t.agent.name}"
                 if slot.done:  # fully scored — reward is final
                     state = "error" if t.has_error else "success"
                     # A trace that recorded nothing shows no reward: a judge or
@@ -594,7 +592,7 @@ def Rows(groups: list[list[RunSlot]], now: float, runtime_type: str) -> Table:
                 # The trace's own stamp, not the run-level runtime: a role's harness
                 # may resolve elsewhere (the judge env's sandboxed judge on a
                 # subprocess run).
-                if t.agent is not None and t.agent.runtime is not None:
+                if t.agent.runtime is not None:
                     rt = t.agent.runtime
                     runtime = f"{rt.type}({rt.id})" if rt.id else rt.type
                 else:

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -505,7 +505,7 @@ def _stage(trace: Trace) -> str:
         stage = "boot"  # trace minted, first span not yet opened (an instant)
     # A boot stuck on a first-use platform image build reads differently from a
     # normal boot — it can sit there for ~10 minutes (prime runtime only).
-    if stage == "boot" and getattr(trace.runtime, "image_cached", None) is False:
+    if stage == "boot" and getattr(trace.agent.runtime, "image_cached", None) is False:
         return "build"
     return stage
 

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -302,7 +302,9 @@ def Progress(
     # run, a modeled user) are `trainable=False` and carry no rewards, so counting
     # them dilutes every mean with structural zeros. An all-untrainable run (every
     # role frozen) falls back to all traces rather than showing nothing.
-    scored = [t for t in done_traces if t.trainable] or done_traces
+    scored = [
+        t for t in done_traces if t.agent is None or t.agent.trainable
+    ] or done_traces
     total = len(slots)
     # Headline reward = mean over non-errored traces; when any errored, `format_mean` appends
     # the global avg (errored count as 0) in parens. `err` is the share of episodes that
@@ -369,7 +371,7 @@ def _breakdown(scored: list[Trace], done: list[Trace]) -> Table | None:
     score_rows = (("rewards", "rewards"), ("metrics", "metrics")) if has_clean else ()
     by_agent: dict[str | None, list[Trace]] = {}
     for trace in done:
-        by_agent.setdefault(trace.agent_name, []).append(trace)
+        by_agent.setdefault(trace.agent.name if trace.agent else None, []).append(trace)
     for label, source in score_rows:
         if len(by_agent) > 1:
             segments = [
@@ -564,14 +566,14 @@ def Rows(groups: list[list[RunSlot]], now: float, runtime_type: str) -> Table:
                     group_rows.append(("pending", [f"task {base}", *[""] * 7], "", ""))
                 continue
             for t in slot.traces:
-                label = f"{base} agent={t.agent_name}" if t.agent_name else base
+                label = f"{base} agent={t.agent.name}" if t.agent else base
                 if slot.done:  # fully scored — reward is final
                     state = "error" if t.has_error else "success"
                     # A trace that recorded nothing shows no reward: a judge or
                     # modeled-user seat's `reward=0.00` would read as a score.
                     result = (
-                        t.error.type
-                        if t.has_error
+                        t.last_error.type
+                        if t.has_error and t.last_error
                         else (f"reward={t.reward:.2f}" if t.rewards else "")
                     )
                     if t.has_error:
@@ -582,7 +584,7 @@ def Rows(groups: list[list[RunSlot]], now: float, runtime_type: str) -> Table:
                             t.is_truncated
                         ):  # flag a clipped rollout next to its stop condition
                             stop = f"{stop} (truncated)".strip()
-                elif t.is_completed and (err := t.error) is not None:
+                elif t.is_completed and (err := t.last_error) is not None:
                     # An errored trace whose episode is still running its other
                     # traces (or `score()`) is already a failure — show it, don't
                     # let it sit as "scoring" until the whole episode lands.
@@ -592,12 +594,9 @@ def Rows(groups: list[list[RunSlot]], now: float, runtime_type: str) -> Table:
                 # The trace's own stamp, not the run-level runtime: a role's harness
                 # may resolve elsewhere (the judge env's sandboxed judge on a
                 # subprocess run).
-                if t.runtime is not None:
-                    runtime = (
-                        f"{t.runtime.type}({t.runtime.id})"
-                        if t.runtime.id
-                        else t.runtime.type
-                    )
+                if t.agent is not None and t.agent.runtime is not None:
+                    rt = t.agent.runtime
+                    runtime = f"{rt.type}({rt.id})" if rt.id else rt.type
                 else:
                     runtime = runtime_type
                 turns = t.num_turns
@@ -635,7 +634,7 @@ def Rows(groups: list[list[RunSlot]], now: float, runtime_type: str) -> Table:
                     f"{nbranches} branch{'es' * (nbranches != 1)}",
                     tokens,
                     f"{format_cost_usd(cost)}" if cost is not None else "",
-                    stop,  # stop condition (agent_completed / max_turns / harness_timeout), once done
+                    stop,  # stop condition (agent_completed / max_turns / error), once done
                 ]
                 # No start time yet (queued, not generating) → blank, not `now - 0` (~56 years).
                 elapsed = format_time(end - start) if start else ""

--- a/verifiers/v1/cli/debug.py
+++ b/verifiers/v1/cli/debug.py
@@ -108,9 +108,9 @@ def error_info(
 
 
 def capture_trace_error(trace: Trace, error: BaseException) -> None:
-    # CancelledError is a BaseException; Trace.capture_error accepts Exception.
+    # CancelledError is a BaseException; Trace.record_error accepts Exception.
     if isinstance(error, Exception):
-        trace.capture_error(error)
+        trace.record_error(error)
         return
     trace.errors.append(
         Error(

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -68,7 +68,7 @@ async def run_eval(env: Env, config: EvalConfig) -> list[Episode]:
 
     async def on_complete(episode: Episode) -> None:
         for trace in episode.traces:
-            trace.stamp(EvalRunInfo(id=config.uuid))
+            trace.record_run(EvalRunInfo(id=config.uuid))
         await append_episode(out, episode, write_lock)
 
     # Serving resources (shared tool servers, interception) come up once for the
@@ -235,7 +235,7 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
                 )
             records = []
             for trace in traces:
-                trace.stamp(EvalRunInfo(id=config.uuid))
+                trace.record_run(EvalRunInfo(id=config.uuid))
                 await append_trace(out, trace, write_lock, env=config.env_id)
                 records.append(Episode.of(trace))
             return records
@@ -249,7 +249,7 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
                     **payload,
                 )
             for trace in episode.traces:
-                trace.stamp(EvalRunInfo(id=config.uuid))
+                trace.record_run(EvalRunInfo(id=config.uuid))
             await append_episode(out, episode, write_lock)
             return [episode]
 

--- a/verifiers/v1/cli/replay.py
+++ b/verifiers/v1/cli/replay.py
@@ -171,7 +171,7 @@ async def run_replay(config: ReplayConfig, source: Path, out: Path) -> list[Trac
                     st.state, st.detail = "scored", f"reward {trace.reward:.3f}"
                 except Exception as exc:
                     st.state, st.detail = "error", type(exc).__name__
-                    trace.capture_error(exc)
+                    trace.record_error(exc)
                     if not config.rich:
                         logger.warning(
                             "replay: scoring failed for task %s",

--- a/verifiers/v1/cli/validate.py
+++ b/verifiers/v1/cli/validate.py
@@ -96,6 +96,12 @@ async def _run_gold(task: Task, config: ValidateConfig) -> ResultRow:
         trace = Trace(
             task=TraceTask(type=type(task).__name__, data=task.data),
             state=state_cls(type(task))(),
+            # No agent plays here: the seat records the runtime policy only.
+            agent=vf.AgentInfo(
+                config=vf.AgentConfig(runtime=config.runtime),
+                name="validate",
+                trainable=False,
+            ),
         )
         await runtime.start()
         await asyncio.wait_for(
@@ -131,6 +137,12 @@ async def _run_setup(task: Task, config: ValidateConfig) -> ResultRow:
         trace = Trace(
             task=TraceTask(type=type(task).__name__, data=task.data),
             state=state_cls(type(task))(),
+            # No agent plays here: the seat records the runtime policy only.
+            agent=vf.AgentInfo(
+                config=vf.AgentConfig(runtime=config.runtime),
+                name="validate",
+                trainable=False,
+            ),
         )
         await runtime.start()
         await asyncio.wait_for(

--- a/verifiers/v1/cli/validate.py
+++ b/verifiers/v1/cli/validate.py
@@ -96,7 +96,7 @@ async def _run_gold(task: Task, config: ValidateConfig) -> ResultRow:
         trace = Trace(
             task=TraceTask(type=type(task).__name__, data=task.data),
             state=state_cls(type(task))(),
-            # No agent plays here: the seat records the runtime policy only.
+            # No agent runs here — the info only records the runtime policy.
             agent=vf.AgentInfo(
                 config=vf.AgentConfig(runtime=config.runtime),
                 name="validate",
@@ -137,7 +137,7 @@ async def _run_setup(task: Task, config: ValidateConfig) -> ResultRow:
         trace = Trace(
             task=TraceTask(type=type(task).__name__, data=task.data),
             state=state_cls(type(task))(),
-            # No agent plays here: the seat records the runtime policy only.
+            # No agent runs here — the info only records the runtime policy.
             agent=vf.AgentInfo(
                 config=vf.AgentConfig(runtime=config.runtime),
                 name="validate",

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -160,7 +160,7 @@ class Env(ABC, Generic[ConfigT]):
         """Cross-agent judgement — THE programmable judgement surface: plain
         imperative Python over the finished episode (per-trace judgement already
         ran on each trace's own task). `episode.traces` is the flat episode in
-        completion order, each trace's `agent_name` stamp naming its agent; attach
+        completion order, each trace's `agent.name` stamp naming its agent; attach
         signals via `record_reward`/`record_metric`, in program order. A raise
         fails the episode (the retryable unit) — validate strictly, never
         record a guess."""

--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -304,7 +304,7 @@ class AgenticJudgeEnv(vf.Env[AgenticJudgeEnvConfig]):
             await agents.judge.run(judge_task, runtime=box)
 
     async def finalize(self, task: vf.Task, episode: vf.Episode) -> None:
-        by_agent = {t.agent.name if t.agent else None: t for t in episode.traces}
+        by_agent = {t.agent.name: t for t in episode.traces}
         solution, verdict = by_agent["solver"], by_agent["judge"]
         data = verdict.info.get("verdict")
         if not isinstance(data, dict) or not isinstance(data.get("verdicts"), list):

--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -304,7 +304,7 @@ class AgenticJudgeEnv(vf.Env[AgenticJudgeEnvConfig]):
             await agents.judge.run(judge_task, runtime=box)
 
     async def finalize(self, task: vf.Task, episode: vf.Episode) -> None:
-        by_agent = {t.agent_name: t for t in episode.traces}
+        by_agent = {t.agent.name if t.agent else None: t for t in episode.traces}
         solution, verdict = by_agent["solver"], by_agent["judge"]
         data = verdict.info.get("verdict")
         if not isinstance(data, dict) or not isinstance(data.get("verdicts"), list):

--- a/verifiers/v1/envs/user_sim/env.py
+++ b/verifiers/v1/envs/user_sim/env.py
@@ -89,7 +89,7 @@ class UserSimEnv(vf.Env[UserSimEnvConfig]):
     async def finalize(self, task, episode):
         """One conversation-shape fact about the user's side, recorded on the
         assistant's trace; judgement stays on the task's rewards."""
-        (user,) = (t for t in episode.traces if t.agent_name == "user")
+        (user,) = (t for t in episode.traces if t.agent and t.agent.name == "user")
         for trace in episode.traces:
-            if trace.agent_name == "assistant":
+            if trace.agent and trace.agent.name == "assistant":
                 trace.record_metric("user_turns", float(user.num_turns))

--- a/verifiers/v1/envs/user_sim/env.py
+++ b/verifiers/v1/envs/user_sim/env.py
@@ -89,7 +89,7 @@ class UserSimEnv(vf.Env[UserSimEnvConfig]):
     async def finalize(self, task, episode):
         """One conversation-shape fact about the user's side, recorded on the
         assistant's trace; judgement stays on the task's rewards."""
-        (user,) = (t for t in episode.traces if t.agent and t.agent.name == "user")
+        (user,) = (t for t in episode.traces if t.agent.name == "user")
         for trace in episode.traces:
-            if trace.agent and trace.agent.name == "assistant":
+            if trace.agent.name == "assistant":
                 trace.record_metric("user_turns", float(user.num_turns))

--- a/verifiers/v1/errors.py
+++ b/verifiers/v1/errors.py
@@ -4,7 +4,7 @@ Four mechanisms, each in one place:
 
 1. Vocabulary (this module): `RolloutError` and the flat boundary types below. Each names the
    boundary a failure crossed — provider, harness, toolset, sandbox, task, or
-   interception — so a recorded `trace.error.type` says where the rollout broke.
+   interception — so a recorded `trace.last_error.type` says where the rollout broke.
 2. Classification (`boundary`): the one helper that runs a framework→code boundary and attributes
    any escaping error to that boundary's type. Extension code (task hooks, harness subclasses)
    raises plain Python errors — it never constructs a `vf` error type; `boundary` classifies them.

--- a/verifiers/v1/gepa/adapter.py
+++ b/verifiers/v1/gepa/adapter.py
@@ -104,8 +104,7 @@ class GEPAAdapter:
                     "completion": trace.last_reply,
                     "reward": trace.reward,
                 }
-                if trace.agent is not None:
-                    record["agent"] = trace.agent.name
+                record["agent"] = trace.agent.name
                 if trace.has_error:
                     record["error"] = str(trace.last_error)
                 if trace.stop_condition:

--- a/verifiers/v1/gepa/adapter.py
+++ b/verifiers/v1/gepa/adapter.py
@@ -104,10 +104,10 @@ class GEPAAdapter:
                     "completion": trace.last_reply,
                     "reward": trace.reward,
                 }
-                if trace.agent_name:
-                    record["agent"] = trace.agent_name
+                if trace.agent is not None:
+                    record["agent"] = trace.agent.name
                 if trace.has_error:
-                    record["error"] = str(trace.error)
+                    record["error"] = str(trace.last_error)
                 if trace.stop_condition:
                     record["stop_condition"] = trace.stop_condition
                 for column in self.reflection_columns:

--- a/verifiers/v1/legacy.py
+++ b/verifiers/v1/legacy.py
@@ -227,7 +227,6 @@ def _timing(raw: Any) -> Timing:
 _V0_TO_V1_TRUNCATION_STOP = {
     "max_turns_reached": "max_turns",
     "prompt_too_long": "context_length",
-    "timeout_reached": "harness_timeout",
     "max_total_completion_tokens_reached": "max_output_tokens",
 }
 

--- a/verifiers/v1/legacy.py
+++ b/verifiers/v1/legacy.py
@@ -271,7 +271,7 @@ def rollout_output_to_trace(out: dict, task_idx: int) -> Trace:
             type="Task",
             data=_to_wire_task(task_idx, out.get("prompt"), out.get("answer")),
         ),
-        # v0 rollouts carry no seat config — record the default seat, like the
+        # v0 rollouts carry no agent config — record the default, like the
         # base task type above.
         agent=AgentInfo(config=AgentConfig()),
         tools=_to_v1_tools(out.get("tool_defs")) or [],

--- a/verifiers/v1/legacy.py
+++ b/verifiers/v1/legacy.py
@@ -24,6 +24,7 @@ from pydantic import ValidationError
 
 from verifiers.v1 import graph
 from verifiers.v1.clients.config import ClientConfig, TrainClientConfig
+from verifiers.v1.configs.agent import AgentConfig
 from verifiers.v1.episode import Episode
 from verifiers.v1.serve.server import EnvServer
 from verifiers.v1.serve.types import (
@@ -34,6 +35,7 @@ from verifiers.v1.serve.types import (
 )
 from verifiers.v1.task import WireTaskData
 from verifiers.v1.trace import (
+    AgentInfo,
     Error,
     GenerationSpan,
     ModelCall,
@@ -269,7 +271,10 @@ def rollout_output_to_trace(out: dict, task_idx: int) -> Trace:
             type="Task",
             data=_to_wire_task(task_idx, out.get("prompt"), out.get("answer")),
         ),
-        tools=_to_v1_tools(out.get("tool_defs")),
+        # v0 rollouts carry no seat config — record the default seat, like the
+        # base task type above.
+        agent=AgentInfo(config=AgentConfig()),
+        tools=_to_v1_tools(out.get("tool_defs")) or [],
         rewards={"reward": Reward(score=float(out.get("reward") or 0.0))},
         metrics={k: float(v) for k, v in (out.get("metrics") or {}).items()},
         info=dict(out.get("info") or {}),

--- a/verifiers/v1/push.py
+++ b/verifiers/v1/push.py
@@ -58,8 +58,8 @@ def trace_to_sample(
         "example_id": trace.task.data.idx,
         "rollout_number": rollout_number,
         "episode_id": episode_id,
-        "agent": trace.agent_name,
-        "trainable": trace.trainable,
+        "agent": trace.agent.name if trace.agent else None,
+        "trainable": trace.agent.trainable if trace.agent else True,
         "task": task,
         "prompt": [],
         "completion": dump(branches[-1].messages) if branches else [],
@@ -73,8 +73,8 @@ def trace_to_sample(
         "is_completed": trace.is_completed,
         "is_truncated": trace.is_truncated,
         "metrics": trace.metrics,
-        "error": trace.error.model_dump(mode="json", exclude_none=True)
-        if trace.error
+        "error": trace.last_error.model_dump(mode="json", exclude_none=True)
+        if trace.last_error
         else None,
         "stop_condition": trace.stop_condition,
         "trajectory": [
@@ -124,7 +124,7 @@ def _run_metrics(episodes: list[Episode], traces: list[Trace]) -> dict[str, Any]
     back to all traces when none are trainable (same rule as the dashboard).
     `avg_error` is the share of EPISODES that aren't ok: a hook failure counts
     even when its traces are clean or it left none."""
-    scored = [t for t in traces if t.trainable] or traces
+    scored = [t for t in traces if t.agent is None or t.agent.trainable] or traces
     sums: dict[str, float] = {}
     counts: dict[str, int] = {}
     for trace in scored:

--- a/verifiers/v1/push.py
+++ b/verifiers/v1/push.py
@@ -58,8 +58,8 @@ def trace_to_sample(
         "example_id": trace.task.data.idx,
         "rollout_number": rollout_number,
         "episode_id": episode_id,
-        "agent": trace.agent.name if trace.agent else None,
-        "trainable": trace.agent.trainable if trace.agent else True,
+        "agent": trace.agent.name,
+        "trainable": trace.agent.trainable,
         "task": task,
         "prompt": [],
         "completion": dump(branches[-1].messages) if branches else [],
@@ -124,7 +124,7 @@ def _run_metrics(episodes: list[Episode], traces: list[Trace]) -> dict[str, Any]
     back to all traces when none are trainable (same rule as the dashboard).
     `avg_error` is the share of EPISODES that aren't ok: a hook failure counts
     even when its traces are clean or it left none."""
-    scored = [t for t in traces if t.agent is None or t.agent.trainable] or traces
+    scored = [t for t in traces if t.agent.trainable] or traces
     sums: dict[str, float] = {}
     counts: dict[str, int] = {}
     for trace in scored:

--- a/verifiers/v1/retries.py
+++ b/verifiers/v1/retries.py
@@ -117,7 +117,9 @@ async def run_episode_with_retry(
         final = await run()
         if attempt == retry.max_retries or not episode_should_retry(final, retry):
             break
-        cause = final.error or next((t.error for t in final.traces if t.error), None)
+        cause = final.error or next(
+            (t.last_error for t in final.traces if t.last_error), None
+        )
         history.extend(final.errors)
         for trace in final.traces:
             history.extend(trace.errors)

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -118,7 +118,7 @@ class RolloutRun:
         wire_data: TaskData | None = None,
         has_user: bool = False,
         setup_timeout: float | None = None,
-        harness_timeout: float | None = None,
+        agent_timeout: float | None = None,
         finalize_timeout: float | None = None,
         scoring_timeout: float | None = None,
         limits: RolloutLimits | None = None,
@@ -133,7 +133,8 @@ class RolloutRun:
         self.runtime_config = runtime_config
         self._has_user = has_user
         self._setup_timeout = setup_timeout
-        self._harness_time_remaining = harness_timeout
+        self._agent_timeout = agent_timeout
+        self._agent_time_remaining = agent_timeout
         self._finalize_timeout = finalize_timeout
         self._scoring_timeout = scoring_timeout
         self._shared_tools = shared_tools or {}
@@ -166,7 +167,7 @@ class RolloutRun:
         self.deadline_at: float | None = None
         """The active harness segment's absolute deadline (event-loop clock), or
         None between segments / when unbounded. An interaction spends one cumulative
-        `harness_timeout` budget only while its own segments run, so time awaiting
+        `agent_timeout` budget only while its own segments run, so time awaiting
         the caller (including another interleaved agent) cannot starve it."""
 
     @property
@@ -308,7 +309,8 @@ class RolloutRun:
         for an exchange the user opens, this is also the first segment, on an
         empty conversation); without, it launches on the task's own prompt.
         Returns whether the exchange can continue — a refused turn (limit, @stop),
-        a timeout, a failure, or a segment that made no progress all end it."""
+        a failure (an expired agent timeout included), or a segment that made no
+        progress all end it."""
         if not self._opened or self._closed or not self.ok:
             return False
         trace = self.trace
@@ -317,11 +319,10 @@ class RolloutRun:
         segment_start = loop.time()
         self.deadline_at = (
             None
-            if self._harness_time_remaining is None
-            else segment_start + max(0.0, self._harness_time_remaining)
+            if self._agent_time_remaining is None
+            else segment_start + max(0.0, self._agent_time_remaining)
         )
         # Prefer an intercepted model/tool error to the harness exit it caused.
-        # A timeout still scores the partial trajectory.
         try:
             async with asyncio.timeout_at(self.deadline_at):
                 await self.harness.run(
@@ -335,11 +336,16 @@ class RolloutRun:
                     messages,
                 )
         except TimeoutError as e:
-            # Only the rollout deadline reads as a clean truncation; a TimeoutError
-            # from the harness's own I/O with no expired deadline is a failure —
-            # recording it as a stop would score a broken run as a partial success.
+            # An expired rollout deadline is the agent breaking its time budget —
+            # an agent failure, never a clean stop. A TimeoutError from the
+            # harness's own I/O with no expired deadline stays the raw failure.
             if self.deadline_at is not None and (loop.time() >= self.deadline_at):
-                trace.stop("harness_timeout")
+                self.fail(
+                    HarnessError(
+                        f"agent timeout: rollout exceeded its "
+                        f"{self._agent_timeout:g}s budget"
+                    )
+                )
             else:
                 self.fail(e)
             return False
@@ -352,9 +358,9 @@ class RolloutRun:
                 self.fail(e)
             return False
         finally:
-            if self._harness_time_remaining is not None:
-                self._harness_time_remaining = max(
-                    0.0, self._harness_time_remaining - (loop.time() - segment_start)
+            if self._agent_time_remaining is not None:
+                self._agent_time_remaining = max(
+                    0.0, self._agent_time_remaining - (loop.time() - segment_start)
                 )
             self.deadline_at = None
         if self._session.error is not None:
@@ -457,6 +463,6 @@ class RolloutRun:
             self.task.data.idx,
             trace.reward,
             trace.num_turns,
-            trace.error.type if trace.error else trace.stop_condition,
+            trace.last_error.type if trace.last_error else trace.stop_condition,
         )
         return trace

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -24,7 +24,6 @@ import time
 from collections.abc import AsyncIterator, Callable
 from contextlib import AsyncExitStack, asynccontextmanager
 
-from verifiers import __version__
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.agent import AgentConfig
 from verifiers.v1.decorators import discover_decorated, invoke
@@ -52,9 +51,8 @@ from verifiers.v1.runtimes import (
 from verifiers.v1.session import RolloutLimits, RolloutSession
 from verifiers.v1.state import state_cls
 from verifiers.v1.task import Task, TaskData
-from verifiers.v1.trace import AgentInfo, Trace, TraceTask, VersionInfo
+from verifiers.v1.trace import AgentInfo, Trace, TraceTask
 from verifiers.v1.types import Messages
-from verifiers.v1.utils.version import verifiers_commit
 
 logger = logging.getLogger(__name__)
 
@@ -147,7 +145,6 @@ class RolloutRun:
                 data=task.data if wire_data is None else wire_data,
             ),
             state=state_cls(type(task))(),
-            verifiers=VersionInfo(version=__version__, commit=verifiers_commit()),
             # The seat's resolved config, role overrides included — the agent
             # this trace can be reproduced with.
             agent=AgentInfo(config=agent_config),

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -201,7 +201,7 @@ class RolloutRun:
             logger.exception("unexpected error in rollout %s", self.trace.id)
         self._failed = True
         self._failure = error
-        self.trace.capture_error(error)
+        self.trace.record_error(error)
 
     async def open(self) -> bool:
         """Boot the rollout's world up to the point where segments can run: start

--- a/verifiers/v1/runtimes/subprocess.py
+++ b/verifiers/v1/runtimes/subprocess.py
@@ -62,7 +62,7 @@ class SubprocessRuntime(Runtime):
             stdout, stderr = await proc.communicate()
         finally:
             # If the await didn't finish, the caller cancelled it (e.g. the rollout's
-            # scoring_timeout / harness_timeout fired): communicate() leaves the process
+            # scoring_timeout / agent_timeout fired): communicate() leaves the process
             # running, so SIGKILL its whole group (start_new_session => pgid == pid) — otherwise
             # a hung child (a wedged uv/sympy verify) outlives the rollout and leaks CPU. A
             # no-op once it has exited on its own.

--- a/verifiers/v1/task.py
+++ b/verifiers/v1/task.py
@@ -89,7 +89,7 @@ class TaskTimeout(StrictBaseModel):
     model_config = ConfigDict(frozen=True)
 
     setup: float | None = None
-    harness: float | None = None
+    agent: float | None = None
     finalize: float | None = None
     scoring: float | None = None
 

--- a/verifiers/v1/tasksets/harbor/taskset.py
+++ b/verifiers/v1/tasksets/harbor/taskset.py
@@ -260,9 +260,9 @@ def parse_task(task_dir: Path, idx: int, harbor_config: HarborConfig) -> HarborD
     if not authors and meta.get("author_name"):
         authors = [Author(name=meta["author_name"], email=meta.get("author_email"))]
     if harbor_config.ignore_timeouts:
-        harness_timeout = scoring_timeout = None
+        agent_timeout = scoring_timeout = None
     else:
-        harness_timeout = (
+        agent_timeout = (
             parsed.agent.timeout_sec
             if "timeout_sec" in parsed.agent.model_fields_set
             else None
@@ -290,8 +290,8 @@ def parse_task(task_dir: Path, idx: int, harbor_config: HarborConfig) -> HarborD
             else list(network.allowed_hosts)
         ),
         timeout=TaskTimeout(
-            harness=harness_timeout * harbor_config.timeout_multiplier
-            if harness_timeout is not None
+            agent=agent_timeout * harbor_config.timeout_multiplier
+            if agent_timeout is not None
             else None,
             scoring=scoring_timeout * harbor_config.timeout_multiplier
             if scoring_timeout is not None

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -7,7 +7,7 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Annotated, Any, Generic, Literal
 
 import numpy as np
-from pydantic import Field, PrivateAttr
+from pydantic import Field, PrivateAttr, model_validator
 from renderers.base import MultiModalData
 from typing_extensions import TypeVar
 
@@ -340,6 +340,26 @@ class Trace(StrictBaseModel, Generic[DataT, StateT, AgentConfigT]):
 
     _head_index: dict = PrivateAttr(default_factory=dict)
     """`(parent, msg_hash) -> node_id` for the graph builder."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_v4(cls, data: Any) -> Any:
+        """Upgrade pre-v5 records to the v5 shape: drop the explicit nulls whose
+        fields v5 defaults now fill, seat records that predate the required
+        `agent`, and drop a run stamp with no id. Current-version records
+        validate strictly; delete this when v4 support is dropped."""
+        if not isinstance(data, dict) or data.get("version", TRACE_VERSION) >= 5:
+            return data
+        data = dict(data)
+        for field in ("tools", "verifiers", "agent"):
+            if field in data and data[field] is None:
+                del data[field]
+        data.setdefault("agent", {"config": {}})
+        run = data.get("run")
+        if isinstance(run, dict) and run.get("id") is None:
+            data["run"] = None
+        data["version"] = 5
+        return data
 
     @property
     def reward(self) -> float:

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -84,28 +84,63 @@ class Error(StrictBaseModel):
     traceback: str | None = None
 
 
-class EvalRunInfo(StrictBaseModel):
-    """An eval run, stamped by the consumer (the eval CLI / a trainer's inline eval)."""
+class VersionInfo(StrictBaseModel):
+    version: str
+    commit: str | None = None
 
+
+def _current_build() -> VersionInfo:
+    # Lazy: `verifiers/__init__` (and its v0 surface) must not load with this module.
+    from verifiers import __version__
+    from verifiers.v1.utils.version import verifiers_commit
+
+    return VersionInfo(version=__version__, commit=verifiers_commit())
+
+
+AgentConfigT = TypeVar("AgentConfigT", bound=AgentConfig, default=AgentConfig)
+
+
+class AgentInfo(StrictBaseModel, Generic[AgentConfigT]):
+    config: AgentConfigT
+    """The resolved config that rebuilds the agent (`Agent(trace.agent.config)`)."""
+    runtime: RuntimeInfo | None = None
+    """The box the rollout ran in; None until provisioning."""
+    name: str = "agent"
+    """The env agent that produced this trace (the config field name, e.g. `solver`)."""
+    trainable: bool = True
+    """Whether this trace's tokens train the run's policy."""
+
+
+class TraceTask(StrictBaseModel, Generic[DataT]):
+    """The task as recorded on the trace, self-describing without the run's config."""
+
+    type: str
+    """The Task class name (`type(task).__name__`)."""
+    data: DataT
+    """The (immutable) row being solved."""
+
+
+class Reward(StrictBaseModel):
+    score: float
+    weight: float = 1.0
+
+    @property
+    def value(self) -> float:
+        return self.score * self.weight
+
+
+class EvalRunInfo(StrictBaseModel):
     type: Literal["eval"] = "eval"
 
-    id: str | None = None
-    """The producing run: the eval CLI stamps its run uuid (a resumed eval counts as
-    a new run; kept traces keep their original id), trainers stamp their own."""
+    id: str
     step: int | None = None
-    """The training step an inline eval was triggered at, stamped by the trainer;
-    None for a standalone eval (the eval CLI doesn't set it)."""
 
 
 class TrainRunInfo(StrictBaseModel):
-    """A training run, stamped by the trainer."""
-
     type: Literal["train"] = "train"
 
-    id: str | None = None
-    """The trainer's run identifier."""
+    id: str
     step: int | None = None
-    """The training step this rollout belongs to."""
 
 
 RunInfo = Annotated[EvalRunInfo | TrainRunInfo, Field(discriminator="type")]
@@ -212,10 +247,8 @@ class Branch(StrictBaseModel):
 
     @property
     def kept_tokens(self) -> KeptTokens | None:
-        """The branch's kept-set sampling masks: `counts` is int32 aligned 1:1 with
-        `token_ids` (0 = no mask, safe under partial coverage — unlike `routed_experts`
-        this is not all-or-nothing), `ids` the flat int32 concatenation of the kept
-        sets in position order. None when no node carries kept-set data."""
+        """int32 kept-set `counts` aligned 1:1 with `token_ids` plus flat `ids` in
+        position order; partial data scatters as 0 counts, no data returns None."""
         if all(n.kept_tokens is None for n in self.nodes):
             return None
         # `_attribute_kept_tokens` validates counts/ids against the node's sampled
@@ -242,94 +275,23 @@ class Branch(StrictBaseModel):
 
     @property
     def last_usage(self) -> Usage | None:
-        """Provider usage from the final model call on this branch — the full context it saw."""
         return next(
             (c.usage for c in reversed(self.calls) if c.usage is not None), None
         )
 
     @property
     def num_total_tokens(self) -> int:
-        """Final sequence length: the last call's prompt + completion. Earlier turns' context
-        is already contained in that prompt, so re-sent tokens are counted once rather than
-        summed per turn."""
         last = self.last_usage
         return last.total_tokens if last is not None else 0
 
     @property
     def num_output_tokens(self) -> int:
-        """Every model-generated token across all turns (completions, reasoning included)."""
         usage = self.usage
         return usage.completion_tokens if usage is not None else 0
 
     @property
     def num_input_tokens(self) -> int:
-        """Tokens fed to the model, counted once: the final sequence minus everything the model
-        generated (i.e. system + user + tool inputs). Not the last prompt — re-sent context is
-        not double-counted."""
         return self.num_total_tokens - self.num_output_tokens
-
-
-class VersionInfo(StrictBaseModel):
-    """The verifiers build that produced this trace."""
-
-    version: str
-    """The installed verifiers package version."""
-    commit: str | None = None
-    """The verifiers git commit, when resolvable (a git-pinned install or a source
-    checkout); None otherwise (e.g. a PyPI wheel)."""
-
-
-def _current_build() -> VersionInfo:
-    # Lazy: `verifiers/__init__` (and its v0 surface) must not load with this module.
-    from verifiers import __version__
-    from verifiers.v1.utils.version import verifiers_commit
-
-    return VersionInfo(version=__version__, commit=verifiers_commit())
-
-
-AgentConfigT = TypeVar("AgentConfigT", bound=AgentConfig, default=AgentConfig)
-"""`default=AgentConfig`: an unparameterized record is the strict, fully-typed
-read (the config is exactly `AgentConfig` at write time, so nothing is lost);
-`WireTrace` parameterizes with `WireAgentConfig` for the plugin-free read."""
-
-
-class AgentInfo(StrictBaseModel, Generic[AgentConfigT]):
-    config: AgentConfigT
-    """The agent's resolved config — the exact value that rebuilds it
-    (`Agent(trace.agent.config)`). Validating a record narrows the harness by
-    its id (the plugin must be importable); consumers without the packages
-    (e.g. a trainer) read through `WireTrace`, which keeps it loose."""
-    runtime: RuntimeInfo | None = None
-    """The box the rollout ran in — the agent's runtime policy resolved for the
-    task, plus the provisioned resource ID; None until provisioning."""
-    name: str = "agent"
-    """The env agent that produced this trace — the config field name (`solver`,
-    `judge`); the default outside an env and for `SingleAgentEnv`'s sole agent.
-    First-class so training can filter and baseline per agent."""
-    trainable: bool = True
-    """Whether this trace's tokens are training data for the run's policy. An env's
-    `setup()` marks fixed-model agents (a frozen judge, a pinned user sim) untrainable."""
-
-
-class TraceTask(StrictBaseModel, Generic[DataT]):
-    """The task as recorded on the trace: the row (`data`, fully typed, flows into
-    scoring) plus the Task class name that produced the rollout (`type`) — so a bare
-    trace is self-describing without the run's config. Only data and a name ride
-    the wire; behavior re-attaches by construction."""
-
-    type: str
-    """The Task class name (`type(task).__name__`)."""
-    data: DataT
-    """The (immutable) row being solved."""
-
-
-class Reward(StrictBaseModel):
-    score: float
-    weight: float = 1.0
-
-    @property
-    def value(self) -> float:
-        return self.score * self.weight
 
 
 class Trace(StrictBaseModel, Generic[DataT, StateT, AgentConfigT]):

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -250,7 +250,7 @@ class Branch(StrictBaseModel):
         return self.num_total_tokens - self.num_output_tokens
 
 
-_NODE_DUMP_EXCLUDE: dict = {
+EXCLUDE_FIELDS: dict = {
     "nodes": {
         "__all__": {
             "multi_modal_data",
@@ -610,7 +610,7 @@ class Trace(StrictBaseModel, Generic[DataT, StateT, AgentConfigT]):
 
     def to_record(self) -> dict[str, Any]:
         """JSON record without raw tensors, which remain available on the msgpack wire."""
-        return self.model_dump(mode="json", exclude=_NODE_DUMP_EXCLUDE)
+        return self.model_dump(mode="json", exclude=EXCLUDE_FIELDS)
 
 
 WireTrace = Trace[WireTaskData, State, WireAgentConfig]

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -341,26 +341,6 @@ class Trace(StrictBaseModel, Generic[DataT, StateT, AgentConfigT]):
     _head_index: dict = PrivateAttr(default_factory=dict)
     """`(parent, msg_hash) -> node_id` for the graph builder."""
 
-    @model_validator(mode="before")
-    @classmethod
-    def _migrate_v4(cls, data: Any) -> Any:
-        """Upgrade pre-v5 records to the v5 shape: drop the explicit nulls whose
-        fields v5 defaults now fill, seat records that predate the required
-        `agent`, and drop a run stamp with no id. Current-version records
-        validate strictly; delete this when v4 support is dropped."""
-        if not isinstance(data, dict) or data.get("version", TRACE_VERSION) >= 5:
-            return data
-        data = dict(data)
-        for field in ("tools", "verifiers", "agent"):
-            if field in data and data[field] is None:
-                del data[field]
-        data.setdefault("agent", {"config": {}})
-        run = data.get("run")
-        if isinstance(run, dict) and run.get("id") is None:
-            data["run"] = None
-        data["version"] = 5
-        return data
-
     @property
     def reward(self) -> float:
         return sum(r.value for r in self.rewards.values())
@@ -537,6 +517,32 @@ class Trace(StrictBaseModel, Generic[DataT, StateT, AgentConfigT]):
     def to_record(self) -> dict[str, Any]:
         """JSON record without raw tensors, which remain available on the msgpack wire."""
         return self.model_dump(mode="json", exclude=EXCLUDE_FIELDS)
+
+    @model_validator(mode="before")
+    @classmethod
+    def migrate(cls, data: Any) -> Any:
+        """Upgrade older records step by step to the current schema. Every schema
+        bump owns its step: bump `TRACE_VERSION`, add a `_to_v<n>` util, chain it
+        here. Current-version records validate strictly."""
+        if not isinstance(data, dict):
+            return data
+        if data.get("version", TRACE_VERSION) < 5:
+            data = _to_v5(dict(data))
+        return data
+
+
+def _to_v5(record: dict) -> dict:
+    """<v5 -> v5: drop the explicit nulls whose fields v5 defaults now fill, seat
+    records that predate the required `agent`, and drop a run stamp with no id."""
+    for field in ("tools", "verifiers", "agent"):
+        if field in record and record[field] is None:
+            del record[field]
+    record.setdefault("agent", {"config": {}})
+    run = record.get("run")
+    if isinstance(run, dict) and run.get("id") is None:
+        record["run"] = None
+    record["version"] = 5
+    return record
 
 
 WireTrace = Trace[WireTaskData, State, WireAgentConfig]

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -355,30 +355,26 @@ class Reward(StrictBaseModel):
 
 
 class Trace(StrictBaseModel, Generic[DataT, StateT, AgentConfigT]):
-    id: str = Field(default_factory=lambda: uuid.uuid4().hex)
-    """Unique id for this rollout, auto-generated per trace."""
-    task: TraceTask[DataT]
-    """The task being solved: its class name (`task.type`) + its row (`task.data`)."""
     version: int = TRACE_VERSION
-    """The trace record schema this trace serializes as."""
+    """The trace schema this trace serializes as."""
+    id: str = Field(default_factory=lambda: uuid.uuid4().hex)
+    """Unique ID for this trace, auto-generated."""
     verifiers: VersionInfo | None = None
-    """The verifiers build that produced this trace, stamped at rollout start —
-    replayed/re-read traces keep the build that originally produced them."""
+    """The verifiers version that produced this trace."""
     run: RunInfo | None = None
     """The run this trace belongs to (eval or train), consumer-stamped."""
+
+    task: TraceTask[DataT]
+    """The task data that seeded this trace."""
     agent: AgentInfo[AgentConfigT] | None = None
-    """The agent (config: harness x model x runtime, plus the provisioned box) that
-    produced the sampled turns."""
+    """The agent (harness x model x runtime) that produced this trace."""
+    tools: list[Tool] | None = None
+    """The tools advertised to the agent, automatically recorded from last intercepted turn."""
+
     nodes: list[MessageNode] = Field(default_factory=list)
     """The message graph; branches are derived views and storage stays linear in turns."""
-    tools: list[Tool] | None = None
-    """The tools advertised to the model, recorded when an intercepted turn commits (last
-    committed turn wins) — never from a refused/failed request the model never saw. The full
-    advertised list (not just tools called), so tool-use SFT can re-render the exact prompt;
-    a trace-level snapshot: mid-rollout changes collapse to the last set the model saw."""
     calls: list[ModelCall] = Field(default_factory=list)
-    """Every provider exchange behind the sampled turns, in order: raw wire request/response
-    plus per-call timing and errors, linked into `nodes` via `ModelCall.node`."""
+    """Every model call; automatically recorded at intercept time + linked into `nodes`."""
 
     rewards: dict[str, Reward] = Field(default_factory=dict)
     """Named rewards from tasks, judges, and the env's `score()` — each keeps its
@@ -394,16 +390,15 @@ class Trace(StrictBaseModel, Generic[DataT, StateT, AgentConfigT]):
     """Usage from judges and other calls outside the agent's message graph."""
 
     is_completed: bool = False
+    """Whether the trace completed."""
     ok: bool = False
-    """THE success sentinel, stamped by the engine when the rollout ran to
-    completion without its final attempt failing. Distinct from `errors`
-    emptiness: a rollout that recovered on retry is `ok` and still keeps its
-    earlier attempts' errors."""
+    """Whether the trace completed successfully."""
     stop_condition: str | None = None
+    """What ended the trace — `agent_completed` / `user_closed` for a normal finish,
+    a limit or `@stop` name for a refused turn, `error` for a failure; None while
+    running."""
     errors: list[Error] = Field(default_factory=list)
-    """Every error captured across attempts, oldest first (more than one only when
-    the rollout was retried). `error` exposes the most recent; success is `ok`,
-    never errors-emptiness."""
+    """Every error captured across attempts, oldest to newest first."""
     timing: Timing = Field(default_factory=Timing)
 
     _head_index: dict = PrivateAttr(default_factory=dict)
@@ -415,33 +410,12 @@ class Trace(StrictBaseModel, Generic[DataT, StateT, AgentConfigT]):
         return sum(r.value for r in self.rewards.values())
 
     @property
-    def error(self) -> Error | None:
+    def last_error(self) -> Error | None:
         return self.errors[-1] if self.errors else None
 
     @property
     def has_error(self) -> bool:
         return not self.ok
-
-    @property
-    def agent_name(self) -> str | None:
-        """The agent that produced this trace (`agent.name`); None only on traces
-        with no agent info (the legacy bridge)."""
-        return self.agent.name if self.agent is not None else None
-
-    @property
-    def trainable(self) -> bool:
-        """Whether this trace's tokens train the run's policy (`agent.trainable`)."""
-        return self.agent.trainable if self.agent is not None else True
-
-    @property
-    def runtime(self) -> RuntimeInfo | None:
-        """The box this rollout ran in (`agent.runtime`); None until provisioning
-        and on traces with no agent info (the legacy bridge)."""
-        return self.agent.runtime if self.agent is not None else None
-
-    def _last_assistant(self) -> MessageNode | None:
-        """Most recent model-produced node, ignoring prompt-supplied assistant messages."""
-        return next((n for n in reversed(self.nodes) if n.sampled), None)
 
     @property
     def num_input_tokens(self) -> int:
@@ -490,8 +464,6 @@ class Trace(StrictBaseModel, Generic[DataT, StateT, AgentConfigT]):
 
     @property
     def num_turns(self) -> int:
-        """Total model turns (sampled responses) across all branches — prompt-supplied
-        assistant messages don't count."""
         return sum(1 for n in self.nodes if n.sampled)
 
     @property
@@ -503,7 +475,6 @@ class Trace(StrictBaseModel, Generic[DataT, StateT, AgentConfigT]):
             "max_output_tokens",
             "max_total_tokens",
             "context_length",
-            "harness_timeout",
         ):
             return True
         last = next((c for c in reversed(self.calls) if c.error is None), None)
@@ -520,13 +491,19 @@ class Trace(StrictBaseModel, Generic[DataT, StateT, AgentConfigT]):
         ]
 
     @property
+    def tool_messages(self) -> list[ToolMessage]:
+        """Every tool result, in order — branch-independent."""
+        return [n.message for n in self.nodes if isinstance(n.message, ToolMessage)]
+
+    @property
     def last_reply(self) -> str:
+        """The last recorded model response, in text format."""
         msgs = self.assistant_messages
         return (msgs[-1].content or "").strip() if msgs else ""
 
     @property
     def transcript(self) -> str:
-        """Final-branch text and tool calls for judges; images and reasoning are omitted."""
+        """Text transcript of the last branch's messages; tool outputs are omitted."""
         branches = self.branches
         blocks: list[str] = []
         for message in branches[-1].messages if branches else []:
@@ -545,14 +522,6 @@ class Trace(StrictBaseModel, Generic[DataT, StateT, AgentConfigT]):
                     lines.append(text)
             blocks.append("\n".join(lines))
         return "\n\n".join(blocks)
-
-    @property
-    def tool_messages(self) -> list[ToolMessage]:
-        """The tool results in the latest full context — the main (last) branch's
-        conversation. For a linear rollout that's every tool result."""
-        branches = self.branches
-        messages = branches[-1].messages if branches else []
-        return [m for m in messages if isinstance(m, ToolMessage)]
 
     def record_metric(self, name: str, value: float) -> None:
         self.metrics[name] = float(value)
@@ -576,7 +545,7 @@ class Trace(StrictBaseModel, Generic[DataT, StateT, AgentConfigT]):
             self.run = run
         self.info.update(info)
 
-    def stop(self, condition: str = "done") -> None:
+    def stop(self, condition: str) -> None:
         """Stop the trace, optionally with a stop condition."""
         self.is_completed = True
         if self.stop_condition is None:

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import time
 import traceback
 import uuid
@@ -34,8 +33,6 @@ from verifiers.v1.types import (
     Usage,
     content_text,
 )
-
-logger = logging.getLogger(__name__)
 
 
 class TimeSpan(StrictBaseModel):
@@ -558,46 +555,35 @@ class Trace(StrictBaseModel, Generic[DataT, StateT, AgentConfigT]):
         return [m for m in messages if isinstance(m, ToolMessage)]
 
     def record_metric(self, name: str, value: float) -> None:
-        if name in self.metrics:
-            logger.warning(
-                "metric %r overridden: %s -> %s", name, self.metrics[name], value
-            )
         self.metrics[name] = float(value)
 
     def record_metrics(self, values: Mapping[str, float]) -> None:
         for name, value in values.items():
             self.record_metric(name, value)
 
+    def record_reward(self, name: str, value: float, weight: float = 1.0) -> None:
+        reward = Reward(score=float(value), weight=float(weight))
+        self.rewards[name] = reward
+
     def record_judge(self, response: JudgeResponse) -> None:
         self.info.setdefault("judge", []).append(response.model_dump())
         if response.usage is not None:
             self.extra_usage.append(response.usage)
 
-    def record_reward(self, name: str, value: float, weight: float = 1.0) -> None:
-        reward = Reward(score=float(value), weight=float(weight))
-        if name in self.rewards:
-            logger.warning(
-                "reward %r overridden: %s -> %s", name, self.rewards[name], reward
-            )
-        self.rewards[name] = reward
-
-    def stamp(self, run: RunInfo | None = None, **info: Any) -> None:
-        """Stamp identity only the consumer knows (the eval CLI / a trainer) onto the
-        trace; anything beyond `run` lands in `info`."""
+    def record_run(self, run: RunInfo | None = None, **info: Any) -> None:
+        """Record the run identity (eval / train), and optional extra info."""
         if run is not None:
             self.run = run
         self.info.update(info)
 
     def stop(self, condition: str = "done") -> None:
+        """Stop the trace, optionally with a stop condition."""
         self.is_completed = True
         if self.stop_condition is None:
             self.stop_condition = condition
 
     def split_generation(self) -> None:
-        """Stamp the closed generation span's model/harness split: model time is the
-        sum of the recorded calls' spans (clamped to the span), harness the complement.
-        Every path that closes the span calls this — a span without model calls (e.g.
-        a debug action) is all harness time."""
+        """Split the generation span into model and harness time."""
         gen = self.timing.generation
         if not gen.end:
             return
@@ -605,7 +591,8 @@ class Trace(StrictBaseModel, Generic[DataT, StateT, AgentConfigT]):
         gen.model.duration = min(model, gen.duration)
         gen.harness.duration = gen.duration - gen.model.duration
 
-    def capture_error(self, error: Exception) -> None:
+    def record_error(self, error: Exception) -> None:
+        """Record an error, and stop the trace as failed."""
         self.errors.append(
             Error(
                 type=type(error).__name__,

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -51,6 +51,8 @@ EXCLUDE_FIELDS: dict = {
 
 
 class TimeSpan(StrictBaseModel):
+    """Wall-clock timestamps with a derived, non-serialized duration in seconds."""
+
     start: float = 0.0
     end: float = 0.0
 
@@ -60,6 +62,8 @@ class TimeSpan(StrictBaseModel):
 
 
 class TimeSplit(StrictBaseModel):
+    """Records a measured duration in seconds."""
+
     duration: float = 0.0
 
 

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -34,10 +34,19 @@ from verifiers.v1.types import (
     content_text,
 )
 
+EXCLUDE_FIELDS: dict = {
+    "nodes": {
+        "__all__": {
+            "multi_modal_data",
+            "routed_experts",
+            "kept_tokens",
+        }
+    }
+}
+"""Raw tensor fields kept on the msgpack wire but excluded from disk serialization."""
+
 
 class TimeSpan(StrictBaseModel):
-    """Wall-clock timestamps with a derived, non-serialized duration in seconds."""
-
     start: float = 0.0
     end: float = 0.0
 
@@ -47,20 +56,10 @@ class TimeSpan(StrictBaseModel):
 
 
 class TimeSplit(StrictBaseModel):
-    """A span's share attributed to one side of a split: disjoint sub-intervals summed
-    into a duration, so there is no single start/end. Serialized, unlike a span's
-    derived `duration`, since it cannot be recomputed from two timestamps."""
-
     duration: float = 0.0
 
 
 class GenerationSpan(TimeSpan):
-    """The generation span plus its split into time inside model calls (`model`) vs.
-    outside them (`harness`: harness logic, tools, user simulation). Stamped from the
-    recorded model calls' spans by `Trace.split_generation` when the span closes, with
-    `model.duration + harness.duration == duration` — concurrent calls (subagent forks)
-    are clamped to the span, saturating the model share."""
-
     model: TimeSplit = Field(default_factory=TimeSplit)
     harness: TimeSplit = Field(default_factory=TimeSplit)
 
@@ -78,40 +77,28 @@ class Error(StrictBaseModel):
     type: str
     message: str
     status_code: int | None = None
-    """The upstream HTTP status a provider failure surfaced (the provider's own, or one
-    chosen for a transport fault); None when the failure carried no HTTP exchange."""
     traceback: str | None = None
 
 
 class ModelCall(StrictBaseModel):
-    """One provider exchange behind a sampled turn; its conversation is the linked
-    node's root-to-self path, never repeated here."""
+    """A model call, automatically recorded at intercept time."""
 
     node: int | None = None
-    """Index into `Trace.nodes` of the assistant node this call committed — the link into
-    the message graph (the call's conversation is that node's root-to-self path). None for
-    a call that committed no turn (see `error`)."""
+    """Index into `Trace.nodes` of the assistant node this call committed."""
     model: str | None = None
-    """The model requested from the provider. The rollout's model override makes this
-    `agent.config.model` on every call; recorded per call because it is cheap and provable."""
+    """The model requested from the provider."""
     sampling: Sampling | None = None
-    """The call's effective settings, scraped off the wire request by the dialect's
-    `sampling_fields` whitelist — the eval-imposed knobs plus whatever the harness set
-    that the eval left alone (`seed`, `tool_choice`, `response_format`, ... as extras)."""
+    """The call's effective sampling settings (may differ from trace-level sampling)."""
     endpoint: str | None = None
-    """The provider endpoint path the request went to (e.g. `/chat/completions`) — says
-    which wire dialect the exchange spoke."""
+    """The provider endpoint path the request went to (e.g. `/chat/completions`)."""
     finish_reason: FinishReason = None
-    """Why the model stopped, normalized (`stop` / `length` / `tool_calls`); None for a
-    failed call or an unrecognized provider reason."""
+    """Why the model stopped, normalized (`stop` / `length` / `tool_calls`)."""
     usage: Usage | None = None
-    """Provider-reported token usage for this exchange, cache reads included; None for
-    a failed call."""
+    """Provider-reported token usage for this exchange, cache reads included."""
     time: TimeSpan = Field(default_factory=TimeSpan)
     """Wall-clock span from sending the request to the fully received response."""
     error: Error | None = None
-    """The failure that ended this call, coupled to the exchange that caused it; None on
-    success. A failed call still records the settings it was sent with."""
+    """The failure that ended this call, coupled to the exchange that caused it."""
 
 
 class Branch(StrictBaseModel):
@@ -250,19 +237,7 @@ class Branch(StrictBaseModel):
         return self.num_total_tokens - self.num_output_tokens
 
 
-EXCLUDE_FIELDS: dict = {
-    "nodes": {
-        "__all__": {
-            "multi_modal_data",
-            "routed_experts",
-            "kept_tokens",
-        }
-    }
-}
-"""Raw tensor fields kept on the msgpack wire but excluded from JSON records."""
-
-
-TRACE_VERSION = 4
+TRACE_VERSION = 5
 """Version of the trace record schema (see `Trace.model_json_schema()`). Bumped on
 breaking shape changes; optional-with-default fields are additive and don't bump it."""
 
@@ -303,6 +278,14 @@ class VersionInfo(StrictBaseModel):
     checkout); None otherwise (e.g. a PyPI wheel)."""
 
 
+def _current_build() -> VersionInfo:
+    # Lazy: `verifiers/__init__` (and its v0 surface) must not load with this module.
+    from verifiers import __version__
+    from verifiers.v1.utils.version import verifiers_commit
+
+    return VersionInfo(version=__version__, commit=verifiers_commit())
+
+
 AgentConfigT = TypeVar("AgentConfigT", bound=AgentConfig, default=AgentConfig)
 """`default=AgentConfig`: an unparameterized record is the strict, fully-typed
 read (the config is exactly `AgentConfig` at write time, so nothing is lost);
@@ -340,17 +323,11 @@ class TraceTask(StrictBaseModel, Generic[DataT]):
 
 
 class Reward(StrictBaseModel):
-    """One named reward as recorded on the trace: the raw score next to its weight,
-    so records keep both readable and the weighted sum stays a derived view."""
-
     score: float
-    """The raw value the reward function returned, unweighted."""
     weight: float = 1.0
-    """The multiplier `score` carries in the trace-level `reward` sum."""
 
     @property
     def value(self) -> float:
-        """This reward's weighted contribution to the trace-level `reward`."""
         return self.score * self.weight
 
 
@@ -359,16 +336,16 @@ class Trace(StrictBaseModel, Generic[DataT, StateT, AgentConfigT]):
     """The trace schema this trace serializes as."""
     id: str = Field(default_factory=lambda: uuid.uuid4().hex)
     """Unique ID for this trace, auto-generated."""
-    verifiers: VersionInfo | None = None
+    verifiers: VersionInfo = Field(default_factory=_current_build)
     """The verifiers version that produced this trace."""
     run: RunInfo | None = None
     """The run this trace belongs to (eval or train), consumer-stamped."""
 
     task: TraceTask[DataT]
     """The task data that seeded this trace."""
-    agent: AgentInfo[AgentConfigT] | None = None
+    agent: AgentInfo[AgentConfigT]
     """The agent (harness x model x runtime) that produced this trace."""
-    tools: list[Tool] | None = None
+    tools: list[Tool] = Field(default_factory=list)
     """The tools advertised to the agent, automatically recorded from last intercepted turn."""
 
     nodes: list[MessageNode] = Field(default_factory=list)
@@ -377,14 +354,13 @@ class Trace(StrictBaseModel, Generic[DataT, StateT, AgentConfigT]):
     """Every model call; automatically recorded at intercept time + linked into `nodes`."""
 
     rewards: dict[str, Reward] = Field(default_factory=dict)
-    """Named rewards from tasks, judges, and the env's `score()` — each keeps its
-    raw `score` and `weight`; the trace-level `reward` is their weighted sum."""
+    """Named, weighted rewards"""
     metrics: dict[str, float] = Field(default_factory=dict)
-    """Unweighted metrics from tasks, harnesses, and judges."""
+    """Unweighted, named metrics"""
     info: dict[str, Any] = Field(default_factory=dict)
-    """Persistent JSON scratch space for task metadata that is not a reward or metric."""
+    """Scratch space for task-specific metadata."""
     state: StateT = Field(default_factory=State, exclude=True)
-    """Transient state shared with servers and scoring; excluded from every dump."""
+    """Runtime (possibly, non-serializable) state shared across runtimes; excluded from serialization."""
 
     extra_usage: list[Usage] = Field(default_factory=list)
     """Usage from judges and other calls outside the agent's message graph."""
@@ -394,24 +370,17 @@ class Trace(StrictBaseModel, Generic[DataT, StateT, AgentConfigT]):
     ok: bool = False
     """Whether the trace completed successfully."""
     stop_condition: str | None = None
-    """What ended the trace — `agent_completed` / `user_closed` for a normal finish,
-    a limit or `@stop` name for a refused turn, `error` for a failure; None while
-    running."""
+    """What stopped the trace."""
     errors: list[Error] = Field(default_factory=list)
-    """Every error captured across attempts, oldest to newest first."""
+    """Every error captured across attempts, oldest to newest."""
     timing: Timing = Field(default_factory=Timing)
 
     _head_index: dict = PrivateAttr(default_factory=dict)
-    """`(parent, msg_hash) -> node_id` for the graph builder (`graph.prepare_turn` / `commit`);
-    rebuilt lazily from `nodes` after deserialization."""
+    """`(parent, msg_hash) -> node_id` for the graph builder."""
 
     @property
     def reward(self) -> float:
         return sum(r.value for r in self.rewards.values())
-
-    @property
-    def last_error(self) -> Error | None:
-        return self.errors[-1] if self.errors else None
 
     @property
     def has_error(self) -> bool:
@@ -500,6 +469,11 @@ class Trace(StrictBaseModel, Generic[DataT, StateT, AgentConfigT]):
         """The last recorded model response, in text format."""
         msgs = self.assistant_messages
         return (msgs[-1].content or "").strip() if msgs else ""
+
+    @property
+    def last_error(self) -> Error | None:
+        """The last error captured across attempts."""
+        return self.errors[-1] if self.errors else None
 
     @property
     def transcript(self) -> str:

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -522,17 +522,67 @@ class Trace(StrictBaseModel, Generic[DataT, StateT, AgentConfigT]):
     @classmethod
     def migrate(cls, data: Any) -> Any:
         """Upgrade older records step by step to the current schema. Every schema
-        bump owns its step: bump `TRACE_VERSION`, add a `_to_v<n>` util, chain it
+        bump owns its step: bump `TRACE_VERSION`, add a `to_v<n>` util, chain it
         here. Current-version records validate strictly."""
         if not isinstance(data, dict):
             return data
-        if data.get("version", TRACE_VERSION) < 5:
-            data = _to_v5(dict(data))
+        if data.get("version", TRACE_VERSION) >= TRACE_VERSION:
+            return data
+        data = dict(data)
+        for version, step in ((2, to_v2), (3, to_v3), (4, to_v4), (5, to_v5)):
+            if data["version"] < version:
+                data = step(data)
         return data
 
 
-def _to_v5(record: dict) -> dict:
-    """<v5 -> v5: drop the explicit nulls whose fields v5 defaults now fill, seat
+def to_v2(record: dict) -> dict:
+    """v1 -> v2 (#2061): per-call metadata moved off the nodes onto `ModelCall`s —
+    lift each node's `usage`/`finish_reason` into a synthesized call linked by
+    node index."""
+    calls = list(record.get("calls") or [])
+    nodes = []
+    for idx, node in enumerate(record.get("nodes") or []):
+        node = dict(node)
+        usage = node.pop("usage", None)
+        finish_reason = node.pop("finish_reason", None)
+        if usage is not None or finish_reason is not None:
+            calls.append({"node": idx, "usage": usage, "finish_reason": finish_reason})
+        nodes.append(node)
+    record["nodes"] = nodes
+    record["calls"] = calls
+    record["version"] = 2
+    return record
+
+
+def to_v3(record: dict) -> dict:
+    """v2 -> v3 (#2106): the top-level runtime and the agent's flat identity fields
+    (model/sampling/harness) moved into `AgentInfo.config` / `AgentInfo.runtime`."""
+    agent = record.pop("agent", None) or {}
+    config = {
+        key: agent[key]
+        for key in ("model", "sampling", "harness")
+        if agent.get(key) is not None
+    }
+    record["agent"] = {"config": config}
+    if (runtime := record.pop("runtime", None)) is not None:
+        record["agent"]["runtime"] = runtime
+    record["version"] = 3
+    return record
+
+
+def to_v4(record: dict) -> dict:
+    """v3 -> v4 (#2119): rewards went from weighted floats to `Reward(score,
+    weight)` — an old float is its weighted contribution, so it maps to weight 1."""
+    record["rewards"] = {
+        name: {"score": value, "weight": 1.0}
+        for name, value in (record.get("rewards") or {}).items()
+    }
+    record["version"] = 4
+    return record
+
+
+def to_v5(record: dict) -> dict:
+    """v4 -> v5: drop the explicit nulls whose fields v5 defaults now fill, seat
     records that predate the required `agent`, and drop a run stamp with no id."""
     for field in ("tools", "verifiers", "agent"):
         if field in record and record[field] is None:

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -7,7 +7,7 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Annotated, Any, Generic, Literal
 
 import numpy as np
-from pydantic import Field, PrivateAttr, model_validator
+from pydantic import Field, PrivateAttr
 from renderers.base import MultiModalData
 from typing_extensions import TypeVar
 
@@ -34,7 +34,7 @@ from verifiers.v1.types import (
     content_text,
 )
 
-TRACE_VERSION = 5
+TRACE_VERSION = 1
 """Current version of the trace schema."""
 
 
@@ -517,82 +517,6 @@ class Trace(StrictBaseModel, Generic[DataT, StateT, AgentConfigT]):
     def to_record(self) -> dict[str, Any]:
         """JSON record without raw tensors, which remain available on the msgpack wire."""
         return self.model_dump(mode="json", exclude=EXCLUDE_FIELDS)
-
-    @model_validator(mode="before")
-    @classmethod
-    def migrate(cls, data: Any) -> Any:
-        """Upgrade older records step by step to the current schema. Every schema
-        bump owns its step: bump `TRACE_VERSION`, add a `to_v<n>` util, chain it
-        here. Current-version records validate strictly."""
-        if not isinstance(data, dict):
-            return data
-        if data.get("version", TRACE_VERSION) >= TRACE_VERSION:
-            return data
-        data = dict(data)
-        for version, step in ((2, to_v2), (3, to_v3), (4, to_v4), (5, to_v5)):
-            if data["version"] < version:
-                data = step(data)
-        return data
-
-
-def to_v2(record: dict) -> dict:
-    """v1 -> v2 (#2061): per-call metadata moved off the nodes onto `ModelCall`s —
-    lift each node's `usage`/`finish_reason` into a synthesized call linked by
-    node index."""
-    calls = list(record.get("calls") or [])
-    nodes = []
-    for idx, node in enumerate(record.get("nodes") or []):
-        node = dict(node)
-        usage = node.pop("usage", None)
-        finish_reason = node.pop("finish_reason", None)
-        if usage is not None or finish_reason is not None:
-            calls.append({"node": idx, "usage": usage, "finish_reason": finish_reason})
-        nodes.append(node)
-    record["nodes"] = nodes
-    record["calls"] = calls
-    record["version"] = 2
-    return record
-
-
-def to_v3(record: dict) -> dict:
-    """v2 -> v3 (#2106): the top-level runtime and the agent's flat identity fields
-    (model/sampling/harness) moved into `AgentInfo.config` / `AgentInfo.runtime`."""
-    agent = record.pop("agent", None) or {}
-    config = {
-        key: agent[key]
-        for key in ("model", "sampling", "harness")
-        if agent.get(key) is not None
-    }
-    record["agent"] = {"config": config}
-    if (runtime := record.pop("runtime", None)) is not None:
-        record["agent"]["runtime"] = runtime
-    record["version"] = 3
-    return record
-
-
-def to_v4(record: dict) -> dict:
-    """v3 -> v4 (#2119): rewards went from weighted floats to `Reward(score,
-    weight)` — an old float is its weighted contribution, so it maps to weight 1."""
-    record["rewards"] = {
-        name: {"score": value, "weight": 1.0}
-        for name, value in (record.get("rewards") or {}).items()
-    }
-    record["version"] = 4
-    return record
-
-
-def to_v5(record: dict) -> dict:
-    """v4 -> v5: drop the explicit nulls whose fields v5 defaults now fill, seat
-    records that predate the required `agent`, and drop a run stamp with no id."""
-    for field in ("tools", "verifiers", "agent"):
-        if field in record and record[field] is None:
-            del record[field]
-    record.setdefault("agent", {"config": {}})
-    run = record.get("run")
-    if isinstance(run, dict) and run.get("id") is None:
-        record["run"] = None
-    record["version"] = 5
-    return record
 
 
 WireTrace = Trace[WireTaskData, State, WireAgentConfig]

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -34,6 +34,10 @@ from verifiers.v1.types import (
     content_text,
 )
 
+TRACE_VERSION = 5
+"""Current version of the trace schema."""
+
+
 EXCLUDE_FIELDS: dict = {
     "nodes": {
         "__all__": {
@@ -78,6 +82,34 @@ class Error(StrictBaseModel):
     message: str
     status_code: int | None = None
     traceback: str | None = None
+
+
+class EvalRunInfo(StrictBaseModel):
+    """An eval run, stamped by the consumer (the eval CLI / a trainer's inline eval)."""
+
+    type: Literal["eval"] = "eval"
+
+    id: str | None = None
+    """The producing run: the eval CLI stamps its run uuid (a resumed eval counts as
+    a new run; kept traces keep their original id), trainers stamp their own."""
+    step: int | None = None
+    """The training step an inline eval was triggered at, stamped by the trainer;
+    None for a standalone eval (the eval CLI doesn't set it)."""
+
+
+class TrainRunInfo(StrictBaseModel):
+    """A training run, stamped by the trainer."""
+
+    type: Literal["train"] = "train"
+
+    id: str | None = None
+    """The trainer's run identifier."""
+    step: int | None = None
+    """The training step this rollout belongs to."""
+
+
+RunInfo = Annotated[EvalRunInfo | TrainRunInfo, Field(discriminator="type")]
+"""The run a trace belongs to, discriminated on `type`."""
 
 
 class ModelCall(StrictBaseModel):
@@ -235,37 +267,6 @@ class Branch(StrictBaseModel):
         generated (i.e. system + user + tool inputs). Not the last prompt — re-sent context is
         not double-counted."""
         return self.num_total_tokens - self.num_output_tokens
-
-
-TRACE_VERSION = 5
-"""Version of the trace record schema (see `Trace.model_json_schema()`). Bumped on
-breaking shape changes; optional-with-default fields are additive and don't bump it."""
-
-
-class EvalRunInfo(StrictBaseModel):
-    """An eval run, stamped by the consumer (the eval CLI / a trainer's inline eval)."""
-
-    type: Literal["eval"] = "eval"
-    id: str | None = None
-    """The producing run: the eval CLI stamps its run uuid (a resumed eval counts as
-    a new run; kept traces keep their original id), trainers stamp their own."""
-    step: int | None = None
-    """The training step an inline eval was triggered at, stamped by the trainer;
-    None for a standalone eval (the eval CLI doesn't set it)."""
-
-
-class TrainRunInfo(StrictBaseModel):
-    """A training run, stamped by the trainer."""
-
-    type: Literal["train"] = "train"
-    id: str | None = None
-    """The trainer's run identifier."""
-    step: int | None = None
-    """The training step this rollout belongs to."""
-
-
-RunInfo = Annotated[EvalRunInfo | TrainRunInfo, Field(discriminator="type")]
-"""The run a trace belongs to, discriminated on `type`."""
 
 
 class VersionInfo(StrictBaseModel):

--- a/verifiers/v1/utils/compile.py
+++ b/verifiers/v1/utils/compile.py
@@ -110,23 +110,23 @@ def validate_pairing(
         )
 
 
-def cap_remote_harness_timeout(
-    harness_timeout: float | None, runtime_config: RuntimeConfig, task: Task
+def cap_remote_agent_timeout(
+    agent_timeout: float | None, runtime_config: RuntimeConfig, task: Task
 ) -> float | None:
-    """Remote sandboxes live at most 24 hours: cap the harness timeout there (with a
+    """Remote sandboxes live at most 24 hours: cap the agent timeout there (with a
     warning) so a long run times out cleanly instead of the provider killing the box
     mid-run."""
     if (
-        harness_timeout is not None
-        and harness_timeout > 24 * 60 * 60
+        agent_timeout is not None
+        and agent_timeout > 24 * 60 * 60
         and not runtime_is_local(runtime_config)
     ):
         logger.warning(
-            "task %r resolves to a %.1f-hour harness timeout, but %s sandboxes have a "
+            "task %r resolves to a %.1f-hour agent timeout, but %s sandboxes have a "
             "maximum lifetime of 24 hours; capping it at 24 hours",
             task.data.idx,
-            harness_timeout / (60 * 60),
+            agent_timeout / (60 * 60),
             runtime_config.type,
         )
         return 24 * 60 * 60
-    return harness_timeout
+    return agent_timeout


### PR DESCRIPTION
## Summary
Companion: PrimeIntellect-ai/prime-rl#3157 (merge together).

- Pin `[tool.uv.exclude-newer-package]` cutoffs as full RFC 3339 UTC timestamps: bare dates resolve to midnight *local* time, so teammates in different timezones kept relocking `uv.lock` and failing the `--locked` pre-commit hooks.
- Treat an expired rollout deadline as an agent failure (`HarnessError`, `ok=False`, no scoring) instead of a clean `harness_timeout` stop that scored the partial trajectory; rename the concept harness timeout → **agent timeout** throughout.
- Tighten the `Trace` schema (`TRACE_VERSION` reset to 1 — a clean break, the old counter is retired): `agent`, `verifiers`, and `RunInfo.id` are required (`verifiers` auto-stamps the current build; the v0 bridge and validate/debug CLIs synthesize their seats), `tools` defaults to `[]`. `run` and `stop_condition` keep their meaningful `None`.
- Slim the `Trace` surface: one verb for mutators (`record_*`), one reader per fact — drop the `agent_name`/`trainable`/`runtime` passthroughs and the duplicate `error` property.
- Align `tool_messages` with `assistant_messages` (nodes-based, branch-independent).
- Drop the override warnings in `record_metric`/`record_reward`: overriding is defined behavior, last write wins.
- Trim trace docstrings to the constraints they add; hoist `TRACE_VERSION`; rename `_NODE_DUMP_EXCLUDE` → `EXCLUDE_FIELDS`.

## Breaking
- `TRACE_VERSION` resets to 1 on the tightened schema. **No backwards compatibility**: pre-existing trace records do not load, and old eval runs cannot be resumed or replayed.
- Timed-out rollouts no longer score: `stop_condition="harness_timeout"` + `ok=True` → recorded `HarnessError` + `ok=False` + `stop_condition="error"`; `harness_timeout` is gone from the stop-condition vocabulary and `Trace.is_truncated` (the v0 bridge maps `timeout_reached` through the generic truncation fallback).
- `TaskTimeout.harness` → `TaskTimeout.agent`; `cap_remote_harness_timeout` → `cap_remote_agent_timeout`.
- `Trace.agent` and `Trace.verifiers` required: constructors must pass `agent=AgentInfo(config=AgentConfig())`; `verifiers` fills itself.
- `Trace.tools`: `list[Tool] | None` → `list[Tool]` (default `[]`).
- `EvalRunInfo.id` / `TrainRunInfo.id`: `str | None` → required `str`.
- `Trace.stamp(run, **info)` → `Trace.record_run(run, **info)`; `Trace.capture_error(e)` → `Trace.record_error(e)`.
- `Trace.error` → `Trace.last_error`; `Trace.agent_name` / `Trace.trainable` / `Trace.runtime` removed — read `trace.agent.name` / `.trainable` / `.runtime`.
- `Trace.stop()` requires an explicit condition (the unused `"done"` default is gone).
- `Trace.tool_messages`: last branch only → every tool result across the node graph (identical for linear rollouts).
- `_NODE_DUMP_EXCLUDE` → `EXCLUDE_FIELDS`.

## Verification
- `uv lock --check` green under `TZ=Europe/Berlin` / `America/Los_Angeles` / `Asia/Tokyo` (previously failed cross-TZ with `exclude newer timestamp changed`).
- `uv run pytest tests/v1` green; ruff + ty hooks green.
- Live 1-rollout smoke of every entrypoint on the new schema: `eval` (rich dashboard + hub push), `validate`, `debug`, `replay` (strict re-read of a v5 record), `serve` (boot), legacy bridge via live `test_legacy` e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking trace schema and API (`TRACE_VERSION` reset, no old record compatibility) plus changed timeout semantics affect eval replay, trainers, and any code reading removed Trace properties.
> 
> **Overview**
> Resets **`TRACE_VERSION` to 1** with a tighter trace record: **`agent`** and auto-stamped **`verifiers`** are required, **`tools`** defaults to `[]`, and top-level shims (`agent_name`, `trainable`, `runtime`, `error`) are removed in favor of **`trace.agent.*`** and **`trace.last_error`**. Mutators are unified as **`record_run`** / **`record_error`** (replacing `stamp` / `capture_error`).
> 
> Rollout wall-clock limits are renamed **harness → agent timeout** (`TaskTimeout.agent`, `cap_remote_agent_timeout`). When that budget expires, the rollout now **`fail()`s with `HarnessError`** (`ok=False`, `stop_condition="error"`) instead of a clean **`harness_timeout`** stop that could still score a partial trajectory; **`harness_timeout`** is dropped from truncation semantics and the v0 bridge mapping.
> 
> **`pyproject.toml`** pins `exclude-newer-package` cutoffs as full **UTC RFC 3339** timestamps so `uv.lock` does not churn across timezones.
> 
> Call sites (envs, dashboard, push, GEPA, tests) and docs are updated to the new trace fields; validate/debug synthesize **`AgentInfo`** on traces that never run a full agent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de8d521032cbd340171739b29b8dfcb75f6e7dce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename harness timeout to agent timeout and migrate Trace API to agent-scoped fields
> - Renames `harness_timeout` to `agent_timeout` across the stack: `TaskTimeout.harness` → `TaskTimeout.agent`, `RolloutRun` constructor, `cap_remote_harness_timeout` → `cap_remote_agent_timeout`, and Harbor taskset parsing.
> - Restructures `Trace` so `agent` (an `AgentInfo` object) is required; removes top-level convenience properties `agent_name`, `trainable`, `runtime`, and `error` in favor of `trace.agent.name`, `trace.agent.trainable`, `trace.agent.runtime`, and `trace.last_error`.
> - Renames `Trace.stamp` → `Trace.record_run`, `Trace.capture_error` → `Trace.record_error`, and updates all call sites across CLI, eval runner, rollout, retries, push, and environment code.
> - `Trace.tools` now defaults to an empty list instead of `None`; `tool_messages` returns results across all graph nodes rather than only the last branch.
> - Updates `uv.lock` exclusion timestamps to full UTC format with an explanatory comment in [pyproject.toml](https://github.com/PrimeIntellect-ai/verifiers/pull/2172/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711).
> - Risk: `EvalRunInfo.id` is now required (was optional); `is_truncated` no longer treats `harness_timeout` as a truncation condition; any code reading removed `Trace` properties will break.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #2172 opened
>
> - Reworded inline comments in `verifiers.v1.cli.validate._run_gold` and `verifiers.v1.cli.validate._run_setup` functions to clarify that no agent runs occur and the info only records the runtime policy [de8d521]
> - Added class docstrings to `verifiers.v1.trace.TimeSpan` and `verifiers.v1.trace.TimeSplit` classes documenting their timestamp and duration semantics [de8d521]
> - Updated comments in `verifiers.v1.legacy.rollout_output_to_trace` function to clarify that v0 rollouts contain no agent config rather than seat config [de8d521]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f0723ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->