### PR TITLE
Simplify dynamic CLI model construction

### DIFF
--- a/verifiers/v1/cli/debug.py
+++ b/verifiers/v1/cli/debug.py
@@ -18,6 +18,7 @@ import verifiers.v1 as vf
 from verifiers.v1.cli.output import append_trace, save_config
 from verifiers.v1.cli.resolve import (
     extract_id,
+    narrow_taskset_config,
     plugin_errors,
     references_config_file,
     with_positional_taskset,
@@ -43,15 +44,7 @@ USAGE = (
 
 def _narrow(argv: list[str]) -> type[DebugConfig]:
     """`DebugConfig` with `taskset` narrowed to the config type of the id on the CLI."""
-    taskset_id = extract_id(argv, "taskset")
-    if not taskset_id:
-        return DebugConfig
-    ftype = vf.taskset_config_type(taskset_id)
-    return type(
-        DebugConfig.__name__,
-        (DebugConfig,),
-        {"__annotations__": {"taskset": ftype}, "taskset": ftype(id=taskset_id)},
-    )
+    return narrow_taskset_config(DebugConfig, extract_id(argv, "taskset"))
 
 
 def output_path(config: DebugConfig) -> Path:

--- a/verifiers/v1/cli/replay.py
+++ b/verifiers/v1/cli/replay.py
@@ -27,6 +27,7 @@ from verifiers.v1.cli.output import (
     save_config,
     write_config,
 )
+from verifiers.v1.cli.resolve import narrow_taskset_config
 from verifiers.v1.configs.agent import WireAgentConfig
 from verifiers.v1.configs.cli.replay import ReplayConfig
 from verifiers.v1.state import state_cls
@@ -49,14 +50,7 @@ def _narrow(config_path: Path) -> type[ReplayConfig]:
     data = tomllib.loads(config_path.read_text())
     taskset = data.get("taskset") or (data.get("env") or {}).get("taskset") or {}
     taskset_id = taskset.get("id")
-    if not taskset_id:
-        return ReplayConfig
-    ftype = vf.taskset_config_type(taskset_id)
-    return type(
-        "ReplayConfig",
-        (ReplayConfig,),
-        {"__annotations__": {"taskset": ftype}, "taskset": ftype(id=taskset_id)},
-    )
+    return narrow_taskset_config(ReplayConfig, taskset_id)
 
 
 def output_dir(config: ReplayConfig) -> Path:

--- a/verifiers/v1/cli/resolve.py
+++ b/verifiers/v1/cli/resolve.py
@@ -8,8 +8,13 @@ states explicitly is pre-narrowed — never to a type a config file could contra
 """
 
 import contextlib
+from typing import TypeVar
+
+from pydantic import BaseModel, create_model
 
 import verifiers.v1 as vf
+
+ConfigT = TypeVar("ConfigT", bound=BaseModel)
 
 
 @contextlib.contextmanager
@@ -68,7 +73,19 @@ def extract_id(argv: list[str], field: str, default: str = "") -> str:
     return found[0] if found else default
 
 
-def narrow_config(base: type, argv: list[str]) -> type:
+def narrow_taskset_config(base: type[ConfigT], taskset_id: str | None) -> type[ConfigT]:
+    """Narrow a CLI config's taskset field to the selected plugin config."""
+    if not taskset_id:
+        return base
+    taskset_type = vf.taskset_config_type(taskset_id)
+    return create_model(
+        base.__name__,
+        __base__=base,
+        taskset=(taskset_type, taskset_type(id=taskset_id)),
+    )
+
+
+def narrow_config(base: type[ConfigT], argv: list[str]) -> type[ConfigT]:
     """`base` with its `env` field narrowed to the config class of the env the CLI
     names (`--env.id`, else the taskset's own env, else the single-agent env),
     including its `taskset` sub-field. Ids a config file may set are left to the
@@ -81,18 +98,10 @@ def narrow_config(base: type, argv: list[str]) -> type:
     env_type = vf.env_config_type(taskset_id, env_id)
     if taskset_id:
         # Nested narrowing: `--env.taskset.<knob>` parses typed and renders in -h.
-        taskset_type = vf.taskset_config_type(taskset_id)
-        env_type = type(
-            env_type.__name__,
-            (env_type,),
-            {
-                "__annotations__": {"taskset": taskset_type},
-                "taskset": taskset_type(id=taskset_id),
-            },
-        )
+        env_type = narrow_taskset_config(env_type, taskset_id)
     default = env_type(id=env_id) if env_id else env_type()
-    return type(
+    return create_model(
         base.__name__,
-        (base,),
-        {"__annotations__": {"env": env_type}, "env": default},
+        __base__=base,
+        env=(env_type, default),
     )

--- a/verifiers/v1/cli/validate.py
+++ b/verifiers/v1/cli/validate.py
@@ -14,6 +14,7 @@ import verifiers.v1 as vf
 from verifiers.v1.cli.dashboard import TaskProgress, validate_dashboard
 from verifiers.v1.cli.resolve import (
     extract_id,
+    narrow_taskset_config,
     plugin_errors,
     references_config_file,
     with_positional_taskset,
@@ -41,15 +42,7 @@ def _narrow(argv: list[str]) -> type[ValidateConfig]:
     """`ValidateConfig` with `taskset` narrowed to the config type of the id on the CLI — so
     the single `cli()` parse stays typed and `-h` renders the taskset's fields. Absent an id
     (a `@ file.toml` may carry it) the base type is left for the validator to resolve."""
-    taskset_id = extract_id(argv, "taskset")
-    if not taskset_id:
-        return ValidateConfig
-    ftype = vf.taskset_config_type(taskset_id)
-    return type(
-        ValidateConfig.__name__,
-        (ValidateConfig,),
-        {"__annotations__": {"taskset": ftype}, "taskset": ftype(id=taskset_id)},
-    )
+    return narrow_taskset_config(ValidateConfig, extract_id(argv, "taskset"))
 
 
 ResultRow = dict[str, Any]


### PR DESCRIPTION
## Overview

Use Pydantic create_model for dynamic CLI configuration models and consolidate the repeated taskset-narrowing implementation shared by eval, debug, validate, and replay.

## Scope

This is an implementation-only slim-down with no intended user-facing functionality change. Typed taskset options, defaults, help output, and config parsing retain the same behavior through Pydantic supported dynamic-model API.