### PR TITLE
feat: composable taskset views

### DIFF
--- a/docs/v1/evaluation.md
+++ b/docs/v1/evaluation.md
@@ -37,7 +37,7 @@ The output from evaluations are written into `outputs/<env>--<model>--<harness>/
 - `sampling` — generation params passed to the model, e.g. `sampling.temperature`
 - `env.taskset.id` — pick the taskset (or the positional `eval <taskset-id>`)
 - `env.taskset.system_prompt` — file whose text overrides each task's
-  `TaskData.system_prompt` at select time (e.g. a GEPA `best_system_prompt.txt`)
+  `TaskData.system_prompt` on iteration (e.g. a GEPA `best_system_prompt.txt`)
 - `env.agent.harness.id` — pick the agent's harness (`[env.agent.harness]` in TOML)
 - `num_tasks` — how many tasks to evaluate. Not setting a value means all tasks; an
   infinite taskset (a procedural generator, e.g. `wordle-v1`) requires it
@@ -46,7 +46,7 @@ The output from evaluations are written into `outputs/<env>--<model>--<harness>/
 - `[serve]` — how the env is hosted under `--server`: `serve.pool` (worker pool), `serve.address`, and `serve.max_concurrent` (a per-worker episode bound; unset takes `max_concurrent`)
 - `[legacy]` — run a classic (v0) environment through the bridge instead of `[env]`: `legacy.id`, `legacy.args`
 - `verbose` — log at debug instead of info
-- `shuffle` — randomizes the order of tasks (fixed seed); a no-op on an infinite taskset
+- `shuffle` — samples the task order (fixed seed); an error on an infinite taskset
 
 ## Resuming evaluations
 

--- a/docs/v1/tasksets.md
+++ b/docs/v1/tasksets.md
@@ -114,7 +114,7 @@ These values can be overridden with `--env.taskset.num-tasks` and `--env.taskset
 
 ## Lazy and infinite tasksets
 
-`load()` may be a generator instead of returning a list: yield each task as it's built. Consumers materialize tasks through `Taskset.select`, which pulls only what a run needs — `eval -n 5` builds 5 tasks, not the whole set — so a generator pays off whenever building a task is expensive.
+`load()` may be a generator instead of returning a list: yield each task as it's built. Consumers iterate the taskset lazily (`Taskset.head` pulls only what a run needs — `eval -n 5` builds 5 tasks, not the whole set) — so a generator pays off whenever building a task is expensive.
 
 A procedural taskset can keep yielding forever. Declare `INFINITE = True` so consumers know the stream never ends — infinity is inherent to the taskset, not a config knob; how many tasks a run takes is the run's choice (`-n`), not the taskset's:
 
@@ -134,7 +134,7 @@ class AdditionTaskset(vf.Taskset[AdditionTask, vf.TasksetConfig]):
             )
 ```
 
-Two rules follow from infinity: a run over an infinite taskset must be bounded with `num_tasks` (`-n` on the CLI — omitting it is an error), and `shuffle` is a no-op (warned): there is no whole set to sample from, and the first `n` generated tasks are already an arbitrary sample. The generator runs once, client-side (the eval entrypoint or the prime-rl orchestrator pulls tasks off it and ships each task's data to the env server), so nothing needs to re-produce the same sequence across processes; keep `load()` deterministic only if you want `--resume` to regenerate the same first `n` tasks (see `alphabet_sort_v1`, `color_codeword_v1`, or the built-in `textarena` taskset).
+Two rules follow from infinity: a run over an infinite taskset must be bounded with `num_tasks` (`-n` on the CLI — omitting it is an error), and `shuffle` is an error: there is no whole set to sample from — bound the stream first (`taskset.head(n).shuffle()`). The generator runs once, client-side (the eval entrypoint or the prime-rl orchestrator pulls tasks off it and ships each task's data to the env server), so nothing needs to re-produce the same sequence across processes; keep `load()` deterministic only if you want `--resume` to regenerate the same first `n` tasks (see `alphabet_sort_v1`, `color_codeword_v1`, or the built-in `textarena` taskset).
 
 ## Adding Tools
 

--- a/tests/v1/test_color_codeword_tasks.py
+++ b/tests/v1/test_color_codeword_tasks.py
@@ -10,9 +10,7 @@ def test_color_images_are_rendered_once(monkeypatch) -> None:
         return render(image)
 
     monkeypatch.setattr(taskset, "image_data_url", counted)
-    tasks = taskset.ColorCodewordTaskset(taskset.ColorCodewordConfig()).select(
-        num_tasks=100
-    )
+    tasks = list(taskset.ColorCodewordTaskset(taskset.ColorCodewordConfig()).head(100))
 
     assert len(tasks) == 100
     assert calls == list(taskset.COLOR_RGB.values())

--- a/tests/v1/test_taskset.py
+++ b/tests/v1/test_taskset.py
@@ -55,6 +55,13 @@ def test_shuffle_samples_the_whole_taskset_reproducibly() -> None:
     assert first != [0, 1, 2, 3, 4]  # sampled from the whole set, not the head
 
 
+def test_shuffle_seed_changes_the_sample() -> None:
+    taskset = FiniteTaskset(vf.TasksetConfig())
+    seeded = idxs(taskset.shuffle(seed=7).head(5))
+    assert seeded == idxs(taskset.shuffle(seed=7).head(5))  # reproducible per seed
+    assert seeded != idxs(taskset.shuffle().head(5))  # differs from the default seed
+
+
 def test_shuffle_raises_on_infinite() -> None:
     with pytest.raises(ValueError, match="infinite"):
         InfiniteTaskset(vf.TasksetConfig()).shuffle()

--- a/tests/v1/test_taskset.py
+++ b/tests/v1/test_taskset.py
@@ -1,4 +1,5 @@
-"""`Taskset.select` over list, generator, and `INFINITE` `load` implementations."""
+"""`Taskset` iteration and the `head`/`shuffle` views over list, generator,
+and `INFINITE` `load` implementations."""
 
 import itertools
 
@@ -25,40 +26,47 @@ class FiniteTaskset(vf.Taskset[CountTask, vf.TasksetConfig]):
             yield CountTask(vf.TaskData(idx=i, prompt=f"task {i}"))
 
 
-def idxs(tasks: list[CountTask]) -> list[int]:
+def idxs(tasks) -> list[int]:
     return [task.data.idx for task in tasks]
 
 
-def test_select_bounds_an_infinite_taskset() -> None:
-    tasks = InfiniteTaskset(vf.TasksetConfig()).select(num_tasks=5)
+def test_head_bounds_an_infinite_taskset() -> None:
+    tasks = list(InfiniteTaskset(vf.TasksetConfig()).head(5))
     assert idxs(tasks) == [0, 1, 2, 3, 4]
 
 
-def test_select_infinite_requires_num_tasks() -> None:
-    with pytest.raises(ValueError, match="infinite"):
-        InfiniteTaskset(vf.TasksetConfig()).select()
-
-
-def test_select_infinite_ignores_shuffle() -> None:
-    tasks = InfiniteTaskset(vf.TasksetConfig()).select(num_tasks=3, shuffle=True)
-    assert idxs(tasks) == [0, 1, 2]
-
-
-def test_select_finite() -> None:
+def test_iteration_materializes_a_finite_taskset() -> None:
     taskset = FiniteTaskset(vf.TasksetConfig())
-    assert len(taskset.select()) == 10
-    assert idxs(taskset.select(num_tasks=4)) == [0, 1, 2, 3]
+    assert len(list(taskset)) == 10
+    assert idxs(taskset.head(4)) == [0, 1, 2, 3]
 
 
-def test_select_shuffle_samples_the_whole_taskset_reproducibly() -> None:
+def test_head_returns_the_same_taskset_type() -> None:
+    view = FiniteTaskset(vf.TasksetConfig()).head(4)
+    assert isinstance(view, FiniteTaskset)
+    assert view.task_type() is CountTask
+
+
+def test_shuffle_samples_the_whole_taskset_reproducibly() -> None:
     taskset = FiniteTaskset(vf.TasksetConfig())
-    first = idxs(taskset.select(num_tasks=5, shuffle=True))
-    assert first == idxs(taskset.select(num_tasks=5, shuffle=True))
+    first = idxs(taskset.shuffle().head(5))
+    assert first == idxs(taskset.shuffle().head(5))
     assert len(first) == 5 and set(first) <= set(range(10))
     assert first != [0, 1, 2, 3, 4]  # sampled from the whole set, not the head
 
 
-def test_select_only_builds_what_the_run_takes() -> None:
+def test_shuffle_raises_on_infinite() -> None:
+    with pytest.raises(ValueError, match="infinite"):
+        InfiniteTaskset(vf.TasksetConfig()).shuffle()
+
+
+def test_head_then_shuffle_bounds_an_infinite_taskset() -> None:
+    head = idxs(InfiniteTaskset(vf.TasksetConfig()).head(5).shuffle())
+    assert sorted(head) == [0, 1, 2, 3, 4]
+    assert head != [0, 1, 2, 3, 4]  # shuffled within the bounded head
+
+
+def test_head_only_builds_what_the_run_takes() -> None:
     built: list[int] = []
 
     class RecordingTaskset(InfiniteTaskset):
@@ -67,5 +75,12 @@ def test_select_only_builds_what_the_run_takes() -> None:
                 built.append(i)
                 yield CountTask(vf.TaskData(idx=i, prompt=f"task {i}"))
 
-    RecordingTaskset(vf.TasksetConfig()).select(num_tasks=3)
+    list(RecordingTaskset(vf.TasksetConfig()).head(3))
     assert built == [0, 1, 2]
+
+
+def test_views_do_not_mutate_the_base_taskset() -> None:
+    taskset = InfiniteTaskset(vf.TasksetConfig())
+    view = taskset.head(3)
+    assert view.INFINITE is False and taskset.INFINITE is True
+    assert idxs(taskset.head(2)) == [0, 1]  # base iterates untransformed

--- a/uv.lock
+++ b/uv.lock
@@ -21,9 +21,9 @@ exclude-newer-span = "P7D"
 prime-tunnel = false
 prime-sandboxes = false
 prime-pydantic-config = false
-ty = "2026-07-28T07:00:00Z"
+ty = "2026-07-28T00:00:00Z"
 renderers = false
-ruff = "2026-07-28T07:00:00Z"
+ruff = "2026-07-28T00:00:00Z"
 
 [[package]]
 name = "aiofile"

--- a/verifiers/v1/cli/debug.py
+++ b/verifiers/v1/cli/debug.py
@@ -263,7 +263,14 @@ async def debug_task(task: Task, config: DebugConfig) -> tuple[Trace, bool]:
 
 async def run_debug(config: DebugConfig) -> list[Trace]:
     taskset = vf.load_taskset(config.taskset)
-    tasks = taskset.select(config.num_tasks, config.shuffle)
+    if config.num_tasks is None and taskset.INFINITE:
+        raise ValueError(
+            f"{type(taskset).__name__} is infinite - bound the run with -n"
+        )
+    selected = taskset.shuffle() if config.shuffle else taskset
+    if config.num_tasks is not None:
+        selected = selected.head(config.num_tasks)
+    tasks = list(selected)
     if isinstance(config.runtime, vf.SubprocessConfig) and any(
         type(t).NEEDS_CONTAINER or t.data.image for t in tasks
     ):

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -26,7 +26,15 @@ logger = logging.getLogger(__name__)
 async def run_eval(env: Env, config: EvalConfig) -> list[Episode]:
     logger.info("eval config:\n%s", config.model_dump_json(indent=2))
     client = resolve_client(config.client)
-    tasks = env.taskset.select(config.num_tasks, config.shuffle)
+    taskset = env.taskset
+    if config.num_tasks is None and taskset.INFINITE:
+        raise ValueError(
+            f"{type(taskset).__name__} is infinite - bound the run with -n"
+        )
+    selected = taskset.shuffle() if config.shuffle else taskset
+    if config.num_tasks is not None:
+        selected = selected.head(config.num_tasks)
+    tasks = list(selected)
     ctx = ModelContext(client=client, model=config.model, sampling=config.sampling)
     semaphore = (
         asyncio.Semaphore(config.max_concurrent) if config.max_concurrent else None
@@ -132,9 +140,15 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
 
         # The client owns the taskset: load it here, once — the server (and its pool
         # workers) never load data, they rebuild each dispatched task from its request.
-        tasks = load_taskset(config.env.taskset).select(
-            config.num_tasks, config.shuffle
-        )
+        taskset = load_taskset(config.env.taskset)
+        if config.num_tasks is None and taskset.INFINITE:
+            raise ValueError(
+                f"{type(taskset).__name__} is infinite - bound the run with -n"
+            )
+        selected = taskset.shuffle() if config.shuffle else taskset
+        if config.num_tasks is not None:
+            selected = selected.head(config.num_tasks)
+        tasks = list(selected)
     # Spawned processes inherit no logging — hand them the main process's setup so
     # their rollout logs land in the output dir.
     level = "DEBUG" if config.verbose else "INFO"

--- a/verifiers/v1/cli/validate.py
+++ b/verifiers/v1/cli/validate.py
@@ -203,7 +203,14 @@ async def _validate_task(task: Task, config: ValidateConfig) -> ResultRow:
 
 async def run_validate(config: ValidateConfig) -> list[dict]:
     taskset = vf.load_taskset(config.taskset)
-    tasks = taskset.select(config.num_tasks, config.shuffle)
+    if config.num_tasks is None and taskset.INFINITE:
+        raise ValueError(
+            f"{type(taskset).__name__} is infinite - bound the run with -n"
+        )
+    selected = taskset.shuffle() if config.shuffle else taskset
+    if config.num_tasks is not None:
+        selected = selected.head(config.num_tasks)
+    tasks = list(selected)
     if isinstance(config.runtime, vf.SubprocessConfig) and any(
         type(t).NEEDS_CONTAINER or t.data.image for t in tasks
     ):

--- a/verifiers/v1/configs/taskset.py
+++ b/verifiers/v1/configs/taskset.py
@@ -17,8 +17,8 @@ class TasksetConfig(BaseConfig):
     task: SerializeAsAny[TaskConfig] = TaskConfig()
     """Config passed to each task, under `--env.taskset.task.*`."""
     system_prompt: Path | None = None
-    """File whose text overrides each task's `TaskData.system_prompt` in
-    `Taskset.select` (e.g. a GEPA `best_system_prompt.txt`)."""
+    """File whose text overrides each task's `TaskData.system_prompt` on
+    iteration (e.g. a GEPA `best_system_prompt.txt`)."""
 
     @property
     def name(self) -> str:

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -33,7 +33,7 @@ from verifiers.v1.retries import run_episode_with_retry
 from verifiers.v1.runtimes import SubprocessConfig, runtime_is_local
 from verifiers.v1.task import Task, resolve_server_config
 from verifiers.v1.trace import Error, Trace
-from verifiers.v1.utils.generic import generic_type
+from verifiers.v1.utils.generic import concrete_type
 from verifiers.v1.utils.memory import trim_memory_periodically
 
 logger = logging.getLogger(__name__)
@@ -83,7 +83,7 @@ class Env(ABC, Generic[ConfigT]):
     def __init__(self, config: ConfigT) -> None:
         from verifiers.v1.loaders import load_harness, load_taskset
 
-        config_cls = generic_type(type(self), EnvConfig, origin=Env) or EnvConfig
+        config_cls = concrete_type(type(self), EnvConfig, origin=Env) or EnvConfig
         if not isinstance(config, config_cls):
             raise TypeError(
                 f"{type(self).__name__} declares Env[{config_cls.__name__}], "

--- a/verifiers/v1/gepa/runner.py
+++ b/verifiers/v1/gepa/runner.py
@@ -37,8 +37,17 @@ class _GEPALog:
 
 def run_gepa(env: Env, config: GEPAConfig) -> GEPAResult:
     logger.info("gepa config:\n%s", config.model_dump_json(indent=2))
-    taskset = env.taskset.shuffle() if config.shuffle else env.taskset
-    all_tasks = list(taskset.head(config.num_train + config.num_val))
+    taskset = env.taskset
+    num_tasks = config.num_train + config.num_val
+    if taskset.INFINITE:
+        # An unbounded stream can't be sampled whole — bound it first, then
+        # shuffle within the head so the train/val split stays randomized.
+        selected = taskset.head(num_tasks)
+        selected = selected.shuffle() if config.shuffle else selected
+    else:
+        selected = taskset.shuffle() if config.shuffle else taskset
+        selected = selected.head(num_tasks)
+    all_tasks = list(selected)
     train_tasks, val_tasks = split_tasks(all_tasks, config.num_train, config.num_val)
     selected_tasks = [*train_tasks, *val_tasks]
     # Seed from the tasks GEPA actually evaluates (train ∪ val), not the full pre-split pool —

--- a/verifiers/v1/gepa/runner.py
+++ b/verifiers/v1/gepa/runner.py
@@ -37,17 +37,10 @@ class _GEPALog:
 
 def run_gepa(env: Env, config: GEPAConfig) -> GEPAResult:
     logger.info("gepa config:\n%s", config.model_dump_json(indent=2))
-    taskset = env.taskset
-    num_tasks = config.num_train + config.num_val
-    if taskset.INFINITE:
-        # An unbounded stream can't be sampled whole — bound it first, then
-        # shuffle within the head so the train/val split stays randomized.
-        selected = taskset.head(num_tasks)
-        selected = selected.shuffle() if config.shuffle else selected
-    else:
-        selected = taskset.shuffle() if config.shuffle else taskset
-        selected = selected.head(num_tasks)
-    all_tasks = list(selected)
+    # Global shuffle, like every entrypoint: an infinite taskset raises here —
+    # run it with shuffle=false (there is no whole set to sample from).
+    taskset = env.taskset.shuffle() if config.shuffle else env.taskset
+    all_tasks = list(taskset.head(config.num_train + config.num_val))
     train_tasks, val_tasks = split_tasks(all_tasks, config.num_train, config.num_val)
     selected_tasks = [*train_tasks, *val_tasks]
     # Seed from the tasks GEPA actually evaluates (train ∪ val), not the full pre-split pool —

--- a/verifiers/v1/gepa/runner.py
+++ b/verifiers/v1/gepa/runner.py
@@ -37,8 +37,8 @@ class _GEPALog:
 
 def run_gepa(env: Env, config: GEPAConfig) -> GEPAResult:
     logger.info("gepa config:\n%s", config.model_dump_json(indent=2))
-    # Global shuffle, like every entrypoint: an infinite taskset raises here —
-    # run it with shuffle=false (there is no whole set to sample from).
+    # Global shuffle: an infinite taskset raises here — run it with
+    # shuffle=false (there is no whole set to sample from).
     taskset = env.taskset.shuffle() if config.shuffle else env.taskset
     all_tasks = list(taskset.head(config.num_train + config.num_val))
     train_tasks, val_tasks = split_tasks(all_tasks, config.num_train, config.num_val)

--- a/verifiers/v1/gepa/runner.py
+++ b/verifiers/v1/gepa/runner.py
@@ -37,7 +37,8 @@ class _GEPALog:
 
 def run_gepa(env: Env, config: GEPAConfig) -> GEPAResult:
     logger.info("gepa config:\n%s", config.model_dump_json(indent=2))
-    all_tasks = env.taskset.select(config.num_train + config.num_val, config.shuffle)
+    taskset = env.taskset.shuffle() if config.shuffle else env.taskset
+    all_tasks = list(taskset.head(config.num_train + config.num_val))
     train_tasks, val_tasks = split_tasks(all_tasks, config.num_train, config.num_val)
     selected_tasks = [*train_tasks, *val_tasks]
     # Seed from the tasks GEPA actually evaluates (train ∪ val), not the full pre-split pool —

--- a/verifiers/v1/judge.py
+++ b/verifiers/v1/judge.py
@@ -63,7 +63,7 @@ from verifiers.v1.configs.judge import (
 from verifiers.v1.dialects.chat import message_to_wire
 from verifiers.v1.scoring import parse_judge_choice
 from verifiers.v1.types import Messages, StrictBaseModel, Usage
-from verifiers.v1.utils.generic import generic_type
+from verifiers.v1.utils.generic import concrete_type
 
 if TYPE_CHECKING:
     from verifiers.v1.task import TaskData
@@ -111,7 +111,7 @@ ConfigT = TypeVar("ConfigT", bound=JudgeConfig, default=JudgeConfig)
 
 def judge_config_cls(cls: type) -> type[JudgeConfig]:
     """Resolve a judge's config specialization through its MRO, else `JudgeConfig`."""
-    return generic_type(cls, JudgeConfig) or JudgeConfig
+    return concrete_type(cls, JudgeConfig) or JudgeConfig
 
 
 class Judge(Generic[ParsedT, ConfigT]):

--- a/verifiers/v1/loaders.py
+++ b/verifiers/v1/loaders.py
@@ -20,7 +20,7 @@ from verifiers.v1.harness import Harness
 from verifiers.v1.judge import Judge, judge_config_cls
 from verifiers.v1.task import Task
 from verifiers.v1.taskset import Taskset
-from verifiers.v1.utils.generic import generic_type, prefix_validation_error
+from verifiers.v1.utils.generic import concrete_type, prefix_validation_error
 from verifiers.v1.utils.install import ensure_installed
 
 
@@ -208,7 +208,7 @@ def load_judge(config: JudgeConfig) -> Judge:
 def taskset_config_type(taskset_id: str) -> type[TasksetConfig]:
     """Resolve the taskset's config specialization through its MRO."""
     return (
-        generic_type(taskset_class(taskset_id), TasksetConfig, origin=Taskset)
+        concrete_type(taskset_class(taskset_id), TasksetConfig, origin=Taskset)
         or TasksetConfig
     )
 
@@ -216,7 +216,7 @@ def taskset_config_type(taskset_id: str) -> type[TasksetConfig]:
 def harness_config_type(harness_id: str) -> type[HarnessConfig]:
     """Resolve the harness's config specialization through its MRO."""
     return (
-        generic_type(harness_class(harness_id), HarnessConfig, origin=Harness)
+        concrete_type(harness_class(harness_id), HarnessConfig, origin=Harness)
         or HarnessConfig
     )
 
@@ -231,7 +231,7 @@ def env_config_type(taskset_id: str, env_id: str = "") -> type[EnvConfig]:
     its MRO — `SingleAgentEnvConfig` for a plain taskset. The run's `env` field
     narrows to this, which is what gives `--env.<role>.model` addressing."""
     return (
-        generic_type(environment_class(taskset_id, env_id), EnvConfig, origin=Env)
+        concrete_type(environment_class(taskset_id, env_id), EnvConfig, origin=Env)
         or EnvConfig
     )
 

--- a/verifiers/v1/mcp/server.py
+++ b/verifiers/v1/mcp/server.py
@@ -13,7 +13,7 @@ from pydantic import TypeAdapter, ValidationError
 from pydantic_config import BaseConfig
 
 from verifiers.v1.state import State, StateT, state_cls
-from verifiers.v1.utils.generic import generic_type
+from verifiers.v1.utils.generic import concrete_type
 
 if TYPE_CHECKING:
     from httpx import AsyncClient, Response
@@ -286,7 +286,7 @@ class ServerBase(Generic[ConfigT, StateT]):
     @classmethod
     def _config_cls(cls) -> type[BaseConfig]:
         """Resolve the server's config specialization through its MRO."""
-        if config_cls := generic_type(cls, BaseConfig):
+        if config_cls := concrete_type(cls, BaseConfig):
             return config_cls
         raise TypeError(
             f"{cls.__name__} must parameterize its config, e.g. Toolset[MyConfig]"

--- a/verifiers/v1/state.py
+++ b/verifiers/v1/state.py
@@ -8,7 +8,7 @@ from pydantic import ConfigDict
 from typing_extensions import TypeVar
 
 from verifiers.v1.types import StrictBaseModel
-from verifiers.v1.utils.generic import generic_type
+from verifiers.v1.utils.generic import concrete_type
 
 
 class State(StrictBaseModel):
@@ -20,4 +20,4 @@ StateT = TypeVar("StateT", bound=State, default=State)
 
 def state_cls(cls: type) -> type[State]:
     """Resolve a class's `State` specialization through its MRO, else `State`."""
-    return generic_type(cls, State) or State
+    return concrete_type(cls, State) or State

--- a/verifiers/v1/task.py
+++ b/verifiers/v1/task.py
@@ -50,27 +50,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _requires_runtime(fn) -> bool:
-    param = inspect.signature(fn).parameters.get("runtime")
-    # A defaulted runtime parameter can still be called offline with None.
-    return param is not None and param.default is inspect.Parameter.empty
-
-
-def _record_result(
-    trace: Trace,
-    name: str,
-    result,
-    weight: float | None = None,
-) -> None:
-    """Record a scalar or keyed scoring result."""
-    values = list(result.items()) if isinstance(result, Mapping) else [(name, result)]
-    for key, value in values:
-        if weight is None:
-            trace.record_metric(key, value)
-        else:
-            trace.record_reward(key, value, weight)
-
-
 class TaskResources(StrictBaseModel):
     model_config = ConfigDict(frozen=True)
 
@@ -239,6 +218,11 @@ class Task(Generic[DataT, StateT, ConfigT]):
         trace: Trace,
         runtime: Runtime | None = None,
     ) -> None:
+        def requires_runtime(fn) -> bool:
+            param = inspect.signature(fn).parameters.get("runtime")
+            # A defaulted runtime parameter can still be called offline with None.
+            return param is not None and param.default is inspect.Parameter.empty
+
         judges = self.plugged_judges()
         available = {"task": self.data, "trace": trace}
         if runtime is not None:
@@ -249,36 +233,50 @@ class Task(Generic[DataT, StateT, ConfigT]):
             rewards = discover_decorated(self, "reward")
             if runtime is None:
                 skipped = [
-                    fn.__name__ for fn in (*metrics, *rewards) if _requires_runtime(fn)
+                    fn.__name__ for fn in (*metrics, *rewards) if requires_runtime(fn)
                 ] + [
                     judge.reward_name
                     for judge in judges
-                    if _requires_runtime(judge.score)
+                    if requires_runtime(judge.score)
                 ]
                 if skipped:
                     logger.info(
                         "score: no runtime — skipped runtime-dependent signals: %s",
                         skipped,
                     )
-                metrics = [fn for fn in metrics if not _requires_runtime(fn)]
-                rewards = [fn for fn in rewards if not _requires_runtime(fn)]
+                metrics = [fn for fn in metrics if not requires_runtime(fn)]
+                rewards = [fn for fn in rewards if not requires_runtime(fn)]
                 judges = [
-                    judge for judge in judges if not _requires_runtime(judge.score)
+                    judge for judge in judges if not requires_runtime(judge.score)
                 ]
 
             metric_results = await invoke_all(metrics, available)
             for fn, result in zip(metrics, metric_results):
-                _record_result(trace, fn.__name__, result)
+                if isinstance(result, Mapping):
+                    trace.record_metrics(result)
+                else:
+                    trace.record_metric(fn.__name__, result)
             reward_results = await invoke_all(rewards, available)
             for fn, result in zip(rewards, reward_results):
-                _record_result(
-                    trace, fn.__name__, result, getattr(fn, "_vf_weight", 1.0)
+                weight = getattr(fn, "_vf_weight", 1.0)
+                items = (
+                    result.items()
+                    if isinstance(result, Mapping)
+                    else [(fn.__name__, result)]
                 )
+                for key, value in items:
+                    trace.record_reward(key, value, weight)
             judge_results = await invoke_all(
                 [judge.score for judge in judges], available
             )
             for judge, result in zip(judges, judge_results):
-                _record_result(trace, judge.reward_name, result, judge.config.weight)
+                items = (
+                    result.items()
+                    if isinstance(result, Mapping)
+                    else [(judge.reward_name, result)]
+                )
+                for key, value in items:
+                    trace.record_reward(key, value, judge.config.weight)
 
 
 TaskT = TypeVar("TaskT", bound=Task)

--- a/verifiers/v1/task.py
+++ b/verifiers/v1/task.py
@@ -39,7 +39,7 @@ from verifiers.v1.decorators import discover_decorated, invoke_all
 from verifiers.v1.errors import TaskError, boundary
 from verifiers.v1.state import StateT
 from verifiers.v1.types import Messages, StrictBaseModel, content_text
-from verifiers.v1.utils.generic import generic_type
+from verifiers.v1.utils.generic import concrete_type
 
 if TYPE_CHECKING:
     from verifiers.v1.judge import Judge
@@ -128,12 +128,12 @@ ConfigT = TypeVar("ConfigT", bound=TaskConfig, default=TaskConfig)
 
 def task_data_cls(cls: type) -> type[TaskData]:
     """Resolve a task's `TaskData` specialization through its MRO, else `TaskData`."""
-    return generic_type(cls, TaskData) or TaskData
+    return concrete_type(cls, TaskData) or TaskData
 
 
 def task_config_cls(cls: type) -> type[TaskConfig]:
     """Resolve a task's `TaskConfig` specialization through its MRO, else `TaskConfig`."""
-    return generic_type(cls, TaskConfig) or TaskConfig
+    return concrete_type(cls, TaskConfig) or TaskConfig
 
 
 def resolve_server_config(

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import copy
 import itertools
+import random
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable, Iterator
 from typing import TYPE_CHECKING, ClassVar, Generic, Self
@@ -26,7 +27,7 @@ from typing_extensions import TypeVar
 from verifiers.v1.configs.taskset import TasksetConfig
 from verifiers.v1.task import Task, TaskT, resolve_server_config
 from verifiers.v1.utils.generic import concrete_type
-from verifiers.v1.utils.sampling import sample
+from verifiers.v1.utils.sampling import SEED
 
 if TYPE_CHECKING:
     from verifiers.v1.mcp import Toolset
@@ -50,10 +51,6 @@ class Taskset(ABC, Generic[TaskT, TasksetConfigT]):
         self.transform: Callable[[Iterator[TaskT]], Iterator[TaskT]] | None = None
         """Iteration transform carried by `head`/`shuffle` views (see `view`)."""
 
-    @classmethod
-    def task_type(cls) -> type[Task]:
-        return concrete_type(cls, Task, origin=Taskset) or Task
-
     @abstractmethod
     def load(self) -> Iterable[TaskT]:
         """Build and yield the taskset's tasks; may be a generator (see module doc)."""
@@ -70,8 +67,7 @@ class Taskset(ABC, Generic[TaskT, TasksetConfigT]):
 
     def view(self, transform: Callable[[Iterator[TaskT]], Iterator[TaskT]]) -> Self:
         """A shallow copy of this taskset iterating through `transform`, composed
-        onto any transform this taskset already carries — the general combinator
-        behind `head`/`shuffle`; use it for custom lazy filters/maps."""
+        onto any transform this taskset already carries."""
         clone = copy.copy(self)
         prev = self.transform
         clone.transform = (
@@ -85,15 +81,26 @@ class Taskset(ABC, Generic[TaskT, TasksetConfigT]):
         view.INFINITE = False
         return view
 
-    def shuffle(self) -> Self:
-        """A fixed-seed shuffled view (materializes the receiver on iteration);
-        raises on an infinite taskset — bound it first (`head(n).shuffle()`)."""
+    def shuffle(self, seed: int | None = None) -> Self:
+        """A shuffled view under `seed` — the shared fixed seed when None, so runs
+        sample reproducibly (materializes the receiver on iteration); raises on an
+        infinite taskset — bound it first (`head(n).shuffle()`)."""
         if self.INFINITE:
             raise ValueError(
                 f"{type(self).__name__} is infinite - cannot shuffle; "
                 "bound it first with head(num_tasks)"
             )
-        return self.view(lambda tasks: iter(sample(tasks, shuffle=True)))
+
+        def shuffled(tasks: Iterator[TaskT]) -> Iterator[TaskT]:
+            materialized = list(tasks)
+            random.Random(SEED if seed is None else seed).shuffle(materialized)
+            return iter(materialized)
+
+        return self.view(shuffled)
+
+    @classmethod
+    def task_type(cls) -> type[Task]:
+        return concrete_type(cls, Task, origin=Taskset) or Task
 
     def server_config(self, server_cls: type) -> BaseConfig:
         """The config a `tools` entry is built with, resolved off `self.config` (the

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -1,29 +1,24 @@
 """The taskset: a thin loader that yields typed tasks.
 
-A `Taskset` is the data half of an environment: config in, tasks out. `load()` — the
-one subclass hook — builds each row's `TaskData` and wraps it in the task type with
-the config's task-facing subtree:
+A `Taskset` is the data half of an environment: config in, tasks out. `load()` is
+the main hook that builds each task:
 
     def load(self) -> Iterable[MyTask]:
-        return [MyTask(MyData(idx=i, ...), self.config.task) for i in ...]
+        for i in ...:
+            yield MyTask(MyData(idx=i, ...), self.config.task)
 
-`load` may also be a generator, possibly infinite (declare `INFINITE = True`); runs
-materialize what they need through `select`, the env server pulls task by task.
-
-Load-time knobs live on the taskset config, task-facing knobs under its `task`
-subtree, shared tool servers on `tools`. All per-task behavior lives on the `Task`.
-
-The class stays generic (`Taskset[TaskT, TasksetConfigT]`) so the loaders can read
-the types: `taskset_config_type` narrows `--env.taskset.*` flags, `task_type` types
-the wire trace — one task type per taskset, so replay can rebuild saved rows.
+`load` may also be a generator for infinite tasksets. There is a one-to-one
+mapping between taskset and task type, i.e. a taskset may only yield one task
+type.
 """
 
 from __future__ import annotations
 
+import copy
 import itertools
-import logging
-from collections.abc import Iterable
-from typing import TYPE_CHECKING, ClassVar, Generic
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Iterable, Iterator
+from typing import TYPE_CHECKING, ClassVar, Generic, Self
 
 from pydantic_config import BaseConfig
 from typing_extensions import TypeVar
@@ -36,58 +31,69 @@ from verifiers.v1.utils.sampling import sample
 if TYPE_CHECKING:
     from verifiers.v1.mcp import Toolset
 
-logger = logging.getLogger(__name__)
-
-
 TasksetConfigT = TypeVar("TasksetConfigT", bound=TasksetConfig, default=TasksetConfig)
 
 
-class Taskset(Generic[TaskT, TasksetConfigT]):
-    INFINITE: ClassVar[bool] = False
-    """Whether `load` yields tasks forever. Inherent to the taskset, not a config
-    knob: runs bound themselves with `select(num_tasks)`, and shuffle is impossible."""
+class Taskset(ABC, Generic[TaskT, TasksetConfigT]):
+    INFINITE: bool = False
+    """Whether the taskset is infinite (yields tasks forever). Class-declared;
+    a `head(n)` view shadows it per instance (bounded by construction)."""
 
     tools: ClassVar[tuple[type[Toolset], ...]] = ()
-    """Tool server classes shared by one environment worker's rollouts."""
+    """Tool servers shared by all tasks in the taskset. The environment will
+    spawn a single, global instance, reused across tasks."""
 
     def __init__(self, config: TasksetConfigT) -> None:
         self.config = config
+        override = config.system_prompt
+        self.system_prompt = override.read_text() if override is not None else None
+        self.transform: Callable[[Iterator[TaskT]], Iterator[TaskT]] | None = None
+        """Iteration transform carried by `head`/`shuffle` views (see `view`)."""
 
     @classmethod
     def task_type(cls) -> type[Task]:
         return generic_type(cls, Task, origin=Taskset) or Task
 
+    @abstractmethod
     def load(self) -> Iterable[TaskT]:
-        raise NotImplementedError
+        """Build and yield the taskset's tasks; may be a generator (see module doc)."""
 
-    def select(
-        self, num_tasks: int | None = None, shuffle: bool = False
-    ) -> list[TaskT]:
-        """Materialize the first `num_tasks` off `load` (all when `None`), pulled
-        lazily. `shuffle` samples from the whole taskset instead (fixed-seed), which
-        materializes everything first; on an `INFINITE` taskset it's a warned no-op —
-        the first `num_tasks` generated are already an arbitrary sample."""
-        if type(self).INFINITE:
-            if num_tasks is None:
-                raise ValueError(
-                    f"{type(self).__name__} is infinite - select a bounded subset "
-                    "with num_tasks (-n on the CLI)"
-                )
-            if shuffle:
-                logger.warning(
-                    "shuffle is a no-op on an infinite taskset - "
-                    "taking the first %d generated tasks",
-                    num_tasks,
-                )
-            shuffle = False  # can't materialize the whole taskset to sample from
-        if shuffle:
-            tasks = sample(self.load(), shuffle=True, limit=num_tasks)
-        else:
-            tasks = list(itertools.islice(self.load(), num_tasks))
-        if self.config.system_prompt is not None:
-            override = self.config.system_prompt.read_text()
-            tasks = [t.with_system_prompt(override) for t in tasks]
-        return tasks
+    def __iter__(self) -> Iterator[TaskT]:
+        """Lazily iterate `load()` with the config-layer system prompt applied and
+        any view transform on top — the read path; `load` is the subclass hook."""
+        prompt = self.system_prompt
+        tasks = (
+            task.with_system_prompt(prompt) if prompt is not None else task
+            for task in self.load()
+        )
+        yield from self.transform(tasks) if self.transform is not None else tasks
+
+    def view(self, transform: Callable[[Iterator[TaskT]], Iterator[TaskT]]) -> Self:
+        """A shallow copy of this taskset iterating through `transform`, composed
+        onto any transform this taskset already carries — the general combinator
+        behind `head`/`shuffle`; use it for custom lazy filters/maps."""
+        clone = copy.copy(self)
+        prev = self.transform
+        clone.transform = (
+            transform if prev is None else lambda tasks: transform(prev(tasks))
+        )
+        return clone
+
+    def head(self, num_tasks: int) -> Self:
+        """A lazy, always-finite view of the first `num_tasks` tasks."""
+        view = self.view(lambda tasks: itertools.islice(tasks, num_tasks))
+        view.INFINITE = False
+        return view
+
+    def shuffle(self) -> Self:
+        """A fixed-seed shuffled view (materializes the receiver on iteration);
+        raises on an infinite taskset — bound it first (`head(n).shuffle()`)."""
+        if self.INFINITE:
+            raise ValueError(
+                f"{type(self).__name__} is infinite - cannot shuffle; "
+                "bound it first with head(num_tasks)"
+            )
+        return self.view(lambda tasks: iter(sample(tasks, shuffle=True)))
 
     def server_config(self, server_cls: type) -> BaseConfig:
         """The config a `tools` entry is built with, resolved off `self.config` (the

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -25,7 +25,7 @@ from typing_extensions import TypeVar
 
 from verifiers.v1.configs.taskset import TasksetConfig
 from verifiers.v1.task import Task, TaskT, resolve_server_config
-from verifiers.v1.utils.generic import generic_type
+from verifiers.v1.utils.generic import concrete_type
 from verifiers.v1.utils.sampling import sample
 
 if TYPE_CHECKING:
@@ -52,7 +52,7 @@ class Taskset(ABC, Generic[TaskT, TasksetConfigT]):
 
     @classmethod
     def task_type(cls) -> type[Task]:
-        return generic_type(cls, Task, origin=Taskset) or Task
+        return concrete_type(cls, Task, origin=Taskset) or Task
 
     @abstractmethod
     def load(self) -> Iterable[TaskT]:

--- a/verifiers/v1/utils/generic.py
+++ b/verifiers/v1/utils/generic.py
@@ -39,7 +39,7 @@ def deep_merge(base: dict, override: dict) -> dict:
     return merged
 
 
-def generic_type(
+def concrete_type(
     cls: type, bound: type[T], *, origin: type | None = None
 ) -> type[T] | None:
     """Find a concrete bounded type through `cls`'s MRO, most-derived first."""

--- a/verifiers/v1/utils/sampling.py
+++ b/verifiers/v1/utils/sampling.py
@@ -2,9 +2,9 @@
 
 Every entrypoint narrows its items the same way: with `--shuffle`, a shuffle under a fixed
 seed so the sampled subset is the *same* every run (reproducible), then an optional slice to
-the first `limit`. Taskset entrypoints (eval, validate, debug, GEPA) go through
-`Taskset.select`, which shares this shuffle; the server eval path and the legacy bridge
-sample plain index lists here directly.
+the first `limit`. Taskset entrypoints compose `Taskset.shuffle()`/`select()`, which share
+this shuffle; the server eval path and the legacy bridge sample plain index lists here
+directly.
 """
 
 import random

--- a/verifiers/v1/utils/sampling.py
+++ b/verifiers/v1/utils/sampling.py
@@ -1,10 +1,9 @@
 """Shared sampling: an optional fixed-seed shuffle, then an optional head-slice.
 
-Every entrypoint narrows its items the same way: with `--shuffle`, a shuffle under a fixed
-seed so the sampled subset is the *same* every run (reproducible), then an optional slice to
-the first `limit`. Taskset entrypoints compose `Taskset.shuffle()`/`select()`, which share
-this shuffle; the server eval path and the legacy bridge sample plain index lists here
-directly.
+With `--shuffle`, a shuffle under the fixed `SEED` so the sampled subset is the *same*
+every run (reproducible), then an optional slice to the first `limit`. Used by the paths
+that sample plain index lists (the server eval path and the legacy bridge); tasksets
+shuffle themselves (`Taskset.shuffle`, same default seed).
 """
 
 import random


### PR DESCRIPTION
## Summary
- `Taskset.__iter__` is the lazy read path: `load()` stays the single subclass hook, iteration applies the config-layer system prompt per task (read once at construction, public `taskset.system_prompt`).
- Composable views that return the **same taskset type** (`Self`) via a shallow copy carrying a public iteration `transform`:
  - `head(n)` — lazy first-`n` view, finite by construction (shadows `INFINITE` per instance),
  - `shuffle(seed=None)` — shuffled view, reproducible under the shared fixed seed by default, seedable per view; **hard error on an infinite taskset** (bound first: `infinite.head(100).shuffle()`). Shuffling is inlined on the taskset; the `sample` util now serves only the index-list paths (server eval, legacy bridge),
  - `view(transform)` — the general `Iterator → Iterator` combinator behind both, open for custom lazy filters/maps.
- Materialization is plain iteration: all tasks = `list(taskset)`, a sample = `list(taskset.shuffle().head(8))`. Call sites (eval runner, validate, debug, GEPA) compose accordingly; the `INFINITE`-without-`-n` guard lives at the CLI boundary.
- `Taskset` is an `ABC` with `load()` abstract, matching the other plugin bases (`Env`, `Harness`, `Client`).
- Inline the private scoring helpers into `Task.score` (`requires_runtime` nested, `_record_result` unrolled into direct `record_metric(s)`/`record_reward` calls; `Mapping` results stay supported).
- Rename `generic_type` → `concrete_type` (it resolves the concrete type argument bound to a generic base, not the generic).
- Sync `uv.lock` to the UTC `exclude-newer` cutoffs — main's lock kept the tz-local stamps, so every `uv run --locked` pre-commit hook fails off-timezone.

## Breaking
- `Taskset.select(num_tasks=None, shuffle=False) -> list` is gone. `head(n)` (required `n`, returns a lazy view) + `shuffle()` replace it; materialize with `list(...)` ("all tasks" is `list(taskset)`).
- `--shuffle` on an `INFINITE` taskset now errors (was: warn and take the head).
- `Taskset` is abstract — instantiating a taskset without `load()` fails at construction.
- `Taskset.INFINITE` is a plain class attribute (was `ClassVar`) so views can shadow it per instance.
- `generic_type` → `concrete_type` (internal util, all 10 call sites updated).

## Verification
- `uv run pytest tests/v1` green (taskset view tests rewritten: head-bounds-infinite, shuffle reproducibility, head-then-shuffle on infinite, laziness, base-not-mutated); ruff + ty hooks green.
- Live CLI e2e: `eval reverse_text_v1 -n 2 --shuffle` and `-n 1`, `validate -n 2 --shuffle` (same fixed-seed sample as eval — idxs 439/621), `debug --command`, `gepa -h`.
- `TZ=Europe/Berlin` / `TZ=America/Los_Angeles` `uv lock --check` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `Taskset.select` with composable lazy iteration via `head()` and `shuffle()` views
> - [`Taskset`](https://github.com/PrimeIntellect-ai/verifiers/pull/2190/files#diff-7e5e561017828ff64ab186fa98a8e394675de1971f358af769aa825f7c7997c9) now implements `__iter__` for lazy task yielding and exposes `head(n)` and `shuffle(seed)` as composable view methods instead of a single `select(num_tasks, shuffle)` call.
> - `shuffle()` now raises an error on infinite tasksets instead of silently doing nothing; callers must bound via `head(n)` first.
> - All CLI entry points (`run_eval`, `run_debug`, `run_validate`, `run_gepa`) are updated to use the new view pipeline: validate → optional `shuffle()` → optional `head(n)` → `list()`.
> - `generic_type` is renamed to `concrete_type` across loaders, env, judge, state, task, and MCP server modules.
> - Behavioral Change: unbounded infinite tasksets now raise an explicit error at runtime when `-n` is not provided; previously `shuffle` on infinite tasksets was a silent no-op.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #2190 opened
>
> - Refactored task selection and shuffling logic in `run_gepa` function [22c656f]
> - Reworded inline comment in `run_gepa` function regarding global shuffle behavior [5dcc7b1]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7b330fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API (`select` removal, shuffle-on-infinite behavior) affects all eval/GEPA entrypoints; task selection logic is central to every run but is covered by rewritten tests.
> 
> **Overview**
> **Replaces `Taskset.select()`** with lazy iteration and composable views: `__iter__` applies config `system_prompt` overrides; `head(n)` bounds lazily; `shuffle(seed)` samples reproducibly and **errors on infinite tasksets** (use `head(n).shuffle()`). Materialize with `list(...)`. `Taskset` is now an **ABC** with abstract `load()`.
> 
> **CLI paths** (eval, debug, validate, GEPA) compose `shuffle` → `head` → `list`, and **raise** when an infinite taskset has no `-n` (was implicit in `select`).
> 
> **Breaking behavior:** `--shuffle` on infinite tasksets is an error, not a warned no-op.
> 
> **Smaller changes:** `Task.score` inlines former `_record_result` / `_requires_runtime` helpers; **`generic_type` → `concrete_type`** across loaders and plugins; docs updated; `uv.lock` exclude-newer timestamps aligned to UTC.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dcc7b1ec06cf8adc73b254b1963b22cac622330. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
