### PR TITLE
Simplify installed package checks

### DIFF
--- a/tests/test_install_utils.py
+++ b/tests/test_install_utils.py
@@ -1,5 +1,5 @@
-import sys
-from unittest.mock import MagicMock, patch
+from importlib.metadata import PackageNotFoundError
+from unittest.mock import patch
 
 import pytest
 
@@ -80,58 +80,32 @@ class TestIsHubEnv:
 
 
 class TestIsInstalled:
-    @patch("verifiers.utils.install_utils.subprocess.run")
-    def test_installed_no_version_check(self, mock_run):
-        mock_run.return_value = MagicMock(
-            returncode=0, stdout="Name: gsm8k\nVersion: 1.0.0\n"
-        )
+    @patch("verifiers.utils.install_utils.package_version", return_value="1.0.0")
+    def test_installed_no_version_check(self, mock_version):
         assert is_installed("gsm8k") is True
-        mock_run.assert_called_once_with(
-            ["uv", "pip", "show", "--python", sys.executable, "gsm8k"],
-            capture_output=True,
-            text=True,
-        )
+        mock_version.assert_called_once_with("gsm8k")
 
-    @patch("verifiers.utils.install_utils.subprocess.run")
-    def test_not_installed(self, mock_run):
-        mock_run.return_value = MagicMock(returncode=1, stdout="")
+    @patch("verifiers.utils.install_utils.package_version")
+    def test_not_installed(self, mock_version):
+        mock_version.side_effect = PackageNotFoundError("gsm8k")
         assert is_installed("gsm8k") is False
 
-    @patch("verifiers.utils.install_utils.subprocess.run")
-    def test_installed_version_matches(self, mock_run):
-        mock_run.return_value = MagicMock(
-            returncode=0, stdout="Name: gsm8k\nVersion: 1.0.0\n"
-        )
+    @patch("verifiers.utils.install_utils.package_version", return_value="1.0.0")
+    def test_installed_version_matches(self, mock_version):
         assert is_installed("gsm8k", version="1.0.0") is True
 
-    @patch("verifiers.utils.install_utils.subprocess.run")
-    def test_installed_version_mismatch(self, mock_run):
-        mock_run.return_value = MagicMock(
-            returncode=0, stdout="Name: gsm8k\nVersion: 1.0.0\n"
-        )
+    @patch("verifiers.utils.install_utils.package_version", return_value="1.0.0")
+    def test_installed_version_mismatch(self, mock_version):
         assert is_installed("gsm8k", version="2.0.0") is False
 
-    @patch("verifiers.utils.install_utils.subprocess.run")
-    def test_latest_version_skips_check(self, mock_run):
-        mock_run.return_value = MagicMock(
-            returncode=0, stdout="Name: gsm8k\nVersion: 1.0.0\n"
-        )
+    @patch("verifiers.utils.install_utils.package_version", return_value="1.0.0")
+    def test_latest_version_skips_check(self, mock_version):
         assert is_installed("gsm8k", version="latest") is True
 
-    @patch("verifiers.utils.install_utils.subprocess.run")
-    def test_normalizes_package_name(self, mock_run):
-        mock_run.return_value = MagicMock(returncode=0, stdout="")
+    @patch("verifiers.utils.install_utils.package_version", return_value="1.0.0")
+    def test_normalizes_package_name(self, mock_version):
         is_installed("my-package")
-        mock_run.assert_called_once_with(
-            ["uv", "pip", "show", "--python", sys.executable, "my_package"],
-            capture_output=True,
-            text=True,
-        )
-
-    @patch("verifiers.utils.install_utils.subprocess.run")
-    def test_exception_returns_false(self, mock_run):
-        mock_run.side_effect = Exception("subprocess error")
-        assert is_installed("gsm8k") is False
+        mock_version.assert_called_once_with("my_package")
 
 
 class TestCheckHubEnvInstalled:

--- a/verifiers/utils/install_utils.py
+++ b/verifiers/utils/install_utils.py
@@ -4,6 +4,7 @@ import importlib
 import logging
 import subprocess
 import sys
+from importlib.metadata import PackageNotFoundError, version as package_version
 from pathlib import Path
 from typing import Optional
 from urllib.parse import urlparse
@@ -66,26 +67,10 @@ def is_installed(env_name: str, version: Optional[str] = None) -> bool:
         True if installed (and version matches if specified)
     """
     try:
-        pkg_name = normalize_package_name(env_name)
-        result = subprocess.run(
-            _uv_pip_cmd("show", pkg_name),
-            capture_output=True,
-            text=True,
-        )
-
-        if result.returncode != 0:
-            return False
-
-        if version and version != "latest":
-            for line in result.stdout.splitlines():
-                if line.startswith("Version:"):
-                    installed_version = line.split(":", 1)[1].strip()
-                    return installed_version == version
-            return False
-
-        return True
-    except Exception:
+        installed_version = package_version(normalize_package_name(env_name))
+    except PackageNotFoundError:
         return False
+    return not version or version == "latest" or installed_version == version
 
 
 def check_hub_env_installed(env_id: str) -> bool:


### PR DESCRIPTION
## Overview

Use importlib.metadata.version and PackageNotFoundError to check installed environment packages instead of spawning uv and parsing command output.

## Scope

This is an implementation-only slim-down with no intended user-facing functionality change. The existing missing-package, latest-version, normalized-name, and exact-version behavior remains the same.