### PR TITLE
docs: drop prose describing the removed toolset config discovery

### DIFF
--- a/environments/scratchpad_v1/scratchpad_v1/servers/scratchpad.py
+++ b/environments/scratchpad_v1/scratchpad_v1/servers/scratchpad.py
@@ -1,6 +1,6 @@
 """A SHARED, writable tool server that exercises per-rollout state isolation.
 
-It is built once per environment worker (taskset-scoped, `Taskset.tools`) but written to by every rollout: `roundtrip`
+It is built once per environment worker (taskset-scoped, `Taskset.toolsets`) but written to by every rollout: `roundtrip`
 stores a word and reads it back. Each rollout's write lands in its own `self.state` — the per-rollout
 shared-state channel the framework tags onto a shared server's URL — so concurrent rollouts never see
 each other's word even though they share one process. `roundtrip` sleeps between the write and the

--- a/environments/wiki_search_v1/wiki_search_v1/taskset.py
+++ b/environments/wiki_search_v1/wiki_search_v1/taskset.py
@@ -1,7 +1,7 @@
 """Answer trivia with a worker-shared wiki corpus and a reference judge.
 
 The tool server builds an expensive corpus/index in its process-level `setup`, so
-`Taskset.tools` launches one instance per environment worker instead of rebuilding it
+`Taskset.toolsets` launches one instance per environment worker instead of rebuilding it
 per rollout. The tools are read-only; grading comes from the plugged wiki-search judge
 (class-level prompt; reject incoherent answers).
 """

--- a/skills/create-environments/SKILL.md
+++ b/skills/create-environments/SKILL.md
@@ -183,8 +183,8 @@ Choose placement from the tool's lifetime and filesystem needs:
 
 - **Task-scoped, own runtime:** construct the server in `Task.toolsets` with a `vf.ToolsetConfig` field. One server is launched per rollout. The default subprocess runtime is inexpensive and host-side.
 - **Task-scoped, colocated:** set `colocated = true` on its `ToolsetConfig` when the tool must see the harness's filesystem or processes. It still launches once per rollout.
-- **Taskset-scoped, shared:** parameterize the toolset with `vf.SharedToolsetConfig`, put the matching config field directly on `TasksetConfig`, and construct the server in `Taskset.toolsets`.
-- **Existing remote service:** set `url` on the matching toolset config. Verifiers connects to the streamable-HTTP MCP endpoint instead of launching the class locally.
+- **Taskset-scoped, shared:** parameterize the toolset with `vf.SharedToolsetConfig`, put its config field directly on `TasksetConfig`, and construct the server in `Taskset.toolsets`.
+- **Existing remote service:** set `url` on the toolset's config. Verifiers connects to the streamable-HTTP MCP endpoint instead of launching the class locally.
 
 ## User simulation
 

--- a/skills/evaluate-environments/references/REFERENCE.md
+++ b/skills/evaluate-environments/references/REFERENCE.md
@@ -235,7 +235,7 @@ Elastic pool: start at one worker and scale up on demand.
 
 `.name` → the package name (id with org / version stripped).
 
-A taskset implements `load()` and declares exactly one task type through its generic base. It may also declare task-agnostic tool classes on `Taskset.tools`; those servers are shared by the rollouts handled by one environment worker.
+A taskset implements `load()` and declares exactly one task type through its generic base. It may also construct task-agnostic tool servers in `Taskset.toolsets`; those servers are shared by the rollouts handled by one environment worker.
 
 ### Task config
 
@@ -460,11 +460,11 @@ Per-row wall-clock timeout requests, in seconds, one for each rollout stage. For
 
 ## Toolset config
 
-`verifiers/v1/mcp/toolset.py`. Tool scope is structural: a class declared on `Task.tools` is task-scoped, while a class declared on `Taskset.tools` is shared by one environment worker. The framework finds the matching config field by the toolset's generic config type. Subclass either config to add knobs consumed by the tool's `@vf.tool` methods.
+`verifiers/v1/mcp/toolset.py`. Tool scope follows the classmethod that constructs the server: `Task.toolsets(config)` is task-scoped, `Taskset.toolsets(config)` is shared by one environment worker. Each returns `Toolset` instances the author constructs with the config field they read (`return [SearchToolset(config.tools)]`), so server and config are paired explicitly. Subclass either config to add knobs consumed by the tool's `@vf.tool` methods. Constructing a `Toolset` starts nothing — the instances describe what to serve, and are built for validation and tunnel sizing before any task exists, so keep `toolsets()` cheap and side-effect-free; expensive work belongs in `setup()` or `setup_task()`.
 
-### `ToolsetConfig` — `Task.tools`
+### `ToolsetConfig` — `Task.toolsets`
 
-A task-scoped server is launched per rollout. Its matching config field normally lives on `TaskConfig`, under `--env.taskset.task.*`.
+A task-scoped server is launched per rollout. Its config field normally lives on `TaskConfig`, under `--env.taskset.task.*`.
 
 The default placement is the toolset's own subprocess runtime on the host, where verifiers and the taskset package are already installed. The harness reaches that server over the host network when local or through a tunnel when remote. `colocated` instead runs the server inside the harness runtime; this is useful when both must see the same filesystem or processes, but a remote sandbox must then upload and install verifiers plus the taskset package for every rollout.
 
@@ -474,9 +474,9 @@ The default placement is the toolset's own subprocess runtime on the host, where
 | `runtime` | `RuntimeConfig` | `SubprocessConfig()` | The server's own runtime when not colocated. Select Docker/Prime/Modal to isolate it from the host. See [Runtime configs](#runtime-configs). |
 | `url` | `str \| None` | `None` | Existing streamable-HTTP MCP endpoint. When set, verifiers connects to it instead of launching the class, so placement fields do not take effect. |
 
-### `SharedToolsetConfig` — `Taskset.tools`
+### `SharedToolsetConfig` — `Taskset.toolsets`
 
-A taskset-scoped tool uses one framework-launched server per environment worker, or reuses a configured external `url` without launching a server. Its matching config field lives directly on the taskset config, not under `task`.
+A taskset-scoped tool uses one framework-launched server per environment worker, or reuses a configured external `url` without launching a server. Its config field lives directly on the taskset config, not under `task`.
 
 The framework-launched form is intended for expensive task-agnostic setup such as loading a corpus, index, or graph: `setup()` runs once per worker and `setup_task()` is not called because no single row owns the server. A vf-native shared tool may still use mutable `self.state`; the framework attaches each calling rollout's state channel to the shared URL so those values remain per rollout. There is no `colocated` option because a shared server has no single harness runtime.
 
@@ -485,7 +485,7 @@ The framework-launched form is intended for expensive task-agnostic setup such a
 | `runtime` | `RuntimeConfig` | `SubprocessConfig()` | The framework-launched server's own runtime. Host subprocess is cheapest; a remote runtime pays setup once per worker. See [Runtime configs](#runtime-configs). |
 | `url` | `str \| None` | `None` | Existing streamable-HTTP MCP endpoint reused across workers and rollouts instead of launching a server. |
 
-There is no `shared` boolean on `ToolsetConfig`: declare the class on `Task.tools` or `Taskset.tools` and use the matching config type to choose its scope.
+There is no `shared` boolean on `ToolsetConfig`: construct the server in `Task.toolsets` or `Taskset.toolsets` to choose its scope, and give it the config type that scope accepts.
 
 ---
 

--- a/tests/v1/fixtures/echo_tool_v1.py
+++ b/tests/v1/fixtures/echo_tool_v1.py
@@ -1,12 +1,13 @@
 """echo (v1, MCP tool): retrieve a stamped echo from a `vf.Toolset`, then report it.
 
-The v1 tool fixture for the e2e matrix. The task declares an `EchoToolset` (`vf.Toolset`)
-with one `@vf.tool` method whose placement is CLI-tunable (`--taskset.task.tools.colocated`,
-`--taskset.task.tools.runtime.type`): it runs colocated in the harness's runtime or in its
-own runtime, and the harness must reach it wherever it lives. The tool stamps its output
-with a token the prompt never reveals, so the reward is 1.0 only if the model actually
-called the tool — trivial when the infra works, impossible when it doesn't. The tool is
-task-agnostic, so it would also serve taskset-scoped (`Taskset.tools`).
+The v1 tool fixture for the e2e matrix. The task constructs an `EchoToolset`
+(`vf.Toolset`) in `Task.toolsets`, with one `@vf.tool` method whose placement is
+CLI-tunable (`--taskset.task.tools.colocated`, `--taskset.task.tools.runtime.type`):
+it runs colocated in the harness's runtime or in its own runtime, and the harness
+must reach it wherever it lives. The tool stamps its output with a token the prompt
+never reveals, so the reward is 1.0 only if the model actually called the tool —
+trivial when the infra works, impossible when it doesn't. The tool is task-agnostic,
+so it would also serve taskset-scoped (`Taskset.toolsets`).
 """
 
 import verifiers.v1 as vf

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -234,7 +234,7 @@ async def test_tool(run_v1, harness_runtime, tool_runtime, tmp_path):
     the harness's runtime, or its own runtime) x the harness `runtime`. The tool stamps
     its output with a token the prompt never reveals, so reward 1.0 proves the tool was
     reachable from wherever the harness runs and actually ran. Eval-wide SHARED servers
-    are a different scope (`Taskset.tools`) with their own env-server-path coverage:
+    are a different scope (`Taskset.toolsets`) with their own env-server-path coverage:
     `test_shared_tool_isolation`."""
     (trace,) = await run_v1(
         "echo-tool-v1",

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -379,7 +379,7 @@ class Env(ABC, Generic[ConfigT]):
     def _requires_tunnel(self, shared: dict[str, SharedToolServer]) -> bool:
         """`requires_tunnel` over the consumers known before any rollout: role
         runtimes, live `shared` servers, and the task class's tool servers
-        (their configs read off the declared `tools` fields, no task needed)."""
+        (`Task.toolsets` is a classmethod, so no task instance is needed)."""
         task_cls = type(self.taskset).task_type()
         configs = [
             server.config for server in task_cls.toolsets(self.taskset.config.task)

--- a/verifiers/v1/task.py
+++ b/verifiers/v1/task.py
@@ -3,8 +3,8 @@
 `TaskData` is the wire half: a frozen pydantic model carrying the data which
 initializes a task instance. Rides on `trace.task.data` in `traces.jsonl`.
 
-`Task` is the behavior half: runtime prep (`setup`/`finalize`), tool declarations
-(`tools`), and scoring (`@reward`/`@metric`) methods.
+`Task` is the behavior half: runtime prep (`setup`/`finalize`), tool servers
+(`toolsets`), and scoring (`@reward`/`@metric`) methods.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Stacked on #2199 (base: `feat/explicit-tool-config`) — docs/comment only, no behavior change.

#2199 replaced `tools = (SearchToolset,)` + the framework's guess-the-config-field step with explicit `Task.toolsets(config)` / `Taskset.toolsets(config)`, but the prose around it still described the old mechanism. This removes it.

**`skills/evaluate-environments/references/REFERENCE.md`** (untouched by #2199, so the most stale):
- dropped *"The framework finds the matching config field by the toolset's generic config type"* — that step no longer exists
- `Task.tools` / `Taskset.tools` → `Task.toolsets` / `Taskset.toolsets` (section headers, taskset overview, the closing "no `shared` boolean" note)
- dropped "matching" from the two config-field sentences (nothing matches anything now — the author passes the field)
- added the one contract a reader can't get from the signature: constructing a `Toolset` starts nothing, and `toolsets()` is called before any task instance exists (validation, tunnel sizing) and may be called more than once, so it must stay cheap and side-effect-free — expensive work belongs in `setup()` / `setup_task()`

**Remaining `Task.tools`/`Taskset.tools` references:** `verifiers/v1/env.py` (`_requires_tunnel`), `verifiers/v1/task.py` (module docstring), `tests/v1/test_e2e.py`, `tests/v1/fixtures/echo_tool_v1.py`, `environments/wiki_search_v1`, `environments/scratchpad_v1`.

**Also** `skills/create-environments/SKILL.md`: same "matching config field" wording in the placement list.

Checks: `ruff check .`, `ruff format --check`, `ty check verifiers`, `uv run pytest tests/` all pass. `markdownlint-cli2` could not run locally (its hook needs node ≥22, sandbox has v12) — CI covers it; `MD013` is disabled and the markdown edits are inline prose only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and documentation updates only; no executable logic changed.
> 
> **Overview**
> Docs-only follow-up to the explicit `Task.toolsets(config)` / `Taskset.toolsets(config)` API: **no runtime behavior changes**.
> 
> **Naming:** `Task.tools` and `Taskset.tools` are updated to **`Task.toolsets`** / **`Taskset.toolsets`** in evaluate reference (`REFERENCE.md`), create-environments skill (`SKILL.md`), module docstrings (`verifiers/v1/task.py`, `verifiers/v1/env.py`), example envs (wiki search, scratchpad), and e2e fixtures/tests.
> 
> **Conceptual edits:** Removes wording about the framework **inferring** the matching config field from the toolset type. Scope is now described as following **where** authors construct servers (`Task.toolsets` vs `Taskset.toolsets`) and **which config they pass** (e.g. `return [SearchToolset(config.tools)]`). The evaluate reference adds that building a `Toolset` does not start a server, `toolsets()` may run before tasks exist and more than once, so it must stay cheap and side-effect-free—with heavy work in `setup()` / `setup_task()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02eebd61302b69857f43d9aae4365967d74ffdfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update docs to replace `Taskset.tools` references with `Taskset.toolsets`
> Removes prose describing the old `Taskset.tools` config discovery in favor of `Taskset.toolsets` across documentation and docstrings. Affected files include [SKILL.md](https://github.com/PrimeIntellect-ai/verifiers/pull/2200/files#diff-1697fb73db30ed7c1e5a0c48ad0e1205e3502967ba1d51da63a4292ae4c4fa3e), [REFERENCE.md](https://github.com/PrimeIntellect-ai/verifiers/pull/2200/files#diff-575f12fd01439aa9c1657a1d188a485753f75ba00d62a0006c7014b0ba7e5fad), and several module/test docstrings. No code logic is changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 02eebd6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->