### PR TITLE
Add Hermes Agent harness

### DIFF
--- a/skills/evaluate-environments/references/REFERENCE.md
+++ b/skills/evaluate-environments/references/REFERENCE.md
@@ -293,6 +293,7 @@ currently support `disabled_tools`.
 | Field | Type | Default | Notes |
 | --- | --- | --- | --- |
 | `version` | `str` | `"0.19.0"` | Hermes Agent release to install, pinned. |
+| `use_bundled_skill` | `bool` | `false` | Enable Hermes Agent's bundled skill catalog in addition to uploaded harness skills. |
 
 #### `RLMHarnessConfig` — `id: "rlm"`
 

--- a/skills/evaluate-environments/references/REFERENCE.md
+++ b/skills/evaluate-environments/references/REFERENCE.md
@@ -284,6 +284,16 @@ Installs the Codex CLI into the runtime and runs `codex exec`.
 | --- | --- | --- | --- |
 | `version` | `str` | `"0.144.5"` | Codex release to install (the `rust-v<version>` GitHub release); pinned. |
 
+#### `HermesAgentHarnessConfig` — `id: "hermes-agent"`
+
+Installs Hermes Agent and runs its native ACP server. Supports image prompts,
+task MCP servers, resumable sessions, and SKILL.md skills. Hermes ACP does not
+currently support `disabled_tools`.
+
+| Field | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `version` | `str` | `"0.19.0"` | Hermes Agent release to install, pinned. |
+
 #### `RLMHarnessConfig` — `id: "rlm"`
 
 Installs the rlm CLI and runs it. Knobs map onto `RLM_*` env vars; base `HarnessConfig.env` passes any other `RLM_*` var through verbatim.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,9 @@ def pytest_configure(config) -> None:
     config.addinivalue_line(
         "markers", "claude_code: v1 e2e cases on the claude-code harness"
     )
+    config.addinivalue_line(
+        "markers", "hermes_agent: v1 e2e cases on the hermes-agent harness"
+    )
 
 
 @pytest.fixture

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -25,7 +25,8 @@ Every combination carries its axes' pytest marks, so subsets select with `-m`:
     uv run pytest tests/v1 -n auto -m modal                       # only modal (needs local setup)
 
 Marks: runtimes `subprocess` / `docker` / `prime` / `modal`, placement `colocated`,
-harnesses `null` / `bash` / `rlm` / `kimi_code` / `pi` / `pool` / `codex` / `claude_code`.
+harnesses `null` / `bash` / `rlm` / `kimi_code` / `pi` / `pool` / `codex` / `claude_code` /
+`hermes_agent`.
 A mark is applied per axis, so it selects every case touching that value on ANY axis; for one exact
 combination use `-k` on the test id (e.g. `-k "harness-in-docker-with-tool-in-subprocess"`).
 prime/modal provision real remote sandboxes (slow, infra-flaky, need setup), so they're local-only.
@@ -69,8 +70,8 @@ def tool_runtime(request) -> dict:
 
 
 # Built-in harnesses are bundled in the `harnesses` package; the agent CLIs (`rlm` /
-# `kimi-code` / `codex` / `claude-code`) install their dependencies at rollout. `compact` (an
-# example harness) and `terminus-2` (drives the host tmux) are excluded from e2e.
+# `kimi-code` / `codex` / `claude-code` / `hermes-agent`) install their dependencies at rollout.
+# `compact` (an example harness) and `terminus-2` (drives the host tmux) are excluded from e2e.
 @pytest.fixture
 def harness(request) -> str:
     return request.param

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -37,6 +37,7 @@ AGENTIC_PLACEMENTS = [
     _pair("kimi-code", "docker", "kimi-code-harness-in-docker"),
     _pair("codex", "docker", "codex-harness-in-docker"),
     _pair("claude-code", "docker", "claude-code-harness-in-docker"),
+    _pair("hermes-agent", "docker", "hermes-agent-harness-in-docker"),
     _pair("bash", "prime", "bash-harness-in-prime"),
     _pair("bash", "modal", "bash-harness-in-modal"),
 ]

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -55,6 +55,7 @@ USER_RUNTIMES = [
 # retain MCP access after resuming. Cover every harness in the local container runtime,
 # plus one remote placement for the sandbox/tunnel boundary.
 ACP_RESUME_PLACEMENTS = [
+    _pair("hermes-agent", "docker", "hermes-agent-acp-in-docker"),
     _pair("kimi-code", "docker", "kimi-code-acp-in-docker"),
     _pair("pi", "docker", "pi-acp-in-docker"),
     _pair("pool", "docker", "pool-acp-in-docker"),

--- a/verifiers/v1/harnesses/__init__.py
+++ b/verifiers/v1/harnesses/__init__.py
@@ -4,6 +4,10 @@ from verifiers.v1.harnesses.claude_code import (
     ClaudeCodeHarnessConfig,
 )
 from verifiers.v1.harnesses.codex import CodexHarness, CodexHarnessConfig
+from verifiers.v1.harnesses.hermes_agent import (
+    HermesAgentHarness,
+    HermesAgentHarnessConfig,
+)
 from verifiers.v1.harnesses.kimi_code import KimiCodeHarness, KimiCodeHarnessConfig
 from verifiers.v1.harnesses.mini_swe_agent import (
     MiniSWEAgentHarness,
@@ -22,6 +26,8 @@ __all__ = [
     "ClaudeCodeHarnessConfig",
     "CodexHarness",
     "CodexHarnessConfig",
+    "HermesAgentHarness",
+    "HermesAgentHarnessConfig",
     "KimiCodeHarness",
     "KimiCodeHarnessConfig",
     "MiniSWEAgentHarness",

--- a/verifiers/v1/harnesses/hermes_agent/__init__.py
+++ b/verifiers/v1/harnesses/hermes_agent/__init__.py
@@ -1,0 +1,6 @@
+from verifiers.v1.harnesses.hermes_agent.harness import (
+    HermesAgentHarness,
+    HermesAgentHarnessConfig,
+)
+
+__all__ = ["HermesAgentHarness", "HermesAgentHarnessConfig"]

--- a/verifiers/v1/harnesses/hermes_agent/harness.py
+++ b/verifiers/v1/harnesses/hermes_agent/harness.py
@@ -1,0 +1,129 @@
+"""Run Hermes Agent against interception through its native ACP server."""
+
+import json
+import logging
+from pathlib import Path
+
+from pydantic import Field
+
+from verifiers.v1.acp import ACP
+from verifiers.v1.clients import ModelContext
+from verifiers.v1.configs.harness import HarnessConfig
+from verifiers.v1.harness import Harness
+from verifiers.v1.runtimes import ProgramResult, Runtime
+from verifiers.v1.task import TaskData
+from verifiers.v1.trace import Trace
+
+PROGRAM_SOURCE = (Path(__file__).resolve().parent / "program.py").read_text()
+SKILLS_DIR = ".vf-hermes-skills"
+HERMES_ACP = ACP()
+PROVIDER = "intercept"
+logger = logging.getLogger(__name__)
+
+
+class HermesAgentHarnessConfig(HarnessConfig):
+    version: str = Field(default="0.19.0", pattern=r"^[A-Za-z0-9._+-]+$")
+    """Hermes Agent release to install, pinned for reproducibility."""
+
+
+class HermesAgentHarness(Harness[HermesAgentHarnessConfig]):
+    APPENDS_SYSTEM_PROMPT = True
+    SUPPORTS_MCP = True
+    SUPPORTS_RESUME = True
+    SUPPORTS_SKILLS = True
+
+    async def setup(self, runtime: Runtime) -> None:
+        await self.install_skills(runtime, SKILLS_DIR)
+        logger.info(
+            "hermes-agent: ensuring Hermes Agent %s is installed", self.config.version
+        )
+        source = PROGRAM_SOURCE.replace("{version}", self.config.version)
+        await runtime.prepare_uv_script(source, self.config.resolved_env)
+        await HERMES_ACP.setup(self, runtime)
+
+    async def launch(
+        self,
+        ctx: ModelContext,
+        trace: Trace,
+        runtime: Runtime,
+        endpoint: str,
+        secret: str,
+        mcp_urls: dict[str, str],
+        data: TaskData,
+    ) -> ProgramResult:
+        if self.config.disabled_tools:
+            raise ValueError("Hermes Agent ACP does not support disabling tools")
+
+        system_prompt, prompt = self.resolve_prompt(data)
+        home = self._home(trace)
+        model: dict[str, object] = {
+            "provider": PROVIDER,
+            "default": ctx.model,
+            "base_url": endpoint,
+            "api_mode": "chat_completions",
+        }
+        if ctx.sampling.max_tokens is not None:
+            model["max_tokens"] = ctx.sampling.max_tokens
+        await runtime.write(
+            f"{home}/config.yaml",
+            json.dumps(
+                {
+                    "model": model,
+                    "providers": {
+                        PROVIDER: {
+                            "api": endpoint,
+                            "api_key": secret,
+                            "transport": "chat_completions",
+                            "discover_models": False,
+                            "models": [ctx.model],
+                        }
+                    },
+                }
+            ).encode(),
+        )
+
+        if self.config.skills:
+            skill_home = f"{home}/skills"
+            for command in (
+                ["rm", "-rf", skill_home],
+                ["cp", "-R", SKILLS_DIR, skill_home],
+            ):
+                copied = await runtime.run(command, {})
+                if copied.exit_code != 0:
+                    raise RuntimeError(
+                        f"failed to stage Hermes skills: {copied.stderr.strip()[-500:]}"
+                    )
+
+        env = {
+            **self.config.resolved_env,
+            "HERMES_HOME": home,
+            "HERMES_ACP_SKIP_CONFIGURED_MCP": "1",
+        }
+        source = PROGRAM_SOURCE.replace("{version}", self.config.version)
+        command = await runtime.prepare_uv_script(source, env)
+        result = await HERMES_ACP.run(
+            runtime,
+            env,
+            command,
+            prompt,
+            mcp_urls=mcp_urls,
+            system_prompt=system_prompt,
+            session_path=f"{home}/acp-session",
+        )
+        if not trace.calls:
+            detail = (result.stderr or result.stdout).strip()[-500:] or "<no output>"
+            raise RuntimeError(
+                "Hermes Agent completed without making a model request: " + detail
+            )
+        return result
+
+    async def cleanup(self, trace: Trace, runtime: Runtime) -> None:
+        result = await runtime.run(["rm", "-rf", self._home(trace)], {})
+        if result.exit_code != 0:
+            raise RuntimeError(
+                f"failed to clean up Hermes home: {result.stderr.strip()[-500:]}"
+            )
+
+    @staticmethod
+    def _home(trace: Trace) -> str:
+        return f".vf-hermes/{trace.id}"

--- a/verifiers/v1/harnesses/hermes_agent/harness.py
+++ b/verifiers/v1/harnesses/hermes_agent/harness.py
@@ -24,6 +24,8 @@ logger = logging.getLogger(__name__)
 class HermesAgentHarnessConfig(HarnessConfig):
     version: str = Field(default="0.19.0", pattern=r"^[A-Za-z0-9._+-]+$")
     """Hermes Agent release to install, pinned for reproducibility."""
+    use_bundled_skill: bool = False
+    """Enable Hermes Agent's bundled skill catalog in addition to uploaded skills."""
 
 
 class HermesAgentHarness(Harness[HermesAgentHarnessConfig]):
@@ -81,6 +83,11 @@ class HermesAgentHarness(Harness[HermesAgentHarnessConfig]):
                 }
             ).encode(),
         )
+        if not self.config.use_bundled_skill:
+            await runtime.write(
+                f"{home}/.no-bundled-skills",
+                b"Verifiers supplies evaluation skills explicitly.\n",
+            )
 
         if self.config.skills:
             skill_home = f"{home}/skills"

--- a/verifiers/v1/harnesses/hermes_agent/harness.py
+++ b/verifiers/v1/harnesses/hermes_agent/harness.py
@@ -127,4 +127,4 @@ class HermesAgentHarness(Harness[HermesAgentHarnessConfig]):
 
     @staticmethod
     def _home(trace: Trace) -> str:
-        return f".vf-hermes/{trace.id}"
+        return f"/tmp/vf-hermes/{trace.id}"

--- a/verifiers/v1/harnesses/hermes_agent/harness.py
+++ b/verifiers/v1/harnesses/hermes_agent/harness.py
@@ -71,6 +71,9 @@ class HermesAgentHarness(Harness[HermesAgentHarnessConfig]):
             json.dumps(
                 {
                     "model": model,
+                    # The ACP client already approves tool requests. Avoid routing Hermes'
+                    # redundant smart-approval model calls through interception as turns.
+                    "approvals": {"mode": "off"},
                     "providers": {
                         PROVIDER: {
                             "api": endpoint,
@@ -118,10 +121,10 @@ class HermesAgentHarness(Harness[HermesAgentHarnessConfig]):
             system_prompt=system_prompt,
             session_path=f"{home}/acp-session",
         )
-        if len(trace.calls) == calls_before:
+        if not any(call.node is not None for call in trace.calls[calls_before:]):
             detail = (result.stderr or result.stdout).strip()[-500:] or "<no output>"
             raise RuntimeError(
-                "Hermes Agent completed without making a model request: " + detail
+                "Hermes Agent completed without committing a model turn: " + detail
             )
         return result
 

--- a/verifiers/v1/harnesses/hermes_agent/harness.py
+++ b/verifiers/v1/harnesses/hermes_agent/harness.py
@@ -101,6 +101,7 @@ class HermesAgentHarness(Harness[HermesAgentHarnessConfig]):
         }
         source = PROGRAM_SOURCE.replace("{version}", self.config.version)
         command = await runtime.prepare_uv_script(source, env)
+        calls_before = len(trace.calls)
         result = await HERMES_ACP.run(
             runtime,
             env,
@@ -110,7 +111,7 @@ class HermesAgentHarness(Harness[HermesAgentHarnessConfig]):
             system_prompt=system_prompt,
             session_path=f"{home}/acp-session",
         )
-        if not trace.calls:
+        if len(trace.calls) == calls_before:
             detail = (result.stderr or result.stdout).strip()[-500:] or "<no output>"
             raise RuntimeError(
                 "Hermes Agent completed without making a model request: " + detail

--- a/verifiers/v1/harnesses/hermes_agent/program.py
+++ b/verifiers/v1/harnesses/hermes_agent/program.py
@@ -1,0 +1,10 @@
+# /// script
+# requires-python = ">=3.11,<3.14"
+# dependencies = ["hermes-agent[acp,mcp]=={version}"]
+# ///
+"""Start Hermes Agent's native ACP server."""
+
+from acp_adapter.entry import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Overview

Adds Hermes Agent as a first-class V1 harness using its native ACP server.

## Details

- Registers `hermes-agent` in the built-in harness loader and configuration surface.
- Configures each rollout with an isolated Hermes home and an interception-backed model provider.
- Carries task prompts, images, MCP servers, resumable sessions, system prompts, and skills through the shared ACP layer.
- Pins the Hermes Agent release and documents the harness configuration alongside the other built-in harnesses.\n- Adds Hermes Agent to the Docker-backed agentic E2E matrix alongside the other coding harnesses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New harness integration touches rollout provisioning, ACP/MCP wiring, and Docker e2e; behavior is isolated to opt-in `hermes-agent` runs but depends on pinned third-party Hermes releases.
> 
> **Overview**
> Introduces **`HermesAgentHarness`** (`id: "hermes-agent"`) as a first-class v1 harness alongside the other agent CLIs.
> 
> **Runtime behavior:** `setup` installs evaluation skills, pins **`hermes-agent[acp,mcp]`** via a uv script (`program.py`), and initializes the shared ACP layer. Each rollout gets an isolated **`HERMES_HOME`** with a **`config.yaml`** that routes the model through the **`intercept`** chat-completions provider (endpoint + API key from the eval), turns **approvals off** so smart-approval calls are not counted as model turns, and optionally writes **`.no-bundled-skills`** unless **`use_bundled_skill`** is enabled. Task MCP URLs, system prompt, skills staging, and **resumable** **`acp-session`** paths go through **`HERMES_ACP.run`**. **`disabled_tools`** is rejected; launch fails if no intercepted model turn is recorded.
> 
> **Surface area:** exports are wired in **`harnesses/__init__.py`**, **`HermesAgentHarnessConfig`** is documented in the evaluate-environments reference (**`version`**, **`use_bundled_skill`**), and pytest marks / pairwise e2e rows add **`hermes-agent`** to **agentic** Docker placements and **ACP resume** tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b6617b735174fe8ab08ade45249d79ae989756b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `HermesAgentHarness` to run Hermes Agent via ACP against an intercepted chat-completions provider
> - Adds [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2173/files#diff-cbaf5caf622dcf083eba9f00cbb57d10c863ebc8d09ced67640444e27591a71e) implementing `HermesAgentHarness` and `HermesAgentHarnessConfig`, with the Hermes Agent version defaulting to `0.19.0`.
> - On `setup`, installs skills, renders a uv entrypoint script from [program.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2173/files#diff-f02e296aa046bfe51f3db6889dfcf93c34b900d00bdc26068f9dc639d04db6f7), and initializes ACP.
> - On `launch`, writes a per-trace `config.yaml` pointing to the intercepted chat-completions endpoint, stages skills, sets `HERMES_HOME` and `HERMES_ACP_SKIP_CONFIGURED_MCP`, runs the agent via ACP, and raises if no model request is observed.
> - Supports MCP URLs, resumable sessions, and skills; rejects `disabled_tools`.
> - Adds the harness to the e2e test matrix in [test_e2e.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2173/files#diff-ebbbd919487889487f891b359a756e6c4630e106b16ddaef8ccddc6b900a96e1) as a Docker-based placement.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #2173 opened
>
> - Added `use_bundled_skill` configuration field to `HermesAgentHarnessConfig` dataclass and modified `HermesAgentHarness.launch` method to write a `.no-bundled-skills` marker file to the Hermes home directory when the field is False [9635c44]
> - Modified post-run validation in `HermesAgentHarness.launch` method to verify at least one new trace call has a non-None `node` attribute instead of comparing trace call counts [1e76c79]
> - Added approvals configuration to `config.yaml` in `HermesAgentHarness.launch` method [1e76c79]
> - Added test case for hermes-agent harness in docker environment [7b6617b]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6d4e184.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->