### PR TITLE
Simplify spawned-process parent monitoring

### DIFF
--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -141,9 +141,6 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
     log_file = str(output_path(config) / "eval.log")
     mpctx = mp.get_context("spawn")
     address_queue: mp.Queue = mpctx.Queue()
-    # Death pipe: serve_env self-terminates if this process dies abruptly — we keep
-    # parent_conn, whose close (even on our SIGKILL) signals the child's watch.
-    parent_conn, child_conn = mpctx.Pipe()
     proc = mpctx.Process(
         target=serve_env,
         kwargs=dict(
@@ -151,14 +148,12 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
             legacy=legacy,
             address="tcp://127.0.0.1:0",
             address_queue=address_queue,
-            death_pipe=child_conn,
             log_setup=partial(setup_logging, level, log_file),
             **server_kwargs,
         ),
         daemon=False,
     )
     proc.start()
-    child_conn.close()  # the child holds its end; we keep parent_conn so our exit closes it
     try:
         address = await asyncio.to_thread(address_queue.get, timeout=600)
         client = EnvClient(address=address)
@@ -273,5 +268,3 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
         proc.terminate()
         with contextlib.suppress(Exception):
             await asyncio.to_thread(proc.join, 10)
-        with contextlib.suppress(Exception):
-            parent_conn.close()

--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -15,7 +15,7 @@ worker.
 
 Scaling is elastic but upscale-only: a new worker is spawned when in-flight requests
 reach 90% of current capacity (`workers * multiplex`). Workers are spawned `spawn`-style
-(own env, own loop) and monitor a death pipe so an orphaned worker self-exits if the
+(own env, own loop) and monitor their parent so an orphaned worker self-exits if the
 broker dies. TODO: downscale idle workers, per-worker restart-on-death, stats/lag
 monitors (v0 had them; omitted here — rollout errors are returned as data, not crashes,
 so worker death is rare).
@@ -44,29 +44,29 @@ logger = logging.getLogger(__name__)
 _HEALTH = msgpack.packb(HealthResponse().model_dump(mode="json"), use_bin_type=True)
 
 
-def _arm_teardown(death_pipe=None) -> None:
+def _arm_teardown() -> None:
     """Arm a spawned process (serve_env broker/single server, or pool worker) for clean
     teardown: it inherits no signal handlers, so by default SIGTERM kills it abruptly, skipping
     asyncio.run()'s serving() cleanup and orphaning host tunnels (and sandboxes).
 
     - SIGTERM -> KeyboardInterrupt so the event loop runs its finallys (serve_env swallows it);
-    - with `death_pipe`, self-SIGTERM when the parent dies (pipe EOF, even on its SIGKILL) so no
-      child is orphaned (main -> serve_env and broker -> worker are both armed this way)."""
+    - when spawned, self-SIGTERM when the parent dies so no child is orphaned
+      (main -> serve_env and broker -> worker are both armed this way)."""
 
     def on_sigterm(*_) -> None:
         signal.signal(signal.SIGTERM, signal.SIG_IGN)
         raise KeyboardInterrupt
 
     signal.signal(signal.SIGTERM, on_sigterm)
-    if death_pipe is None:
+    parent = mp.parent_process()
+    if parent is None:
         return
 
-    def _watch() -> None:
-        with contextlib.suppress(Exception):
-            death_pipe.recv()
+    def watch_parent() -> None:
+        parent.join()
         os.kill(os.getpid(), signal.SIGTERM)
 
-    threading.Thread(target=_watch, daemon=True).start()
+    threading.Thread(target=watch_parent, daemon=True).start()
 
 
 class EnvServerPool:
@@ -115,13 +115,11 @@ class EnvServerPool:
     def _spawn_worker(self) -> None:
         i = len(self.workers)  # upscale-only, so the next index is the current count
         address = f"ipc://{self._worker_path(i)}"
-        parent_conn, child_conn = self._mpctx.Pipe()
         proc = self._mpctx.Process(
             target=serve_env,
             kwargs=dict(
                 max_workers=1,
                 address=address,
-                death_pipe=child_conn,
                 legacy=self.legacy,
                 log_setup=self.log_setup,
                 **self.server_kwargs,
@@ -129,7 +127,6 @@ class EnvServerPool:
             daemon=False,
         )
         proc.start()
-        child_conn.close()  # parent keeps the write end (its close signals death)
         dealer = self.ctx.socket(zmq.DEALER)
         dealer.setsockopt(zmq.LINGER, 0)
         dealer.connect(address)  # connect before bind is fine — ZMQ queues
@@ -137,7 +134,6 @@ class EnvServerPool:
             {
                 "process": proc,
                 "dealer": dealer,
-                "pipe": parent_conn,
                 "active": 0,
                 "index": i,
             }
@@ -243,8 +239,6 @@ class EnvServerPool:
     def _shutdown(self) -> None:
         for w in self.workers:
             with contextlib.suppress(Exception):
-                w["pipe"].close()
-            with contextlib.suppress(Exception):
                 w["process"].terminate()
         for w in self.workers:
             with contextlib.suppress(Exception):
@@ -274,7 +268,6 @@ def serve_env(
     legacy: bool = False,
     address: str = "tcp://127.0.0.1:5000",
     address_queue=None,
-    death_pipe=None,
     log_setup: Callable[[], None] | None = None,
     multiplex: int = 128,
     elastic: bool = True,
@@ -300,11 +293,11 @@ def serve_env(
     spawned worker — without it a spawned server inherits no handlers and its INFO logs
     (rollout start/done, the pool line) are silently dropped.
 
-    `death_pipe` (when spawned by a parent, e.g. the eval main process) makes this server
-    self-terminate if that parent dies abruptly — see `_arm_teardown`."""
+    When spawned by a parent, e.g. the eval main process, this server self-terminates if
+    that parent dies abruptly — see `_arm_teardown`."""
     # Graceful SIGTERM (run asyncio teardown) + self-terminate if the parent dies. The
     # re-raised KeyboardInterrupt is swallowed below for a clean exit (no spurious traceback).
-    _arm_teardown(death_pipe)
+    _arm_teardown()
     if log_setup is not None:
         log_setup()
     try:

--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -115,6 +115,9 @@ class EnvServerPool:
     def _spawn_worker(self) -> None:
         i = len(self.workers)  # upscale-only, so the next index is the current count
         address = f"ipc://{self._worker_path(i)}"
+        dealer = self.ctx.socket(zmq.DEALER)
+        dealer.setsockopt(zmq.LINGER, 0)
+        dealer.connect(address)  # connect before bind is fine — ZMQ queues
         proc = self._mpctx.Process(
             target=serve_env,
             kwargs=dict(
@@ -126,10 +129,6 @@ class EnvServerPool:
             ),
             daemon=False,
         )
-        proc.start()
-        dealer = self.ctx.socket(zmq.DEALER)
-        dealer.setsockopt(zmq.LINGER, 0)
-        dealer.connect(address)  # connect before bind is fine — ZMQ queues
         self.workers.append(
             {
                 "process": proc,
@@ -138,6 +137,7 @@ class EnvServerPool:
                 "index": i,
             }
         )
+        proc.start()
         if self._poller is not None:
             self._poller.register(dealer, zmq.POLLIN)
 
@@ -165,21 +165,21 @@ class EnvServerPool:
     async def run(self) -> None:
         self._poller = zmq.asyncio.Poller()
         self._poller.register(self.frontend, zmq.POLLIN)
-        # Elastic: start with one and scale up on demand. Otherwise pre-spawn the lot
-        # (`max_workers` is a concrete count when elastic is off).
-        for _ in range(1 if self.elastic else (self.max_workers or 1)):
-            self._spawn_worker()
-        # request_id -> {client_id, worker, rollout_slots}
-        pending: dict[bytes, dict] = {}
-        logger.info(
-            "EnvServerPool up: address=%s workers=%d/%s multiplex=%d elastic=%s",
-            self.address,
-            len(self.workers),
-            self._cap_str,
-            self.multiplex,
-            self.elastic,
-        )
         try:
+            # Elastic: start with one and scale up on demand. Otherwise pre-spawn the lot
+            # (`max_workers` is a concrete count when elastic is off).
+            for _ in range(1 if self.elastic else (self.max_workers or 1)):
+                self._spawn_worker()
+            # request_id -> {client_id, worker, rollout_slots}
+            pending: dict[bytes, dict] = {}
+            logger.info(
+                "EnvServerPool up: address=%s workers=%d/%s multiplex=%d elastic=%s",
+                self.address,
+                len(self.workers),
+                self._cap_str,
+                self.multiplex,
+                self.elastic,
+            )
             in_flight = 0
             while True:
                 events = dict(await self._poller.poll())


### PR DESCRIPTION
## Overview

Use multiprocessing.parent_process and its existing sentinel to monitor spawned server and worker parents, removing the custom death-pipe lifecycle.

## Scope

This is an implementation-only slim-down with no intended user-facing functionality change. Abrupt parent death still triggers the same SIGTERM cleanup path for both eval main to broker and broker to worker.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches spawned-process teardown and orphan detection for eval servers and elastic workers; behavior is intended to be unchanged but relies on parent-process sentinel semantics instead of pipe EOF.
> 
> **Overview**
> Replaces the custom **death-pipe** wiring between eval/spawned `serve_env` and pool workers with **`multiprocessing.parent_process()`** and a background thread that **`parent.join()`**s then **SIGTERM**s the child—same orphan-avoidance goal, less pipe lifecycle in callers.
> 
> The eval runner and **`serve_env`** no longer create, pass, or close **`death_pipe`**; **`_arm_teardown()`** takes no arguments. Pool **`_spawn_worker`** drops per-worker pipes from worker state and shutdown; worker spawn order is slightly adjusted (dealer socket + worker entry before **`proc.start()`**). **`EnvServerPool.run`** moves initial worker bootstrapping and the startup log inside the existing **`try`** so teardown still runs through **`finally`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 483c9e8b85d451e3e69323bf9cca2d0f9111f7ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace death-pipe parent monitoring with `multiprocessing.parent_process()` in spawned serve_env processes
> - [`_arm_teardown`](https://github.com/PrimeIntellect-ai/verifiers/pull/2185/files#diff-0c9c59578214be2580d340bc524321e352f48038207a68945637d00fc399600c) now spawns a watcher thread that joins the parent process via `multiprocessing.parent_process()` and sends SIGTERM to itself when the parent exits, eliminating the need for an explicit pipe.
> - The `death_pipe` parameter is removed from `serve_env` and `_spawn_worker`; no pipe is created, passed, or tracked anywhere in the spawn lifecycle.
> - Risk: any external caller passing `death_pipe` to `serve_env` will now raise a `TypeError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 483c9e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->