### PR TITLE
Support restricted shared agent runtimes

### DIFF
--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -435,7 +435,10 @@ async def test_env_id_agentic_judge(run_v1, tmp_path):
         harness=None,
         env={
             "id": "agentic-judge",
-            "solver": {"harness": {"id": "bash"}, "runtime": {"type": "docker"}},
+            "solver": {
+                "harness": {"id": "bash"},
+                "runtime": {"type": "docker", "block": ["example.com"]},
+            },
             "judge": {
                 "harness": {"id": "bash"},
                 "max_output_tokens": 8192,

--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -165,6 +165,8 @@ class JudgeTask(vf.Task):
                 image=solved.image,
                 workdir=solved.workdir,
                 resources=solved.resources,
+                network_allow=solved.network_allow,
+                network_block=solved.network_block,
             ),
             files=files,
             artifacts={} if share_runtime else solution.state.artifacts,

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -332,19 +332,17 @@ class Runtime(ABC):
         return url
 
     async def prepare_setup(self) -> None:
-        """Claim the runtime for trusted setup; restricted runtimes may reject reuse."""
+        """Open egress for trusted setup when reusing a restricted runtime."""
         if not self.network_restricted:
             return
         if self._setup_claimed:
-            raise SandboxError(
-                f"network-filtered {self.type} runtimes are single-rollout; "
-                "provision a fresh runtime instead of reusing this one"
-            )
+            await self.prepare_execution(None)
         self._setup_claimed = True
 
-    async def prepare_execution(self, routes: list[str]) -> None:
+    async def prepare_execution(self, routes: list[str] | None) -> None:
         """Last setup step, right before the agent starts. Restricted runtimes enforce
-        their policy here; `routes` identifies the interception and MCP endpoints."""
+        their policy here; `routes` identifies the interception and MCP endpoints.
+        None restores unrestricted egress for another trusted setup phase."""
 
     @property
     def network_restricted(self) -> bool:

--- a/verifiers/v1/runtimes/docker/__init__.py
+++ b/verifiers/v1/runtimes/docker/__init__.py
@@ -233,11 +233,16 @@ class DockerRuntime(Runtime):
             return url.replace(host, "host.docker.internal", 1)
         return url
 
-    async def prepare_execution(self, routes: list[str]) -> None:
+    async def prepare_execution(self, routes: list[str] | None) -> None:
         """Allow the declared framework routes, then leave the proxy as the only route."""
         if not self.network_restricted:
             return
         assert self._proxy is not None
+        if routes is None:
+            self._proxy.policy = NetworkPolicy(
+                ["*"], [], [HOST_ALIAS], allow_non_global=True
+            )
+            return
         framework = [
             urlsplit(url)._replace(path="", query="", fragment="").geturl()
             for url in routes
@@ -247,6 +252,8 @@ class DockerRuntime(Runtime):
             self.config.block,
             framework,
         )
+        if self._cut:
+            return
         script = (
             "set -eu; HOST=$1; "
             "PORT=$2; "

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -181,22 +181,25 @@ class PrimeRuntime(Runtime):
         ) as e:  # provisioning failure is one rollout's problem, not the eval's
             raise SandboxError(f"prime sandbox provisioning failed: {e}") from e
 
-    async def prepare_execution(self, routes: list[str]) -> None:
+    async def prepare_execution(self, routes: list[str] | None) -> None:
         """Apply the host policy after setup and wait until the platform enforces it."""
         if not self.network_restricted:
             return
         try:
-            hosts = list(
-                dict.fromkeys(
-                    h for h in (urlsplit(route).hostname for route in routes) if h
-                )
-            )
-            if self.config.allow == ["*"]:
-                policy = {"deny": self.config.block}
+            if routes is None:
+                policy = {"allow": ["*"]}
             else:
-                entries = list(dict.fromkeys([*hosts, *self.config.allow]))
-                validate_egress_lists(entries, None)
-                policy = {"allow": entries} if entries else {"deny": ["*"]}
+                hosts = list(
+                    dict.fromkeys(
+                        h for h in (urlsplit(route).hostname for route in routes) if h
+                    )
+                )
+                if self.config.allow == ["*"]:
+                    policy = {"deny": self.config.block}
+                else:
+                    entries = list(dict.fromkeys([*hosts, *self.config.allow]))
+                    validate_egress_lists(entries, None)
+                    policy = {"allow": entries} if entries else {"deny": ["*"]}
             status = await self._client.set_network(self.info.id, **policy)
             try:
                 async with asyncio.timeout(60):
@@ -217,8 +220,8 @@ class PrimeRuntime(Runtime):
         logger.info(
             "prime: egress policy applied on sandbox %s (allow=%s block=%s)",
             self.info.id,
-            self.config.allow,
-            self.config.block,
+            policy.get("allow"),
+            policy.get("deny"),
         )
 
     async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:


### PR DESCRIPTION
## Overview

Allow agentic judges to reuse a solver's restricted runtime with the same normal setup flow used by separate runtimes.

## Details

When a restricted runtime begins a second trusted setup phase, it temporarily restores unrestricted egress. Docker widens the existing proxy policy without repeating the one-way network cut, while Prime applies an `allow = ["*"]` policy.

The judge then runs its ordinary task and harness setup. Immediately before the judge acts, the existing `prepare_execution(...)` step reapplies the runtime's original allow/block policy together with the judge's framework routes.

Judge tasks also carry the solver task's network policy, and the agentic-judge E2E exercises a blocklisted shared Docker runtime.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support restricted shared agent runtimes by reopening egress for trusted setup phases
> - `Runtime.prepare_setup` in [base.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2213/files#diff-0811c040a163eb5a3212208f1e3a6c6388d7690fcc4780c081cc7754036232b9) now calls `prepare_execution(None)` instead of raising when a restricted runtime is reused, reopening unrestricted egress for a second trusted setup phase.
> - `DockerRuntime.prepare_execution` and `PrimeRuntime.prepare_execution` accept `routes: list[str] | None`; when `None`, they set the proxy policy to allow all egress rather than applying the configured block/allow lists.
> - `DockerRuntime.prepare_execution` skips reapplying the iptables setup script on repeated calls after the network has been cut (`self._cut is True`).
> - `JudgeTask.from_trace` propagates `network_allow` and `network_block` from the solver trace to the judge task, so network policy is inherited by the judge runtime.
> - Risk: restricted runtimes that previously raised on reuse will now silently reopen egress — callers relying on the error for enforcement will no longer receive it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1dd096f.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change: restricted runtime reuse no longer errors and briefly widens egress during judge setup; callers that relied on the hard failure lose that guard.
> 
> **Overview**
> Restricted runtimes can be **reused** for a second trusted setup phase (e.g. solver then judge in the same Docker box) instead of failing on the second `prepare_setup`.
> 
> **Runtime contract:** `prepare_setup` on an already-claimed restricted runtime calls `prepare_execution(None)` to **temporarily restore unrestricted egress**. `prepare_execution` now accepts `routes: list[str] | None`; `None` means setup-mode egress, not agent execution policy.
> 
> **Docker:** `routes is None` widens the egress proxy to allow `*` without re-running the one-way iptables **network cut** when `self._cut` is already set.
> 
> **Prime:** `routes is None` applies `allow: ["*"]` on the platform; agent phase still reapplies the configured allow/block plus framework routes.
> 
> **Agentic judge:** `JudgeTask.from_trace` copies `network_allow` and `network_block` from the solver task so the judge runtime keeps the same network policy surface. E2E adds `block: ["example.com"]` on the shared solver Docker runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dd096ff72580366c9526eb8a28b48730022f03f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->