### PR TITLE
chore: bump renderers to 0.1.9.dev9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "uvloop>=0.21.0; sys_platform != 'win32' and sys_platform != 'cygwin' and platform_python_implementation != 'PyPy'",
     "loguru>=0.7.0",
     "tomli-w>=1.0.0",
-    "renderers>=0.1.8",
+    "renderers>=0.1.9.dev9",
     "typing_extensions>=4.12.2",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 4
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'win32'",
@@ -21,9 +21,9 @@ exclude-newer-span = "P7D"
 prime-tunnel = false
 prime-sandboxes = false
 prime-pydantic-config = false
-ty = "2026-07-27T22:00:00Z"
+ty = "2026-07-28T00:00:00Z"
 renderers = false
-ruff = "2026-07-27T22:00:00Z"
+ruff = "2026-07-28T00:00:00Z"
 
 [[package]]
 name = "aiofile"
@@ -159,12 +159,6 @@ name = "alphabet-sort-v1"
 version = "0.1.0"
 source = { editable = "environments/alphabet_sort_v1" }
 dependencies = [
-    { name = "datasets" },
-    { name = "verifiers" },
-]
-
-[package.metadata]
-requires-dist = [
     { name = "datasets" },
     { name = "verifiers" },
 ]
@@ -698,21 +692,12 @@ dependencies = [
     { name = "verifiers" },
 ]
 
-[package.metadata]
-requires-dist = [{ name = "verifiers" }]
-
 [[package]]
 name = "color-codeword-v1"
 version = "0.1.0"
 source = { editable = "environments/color_codeword_v1" }
 dependencies = [
     { name = "pillow" },
-    { name = "verifiers" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "pillow", specifier = ">=11.0.0" },
     { name = "verifiers" },
 ]
 
@@ -732,9 +717,6 @@ source = { editable = "environments/compact" }
 dependencies = [
     { name = "verifiers" },
 ]
-
-[package.metadata]
-requires-dist = [{ name = "verifiers" }]
 
 [[package]]
 name = "connect-python"
@@ -969,9 +951,6 @@ source = { editable = "environments/deepwiki_v1" }
 dependencies = [
     { name = "verifiers" },
 ]
-
-[package.metadata]
-requires-dist = [{ name = "verifiers" }]
 
 [[package]]
 name = "defusedxml"
@@ -1376,9 +1355,6 @@ dependencies = [
     { name = "verifiers" },
 ]
 
-[package.metadata]
-requires-dist = [{ name = "verifiers" }]
-
 [[package]]
 name = "googleapis-common-protos"
 version = "1.75.0"
@@ -1526,9 +1502,6 @@ source = { editable = "environments/gsm8k_v1" }
 dependencies = [
     { name = "datasets" },
 ]
-
-[package.metadata]
-requires-dist = [{ name = "datasets" }]
 
 [[package]]
 name = "h11"
@@ -2087,9 +2060,6 @@ source = { editable = "environments/kuhn_poker_v1" }
 dependencies = [
     { name = "verifiers" },
 ]
-
-[package.metadata]
-requires-dist = [{ name = "verifiers" }]
 
 [[package]]
 name = "latex2sympy2-extended"
@@ -2840,9 +2810,6 @@ dependencies = [
     { name = "verifiers", extra = ["openenv"] },
 ]
 
-[package.metadata]
-requires-dist = [{ name = "verifiers", extras = ["openenv"] }]
-
 [[package]]
 name = "opentelemetry-api"
 version = "1.43.0"
@@ -3282,9 +3249,6 @@ source = { editable = "environments/proposer_solver_v1" }
 dependencies = [
     { name = "verifiers" },
 ]
-
-[package.metadata]
-requires-dist = [{ name = "verifiers" }]
 
 [[package]]
 name = "protobuf"
@@ -4035,7 +3999,7 @@ wheels = [
 
 [[package]]
 name = "renderers"
-version = "0.1.8"
+version = "0.1.9.dev9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
@@ -4047,9 +4011,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/82/e493c5f6752283b18f43b8bb3e6f3b2068310a0a42b0650de1b841713fa3/renderers-0.1.8.tar.gz", hash = "sha256:7a50b59cc64593da504c054bf3e2f0f147af5c1770bad7107de7b18887377280", size = 343291, upload-time = "2026-07-15T14:10:22.918Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/55/e7ec6c23404c18b7ee0e38d7f9825f6adfe87334ce9968733e179c4cb4e1/renderers-0.1.9.dev9.tar.gz", hash = "sha256:d46c34f6a94151bf705e4213df197a766b8508e9c5828fac6d733e677f62beaf", size = 349151, upload-time = "2026-07-29T22:54:15.097Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/2b/6defb0cc5ca19d66798a6c656d30aab86d7c9d4cec14c2b24248b5421c86/renderers-0.1.8-py3-none-any.whl", hash = "sha256:40e6b2c766e23feb12f73b1fbdfef4dea51921479454756ac796612e3bef8397", size = 189915, upload-time = "2026-07-15T14:10:21.371Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/14/996990b4c5669a8979fdc0852c207366dd7d5c61a664274db8f4755328c3/renderers-0.1.9.dev9-py3-none-any.whl", hash = "sha256:f97d31ab83999bcc88bd4471c09f17deb8919b57cc1bba14928155d1e6deef3d", size = 192995, upload-time = "2026-07-29T22:54:13.779Z" },
 ]
 
 [[package]]
@@ -4087,9 +4051,6 @@ source = { editable = "environments/reverse_text_v1" }
 dependencies = [
     { name = "datasets" },
 ]
-
-[package.metadata]
-requires-dist = [{ name = "datasets" }]
 
 [[package]]
 name = "rich"
@@ -4263,9 +4224,6 @@ source = { editable = "environments/scratchpad_v1" }
 dependencies = [
     { name = "verifiers" },
 ]
-
-[package.metadata]
-requires-dist = [{ name = "verifiers" }]
 
 [[package]]
 name = "secretstorage"
@@ -4960,79 +4918,6 @@ examples = [
     { name = "wordle-v1" },
 ]
 
-[package.metadata]
-requires-dist = [
-    { name = "aiohttp", specifier = ">=3.9.0" },
-    { name = "aiolimiter", specifier = ">=1.2.1" },
-    { name = "anthropic", specifier = ">=0.78.0" },
-    { name = "datasets", specifier = ">=3.3.0,<6.0.0" },
-    { name = "gepa", specifier = ">=0.0.6" },
-    { name = "harbor", marker = "python_full_version >= '3.12' and extra == 'harbor'", specifier = "==0.20.0" },
-    { name = "httpx", specifier = ">=0.27.0" },
-    { name = "loguru", specifier = ">=0.7.0" },
-    { name = "math-verify", specifier = ">=0.8.0" },
-    { name = "mcp", specifier = ">=1.24.0,<2" },
-    { name = "modal", marker = "extra == 'modal'", specifier = ">=1.4.0" },
-    { name = "msgpack", specifier = ">=1.1.2" },
-    { name = "nest-asyncio", marker = "extra == 'notebook'", specifier = ">=1.6.0" },
-    { name = "nltk", marker = "extra == 'ta'", specifier = ">=3.9.2" },
-    { name = "numpy", specifier = ">=2.1.0" },
-    { name = "openai", specifier = ">=2.9.0" },
-    { name = "openai-agents", specifier = ">=0.8.2" },
-    { name = "openenv", marker = "extra == 'openenv'", specifier = ">=0.4.1" },
-    { name = "prime-pydantic-config", extras = ["toml"], specifier = ">=0.4.2" },
-    { name = "prime-sandboxes", specifier = ">=0.2.33" },
-    { name = "prime-tunnel", specifier = ">=0.1.8" },
-    { name = "pydantic", specifier = ">=2.12.3" },
-    { name = "python-dotenv", marker = "extra == 'browser'", specifier = ">=1.0.0" },
-    { name = "pyzmq", specifier = ">=27.1.0" },
-    { name = "reasoning-gym", marker = "extra == 'rg'", specifier = ">=0.1.8" },
-    { name = "renderers", specifier = ">=0.1.8" },
-    { name = "requests" },
-    { name = "rich", specifier = ">=11.0.0" },
-    { name = "setproctitle", specifier = ">=1.3.0" },
-    { name = "stagehand", marker = "extra == 'browser'", specifier = ">=3.4.0" },
-    { name = "tenacity", specifier = ">=8.5.0" },
-    { name = "textarena", marker = "extra == 'ta'", specifier = "==0.7.4" },
-    { name = "tomli-w", specifier = ">=1.0.0" },
-    { name = "typing-extensions", specifier = ">=4.12.2" },
-    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'", specifier = ">=0.21.0" },
-]
-provides-extras = ["browser", "harbor", "modal", "notebook", "openenv", "rg", "ta"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "nest-asyncio", specifier = ">=1.6.0" },
-    { name = "nltk", specifier = ">=3.9.2" },
-    { name = "pre-commit", specifier = ">=2.19.0" },
-    { name = "pytest", specifier = ">=7.0.0,<9.1.0" },
-    { name = "pytest-asyncio", specifier = ">=0.21.0" },
-    { name = "pytest-cov", specifier = ">=4.0.0" },
-    { name = "pytest-xdist", specifier = ">=3.8.0" },
-    { name = "python-dotenv", specifier = ">=1.0.0" },
-    { name = "reasoning-gym", specifier = ">=0.1.8" },
-    { name = "ruff", specifier = ">=0.16.0" },
-    { name = "stagehand", specifier = ">=3.4.0" },
-    { name = "textarena", specifier = "==0.7.4" },
-    { name = "ty", specifier = ">=0.0.63" },
-]
-examples = [
-    { name = "alphabet-sort-v1", editable = "environments/alphabet_sort_v1" },
-    { name = "code-golf-v1", editable = "environments/code_golf_v1" },
-    { name = "color-codeword-v1", editable = "environments/color_codeword_v1" },
-    { name = "compact", editable = "environments/compact" },
-    { name = "deepwiki-v1", editable = "environments/deepwiki_v1" },
-    { name = "glossary-v1", editable = "environments/glossary_v1" },
-    { name = "gsm8k-v1", editable = "environments/gsm8k_v1" },
-    { name = "kuhn-poker-v1", editable = "environments/kuhn_poker_v1" },
-    { name = "openenv-wordle-v1", editable = "environments/openenv_wordle_v1" },
-    { name = "proposer-solver-v1", editable = "environments/proposer_solver_v1" },
-    { name = "reverse-text-v1", editable = "environments/reverse_text_v1" },
-    { name = "scratchpad-v1", editable = "environments/scratchpad_v1" },
-    { name = "wiki-search-v1", editable = "environments/wiki_search_v1" },
-    { name = "wordle-v1", editable = "environments/wordle_v1" },
-]
-
 [[package]]
 name = "virtualenv"
 version = "21.6.1"
@@ -5177,13 +5062,6 @@ dependencies = [
     { name = "verifiers" },
 ]
 
-[package.metadata]
-requires-dist = [
-    { name = "chromadb", specifier = ">=0.4.13" },
-    { name = "datasets" },
-    { name = "verifiers" },
-]
-
 [[package]]
 name = "win32-setctime"
 version = "1.2.0"
@@ -5200,9 +5078,6 @@ source = { editable = "environments/wordle_v1" }
 dependencies = [
     { name = "verifiers", extra = ["ta"] },
 ]
-
-[package.metadata]
-requires-dist = [{ name = "verifiers", extras = ["ta"] }]
 
 [[package]]
 name = "xxhash"


### PR DESCRIPTION
## Summary

- Bump the `renderers` floor from `0.1.8` to `0.1.9.dev9` (current upstream main, `5fdf78c`), picking up the GLM tool-name validation fix (renderers#114), the malformed sampled-token evidence rejection (renderers#108), and the Qwen empty-think-wrapper fix for disabled thinking on historical turns (renderers#105).
- Regenerate `uv.lock` (the lock-revision bump and dropped `[package.metadata]` blocks are format churn from the newer uv, not dependency changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `renderers` minimum version to 0.1.9.dev9
> Updates the `renderers` dependency constraint in [pyproject.toml](https://github.com/PrimeIntellect-ai/verifiers/pull/2175/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) from `>=0.1.8` to `>=0.1.9.dev9` and updates the lock file accordingly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d1de9a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `renderers` drives client-side tokenization and multi-turn bridging in `renderer_client`; a dev pre-release can change parsing/validation behavior for rollouts even though this PR only touches dependency pins.
> 
> **Overview**
> Raises the **`renderers`** floor in `pyproject.toml` from **`>=0.1.8`** to **`>=0.1.9.dev9`** and refreshes **`uv.lock`** so installs resolve to that pre-release build.
> 
> The lock refresh also bumps **`uv.lock`** revision and drops duplicated **`[package.metadata]`** blocks (uv format churn), and nudges **`ruff`** / **`ty`** exclude-newer cutoffs by a couple of hours—no other dependency graph changes beyond **`renderers`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1de9a9965f1a25ae7468907d913ae12173b180d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->