### PR TITLE
chore: bundle per-stage rollout timeouts into RolloutTimeouts

### DIFF
--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -25,7 +25,7 @@ from verifiers.v1.harness import Harness
 from verifiers.v1.interception import Interception, InterceptionServer
 from verifiers.v1.mcp import SharedToolServer
 from verifiers.v1.retries import backoff, trace_should_retry
-from verifiers.v1.rollout import RolloutRun, _as_messages
+from verifiers.v1.rollout import RolloutRun, RolloutTimeouts, _as_messages
 from verifiers.v1.runtimes import (
     NetworkPolicyConfig,
     Runtime,
@@ -533,23 +533,23 @@ class Agent:
             "harness": self.harness,
             "ctx": self.ctx,
             "runtime_config": runtime_config,
-            "setup_timeout": (
-                self.timeout.setup
-                if self.timeout.setup is not None
-                else task.data.timeout.setup
-            ),
-            "agent_timeout": cap_remote_agent_timeout(
-                agent_timeout, runtime_config, task
-            ),
-            "finalize_timeout": (
-                self.timeout.finalize
-                if self.timeout.finalize is not None
-                else task.data.timeout.finalize
-            ),
-            "scoring_timeout": (
-                self.timeout.scoring
-                if self.timeout.scoring is not None
-                else task.data.timeout.scoring
+            "timeouts": RolloutTimeouts(
+                setup=(
+                    self.timeout.setup
+                    if self.timeout.setup is not None
+                    else task.data.timeout.setup
+                ),
+                agent=cap_remote_agent_timeout(agent_timeout, runtime_config, task),
+                finalize=(
+                    self.timeout.finalize
+                    if self.timeout.finalize is not None
+                    else task.data.timeout.finalize
+                ),
+                scoring=(
+                    self.timeout.scoring
+                    if self.timeout.scoring is not None
+                    else task.data.timeout.scoring
+                ),
             ),
             "limits": self.limits,
             "shared_tools": shared_tools,

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -23,6 +23,7 @@ import logging
 import time
 from collections.abc import AsyncIterator, Callable
 from contextlib import AsyncExitStack, asynccontextmanager
+from dataclasses import dataclass
 
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.agent import AgentConfig
@@ -55,6 +56,19 @@ from verifiers.v1.trace import AgentInfo, Trace, TraceTask
 from verifiers.v1.types import Messages
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RolloutTimeouts:
+    """Per-stage rollout timeouts in seconds (None = unlimited), each bounding one
+    lifecycle stage: `setup` covers task + harness setup in `open()`, `agent` is the
+    cumulative budget the run's segments draw down across `step()`s, `finalize` and
+    `scoring` bound their `close()` stages."""
+
+    setup: float | None = None
+    agent: float | None = None
+    finalize: float | None = None
+    scoring: float | None = None
 
 
 def _as_messages(raw: Messages) -> Messages:
@@ -115,10 +129,7 @@ class RolloutRun:
         runtime_config: RuntimeConfig,
         wire_data: TaskData | None = None,
         has_user: bool = False,
-        setup_timeout: float | None = None,
-        agent_timeout: float | None = None,
-        finalize_timeout: float | None = None,
-        scoring_timeout: float | None = None,
+        timeouts: RolloutTimeouts | None = None,
         limits: RolloutLimits | None = None,
         shared_tools: dict[str, SharedToolServer] | None = None,
         interception: Interception | None = None,
@@ -130,11 +141,8 @@ class RolloutRun:
         self.ctx = ctx
         self.runtime_config = runtime_config
         self._has_user = has_user
-        self._setup_timeout = setup_timeout
-        self._agent_timeout = agent_timeout
-        self._agent_time_remaining = agent_timeout
-        self._finalize_timeout = finalize_timeout
-        self._scoring_timeout = scoring_timeout
+        self._timeouts = timeouts or RolloutTimeouts()
+        self._agent_time_remaining = self._timeouts.agent
         self._shared_tools = shared_tools or {}
         self._interception = interception
         self.runtime = runtime
@@ -164,7 +172,7 @@ class RolloutRun:
         self.deadline_at: float | None = None
         """The active harness segment's absolute deadline (event-loop clock), or
         None between segments / when unbounded. An interaction spends one cumulative
-        `agent_timeout` budget only while its own segments run, so time awaiting
+        `timeouts.agent` budget only while its own segments run, so time awaiting
         the caller (including another interleaved agent) cannot starve it."""
 
     @property
@@ -244,8 +252,8 @@ class RolloutRun:
             # Task setup and harness provisioning share one setup-stage deadline.
             setup_deadline = (
                 None
-                if self._setup_timeout is None
-                else asyncio.get_running_loop().time() + self._setup_timeout
+                if self._timeouts.setup is None
+                else asyncio.get_running_loop().time() + self._timeouts.setup
             )
             async with (
                 boundary(TaskError, "task setup"),
@@ -340,7 +348,7 @@ class RolloutRun:
                 self.fail(
                     HarnessError(
                         f"agent timeout: rollout exceeded its "
-                        f"{self._agent_timeout:g}s budget"
+                        f"{self._timeouts.agent:g}s budget"
                     )
                 )
             else:
@@ -406,7 +414,7 @@ class RolloutRun:
                         invoke(
                             self.task.finalize, {"trace": trace, "runtime": runtime}
                         ),
-                        self._finalize_timeout,
+                        self._timeouts.finalize,
                     )
                 now = time.time()
                 trace.timing.finalize.end = now
@@ -418,7 +426,7 @@ class RolloutRun:
                             self.task.score(trace, runtime),
                             self.harness.score(trace, runtime),
                         ),
-                        self._scoring_timeout,
+                        self._timeouts.scoring,
                     )
                 trace.timing.scoring.end = time.time()
         except Exception as e:  # noqa: BLE001 - finalize boundary records every rollout failure


### PR DESCRIPTION
## Summary

- Add `RolloutTimeouts`, a frozen dataclass in `rollout.py` bundling the four per-stage timeouts (`setup`, `agent`, `finalize`, `scoring`; `None` = unlimited), mirroring how `RolloutLimits` bundles the per-rollout caps.
- `RolloutRun` now takes a single `timeouts: RolloutTimeouts | None = None` instead of four `*_timeout` kwargs and reads stages off `self._timeouts`.
- `Agent._rollout_params` resolves the agent-level/task-level precedence into one `RolloutTimeouts` (agent budget still capped via `cap_remote_agent_timeout`).

## Breaking

- `RolloutRun(setup_timeout=..., agent_timeout=..., finalize_timeout=..., scoring_timeout=...)` → `RolloutRun(timeouts=RolloutTimeouts(setup=..., agent=..., finalize=..., scoring=...))`. `RolloutRun` is not re-exported from `verifiers.v1` (its only in-tree driver is `Agent`), so this only affects code importing `verifiers.v1.rollout` directly.

## Verification

`uv run ruff check`, `uv run pre-commit run`, and `uv run pytest tests/v1` (66 passed, 66 skipped — skips need `PRIME_API_KEY`) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with no intended behavior change; risk is limited to external code that imported `RolloutRun` and passed the old keyword arguments.
> 
> **Overview**
> Per-stage rollout limits (`setup`, `agent`, `finalize`, `scoring`) are now grouped in a frozen **`RolloutTimeouts`** dataclass in `rollout.py`, parallel to how **`RolloutLimits`** groups caps.
> 
> **`RolloutRun`** takes **`timeouts: RolloutTimeouts | None`** instead of four separate `*_timeout` arguments; setup, segment deadlines, finalize, and scoring still read the same values via **`self._timeouts`**. **`Agent._rollout_params`** builds one **`RolloutTimeouts`** (agent config overrides task defaults; remote agent budget still goes through **`cap_remote_agent_timeout`**).
> 
> **Breaking:** callers that construct **`RolloutRun`** directly must pass **`timeouts=RolloutTimeouts(...)`** instead of **`setup_timeout=`** / **`agent_timeout=`** / etc. In-tree usage goes through **`Agent`** only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b12600ea536a03c2dc9a24d159197ad1ae9ee959. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bundle per-stage rollout timeouts into a `RolloutTimeouts` dataclass
> - Introduces a new frozen `RolloutTimeouts` dataclass in [rollout.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2205/files#diff-f886b7f4717cf8fce9270bd4ff4790f3182aa1016abb9efb7f6e57efe18d1bf2) with optional `setup`, `agent`, `finalize`, and `scoring` float fields.
> - Replaces the four separate `*_timeout` parameters in `RolloutRun.__init__` with a single `timeouts: RolloutTimeouts | None` parameter; all internal timeout references are updated accordingly.
> - Updates [agent.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2205/files#diff-f719e773e216506045964fdfb9fad948b7b504ea092359ced06c928ab5148ea2) to pass a `RolloutTimeouts` instance under the `timeouts` key instead of four individual keys when constructing rollout args.
> - Risk: any code instantiating `RolloutRun` directly with the old `setup_timeout`, `agent_timeout`, `finalize_timeout`, or `scoring_timeout` keyword arguments will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b12600e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->