### PR TITLE
Fix OpenClaw ACP session resume

### DIFF
--- a/verifiers/v1/harnesses/openclaw/harness.py
+++ b/verifiers/v1/harnesses/openclaw/harness.py
@@ -309,7 +309,9 @@ class OpenClawHarness(Harness[OpenClawHarnessConfig]):
                 'while kill -0 "$gateway_pid" 2>/dev/null; do sleep 0.1; done; '
                 f"rm -f {shlex.quote(pid_path)}' EXIT; "
                 f'{shlex.quote(binary)} acp --url "ws://127.0.0.1:{gateway_port}" '
-                f"--token {shlex.quote(trace.id)} --no-prefix-cwd"
+                f"--token {shlex.quote(trace.id)} "
+                f"--session {shlex.quote(f'agent:main:acp-bridge:{trace.id}')} "
+                "--no-prefix-cwd"
             ),
         ]
         # OpenClaw rejects ACP per-session MCP declarations; the isolated Gateway


### PR DESCRIPTION
## Overview

Ensure OpenClaw ACP sessions can resume across harness segment relaunches.

## Details

- Assign each rollout a stable, canonical OpenClaw Gateway session key derived from its trace ID.
- Reuse that key for every ACP process launched during the rollout, preserving conversation continuity across interaction turns.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change to the OpenClaw harness command; affects test/verifier agent orchestration only, not production auth or data paths.
> 
> **Overview**
> OpenClaw harness relaunches can now keep the same Gateway conversation when a rollout spans multiple ACP invocations.
> 
> Each `acp` subprocess is started with **`--session agent:main:acp-bridge:<trace.id>`**, so the session key is tied to the trace ID instead of varying per launch. That matches the harness’s resume path and lets OpenClaw pick up the prior thread after segment relaunches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03f781f8a19eb15488c8f245d45d7627e004b28d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix OpenClaw ACP session resume by passing explicit `--session` flag to `acp` binary
> Adds a `--session` argument to the OpenClaw `acp` subprocess invocation in [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2207/files#diff-d7278b9055ef0f18d323c2ac3010b475bc2122a03e99b44977384fab44c24362), using the value `agent:main:acp-bridge:<trace.id>`. This ensures the ACP session can be correctly resumed by tying it to the current trace ID.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 03f781f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->