### PR TITLE
fix: e2e tests sample at the provider default temperature

### DIFF
--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -135,9 +135,11 @@ def _eval_config(
     `{id: ...}` config; `runtime` places the `agent` seat's harness (an agent field, not a
     harness one); `model` overrides the default text model (e.g. a VLM for an image task).
 
-    `temperature=0` (greedy) makes the run reproducible; `max_tokens` is generous headroom,
-    not a target — these trivial tasks finish in a few hundred tokens, so capping tighter only
-    risks truncating the reasoning before the answer (which tanks the reward).
+    Temperature stays at the provider default: greedy decoding (`temperature=0`) made
+    flash-tier models repetition-loop to the token cap, flaking the tool-call tests.
+    `max_tokens` is generous headroom, not a target — these trivial tasks finish in a
+    few hundred tokens, so capping tighter only risks truncating the reasoning before
+    the answer (which tanks the reward).
 
     `harness=None` leaves every seat on its own story — the multi-agent case: there
     is no run-level harness, so a single-agent test's `harness` lands on the `agent`
@@ -175,7 +177,6 @@ def _eval_config(
         num_rollouts=n,
         sampling={
             "max_tokens": max_tokens,
-            "temperature": 0,
             "reasoning_effort": reasoning_effort,
         },
         rich=False,
@@ -219,8 +220,8 @@ def run_v1_server():
 
 @pytest.fixture
 async def live_ctx():
-    """A live `ModelContext` (the e2e default model + endpoint, greedy) for driving
-    `Agent` directly — the agent-surface counterpart of `run_v1`."""
+    """A live `ModelContext` (the e2e default model + endpoint, provider-default
+    sampling) for driving `Agent` directly — the agent-surface counterpart of `run_v1`."""
     from verifiers.v1.clients import EvalClientConfig, ModelContext, resolve_client
     from verifiers.v1.types import SamplingConfig
 
@@ -229,7 +230,7 @@ async def live_ctx():
         yield ModelContext(
             model="deepseek/deepseek-v4-flash",
             client=client,
-            sampling=SamplingConfig(max_tokens=2048, temperature=0),
+            sampling=SamplingConfig(max_tokens=2048),
         )
     finally:
         await client.close()
@@ -252,7 +253,7 @@ def run_v0():
             legacy={"id": env_id, "args": args or {}},
             num_tasks=1,
             num_rollouts=n,
-            sampling={"max_tokens": max_tokens, "temperature": 0},
+            sampling={"max_tokens": max_tokens},
             rich=False,
             output_dir=output_dir,
         )

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -135,12 +135,6 @@ def _eval_config(
     `{id: ...}` config; `runtime` places the `agent` seat's harness (an agent field, not a
     harness one); `model` overrides the default text model (e.g. a VLM for an image task).
 
-    Temperature stays at the provider default: greedy decoding (`temperature=0`) made
-    flash-tier models repetition-loop to the token cap, flaking the tool-call tests.
-    `max_tokens` is generous headroom, not a target — these trivial tasks finish in a
-    few hundred tokens, so capping tighter only risks truncating the reasoning before
-    the answer (which tanks the reward).
-
     `harness=None` leaves every seat on its own story — the multi-agent case: there
     is no run-level harness, so a single-agent test's `harness` lands on the `agent`
     seat and a multi-agent test pins its seats through `env` role fields instead."""

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -109,7 +109,7 @@ async def test_single_turn(run_v1, harness, harness_runtime, tmp_path):
     assert trace.stop_condition == "agent_completed"
     assert trace.reward == 1.0
     # The seat's resolved identity rides the trace (policy metadata for trainers).
-    assert trace.agent is not None and trace.agent.config.sampling.temperature == 0
+    assert trace.agent is not None and trace.agent.config.sampling.max_tokens == 2048
     # Every sampled turn has one per-call record, linked to its assistant node.
     sampled = [i for i, n in enumerate(trace.nodes) if n.sampled]
     assert [c.node for c in trace.calls if c.error is None] == sampled

--- a/uv.lock
+++ b/uv.lock
@@ -21,9 +21,9 @@ exclude-newer-span = "P7D"
 prime-tunnel = false
 prime-sandboxes = false
 prime-pydantic-config = false
-ty = "2026-07-28T07:00:00Z"
+ty = "2026-07-28T00:00:00Z"
 renderers = false
-ruff = "2026-07-28T07:00:00Z"
+ruff = "2026-07-28T00:00:00Z"
 
 [[package]]
 name = "aiofile"


### PR DESCRIPTION
## Summary
- Drop the `temperature=0` pin from the three e2e sampling configs in `tests/v1/conftest.py` (`_eval_config`, `live_ctx`, the legacy-bridge fixture) — e2e runs now sample at the provider default.
- Rationale: greedy decoding made `deepseek/deepseek-v4-flash` repetition-loop until the 2048-token cap (`finish_reason='length'`, no tool call, reward 0), flaking a **different** live-E2E leg on each of the last three CI runs on #2190 — and main's history shows the same single-job (`V1 live E2E`) failure pattern. The failing traces show clean API exchanges (`error=None`, full provider usage, no retries fired), i.e. pure generation degeneracy under greedy decoding, not an API fault.
- Also carries the 2-line `uv.lock` timestamp sync (same commit as on #2190; whichever lands first, the other rebases clean) — without it no commit passes the `--locked` hooks off-timezone.

- `test_single_turn` asserted the seat's recorded `sampling.temperature == 0`; it now asserts the still-pinned `max_tokens == 2048` (the check's point is that the resolved identity rides the trace, not which knob).

## Verification
- `tests/v1/test_e2e.py::test_tool[harness-in-subprocess-with-tool-colocated]` — the leg that flaked on the latest run — passes live at the provider default temperature, as does `test_single_turn[null-harness-in-subprocess]` (the assert that CI caught).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix e2e tests to sample at provider default temperature instead of greedy
> Removes explicit `temperature=0` from all e2e test fixtures and helpers in [conftest.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2191/files#diff-bc28790d38dc6e7e4f2c44639d40bc33dea724d6c73149abf7ba82b37d14f40b), so evaluations now rely on the provider's default sampling behavior. The assertion in [test_e2e.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2191/files#diff-ebbbd919487889487f891b359a756e6c4630e106b16ddaef8ccddc6b900a96e1) is updated to check `sampling.max_tokens == 2048` instead of `sampling.temperature == 0`. Behavioral Change: e2e test runs no longer use greedy decoding; outputs may vary between runs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d6d4cb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only sampling and assertion changes plus lockfile timestamp tweaks; no production eval or runtime behavior.
> 
> **Overview**
> **E2E sampling no longer forces greedy decoding.** The shared `_eval_config`, `live_ctx`, and legacy `run_v0` fixtures drop `temperature: 0` from eval sampling so live runs use the provider default. That avoids `deepseek/deepseek-v4-flash` repetition loops under greedy decoding that hit the 2048-token cap and flake CI.
> 
> `test_single_turn` now checks that the resolved seat identity on the trace still records **`max_tokens == 2048`** instead of asserting `temperature == 0`, since the test’s goal is trace metadata, not a specific temperature pin.
> 
> **Lockfile:** `uv.lock` `exclude-newer` timestamps for `ty` and `ruff` are adjusted by a few hours so `--locked` hooks pass off-timezone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d6d4cb00e5cb60ee876453579d805405532dbf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->