### PR TITLE
fix: fall back to ACP session/load when session/resume fails

### DIFF
--- a/verifiers/v1/acp/_runner.py
+++ b/verifiers/v1/acp/_runner.py
@@ -146,16 +146,30 @@ async def run_client(config: dict) -> None:
         else:
             session_id = session_path.read_text().strip()
             session_capabilities = capabilities and capabilities.session_capabilities
-            if session_capabilities and session_capabilities.resume is not None:
-                await connection.resume_session(
-                    cwd=os.getcwd(), session_id=session_id, mcp_servers=mcp_servers
-                )
-            elif capabilities and capabilities.load_session:
+            can_resume = bool(
+                session_capabilities and session_capabilities.resume is not None
+            )
+            can_load = bool(capabilities and capabilities.load_session)
+            if not can_resume and not can_load:
+                raise RuntimeError("ACP agent does not support resuming sessions")
+            try:
+                if can_resume:
+                    await connection.resume_session(
+                        cwd=os.getcwd(), session_id=session_id, mcp_servers=mcp_servers
+                    )
+                else:
+                    await connection.load_session(
+                        cwd=os.getcwd(), session_id=session_id, mcp_servers=mcp_servers
+                    )
+            except RequestError:
+                if not (can_resume and can_load):
+                    raise
+                # Some agents (e.g. OpenClaw) advertise resume but only track sessions
+                # created by the same agent process; session/load replays the exchange
+                # from the agent's persisted store instead.
                 await connection.load_session(
                     cwd=os.getcwd(), session_id=session_id, mcp_servers=mcp_servers
                 )
-            else:
-                raise RuntimeError("ACP agent does not support resuming sessions")
 
         messages = config["messages"]
         if not is_new:


### PR DESCRIPTION
## Summary

- Fixes the `test_acp_resume_with_tool[openclaw-acp-in-docker]` e2e failing on `main` since #2174 (the live e2e job is skipped on fork PRs, so it never ran pre-merge).
- The ACP runner now falls back to `session/load` when `session/resume` fails with a `RequestError` and the agent advertises both capabilities. Agents whose resume works keep taking the resume path unchanged.

## Verification

Root cause, reproduced against a pinned OpenClaw 2026.7.1-2 gateway in `python:3.11-slim`: the `openclaw acp` bridge advertises `sessionCapabilities.resume`, but `session/resume` only finds sessions created by the same bridge process — a fresh bridge (which every resumed segment gets) fails with `Internal error` (`"Session <id> not found"`), while `session/load` replays the session from the gateway's persisted store and succeeds, including across gateway restarts:

```
# fresh bridge process, same live gateway, session created by a previous bridge
session/resume -> {"error": {"code": -32603, "message": "Internal error",
                   "data": {"details": "Session e0b8442b-… not found"}}}
session/load   -> OK
```

- Before: `test_acp_resume_with_tool[openclaw-acp-in-docker]` fails deterministically with `harness 'openclaw' exited 1: … acp.exceptions.RequestError: Internal error` (two consecutive `main` runs + local repro).
- After: `test_acp_resume_with_tool[openclaw-acp-in-prime]` passes locally with this change; `test_acp_resume_with_tool[kimi-code-acp-in-docker]` still passes (resume path unchanged for agents with working resume). The docker leg OOMs on a local 2 GiB colima VM (kernel kills the gateway) — this PR's e2e run covers it on the 7 GB CI runner.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to ACP session reconnection in the verifier runner; improves compatibility without altering auth or data paths.
> 
> **Overview**
> **ACP session restore** now treats `resume` and `load_session` as explicit capability flags and picks `session/resume` when advertised, otherwise `session/load`.
> 
> When both are advertised and **`session/resume` raises `RequestError`**, the runner retries with **`session/load`** so agents like OpenClaw (resume only works in-process) can still continue harness segments from persisted session state. Agents where resume works are unchanged; agents with only `load_session` still use load only, with no fallback path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba60c603e6742dc9caa1ba57208a3e9c2af43c9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fall back to `load_session` when `resume_session` fails in ACP runner
> When reusing an existing session ID, the ACP runner in [`_runner.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/2206/files#diff-d382c5bf34763d245280e299f2edacb56db3f010e8c820587d752f9139cafa51) now catches `RequestError` from `resume_session` and falls back to `load_session` if both capabilities are advertised. If neither capability is present, the runner raises immediately rather than attempting a doomed call.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ba60c60.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->