### PR TITLE
fix(v1): read episode retry cause from last error

### DIFF
--- a/verifiers/v1/utils/retries.py
+++ b/verifiers/v1/utils/retries.py
@@ -117,7 +117,7 @@ async def run_episode_with_retry(
         final = await run()
         if attempt == retry.max_retries or not episode_should_retry(final, retry):
             break
-        cause = final.error or next(
+        cause = final.last_error or next(
             (t.last_error for t in final.traces if t.last_error), None
         )
         history.extend(final.errors)


### PR DESCRIPTION
## Summary

- use the existing `Episode.last_error` accessor when logging whole-episode retries
- avoid crashing retryable multi-agent episodes with `AttributeError: Episode has no attribute error`

## Validation

- `uv run ruff check verifiers/v1/utils/retries.py`
- focused async regression: failed episode retries once, succeeds, and retains prior error history
- push-hook CI parity checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-attribute fix in retry logging; behavior change is limited to correct error typing in logs and avoiding a crash on retry.
> 
> **Overview**
> Fixes whole-episode retry logging so it reads the retry **cause** from `Episode.last_error` (with the same trace fallback as before) instead of a non-existent `Episode.error` attribute.
> 
> That prevents retryable multi-agent episodes from failing during backoff with `AttributeError` before the next attempt runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08d024d0bd63e565f27dcbd4d18c3a6e599b8562. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix retry cause logging in `run_episode_with_retry` to read `last_error`
> In [retries.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2220/files#diff-4fd4916191300939b5f48317db0b7957d414c54402780c71a0ef9085e53d809c), the warning log before a retry was reading `final.error` to determine the cause, but the relevant field is `final.last_error`. When `last_error` is set and `error` is `None`, the logged cause was showing `?` instead of the actual error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08d024d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->