### PR TITLE
feat: explicit tool-server construction on Task and Taskset

### DIFF
--- a/docs/v1/tasksets.md
+++ b/docs/v1/tasksets.md
@@ -162,7 +162,7 @@ class SearchConfig(vf.TasksetConfig):
 
 class SearchTaskset(vf.Taskset[vf.Task, SearchConfig]):
     @classmethod
-    def tool_servers(cls, config: SearchConfig) -> list[vf.Toolset]:
+    def toolsets(cls, config: SearchConfig) -> list[vf.Toolset]:
         return [SearchToolset(config.tools)]
 ```
 

--- a/docs/v1/tasksets.md
+++ b/docs/v1/tasksets.md
@@ -161,7 +161,9 @@ class SearchConfig(vf.TasksetConfig):
 
 
 class SearchTaskset(vf.Taskset[vf.Task, SearchConfig]):
-    tools = (SearchToolset,)
+    @classmethod
+    def tool_servers(cls, config: SearchConfig) -> list[vf.Toolset]:
+        return [SearchToolset(config.tools)]
 ```
 
 Taskset tools are shared by a worker's rollouts. Tools can also be set per task.

--- a/environments/deepwiki_v1/deepwiki_v1/taskset.py
+++ b/environments/deepwiki_v1/deepwiki_v1/taskset.py
@@ -27,7 +27,7 @@ class DeepWikiTaskData(vf.TaskData):
 
 class DeepWikiTask(vf.Task[DeepWikiTaskData, vf.State, DeepWikiTaskConfig]):
     @classmethod
-    def tool_servers(cls, config: DeepWikiTaskConfig) -> list[vf.Toolset]:
+    def toolsets(cls, config: DeepWikiTaskConfig) -> list[vf.Toolset]:
         return [DeepWikiToolset(config.tools)]
 
     @vf.reward(weight=1.0)

--- a/environments/deepwiki_v1/deepwiki_v1/taskset.py
+++ b/environments/deepwiki_v1/deepwiki_v1/taskset.py
@@ -26,7 +26,9 @@ class DeepWikiTaskData(vf.TaskData):
 
 
 class DeepWikiTask(vf.Task[DeepWikiTaskData, vf.State, DeepWikiTaskConfig]):
-    tools = (DeepWikiToolset,)
+    @classmethod
+    def tool_servers(cls, config: DeepWikiTaskConfig) -> list[vf.Toolset]:
+        return [DeepWikiToolset(config.tools)]
 
     @vf.reward(weight=1.0)
     async def answered(self, trace: vf.Trace) -> float:

--- a/environments/glossary_v1/glossary_v1/taskset.py
+++ b/environments/glossary_v1/glossary_v1/taskset.py
@@ -20,7 +20,7 @@ class GlossaryTaskData(vf.TaskData):
 
 class GlossaryTask(vf.Task[GlossaryTaskData, vf.State, GlossaryTaskConfig]):
     @classmethod
-    def tool_servers(cls, config: GlossaryTaskConfig) -> list[vf.Toolset]:
+    def toolsets(cls, config: GlossaryTaskConfig) -> list[vf.Toolset]:
         return [GlossaryToolset(config.tools)]
 
     @vf.reward(weight=1.0)

--- a/environments/glossary_v1/glossary_v1/taskset.py
+++ b/environments/glossary_v1/glossary_v1/taskset.py
@@ -19,7 +19,9 @@ class GlossaryTaskData(vf.TaskData):
 
 
 class GlossaryTask(vf.Task[GlossaryTaskData, vf.State, GlossaryTaskConfig]):
-    tools = (GlossaryToolset,)
+    @classmethod
+    def tool_servers(cls, config: GlossaryTaskConfig) -> list[vf.Toolset]:
+        return [GlossaryToolset(config.tools)]
 
     @vf.reward(weight=1.0)
     async def looked_up(self, trace: vf.Trace) -> float:

--- a/environments/scratchpad_v1/scratchpad_v1/taskset.py
+++ b/environments/scratchpad_v1/scratchpad_v1/taskset.py
@@ -49,7 +49,7 @@ class ScratchpadConfig(vf.TasksetConfig):
 
 class ScratchpadTaskset(vf.Taskset[ScratchpadTask, ScratchpadConfig]):
     @classmethod
-    def tool_servers(cls, config: ScratchpadConfig) -> list[vf.Toolset]:
+    def toolsets(cls, config: ScratchpadConfig) -> list[vf.Toolset]:
         return [ScratchpadToolset(config.tools)]
 
     def load(self) -> list[ScratchpadTask]:

--- a/environments/scratchpad_v1/scratchpad_v1/taskset.py
+++ b/environments/scratchpad_v1/scratchpad_v1/taskset.py
@@ -48,7 +48,9 @@ class ScratchpadConfig(vf.TasksetConfig):
 
 
 class ScratchpadTaskset(vf.Taskset[ScratchpadTask, ScratchpadConfig]):
-    tools = (ScratchpadToolset,)
+    @classmethod
+    def tool_servers(cls, config: ScratchpadConfig) -> list[vf.Toolset]:
+        return [ScratchpadToolset(config.tools)]
 
     def load(self) -> list[ScratchpadTask]:
         return [

--- a/environments/wiki_search_v1/wiki_search_v1/taskset.py
+++ b/environments/wiki_search_v1/wiki_search_v1/taskset.py
@@ -45,7 +45,9 @@ class WikiSearchConfig(vf.TasksetConfig):
 
 
 class WikiSearchTaskset(vf.Taskset[TriviaTask, WikiSearchConfig]):
-    tools = (WikiSearchToolset,)
+    @classmethod
+    def tool_servers(cls, config: WikiSearchConfig) -> list[vf.Toolset]:
+        return [WikiSearchToolset(config.tools)]
 
     def load(self) -> list[TriviaTask]:
         from datasets import load_dataset

--- a/environments/wiki_search_v1/wiki_search_v1/taskset.py
+++ b/environments/wiki_search_v1/wiki_search_v1/taskset.py
@@ -46,7 +46,7 @@ class WikiSearchConfig(vf.TasksetConfig):
 
 class WikiSearchTaskset(vf.Taskset[TriviaTask, WikiSearchConfig]):
     @classmethod
-    def tool_servers(cls, config: WikiSearchConfig) -> list[vf.Toolset]:
+    def toolsets(cls, config: WikiSearchConfig) -> list[vf.Toolset]:
         return [WikiSearchToolset(config.tools)]
 
     def load(self) -> list[TriviaTask]:

--- a/skills/create-environments/SKILL.md
+++ b/skills/create-environments/SKILL.md
@@ -119,7 +119,7 @@ Only `TaskData` is stored on the trace. Do not put live clients, runtime handles
 - task-scoped tool declarations;
 - task-facing configuration read from `self.config`.
 
-`Taskset` owns loading and selection-time concerns. Its `load()` constructs the tasks, its direct config fields hold dataset/split/seed/sample-count knobs, and `Taskset.tool_servers` may construct task-agnostic servers shared by one environment worker's rollouts.
+`Taskset` owns loading and selection-time concerns. Its `load()` constructs the tasks, its direct config fields hold dataset/split/seed/sample-count knobs, and `Taskset.toolsets` may construct task-agnostic servers shared by one environment worker's rollouts.
 
 The harness owns:
 
@@ -169,9 +169,9 @@ class SearchTaskConfig(vf.TaskConfig):
 
 
 class SearchTask(vf.Task[vf.TaskData, vf.State, SearchTaskConfig]):
-    # Constructing on Task.tool_servers gives it one-server-per-rollout scope.
+    # Constructing on Task.toolsets gives it one-server-per-rollout scope.
     @classmethod
-    def tool_servers(cls, config: SearchTaskConfig) -> list[vf.Toolset]:
+    def toolsets(cls, config: SearchTaskConfig) -> list[vf.Toolset]:
         return [SearchToolset(config.tools)]
 
 
@@ -181,9 +181,9 @@ if __name__ == "__main__":
 
 Choose placement from the tool's lifetime and filesystem needs:
 
-- **Task-scoped, own runtime:** construct the server in `Task.tool_servers` with a `vf.ToolsetConfig` field. One server is launched per rollout. The default subprocess runtime is inexpensive and host-side.
+- **Task-scoped, own runtime:** construct the server in `Task.toolsets` with a `vf.ToolsetConfig` field. One server is launched per rollout. The default subprocess runtime is inexpensive and host-side.
 - **Task-scoped, colocated:** set `colocated = true` on its `ToolsetConfig` when the tool must see the harness's filesystem or processes. It still launches once per rollout.
-- **Taskset-scoped, shared:** parameterize the toolset with `vf.SharedToolsetConfig`, put the matching config field directly on `TasksetConfig`, and construct the server in `Taskset.tool_servers`.
+- **Taskset-scoped, shared:** parameterize the toolset with `vf.SharedToolsetConfig`, put the matching config field directly on `TasksetConfig`, and construct the server in `Taskset.toolsets`.
 - **Existing remote service:** set `url` on the matching toolset config. Verifiers connects to the streamable-HTTP MCP endpoint instead of launching the class locally.
 
 ## User simulation
@@ -234,7 +234,7 @@ Map concepts directly:
 | `load_environment(**kwargs)` | Exported `vf.Taskset` class + typed config |
 | `Rubric` reward function | Task `@vf.reward` method |
 | Parser object | Ordinary parsing inside task scoring |
-| `ToolEnv` tools | `vf.Toolset` constructed in `Task.tool_servers` or `Taskset.tool_servers` |
+| `ToolEnv` tools | `vf.Toolset` constructed in `Task.toolsets` or `Taskset.toolsets` |
 | `MultiTurnEnv.env_response` | an interaction loop in the env's `run()` |
 | Dict state | Typed `vf.State` |
 | Sandbox subclass | Runtime config + task hooks |

--- a/skills/create-environments/SKILL.md
+++ b/skills/create-environments/SKILL.md
@@ -119,7 +119,7 @@ Only `TaskData` is stored on the trace. Do not put live clients, runtime handles
 - task-scoped tool declarations;
 - task-facing configuration read from `self.config`.
 
-`Taskset` owns loading and selection-time concerns. Its `load()` constructs the tasks, its direct config fields hold dataset/split/seed/sample-count knobs, and `Taskset.tools` may declare task-agnostic servers shared by one environment worker's rollouts.
+`Taskset` owns loading and selection-time concerns. Its `load()` constructs the tasks, its direct config fields hold dataset/split/seed/sample-count knobs, and `Taskset.tool_servers` may construct task-agnostic servers shared by one environment worker's rollouts.
 
 The harness owns:
 
@@ -169,8 +169,10 @@ class SearchTaskConfig(vf.TaskConfig):
 
 
 class SearchTask(vf.Task[vf.TaskData, vf.State, SearchTaskConfig]):
-    # Declaring the class on Task.tools gives it one-server-per-rollout scope.
-    tools = (SearchToolset,)
+    # Constructing on Task.tool_servers gives it one-server-per-rollout scope.
+    @classmethod
+    def tool_servers(cls, config: SearchTaskConfig) -> list[vf.Toolset]:
+        return [SearchToolset(config.tools)]
 
 
 if __name__ == "__main__":
@@ -179,9 +181,9 @@ if __name__ == "__main__":
 
 Choose placement from the tool's lifetime and filesystem needs:
 
-- **Task-scoped, own runtime:** declare the class on `Task.tools` with `vf.ToolsetConfig`. One server is launched per rollout. The default subprocess runtime is inexpensive and host-side.
+- **Task-scoped, own runtime:** construct the server in `Task.tool_servers` with a `vf.ToolsetConfig` field. One server is launched per rollout. The default subprocess runtime is inexpensive and host-side.
 - **Task-scoped, colocated:** set `colocated = true` on its `ToolsetConfig` when the tool must see the harness's filesystem or processes. It still launches once per rollout.
-- **Taskset-scoped, shared:** parameterize the toolset with `vf.SharedToolsetConfig`, put the matching config field directly on `TasksetConfig`, and declare the class on `Taskset.tools`.
+- **Taskset-scoped, shared:** parameterize the toolset with `vf.SharedToolsetConfig`, put the matching config field directly on `TasksetConfig`, and construct the server in `Taskset.tool_servers`.
 - **Existing remote service:** set `url` on the matching toolset config. Verifiers connects to the streamable-HTTP MCP endpoint instead of launching the class locally.
 
 ## User simulation
@@ -232,7 +234,7 @@ Map concepts directly:
 | `load_environment(**kwargs)` | Exported `vf.Taskset` class + typed config |
 | `Rubric` reward function | Task `@vf.reward` method |
 | Parser object | Ordinary parsing inside task scoring |
-| `ToolEnv` tools | `vf.Toolset` declared on `Task.tools` or `Taskset.tools` |
+| `ToolEnv` tools | `vf.Toolset` constructed in `Task.tool_servers` or `Taskset.tool_servers` |
 | `MultiTurnEnv.env_response` | an interaction loop in the env's `run()` |
 | Dict state | Typed `vf.State` |
 | Sandbox subclass | Runtime config + task hooks |

--- a/tests/v1/fixtures/counter_tool_v1.py
+++ b/tests/v1/fixtures/counter_tool_v1.py
@@ -25,7 +25,7 @@ class CounterTaskConfig(vf.TaskConfig):
 
 class CounterTask(vf.Task[vf.TaskData, CounterState, CounterTaskConfig]):
     @classmethod
-    def tool_servers(cls, config: CounterTaskConfig) -> list[vf.Toolset]:
+    def toolsets(cls, config: CounterTaskConfig) -> list[vf.Toolset]:
         return [CounterToolset(config.tools)]
 
     @vf.reward(weight=1.0)

--- a/tests/v1/fixtures/counter_tool_v1.py
+++ b/tests/v1/fixtures/counter_tool_v1.py
@@ -24,7 +24,9 @@ class CounterTaskConfig(vf.TaskConfig):
 
 
 class CounterTask(vf.Task[vf.TaskData, CounterState, CounterTaskConfig]):
-    tools = (CounterToolset,)
+    @classmethod
+    def tool_servers(cls, config: CounterTaskConfig) -> list[vf.Toolset]:
+        return [CounterToolset(config.tools)]
 
     @vf.reward(weight=1.0)
     async def counted(self, trace: vf.Trace) -> float:

--- a/tests/v1/fixtures/echo_acp_resume_v1.py
+++ b/tests/v1/fixtures/echo_acp_resume_v1.py
@@ -29,7 +29,7 @@ class ACPResumeConfig(vf.TasksetConfig):
 
 class ACPResumeTask(vf.Task[vf.TaskData, vf.State, ACPResumeTaskConfig]):
     @classmethod
-    def tool_servers(cls, config: ACPResumeTaskConfig) -> list[vf.Toolset]:
+    def toolsets(cls, config: ACPResumeTaskConfig) -> list[vf.Toolset]:
         return [ResumeToolset(config.tools)]
 
     @vf.reward(weight=1.0)

--- a/tests/v1/fixtures/echo_acp_resume_v1.py
+++ b/tests/v1/fixtures/echo_acp_resume_v1.py
@@ -28,7 +28,9 @@ class ACPResumeConfig(vf.TasksetConfig):
 
 
 class ACPResumeTask(vf.Task[vf.TaskData, vf.State, ACPResumeTaskConfig]):
-    tools = (ResumeToolset,)
+    @classmethod
+    def tool_servers(cls, config: ACPResumeTaskConfig) -> list[vf.Toolset]:
+        return [ResumeToolset(config.tools)]
 
     @vf.reward(weight=1.0)
     async def resumed(self, trace: vf.Trace) -> float:

--- a/tests/v1/fixtures/echo_tool_v1.py
+++ b/tests/v1/fixtures/echo_tool_v1.py
@@ -29,7 +29,9 @@ class EchoToolTaskConfig(vf.TaskConfig):
 
 
 class EchoToolTask(vf.Task[vf.TaskData, vf.State, EchoToolTaskConfig]):
-    tools = (EchoToolset,)
+    @classmethod
+    def tool_servers(cls, config: EchoToolTaskConfig) -> list[vf.Toolset]:
+        return [EchoToolset(config.tools)]
 
     @vf.reward(weight=1.0)
     async def echoed(self, trace: vf.Trace) -> float:

--- a/tests/v1/fixtures/echo_tool_v1.py
+++ b/tests/v1/fixtures/echo_tool_v1.py
@@ -30,7 +30,7 @@ class EchoToolTaskConfig(vf.TaskConfig):
 
 class EchoToolTask(vf.Task[vf.TaskData, vf.State, EchoToolTaskConfig]):
     @classmethod
-    def tool_servers(cls, config: EchoToolTaskConfig) -> list[vf.Toolset]:
+    def toolsets(cls, config: EchoToolTaskConfig) -> list[vf.Toolset]:
         return [EchoToolset(config.tools)]
 
     @vf.reward(weight=1.0)

--- a/tests/v1/fixtures/tool_response_image_v1.py
+++ b/tests/v1/fixtures/tool_response_image_v1.py
@@ -47,7 +47,13 @@ class ToolResponseImageTask(
         return 0.0
 
 
-class ToolResponseImageTaskset(vf.Taskset[ToolResponseImageTask, vf.TasksetConfig]):
+class ToolResponseImageConfig(vf.TasksetConfig):
+    task: ToolResponseImageTaskConfig = ToolResponseImageTaskConfig()
+
+
+class ToolResponseImageTaskset(
+    vf.Taskset[ToolResponseImageTask, ToolResponseImageConfig]
+):
     def load(self) -> list[ToolResponseImageTask]:
         return [
             ToolResponseImageTask(

--- a/tests/v1/fixtures/tool_response_image_v1.py
+++ b/tests/v1/fixtures/tool_response_image_v1.py
@@ -34,7 +34,7 @@ class ToolResponseImageTask(
     vf.Task[vf.TaskData, vf.State, ToolResponseImageTaskConfig]
 ):
     @classmethod
-    def tool_servers(cls, config: ToolResponseImageTaskConfig) -> list[vf.Toolset]:
+    def toolsets(cls, config: ToolResponseImageTaskConfig) -> list[vf.Toolset]:
         return [VisionToolset(config.tools)]
 
     @vf.reward(weight=1.0)

--- a/tests/v1/fixtures/tool_response_image_v1.py
+++ b/tests/v1/fixtures/tool_response_image_v1.py
@@ -26,8 +26,16 @@ class VisionToolset(vf.Toolset[vf.ToolsetConfig]):
         ]
 
 
-class ToolResponseImageTask(vf.Task):
-    tools = (VisionToolset,)
+class ToolResponseImageTaskConfig(vf.TaskConfig):
+    tools: vf.ToolsetConfig = vf.ToolsetConfig()
+
+
+class ToolResponseImageTask(
+    vf.Task[vf.TaskData, vf.State, ToolResponseImageTaskConfig]
+):
+    @classmethod
+    def tool_servers(cls, config: ToolResponseImageTaskConfig) -> list[vf.Toolset]:
+        return [VisionToolset(config.tools)]
 
     @vf.reward(weight=1.0)
     async def preserved_image_tool_result(self, trace: vf.Trace) -> float:

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -335,7 +335,7 @@ class Agent:
         if self._server is None:
             return None
         if self._server.tunnel is not None or (
-            run_is_local and not shared_tools and not type(task).tools
+            run_is_local and not shared_tools and not task.tool_servers(task.config)
         ):
             return self._server
         return None
@@ -517,7 +517,11 @@ class Agent:
             )
             run_is_local = runtime_is_local(runtime_config)
         validate_pairing(
-            self.harness, type(task), runtime_config, shared_tools=shared_tools
+            self.harness,
+            type(task),
+            runtime_config,
+            task_tools=task.tool_servers(task.config),
+            shared_tools=shared_tools,
         )
         # Timeout precedence: agent-level wins, else the task's, else no limit.
         agent_timeout = (

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -335,7 +335,7 @@ class Agent:
         if self._server is None:
             return None
         if self._server.tunnel is not None or (
-            run_is_local and not shared_tools and not task.tool_servers(task.config)
+            run_is_local and not shared_tools and not task.toolsets(task.config)
         ):
             return self._server
         return None
@@ -520,7 +520,7 @@ class Agent:
             self.harness,
             type(task),
             runtime_config,
-            task_tools=task.tool_servers(task.config),
+            task_tools=task.toolsets(task.config),
             shared_tools=shared_tools,
         )
         # Timeout precedence: agent-level wins, else the task's, else no limit.

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -520,8 +520,7 @@ class Agent:
             self.harness,
             type(task),
             runtime_config,
-            task_tools=task.toolsets(task.config),
-            shared_tools=shared_tools,
+            tools=[*task.toolsets(task.config), *shared_tools.values()],
         )
         # Timeout precedence: agent-level wins, else the task's, else no limit.
         agent_timeout = (

--- a/verifiers/v1/cli/init.py
+++ b/verifiers/v1/cli/init.py
@@ -73,7 +73,7 @@ def _taskset_py(pkg: str, prefix: str, *, add_tool: bool) -> str:
         task_config_fields += "\n    tools: vf.ToolsetConfig = vf.ToolsetConfig()"
         task_decls += (
             "\n\n    @classmethod"
-            f"\n    def tool_servers(cls, config: {prefix}TaskConfig) -> list[vf.Toolset]:"
+            f"\n    def toolsets(cls, config: {prefix}TaskConfig) -> list[vf.Toolset]:"
             f"\n        return [{prefix}Toolset(config.tools)]"
             "\n"
         )
@@ -183,7 +183,7 @@ def _readme(dash: str, pkg: str, *, add_tool: bool, add_harness: bool) -> str:
     ]
     if add_tool:
         layout.append(
-            f"- `{pkg}/servers/tool.py` — a `vf.Toolset` tool server, constructed in `Task.tool_servers`."
+            f"- `{pkg}/servers/tool.py` — a `vf.Toolset` tool server, constructed in `Task.toolsets`."
         )
     if add_harness:
         layout.append(

--- a/verifiers/v1/cli/init.py
+++ b/verifiers/v1/cli/init.py
@@ -71,7 +71,12 @@ def _taskset_py(pkg: str, prefix: str, *, add_tool: bool) -> str:
     if add_tool:
         local_imports.append(f"from {pkg}.servers.tool import {prefix}Toolset")
         task_config_fields += "\n    tools: vf.ToolsetConfig = vf.ToolsetConfig()"
-        task_decls += f"\n    tools = ({prefix}Toolset,)"
+        task_decls += (
+            "\n\n    @classmethod"
+            f"\n    def tool_servers(cls, config: {prefix}TaskConfig) -> list[vf.Toolset]:"
+            f"\n        return [{prefix}Toolset(config.tools)]"
+            "\n"
+        )
     if local_imports:
         imports += "\n\n" + "\n".join(local_imports)
     methods_block = ""
@@ -178,7 +183,7 @@ def _readme(dash: str, pkg: str, *, add_tool: bool, add_harness: bool) -> str:
     ]
     if add_tool:
         layout.append(
-            f"- `{pkg}/servers/tool.py` — a `vf.Toolset` tool server, declared on `Task.tools`."
+            f"- `{pkg}/servers/tool.py` — a `vf.Toolset` tool server, constructed in `Task.tool_servers`."
         )
     if add_harness:
         layout.append(

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -31,7 +31,7 @@ from verifiers.v1.interception import (
 from verifiers.v1.mcp import SharedToolServer, serve_shared
 from verifiers.v1.retries import run_episode_with_retry
 from verifiers.v1.runtimes import SubprocessConfig, runtime_is_local
-from verifiers.v1.task import Task, resolve_server_config
+from verifiers.v1.task import Task
 from verifiers.v1.trace import Error, Trace
 from verifiers.v1.utils.generic import concrete_type
 from verifiers.v1.utils.memory import trim_memory_periodically
@@ -378,24 +378,17 @@ class Env(ABC, Generic[ConfigT]):
 
     def _requires_tunnel(self, shared: dict[str, SharedToolServer]) -> bool:
         """`requires_tunnel` over the consumers known before any rollout: role
-        runtimes, live `shared` servers, and the task class's tool servers;
-        a class overriding `server_config` conservatively counts as remote."""
+        runtimes, live `shared` servers, and the task class's tool servers
+        (their configs read off the declared `tools` fields, no task needed)."""
         task_cls = type(self.taskset).task_type()
-        server_classes = [*task_cls.tools]
-        if server_classes and task_cls.server_config is not Task.server_config:
-            return True
-        sole = len({*task_cls.tools}) == 1
         configs = [
-            resolve_server_config(
-                task_cls.__name__, self.taskset.config.task, server_cls, sole=sole
-            )
-            for server_cls in server_classes
+            server.config for server in task_cls.tool_servers(self.taskset.config.task)
         ]
         return requires_tunnel(self._runs_local(), configs, shared.values())
 
     @contextlib.asynccontextmanager
     async def shared_tools(self):
-        servers = self.taskset.tool_servers()
+        servers = self.taskset.tool_servers(self.taskset.config)
         if not servers:
             yield {}
             return

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -382,13 +382,13 @@ class Env(ABC, Generic[ConfigT]):
         (their configs read off the declared `tools` fields, no task needed)."""
         task_cls = type(self.taskset).task_type()
         configs = [
-            server.config for server in task_cls.tool_servers(self.taskset.config.task)
+            server.config for server in task_cls.toolsets(self.taskset.config.task)
         ]
         return requires_tunnel(self._runs_local(), configs, shared.values())
 
     @contextlib.asynccontextmanager
     async def shared_tools(self):
-        servers = self.taskset.tool_servers(self.taskset.config)
+        servers = self.taskset.toolsets(self.taskset.config)
         if not servers:
             yield {}
             return

--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -343,7 +343,7 @@ async def serve_shared(toolsets: list[Toolset], harness_is_local: bool = True):
             name = toolset.server_name
             if name in servers:
                 raise ToolsetError(
-                    f"duplicate shared tool server name '{name}' in Taskset.tools — "
+                    f"duplicate shared tool server name '{name}' in Taskset.tool_servers — "
                     f"give one a distinct TOOL_PREFIX"
                 )
             if type(toolset).setup_task is not ServerBase.setup_task:
@@ -351,7 +351,7 @@ async def serve_shared(toolsets: list[Toolset], harness_is_local: bool = True):
                     "shared server %r overrides `setup_task`, but `setup_task` is NEVER "
                     "called for a taskset-scoped server (it's built once, task-agnostic) — "
                     "its per-task logic will not run. Move task-agnostic work into `setup`, "
-                    "or declare it on `Task.tools` to run it per-rollout.",
+                    "or construct it in `Task.tool_servers` to run it per-rollout.",
                     name,
                 )
             if cfg.url:  # already running remotely; nothing launched, nothing to bridge

--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -343,7 +343,7 @@ async def serve_shared(toolsets: list[Toolset], harness_is_local: bool = True):
             name = toolset.server_name
             if name in servers:
                 raise ToolsetError(
-                    f"duplicate shared tool server name '{name}' in Taskset.tool_servers — "
+                    f"duplicate shared tool server name '{name}' in Taskset.toolsets — "
                     f"give one a distinct TOOL_PREFIX"
                 )
             if type(toolset).setup_task is not ServerBase.setup_task:
@@ -351,7 +351,7 @@ async def serve_shared(toolsets: list[Toolset], harness_is_local: bool = True):
                     "shared server %r overrides `setup_task`, but `setup_task` is NEVER "
                     "called for a taskset-scoped server (it's built once, task-agnostic) — "
                     "its per-task logic will not run. Move task-agnostic work into `setup`, "
-                    "or construct it in `Task.tool_servers` to run it per-rollout.",
+                    "or construct it in `Task.toolsets` to run it per-rollout.",
                     name,
                 )
             if cfg.url:  # already running remotely; nothing launched, nothing to bridge

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -258,7 +258,7 @@ class RolloutRun:
             ):
                 await self.harness.setup(runtime)
             async with boundary(ToolsetError, "building tool servers"):
-                tool_servers = self.task.tool_servers()
+                tool_servers = self.task.tool_servers(self.task.config)
             # `base_url` is the interception server's reachable URL for this rollout.
             # The harness reaches the model at `{base_url}/v1`; tool servers reach this
             # rollout's `/state` + `/task` at `base_url` — it's universally reachable

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -258,7 +258,7 @@ class RolloutRun:
             ):
                 await self.harness.setup(runtime)
             async with boundary(ToolsetError, "building tool servers"):
-                tool_servers = self.task.tool_servers(self.task.config)
+                toolsets = self.task.toolsets(self.task.config)
             # `base_url` is the interception server's reachable URL for this rollout.
             # The harness reaches the model at `{base_url}/v1`; tool servers reach this
             # rollout's `/state` + `/task` at `base_url` — it's universally reachable
@@ -268,7 +268,7 @@ class RolloutRun:
                     self._interception,
                     runtime,
                     self._session,
-                    tool_servers,
+                    toolsets,
                     self._shared_tools,
                 )
             )
@@ -276,7 +276,7 @@ class RolloutRun:
             self._secret = secret
             self._urls = await self._stack.enter_async_context(
                 serve_tools(
-                    tool_servers,
+                    toolsets,
                     runtime,
                     shared=self._shared_tools,
                     state_secret=secret,

--- a/verifiers/v1/task.py
+++ b/verifiers/v1/task.py
@@ -222,12 +222,12 @@ class Task(Generic[DataT, StateT, ConfigT]):
         return [load_judge(config) for config in self.config.judges]
 
     @classmethod
-    def tool_servers(cls, config: ConfigT) -> list[Toolset]:
+    def toolsets(cls, config: ConfigT) -> list[Toolset]:
         """Tool servers launched per rollout, each constructed with its config off
         `config` — override and wire explicitly:
 
             @classmethod
-            def tool_servers(cls, config: MyTaskConfig) -> list[vf.Toolset]:
+            def toolsets(cls, config: MyTaskConfig) -> list[vf.Toolset]:
                 return [SearchToolset(config.tools)]
 
         A classmethod so consumers can size placement (tunnels) off the class

--- a/verifiers/v1/task.py
+++ b/verifiers/v1/task.py
@@ -16,7 +16,6 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, ClassVar, Generic, Self
 
 from pydantic import BaseModel, ConfigDict, Field
-from pydantic_config import BaseConfig
 from typing_extensions import TypeVar
 
 from verifiers.v1.artifacts import Artifact
@@ -122,36 +121,9 @@ DataT = TypeVar("DataT", bound=TaskData)
 ConfigT = TypeVar("ConfigT", bound=TaskConfig, default=TaskConfig)
 
 
-def resolve_server_config(
-    owner: str, config: BaseConfig, server_cls: type, *, sole: bool = True
-) -> BaseConfig:
-    """The config a declared server class is built with, resolved off `config`'s
-    fields: exact type match, else — only for a `sole` declared server — the unique
-    isinstance match, else a default-constructed one. Two matching fields raise; the
-    `server_config` methods are the explicit-pairing override. The isinstance
-    fallback is `sole`-gated because with several servers a subclass-typed field
-    could silently pair with the wrong one."""
-    cfg_cls = server_cls._config_cls()
-    values = {name: getattr(config, name) for name in type(config).model_fields}
-    matched = [name for name, v in values.items() if type(v) is cfg_cls]
-    if not matched and sole:
-        matched = [name for name, v in values.items() if isinstance(v, cfg_cls)]
-    if len(matched) > 1:
-        raise TaskError(
-            f"{owner}: ambiguous config for {server_cls.__name__} — config fields "
-            f"{matched} all match {cfg_cls.__name__}; override `server_config` to pair "
-            f"them explicitly"
-        )
-    if matched:
-        return values[matched[0]]
-    return cfg_cls()
-
-
 class Task(Generic[DataT, StateT, ConfigT]):
     NEEDS_CONTAINER: ClassVar[bool] = False
     """Whether the task needs a containerized environment (isolated filesystem, ...)."""
-
-    tools: ClassVar[tuple[type[Toolset], ...]] = ()
 
     def __init__(self, data: DataT, config: ConfigT | None = None) -> None:
         self.data = data
@@ -249,16 +221,18 @@ class Task(Generic[DataT, StateT, ConfigT]):
 
         return [load_judge(config) for config in self.config.judges]
 
-    def server_config(self, server_cls: type) -> BaseConfig:
-        return resolve_server_config(
-            type(self).__name__,
-            self.config,
-            server_cls,
-            sole=len(set(type(self).tools)) == 1,
-        )
+    @classmethod
+    def tool_servers(cls, config: ConfigT) -> list[Toolset]:
+        """Tool servers launched per rollout, each constructed with its config off
+        `config` — override and wire explicitly:
 
-    def tool_servers(self) -> list[Toolset]:
-        return [cls(self.server_config(cls)) for cls in type(self).tools]
+            @classmethod
+            def tool_servers(cls, config: MyTaskConfig) -> list[vf.Toolset]:
+                return [SearchToolset(config.tools)]
+
+        A classmethod so consumers can size placement (tunnels) off the class
+        before any task instance exists."""
+        return []
 
 
 TaskT = TypeVar("TaskT", bound=Task)

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -98,13 +98,13 @@ class Taskset(ABC, Generic[TaskT, TasksetConfigT]):
         return concrete_type(cls, Task, origin=Taskset) or Task
 
     @classmethod
-    def tool_servers(cls, config: TasksetConfigT) -> list[Toolset]:
+    def toolsets(cls, config: TasksetConfigT) -> list[Toolset]:
         """Tool servers shared by all tasks in the taskset (one global instance
         per server, reused across an environment worker's rollouts), each
         constructed with its config off `config` — override and wire explicitly:
 
             @classmethod
-            def tool_servers(cls, config: MyConfig) -> list[vf.Toolset]:
+            def toolsets(cls, config: MyConfig) -> list[vf.Toolset]:
                 return [SearchToolset(config.tools)]
         """
         return []

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -19,13 +19,12 @@ import itertools
 import random
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable, Iterator
-from typing import TYPE_CHECKING, ClassVar, Generic, Self
+from typing import TYPE_CHECKING, Generic, Self
 
-from pydantic_config import BaseConfig
 from typing_extensions import TypeVar
 
 from verifiers.v1.configs.taskset import TasksetConfig
-from verifiers.v1.task import Task, TaskT, resolve_server_config
+from verifiers.v1.task import Task, TaskT
 from verifiers.v1.utils.generic import concrete_type
 from verifiers.v1.utils.sampling import SEED
 
@@ -39,10 +38,6 @@ class Taskset(ABC, Generic[TaskT, TasksetConfigT]):
     INFINITE: bool = False
     """Whether the taskset is infinite (yields tasks forever). Class-declared;
     a `head(n)` view shadows it per instance (bounded by construction)."""
-
-    tools: ClassVar[tuple[type[Toolset], ...]] = ()
-    """Tool servers shared by all tasks in the taskset. The environment will
-    spawn a single, global instance, reused across tasks."""
 
     def __init__(self, config: TasksetConfigT) -> None:
         self.config = config
@@ -102,13 +97,14 @@ class Taskset(ABC, Generic[TaskT, TasksetConfigT]):
     def task_type(cls) -> type[Task]:
         return concrete_type(cls, Task, origin=Taskset) or Task
 
-    def server_config(self, server_cls: type) -> BaseConfig:
-        return resolve_server_config(
-            type(self).__name__,
-            self.config,
-            server_cls,
-            sole=len(set(type(self).tools)) == 1,
-        )
+    @classmethod
+    def tool_servers(cls, config: TasksetConfigT) -> list[Toolset]:
+        """Tool servers shared by all tasks in the taskset (one global instance
+        per server, reused across an environment worker's rollouts), each
+        constructed with its config off `config` — override and wire explicitly:
 
-    def tool_servers(self) -> list[Toolset]:
-        return [cls(self.server_config(cls)) for cls in type(self).tools]
+            @classmethod
+            def tool_servers(cls, config: MyConfig) -> list[vf.Toolset]:
+                return [SearchToolset(config.tools)]
+        """
+        return []

--- a/verifiers/v1/utils/compile.py
+++ b/verifiers/v1/utils/compile.py
@@ -77,19 +77,19 @@ def validate_pairing(
     task_cls: type[Task],
     runtime_config: RuntimeConfig,
     *,
-    task_tools: Collection = (),
-    shared_tools: Collection = (),
+    tools: Collection = (),
 ) -> None:
     """Reject an impossible harness/task/runtime combination before any work happens.
-    A failure holds for every row the task class can carry. For `task_tools` and
-    `shared_tools` only emptiness matters — declarations and live servers alike mean
-    MCP is in play. (Hosting a user is interaction-scoped, not task-scoped —
-    `Agent.interaction` checks the harness can resume an exchange.)"""
-    if not harness.SUPPORTS_MCP and (task_tools or shared_tools):
+    A failure holds for every row the task class can carry. For `tools` only
+    emptiness matters — task-declared and shared servers alike mean MCP is in play.
+    (Hosting a user is interaction-scoped, not task-scoped — `Agent.interaction`
+    checks the harness can resume an exchange.)"""
+    if not harness.SUPPORTS_MCP and tools:
         raise ValueError(
-            f"Harness {harness.config.id!r} does not support MCP tools, but "
-            f"{task_cls.__name__} exposes tool servers (MCP). Run it with a harness that "
-            f"supports MCP (e.g. --env.agent.harness.id bash), or use tasks without tools."
+            f"Harness {harness.config.id!r} does not support MCP tools, but the run "
+            f"serves some ({task_cls.__name__}'s or the taskset's shared servers). Run "
+            f"it with a harness that supports MCP (e.g. --env.agent.harness.id bash), "
+            f"or use tasks without tools."
         )
     if not harness.SUPPORTS_SKILLS and harness.config.skills:
         raise ValueError(

--- a/verifiers/v1/utils/compile.py
+++ b/verifiers/v1/utils/compile.py
@@ -77,14 +77,15 @@ def validate_pairing(
     task_cls: type[Task],
     runtime_config: RuntimeConfig,
     *,
+    task_tools: Collection = (),
     shared_tools: Collection = (),
 ) -> None:
     """Reject an impossible harness/task/runtime combination before any work happens.
-    Every check reads class-level facts, so a failure holds for every row the task
-    class can carry. For `shared_tools` only emptiness matters — declarations and
-    live servers alike mean MCP is in play. (Hosting a user is interaction-scoped,
-    not task-scoped — `Agent.interaction` checks the harness can resume an exchange.)"""
-    if not harness.SUPPORTS_MCP and (task_cls.tools or shared_tools):
+    A failure holds for every row the task class can carry. For `task_tools` and
+    `shared_tools` only emptiness matters — declarations and live servers alike mean
+    MCP is in play. (Hosting a user is interaction-scoped, not task-scoped —
+    `Agent.interaction` checks the harness can resume an exchange.)"""
+    if not harness.SUPPORTS_MCP and (task_tools or shared_tools):
         raise ValueError(
             f"Harness {harness.config.id!r} does not support MCP tools, but "
             f"{task_cls.__name__} exposes tool servers (MCP). Run it with a harness that "


### PR DESCRIPTION
## Summary
- Replace the `tools` classvar + best-effort config pairing with one explicit hook on both `Task` and `Taskset`:

  ```python
  @classmethod
  def toolsets(cls, config: MyTaskConfig) -> list[vf.Toolset]:
      return [SearchToolset(config.tools)]
  ```

  Authors construct each server with exactly the config they choose — no field scanning, no `sole`/isinstance fallbacks, no "ambiguous config" errors.
- `config` is a **parameter, not instance state**, which is the load-bearing trick: `Env._requires_tunnel` can call `task_cls.toolsets(taskset.config.task)` at serving time — before any task instance exists (the served topology never holds task rows at boot) — and read real placements off the constructed instances. No conservative over-tunneling, no probe hacks; the "overridden `server_config` → assume tunnel" escape hatch dies with the scanner.
- Delete `resolve_server_config` and both `server_config` methods; `validate_pairing` now takes the constructed `task_tools` instead of reading a classvar.
- Migrate the 4 tool-using environments (glossary, deepwiki, wiki_search, scratchpad), 4 test fixtures, the `init -T` scaffold, and the docs/skill idiom. `tool_response_image_v1` gains an explicit task config (it relied on the deleted default-construct fallback).

## Breaking
- `Task.tools` / `Taskset.tools` classvars are gone — declare servers by overriding `toolsets(cls, config)` (classmethod) and constructing them explicitly.
- `toolsets()` is now a classmethod taking the config: `task.toolsets(task.config)` / `taskset.toolsets(taskset.config)`.
- `resolve_server_config` and `Task.server_config` / `Taskset.server_config` removed (explicit construction replaces pairing).
- `validate_pairing` takes a single combined `tools=` collection (task-declared + shared servers; only emptiness matters).

## Verification
- `uv run pytest tests/v1` green; ruff + ty green.
- Live 1-rollout evals of all three tool scopes, each reward 1.0: `glossary_v1` (task-scoped, per-rollout server), `scratchpad_v1` (taskset-scoped shared server), `deepwiki_v1` (external `url` server).
- `init -T` scaffold generates the new idiom and parses clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace class-level `tools` tuple with explicit `toolsets(cls, config)` classmethod on `Task` and `Taskset`
> - Removes the `tools` class attribute and `tool_servers()`/`server_config()` methods from `Task` and `Taskset` base classes in favor of a `toolsets(cls, config) -> list[Toolset]` classmethod that subclasses override to construct tool servers from config.
> - All environment tasksets, test fixtures, and the CLI scaffold generator are updated to use the new API.
> - `Env`, `RolloutRun`, and `Agent` now call `task.toolsets(task.config)` / `taskset.toolsets(config)` instead of reading class-declared tuples or calling `tool_servers()`.
> - `validate_pairing` consolidates its `shared_tools` and task-class tool parameters into a single `tools` collection of instantiated toolsets.
> - Behavioral Change: tool server instantiation now always receives a config object; subclasses that previously relied on the implicit `tools = (...)` tuple must implement `toolsets(cls, config)` explicitly.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #2199 opened
>
> - Introduced dedicated configuration type for tool response image taskset [6fab3ce]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 12632da.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for any external taskset still declaring `tools` tuples; core rollout/MCP/tunnel paths are touched but migrated in-repo and behavior is intended to be equivalent with explicit wiring.
> 
> **Overview**
> **Breaking API change:** `Task.tools` / `Taskset.tools` class attributes, `tool_servers()`, `server_config()`, and `resolve_server_config` are removed. Subclasses override **`toolsets(cls, config) -> list[Toolset]`** and construct each server with an explicit config (e.g. `[SearchToolset(config.tools)]`).
> 
> Because **`toolsets` is a classmethod**, the framework can call `task_cls.toolsets(taskset.config.task)` at env boot (tunnel sizing in `Env._requires_tunnel`) without instantiating a task row. Rollout, agent pairing, and shared-tool serving now use **`task.toolsets(task.config)`** / **`taskset.toolsets(taskset.config)`**; **`validate_pairing`** takes one combined **`tools=`** collection of instantiated toolsets.
> 
> All tool-using environments, v1 test fixtures, **`init -T`** scaffolding, and docs/skills are migrated; **`tool_response_image_v1`** gains an explicit task config where the old default-construct fallback applied.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fab3cea117c4470bc598804e1f2a347db3cf4c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->