### PR TITLE
fix(v1): reject separate Harbor verifier environments

### DIFF
--- a/verifiers/v1/tasksets/harbor/taskset.py
+++ b/verifiers/v1/tasksets/harbor/taskset.py
@@ -372,14 +372,12 @@ def parse_verifier_extras(
         effective_artifact_service,
         normalize_artifact_entries,
     )
+    from harbor.models.task.verifier_mode import task_has_any_separate_verifier
 
     verifier = parsed.verifier
-    if verifier.environment is not None:
+    if task_has_any_separate_verifier(parsed):
         raise ValueError(
-            f"{task_dir.name}: [verifier.environment] declares a separate verifier "
-            "image. Grading runs in a fresh box built from the task's own image, so "
-            "only the agent's delta has to travel; a different verifier image needs "
-            "the full working tree copied over and isn't supported yet."
+            f"{task_dir.name}: separate verifier environments are not supported"
         )
     if verifier.user is not None:
         raise ValueError(f"{task_dir.name}: [verifier].user is not supported")


### PR DESCRIPTION
## Overview

Use Harbor effective verifier-mode resolution when loading tasks so unsupported separate verifier environments fail before evaluation.

## Details

Harbor resolves both an explicit environment_mode = "separate" and a declared verifier environment to separate verification. When the mode is explicit but no verifier environment is supplied, Harbor uses a fresh copy of the top-level environment.

The V1 Harbor taskset scores inside the agent runtime, so it now reuses Harbor task_has_any_separate_verifier helper to accept shared verification and reject every effective separate mode consistently.

See the [Harbor verifier environment documentation](https://www.harborframework.com/docs/tasks#verifier-environment-shared-vs-separate) for the mode resolution rules.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow validation change at task load time; only affects tasks that Harbor already treats as separate verification and that V1 cannot run anyway.
> 
> **Overview**
> Harbor V1 task loading now rejects **every effective “separate” verifier setup** using Harbor’s `task_has_any_separate_verifier` helper, instead of only failing when `[verifier.environment]` declares a separate image.
> 
> That aligns validation with Harbor’s verifier-mode rules (including explicit `environment_mode = "separate"` even when no separate verifier image is set), so unsupported tasks fail at parse time before evaluation. The error text is shortened to a single “separate verifier environments are not supported” message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ffe62bfa446ee9cd6936a91f697af67fa99e9e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject separate Harbor verifier environments in `parse_verifier_extras`
> Replaces the `verifier.environment is not None` check with `task_has_any_separate_verifier()` in [taskset.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2203/files#diff-2bff5dabcb9a41f4d830e8bbb890e8cc6f5b8331ef2ac4c3b19ffad0e046fe00), so all tasks declaring a separate verifier environment are rejected, not just those with a directly set `verifier.environment`. The error message is updated to `"{task_dir.name}: separate verifier environments are not supported"`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ffe62b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->