### PR TITLE
fix(serve): fall back to loopback TCP where zmq has no ipc transport

### DIFF
--- a/tests/test_serve_utils_addresses.py
+++ b/tests/test_serve_utils_addresses.py
@@ -5,6 +5,7 @@ socket transport, so on Windows `EnvRouter.__init__` could not bind at all and t
 server died before a single rollout ran.
 """
 
+import os
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -12,7 +13,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 import zmq
 
-from verifiers.utils.serve_utils import get_free_port, ipc_path_of, make_ipc_address
+from verifiers.utils.serve_utils import (
+    _SUN_PATH_MAX,
+    get_free_port,
+    ipc_path_of,
+    make_ipc_address,
+)
 
 
 class _ScriptedProbe:
@@ -64,13 +70,23 @@ class TestIpcPathOf:
 
 
 class TestMakeIpcAddressWithIpcSupport:
-    def test_uses_ipc_and_the_resolved_temp_dir(self):
+    def test_uses_ipc_and_a_writable_directory(self):
         with patch.object(zmq, "has", return_value=True):
             address = make_ipc_address("abc123", "responses")
         assert address.startswith("ipc://")
-        # not a hardcoded /tmp: it has to follow tempfile.gettempdir()
-        expected = Path(tempfile.gettempdir()) / "vf-abc123-responses"
-        assert address == f"ipc://{expected}"
+        path = Path(ipc_path_of(address))
+        assert path.name == "vf-abc123-responses"
+        # not a hardcoded /tmp: whatever directory is chosen has to be writable
+        assert os.access(path.parent, os.W_OK)
+
+    def test_falls_back_to_gettempdir_when_tmp_is_not_writable(self):
+        """The reason the hardcoded /tmp went away in the first place."""
+        with (
+            patch.object(zmq, "has", return_value=True),
+            patch("verifiers.utils.serve_utils.os.access", return_value=False),
+        ):
+            address = make_ipc_address("abc123", "responses")
+        assert Path(ipc_path_of(address)).parent == Path(tempfile.gettempdir())
 
     def test_slashes_in_name_are_flattened(self):
         """Worker names embed the env id, which can contain a slash."""
@@ -78,6 +94,59 @@ class TestMakeIpcAddressWithIpcSupport:
             address = make_ipc_address("abc123", "some/env-0")
         assert ipc_path_of(address) is not None
         assert Path(ipc_path_of(address)).name == "vf-abc123-some--env-0"
+
+
+class TestIpcPathFitsInSunPath:
+    """`sun_path` is 104 bytes on macOS, 108 on Linux. A worker name carries the env
+    id, which is arbitrary and often an `org/name` pair, and macOS puts TMPDIR under a
+    ~48 byte `/var/folders/...` path. Overflowing means the worker cannot bind after
+    the router is already up, which is the late startup failure this fix removes.
+    """
+
+    LONG_TMPDIR = "/var/folders/qx/8m4n2z1d5kv7wcpr3hb9xlk80000gn/T"
+
+    def _address_under(self, tmpdir, name, tmp_writable=False):
+        """Build an address as if gettempdir() were `tmpdir`, /tmp optionally absent."""
+        with (
+            patch.object(zmq, "has", return_value=True),
+            patch(
+                "verifiers.utils.serve_utils.tempfile.gettempdir", return_value=tmpdir
+            ),
+            patch(
+                "verifiers.utils.serve_utils.os.access",
+                side_effect=lambda p, _: Path(p) != Path("/tmp") or tmp_writable,
+            ),
+        ):
+            return make_ipc_address("abc123", name)
+
+    def test_a_long_temp_dir_is_passed_over_for_tmp(self):
+        """macOS: the per-user TMPDIR costs 44 bytes of name budget for nothing."""
+        address = self._address_under(self.LONG_TMPDIR, "org/env", tmp_writable=True)
+        assert Path(ipc_path_of(address)).parent == Path("/tmp")
+
+    def test_a_long_name_is_shortened_rather_than_overflowing(self):
+        env_id = "some-organization/a-fairly-long-environment-name-v2-hard"
+        address = self._address_under(self.LONG_TMPDIR, f"{env_id}-0")
+        assert len(ipc_path_of(address).encode()) <= _SUN_PATH_MAX
+
+    def test_shortened_names_stay_distinct_between_workers(self):
+        """Truncation alone would collide: the ids differ only past the cut."""
+        env_id = "some-organization/a-fairly-long-environment-name-v2-hard"
+        addresses = {
+            self._address_under(self.LONG_TMPDIR, f"{env_id}-{worker}")
+            for worker in range(4)
+        }
+        assert len(addresses) == 4
+
+    def test_a_name_that_already_fits_is_left_alone(self):
+        """No digest suffix on the common case: the paths stay readable."""
+        address = self._address_under("/tmp", "env-0", tmp_writable=True)
+        assert Path(ipc_path_of(address)) == Path("/tmp/vf-abc123-env-0")
+
+    def test_a_directory_with_no_room_left_fails_loudly(self):
+        """Better to say so than to hand back a path that cannot bind."""
+        with pytest.raises(RuntimeError, match="cannot fit a socket name"):
+            self._address_under("/" + "d" * _SUN_PATH_MAX, "env-0")
 
 
 class TestMakeIpcAddressWithoutIpcSupport:

--- a/tests/test_serve_utils_addresses.py
+++ b/tests/test_serve_utils_addresses.py
@@ -1,0 +1,89 @@
+"""Tests for router/worker address construction.
+
+See issue #2030: `make_ipc_address` hardcoded `ipc:///tmp/...`. `ipc://` is a Unix domain
+socket transport, so on Windows `EnvRouter.__init__` could not bind at all and the env
+server died before a single rollout ran.
+"""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import zmq
+
+from verifiers.utils.serve_utils import ipc_path_of, make_ipc_address
+
+
+class TestIpcPathOf:
+    def test_returns_path_for_ipc_address(self):
+        assert ipc_path_of("ipc:///tmp/vf-abc-responses") == "/tmp/vf-abc-responses"
+
+    @pytest.mark.parametrize(
+        "address",
+        ["tcp://127.0.0.1:5555", "inproc://x", "pgm://eth0;239.0.0.1:5555"],
+    )
+    def test_returns_none_for_non_ipc_address(self, address):
+        """Only ipc:// has a file to unlink; anything else must not reach os.unlink."""
+        assert ipc_path_of(address) is None
+
+
+class TestMakeIpcAddressWithIpcSupport:
+    def test_uses_ipc_and_the_resolved_temp_dir(self):
+        with patch.object(zmq, "has", return_value=True):
+            address = make_ipc_address("abc123", "responses")
+        assert address.startswith("ipc://")
+        # not a hardcoded /tmp: it has to follow tempfile.gettempdir()
+        expected = Path(tempfile.gettempdir()) / "vf-abc123-responses"
+        assert address == f"ipc://{expected}"
+
+    def test_slashes_in_name_are_flattened(self):
+        """Worker names embed the env id, which can contain a slash."""
+        with patch.object(zmq, "has", return_value=True):
+            address = make_ipc_address("abc123", "some/env-0")
+        assert ipc_path_of(address) is not None
+        assert Path(ipc_path_of(address)).name == "vf-abc123-some--env-0"
+
+
+class TestMakeIpcAddressWithoutIpcSupport:
+    """The Windows case, and any libzmq built without ipc."""
+
+    def test_falls_back_to_loopback_tcp(self):
+        with patch.object(zmq, "has", return_value=False):
+            address = make_ipc_address("abc123", "responses")
+        assert address.startswith("tcp://127.0.0.1:")
+        assert int(address.rsplit(":", 1)[1]) > 0
+
+    def test_fallback_address_has_no_file_to_unlink(self):
+        with patch.object(zmq, "has", return_value=False):
+            address = make_ipc_address("abc123", "responses")
+        assert ipc_path_of(address) is None
+
+    def test_distinct_names_get_distinct_ports(self):
+        """Router and each worker bind separately, so addresses must not collide."""
+        with patch.object(zmq, "has", return_value=False):
+            addresses = {
+                make_ipc_address("abc123", name)
+                for name in ("responses", "stats", "env-0", "env-1")
+            }
+        assert len(addresses) == 4
+
+    def test_fallback_address_actually_binds(self):
+        """The point of the fix: the returned address must be bindable."""
+        with patch.object(zmq, "has", return_value=False):
+            address = make_ipc_address("abc123", "responses")
+        ctx = zmq.Context()
+        try:
+            socket = ctx.socket(zmq.PULL)
+            try:
+                socket.bind(address)
+            finally:
+                socket.close()
+        finally:
+            ctx.term()
+
+    def test_hardcoded_tmp_ipc_address_is_never_returned(self):
+        """Regression guard for the exact string in issue #2030."""
+        with patch.object(zmq, "has", return_value=False):
+            address = make_ipc_address("abc123", "responses")
+        assert not address.startswith("ipc:///tmp/")

--- a/tests/test_serve_utils_addresses.py
+++ b/tests/test_serve_utils_addresses.py
@@ -7,12 +7,47 @@ server died before a single rollout ran.
 
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import zmq
 
-from verifiers.utils.serve_utils import ipc_path_of, make_ipc_address
+from verifiers.utils.serve_utils import get_free_port, ipc_path_of, make_ipc_address
+
+
+class _ScriptedProbe:
+    """A stand-in for a probe socket that reports a caller-chosen port."""
+
+    def __init__(self, port):
+        self.port = port
+        self.closed = False
+
+    def bind(self, address):
+        pass
+
+    def getsockname(self):
+        return ("127.0.0.1", self.port)
+
+    def close(self):
+        self.closed = True
+
+
+def _scripted_socket_module(ports):
+    """Patch target for `serve_utils.socket` that hands out `ports` in order."""
+    remaining = list(ports)
+    made: list[_ScriptedProbe] = []
+
+    module = MagicMock()
+    module.AF_INET = 2
+    module.SOCK_STREAM = 1
+
+    def make_probe(family, kind):
+        probe = _ScriptedProbe(remaining.pop(0))
+        made.append(probe)
+        return probe
+
+    module.socket.side_effect = make_probe
+    return module, made
 
 
 class TestIpcPathOf:
@@ -87,3 +122,65 @@ class TestMakeIpcAddressWithoutIpcSupport:
         with patch.object(zmq, "has", return_value=False):
             address = make_ipc_address("abc123", "responses")
         assert not address.startswith("ipc:///tmp/")
+
+
+class TestPortIsNotReissuedBeforeItIsBound:
+    """A worker address is built in the parent but bound in the child, after
+    `load_environment`. The port is free for that whole window, so a later
+    allocation must not be handed it again: the second worker would die on
+    `Address already in use`, which is the crash this fix exists to remove.
+    """
+
+    def test_get_free_port_skips_an_excluded_port(self):
+        """The OS re-offering a port already issued must not be passed through."""
+        module, made = _scripted_socket_module([5001, 5001, 5002])
+        with patch("verifiers.utils.serve_utils.socket", module):
+            port = get_free_port(exclude={5001})
+        assert port == 5002
+        # every probe is closed, including the ones held open to force a new offer
+        assert all(probe.closed for probe in made)
+
+    def test_get_free_port_returns_the_first_acceptable_port(self):
+        module, made = _scripted_socket_module([5001])
+        with patch("verifiers.utils.serve_utils.socket", module):
+            assert get_free_port(exclude={5002}) == 5001
+        assert made[0].closed
+
+    def test_get_free_port_gives_up_rather_than_returning_a_used_port(self):
+        module, _ = _scripted_socket_module([5001] * 200)
+        with (
+            patch("verifiers.utils.serve_utils.socket", module),
+            pytest.raises(RuntimeError, match="no free port"),
+        ):
+            get_free_port(exclude={5001})
+
+    def test_make_ipc_address_records_the_port_it_issued(self):
+        issued: set[int] = set()
+        module, _ = _scripted_socket_module([5001])
+        with (
+            patch.object(zmq, "has", return_value=False),
+            patch("verifiers.utils.serve_utils.socket", module),
+        ):
+            make_ipc_address("abc123", "responses", issued)
+        assert issued == {5001}
+
+    def test_a_shared_set_stops_the_second_worker_reusing_the_first_port(self):
+        """The exact race: the OS offers 5001 twice because worker 0 has not bound it."""
+        issued: set[int] = set()
+        module, _ = _scripted_socket_module([5001, 5001, 5002])
+        with (
+            patch.object(zmq, "has", return_value=False),
+            patch("verifiers.utils.serve_utils.socket", module),
+        ):
+            first = make_ipc_address("abc123", "env-0", issued)
+            second = make_ipc_address("abc123", "env-1", issued)
+        assert first == "tcp://127.0.0.1:5001"
+        assert second == "tcp://127.0.0.1:5002"
+        assert issued == {5001, 5002}
+
+    def test_ipc_path_callers_are_unaffected(self):
+        """The set is only touched on the tcp path; ipc addresses use no port."""
+        issued: set[int] = set()
+        with patch.object(zmq, "has", return_value=True):
+            make_ipc_address("abc123", "responses", issued)
+        assert issued == set()

--- a/verifiers/serve/server/env_router.py
+++ b/verifiers/serve/server/env_router.py
@@ -30,7 +30,7 @@ from pydantic import BaseModel
 from verifiers.serve.server.env_worker import EnvWorkerStats
 from verifiers.utils.async_utils import EventLoopLagMonitor, EventLoopLagStats
 from verifiers.utils.process_utils import terminate_process, terminate_processes
-from verifiers.utils.serve_utils import make_ipc_address
+from verifiers.utils.serve_utils import ipc_path_of, make_ipc_address
 
 # Callback type: (client_id, request_id, response_bytes) -> awaitable
 OnResponseCallback = Callable[[bytes, bytes, bytes], Awaitable[None]]
@@ -146,9 +146,15 @@ class EnvRouter:
         self.request_to_worker: dict[bytes, int] = {}  # request_id → worker_id
         self.lag_monitor = EventLoopLagMonitor()
 
+        # Only ipc:// addresses have a file behind them to unlink on shutdown; a tcp
+        # fallback address has none, so it must not end up in this list.
         self.ipc_paths: list[str] = [
-            self.response_address.replace("ipc://", ""),
-            self.stats_address.replace("ipc://", ""),
+            path
+            for path in (
+                ipc_path_of(self.response_address),
+                ipc_path_of(self.stats_address),
+            )
+            if path is not None
         ]
 
     @property
@@ -175,7 +181,9 @@ class EnvRouter:
 
         worker_name = self.get_worker_name(worker_id)
         worker_addr = self.get_worker_address(worker_id)
-        self.ipc_paths.append(worker_addr.replace("ipc://", ""))
+        worker_ipc_path = ipc_path_of(worker_addr)
+        if worker_ipc_path is not None:
+            self.ipc_paths.append(worker_ipc_path)
 
         ctx = mp.get_context("spawn")
         process = ctx.Process(

--- a/verifiers/serve/server/env_router.py
+++ b/verifiers/serve/server/env_router.py
@@ -129,13 +129,22 @@ class EnvRouter:
         # setup sockets
         self.ctx = zmq.asyncio.Context()
 
-        self.response_address = make_ipc_address(self.session_id, "responses")
+        # Ports handed out on the tcp fallback path. A worker binds its address in the
+        # child, after load_environment, so the port stays free across the spawn and a
+        # later allocation must not be given it again.
+        self.issued_ports: set[int] = set()
+
+        self.response_address = make_ipc_address(
+            self.session_id, "responses", self.issued_ports
+        )
         self.response_pull = self.ctx.socket(zmq.PULL)
         self.response_pull.setsockopt(zmq.RCVHWM, 0)
         self.response_pull.setsockopt(zmq.LINGER, 0)
         self.response_pull.bind(self.response_address)
 
-        self.stats_address = make_ipc_address(self.session_id, "stats")
+        self.stats_address = make_ipc_address(
+            self.session_id, "stats", self.issued_ports
+        )
         self.stats_pull = self.ctx.socket(zmq.PULL)
         self.stats_pull.setsockopt(zmq.RCVHWM, 0)
         self.stats_pull.setsockopt(zmq.LINGER, 0)
@@ -173,7 +182,7 @@ class EnvRouter:
     def get_worker_address(self, worker_id: int) -> str:
         """Get the address of an env worker."""
         worker_name = self.get_worker_name(worker_id)
-        return make_ipc_address(self.session_id, worker_name)
+        return make_ipc_address(self.session_id, worker_name, self.issued_ports)
 
     def start_worker(self, worker_id: int) -> WorkerHandle:
         """Start an EnvWorker process."""

--- a/verifiers/utils/serve_utils.py
+++ b/verifiers/utils/serve_utils.py
@@ -1,5 +1,7 @@
 import dataclasses
+import hashlib
 import logging
+import os
 import socket
 import sys
 import tempfile
@@ -24,6 +26,11 @@ TENSOR_TAG = "__torch_tensor__"
 # to offer a distinct port every attempt and the search converges in a few tries even
 # with many ports already issued.
 _PORT_PROBE_ATTEMPTS = 100
+
+# A unix socket path goes in `sockaddr_un.sun_path`, which is 108 bytes on Linux and
+# 104 on macOS, both including the terminating NUL. Hold to the smaller one everywhere
+# rather than branching on the platform, and leave a few bytes spare.
+_SUN_PATH_MAX = 100
 
 
 def _encode_array_like(arr: "np.ndarray") -> dict:
@@ -125,6 +132,48 @@ def walk_decode_tensors(obj: Any, *, to_torch: bool = True):
     return obj
 
 
+def _ipc_socket_dir() -> Path:
+    """Shortest writable directory to hold the unix socket files.
+
+    The directory is charged against the same `sun_path` budget as the socket name, so
+    a long temp dir is paid for out of the env id. macOS gives every process a per-user
+    `TMPDIR` under `/var/folders/` that runs to about 48 bytes, against 4 for `/tmp`,
+    which is most of the budget gone before the name starts. Prefer whichever candidate
+    is shorter and actually writable: `/tmp` on a normal machine, `gettempdir()`
+    wherever `/tmp` is not writable, which is the case this stopped hardcoding for.
+    """
+    candidates = sorted(
+        {Path(tempfile.gettempdir()), Path("/tmp")},
+        key=lambda directory: len(str(directory).encode()),
+    )
+    for directory in candidates:
+        if os.access(directory, os.W_OK):
+            return directory
+    return Path(tempfile.gettempdir())
+
+
+def _fit_socket_path(directory: Path, filename: str) -> Path:
+    """Path under `directory` for `filename`, shortened if `sun_path` cannot hold it.
+
+    Worker names carry the env id, which is arbitrarily long and often an `org/name`
+    pair, so a name that fits on one machine can overflow on another. Overflowing means
+    the worker fails to bind after the router has already come up, which is the same
+    class of late startup failure this module is trying to remove. Replacing the tail
+    with a digest of the whole name keeps distinct workers distinct.
+    """
+    if len(str(directory / filename).encode()) <= _SUN_PATH_MAX:
+        return directory / filename
+    digest = hashlib.sha256(filename.encode()).hexdigest()[:8]
+    room = _SUN_PATH_MAX - len(str(directory / f"-{digest}").encode())
+    if room < 1:
+        raise RuntimeError(
+            f"cannot fit a socket name under {directory}: the directory alone takes "
+            f"{len(str(directory).encode())} of the {_SUN_PATH_MAX} bytes available"
+        )
+    head = filename.encode()[:room].decode(errors="ignore")
+    return directory / f"{head}-{digest}"
+
+
 def make_ipc_address(
     session_id: str, name: str, issued_ports: set[int] | None = None
 ) -> str:
@@ -136,8 +185,8 @@ def make_ipc_address(
     Capability is read from `zmq.has("ipc")` rather than sniffing the platform, so a
     libzmq built without ipc on any OS is handled too.
 
-    The socket directory comes from `tempfile.gettempdir()` rather than a hardcoded
-    `/tmp`, so it also lands somewhere writable when `/tmp` is not.
+    The socket directory is no longer a hardcoded `/tmp`, so it also lands somewhere
+    writable when `/tmp` is not, and the result is length-checked against `sun_path`.
 
     `issued_ports` is read and updated on the TCP path. A worker address is built in
     the parent but only bound in the child, after `load_environment`, so the port sits
@@ -151,7 +200,8 @@ def make_ipc_address(
             issued_ports.add(port)
         return f"tcp://127.0.0.1:{port}"
     safe_name = name.replace("/", "--")
-    return f"ipc://{Path(tempfile.gettempdir()) / f'vf-{session_id}-{safe_name}'}"
+    directory = _ipc_socket_dir()
+    return f"ipc://{_fit_socket_path(directory, f'vf-{session_id}-{safe_name}')}"
 
 
 def ipc_path_of(address: str) -> str | None:

--- a/verifiers/utils/serve_utils.py
+++ b/verifiers/utils/serve_utils.py
@@ -3,6 +3,7 @@ import logging
 import socket
 import sys
 import tempfile
+from collections.abc import Container
 from datetime import date, datetime
 from enum import Enum
 from pathlib import Path
@@ -18,6 +19,11 @@ logger = logging.getLogger(__name__)
 # Marker key inside the encoded payload so the decoder can recognize a
 # tensor round-trip without disturbing arbitrary user dicts.
 TENSOR_TAG = "__torch_tensor__"
+
+# Bounds the search in get_free_port. Each rejected probe is held open, so the OS has
+# to offer a distinct port every attempt and the search converges in a few tries even
+# with many ports already issued.
+_PORT_PROBE_ATTEMPTS = 100
 
 
 def _encode_array_like(arr: "np.ndarray") -> dict:
@@ -119,7 +125,9 @@ def walk_decode_tensors(obj: Any, *, to_torch: bool = True):
     return obj
 
 
-def make_ipc_address(session_id: str, name: str) -> str:
+def make_ipc_address(
+    session_id: str, name: str, issued_ports: set[int] | None = None
+) -> str:
     """Build an address for router-to-worker communication.
 
     Prefers a Unix domain socket, which needs no port and is faster, but falls back to
@@ -130,9 +138,18 @@ def make_ipc_address(session_id: str, name: str) -> str:
 
     The socket directory comes from `tempfile.gettempdir()` rather than a hardcoded
     `/tmp`, so it also lands somewhere writable when `/tmp` is not.
+
+    `issued_ports` is read and updated on the TCP path. A worker address is built in
+    the parent but only bound in the child, after `load_environment`, so the port sits
+    free across the spawn. Callers that allocate several addresses in a row must pass a
+    shared set, or a later allocation can be handed a port an earlier worker has not
+    bound yet.
     """
     if not zmq.has("ipc"):
-        return f"tcp://127.0.0.1:{get_free_port()}"
+        port = get_free_port(exclude=issued_ports if issued_ports is not None else ())
+        if issued_ports is not None:
+            issued_ports.add(port)
+        return f"tcp://127.0.0.1:{port}"
     safe_name = name.replace("/", "--")
     return f"ipc://{Path(tempfile.gettempdir()) / f'vf-{session_id}-{safe_name}'}"
 
@@ -147,8 +164,29 @@ def ipc_path_of(address: str) -> str | None:
     return address[len(prefix) :] if address.startswith(prefix) else None
 
 
-def get_free_port() -> int:
-    """Get a free port on the system."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("localhost", 0))
-        return s.getsockname()[1]
+def get_free_port(exclude: Container[int] = ()) -> int:
+    """Get a free port on the system, skipping any in `exclude`.
+
+    The probe socket is closed before returning, so the port is only free until
+    something binds it. Callers that bind later, and allocate more than one port in
+    the meantime, have to pass back what they were already given.
+
+    Rejected probes are held open rather than closed immediately, which forces the OS
+    to offer a different port on the next attempt instead of possibly repeating the
+    one just refused.
+    """
+    held: list[socket.socket] = []
+    try:
+        for _ in range(_PORT_PROBE_ATTEMPTS):
+            probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            held.append(probe)
+            probe.bind(("localhost", 0))
+            port = probe.getsockname()[1]
+            if port not in exclude:
+                return port
+        raise RuntimeError(
+            f"no free port outside the set already issued, after {_PORT_PROBE_ATTEMPTS} attempts"
+        )
+    finally:
+        for probe in held:
+            probe.close()

--- a/verifiers/utils/serve_utils.py
+++ b/verifiers/utils/serve_utils.py
@@ -2,6 +2,7 @@ import dataclasses
 import logging
 import socket
 import sys
+import tempfile
 from datetime import date, datetime
 from enum import Enum
 from pathlib import Path
@@ -9,6 +10,7 @@ from typing import Any
 from uuid import UUID
 
 import numpy as np
+import zmq
 
 logger = logging.getLogger(__name__)
 
@@ -118,8 +120,31 @@ def walk_decode_tensors(obj: Any, *, to_torch: bool = True):
 
 
 def make_ipc_address(session_id: str, name: str) -> str:
-    """Build an IPC address for inter-process communication."""
-    return f"ipc:///tmp/vf-{session_id}-{name.replace('/', '--')}"
+    """Build an address for router-to-worker communication.
+
+    Prefers a Unix domain socket, which needs no port and is faster, but falls back to
+    loopback TCP wherever libzmq was built without ipc support. That is always the case
+    on Windows, where `ipc://` cannot bind at all and the router dies in `__init__`.
+    Capability is read from `zmq.has("ipc")` rather than sniffing the platform, so a
+    libzmq built without ipc on any OS is handled too.
+
+    The socket directory comes from `tempfile.gettempdir()` rather than a hardcoded
+    `/tmp`, so it also lands somewhere writable when `/tmp` is not.
+    """
+    if not zmq.has("ipc"):
+        return f"tcp://127.0.0.1:{get_free_port()}"
+    safe_name = name.replace("/", "--")
+    return f"ipc://{Path(tempfile.gettempdir()) / f'vf-{session_id}-{safe_name}'}"
+
+
+def ipc_path_of(address: str) -> str | None:
+    """Filesystem path backing an `ipc://` address, or None for any other transport.
+
+    Callers unlink these on shutdown. A TCP address has no file behind it, so it must
+    not be handed to `os.unlink`.
+    """
+    prefix = "ipc://"
+    return address[len(prefix) :] if address.startswith(prefix) else None
 
 
 def get_free_port() -> int:


### PR DESCRIPTION
Partially addresses #2030, reported by @martian56, who identified the root cause correctly.

## What is wrong

`prime eval run` cannot start on native Windows. `make_ipc_address` hardcodes the transport:

```python
def make_ipc_address(session_id: str, name: str) -> str:
    return f"ipc:///tmp/vf-{session_id}-{name.replace('/', '--')}"
```

`ipc://` is a Unix domain socket transport. On Windows libzmq is built without it, so `EnvRouter.__init__` dies on the very first `bind()`, before a single rollout runs.

Measured on Windows 11, pyzmq 27.1.0, libzmq 4.3.5:

```
zmq.has("ipc") = False

main         binds response_pull to  ipc:///tmp/vf-abc123-responses
                                     -> ZMQError: Protocol not supported

this branch  binds response_pull to  tcp://127.0.0.1:50465
                                     -> binds
```

## The fix, and why it gates on a capability rather than the platform

`zmq.has("ipc")`, not `os.name == "nt"`. The transport choice depends on whether libzmq has ipc compiled in, which is exactly what that call reports, and it also covers a libzmq built without ipc on any OS. Where ipc is unavailable it falls back to `tcp://127.0.0.1` using the `get_free_port` helper that already sits directly below in the same module, so no new dependency and no new idiom.

## Two more defects in the same three lines

- **`/tmp` was hardcoded**, so the socket path ignored `tempfile.gettempdir()`. That breaks anywhere `/tmp` is not writable, independent of Windows. It now resolves.
- **Cleanup would have tried to unlink a TCP address.** `EnvRouter` builds `ipc_paths` by stripping the `"ipc://"` prefix, and shutdown calls `os.unlink` on every entry. A TCP address has no file behind it. Added `ipc_path_of`, which returns the path for `ipc://` and `None` for anything else, and only real paths are tracked. Without this the fix would have swapped one Windows failure for a different one on shutdown.

## One thing I checked before changing it

A random port makes `make_ipc_address` non-deterministic, and `get_worker_address` recomputes the address rather than reading a stored one, so I checked whether anything relies on calling it twice for the same worker. It does not: `get_worker_address` has exactly one caller, in `start_worker`, and the result is handed to the spawned process as the `request_address` kwarg rather than recomputed worker-side. So non-determinism is safe here. If you would rather it stayed deterministic, the alternative is to bind with `bind_to_random_port` and read `zmq.LAST_ENDPOINT` back, which is more robust against the small TOCTOU window in `get_free_port` but touches all three bind sites. Happy to do it that way instead.

## Tests

`tests/test_serve_utils_addresses.py`, 11 cases, all passing. They cover both branches by patching `zmq.has`, so they exercise the Windows path on Linux CI too and the ipc path on Windows.

- ipc branch uses the resolved temp dir, not `/tmp`, and flattens a slash in the env id
- fallback returns loopback TCP, and **the returned address is actually bound** to prove it works rather than just asserting on the string
- distinct names get distinct ports, since router and each worker bind separately
- `ipc_path_of` returns `None` for tcp, inproc and pgm, so nothing but a real path reaches `os.unlink`
- a regression guard that the literal `ipc:///tmp/` prefix from the issue is never returned again

```
tests/test_serve_utils_addresses.py  11 passed
ruff format, ruff check: clean
```

## Scope, deliberately

The issue reports a second error: the client receive loop needs a selector event loop for zmq, and pyzmq already works under Proactor when `tornado>=6.1` is installed. That reads as a dependency or CLI-entry-point concern rather than a transport bug, and setting a global `asyncio` event loop policy from inside a library affects anyone embedding this. So it is not in here. Say the word and I will add it at the CLI entry point.

I also could not verify end to end: `prime eval run demo -m openai/gpt-4o-mini -p openrouter -n 1 -c 1` needs a provider key I do not have. What is verified is that the router's binds now succeed on Windows where they previously raised, plus the unit tests above. Worth a maintainer running the full command on Windows before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core serve startup/shutdown transport and port allocation for all platforms; misallocation could still cause bind races or failed env server startup, though behavior is heavily unit-tested.
> 
> **Overview**
> Fixes **#2030** by replacing hardcoded `ipc:///tmp/...` router/worker addresses with transport-aware construction so `EnvRouter` can bind on Windows and in other environments where `/tmp` or Unix sockets are unusable.
> 
> **`make_ipc_address`** now uses **`zmq.has("ipc")`**: when ipc is available it builds paths under the shortest writable temp directory (not fixed `/tmp`), flattens slashes in names, and shortens paths that would exceed **`sun_path`** limits; when ipc is missing it returns **`tcp://127.0.0.1:<port>`** via an enhanced **`get_free_port`** that skips excluded ports and avoids reissuing recently probed ports. **`ipc_path_of`** ensures shutdown only **`unlink`**s real ipc socket files.
> 
> **`EnvRouter`** tracks **`issued_ports`** across response, stats, and worker addresses so TCP ports allocated before child processes bind are not reused, and only ipc paths are added to **`ipc_paths`**.
> 
> Adds **`tests/test_serve_utils_addresses.py`** covering ipc vs TCP branches, **`sun_path`** shortening, port exclusion, and bindability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99618300542e0cded08b641f65dd46f4c18d8d77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fall back to loopback TCP in `make_ipc_address` when zmq has no ipc transport
> - `make_ipc_address` in [`serve_utils.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/2176/files#diff-573ce1050a71bef580f9e082113a30474324c2d0e92c785579dce9d67eb1a4ca) now detects `zmq.has("ipc") == False` and returns a `localhost` TCP address instead of an ipc path, using `get_free_port` with an exclusion set to avoid port reuse.
> - `get_free_port` holds probe sockets open during selection and accepts an `exclude` container, reducing the chance of issuing the same port to multiple sockets.
> - [`EnvRouter`](https://github.com/PrimeIntellect-ai/verifiers/pull/2176/files#diff-5f42e5c44b82aeddf6020de01b59c5480cac9144a3f6ffc79c3ee01683ad92ec) passes a shared `issued_ports` set into every `make_ipc_address` call and uses the new `ipc_path_of` helper to track only real filesystem paths, avoiding bogus unlink attempts on TCP addresses.
> - Risk: `get_free_port` now raises `RuntimeError` if no acceptable port is found within 100 attempts, whereas it previously always succeeded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9961830.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->