### PR TITLE
fix: raise eval push payload limit to 100 MiB (match prime#818)

### DIFF
--- a/verifiers/v1/utils/platform.py
+++ b/verifiers/v1/utils/platform.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_API_URL = "https://api.primeintellect.ai"
 DEFAULT_FRONTEND_URL = "https://app.primeintellect.ai"
 # Repeated /samples posts append; match the Prime Evals client's request ceiling.
-_MAX_SAMPLES_PAYLOAD_BYTES = 25 * 1024 * 1024
+_MAX_SAMPLES_PAYLOAD_BYTES = 100 * 1024 * 1024
 
 
 @dataclass


### PR DESCRIPTION
Companion to PrimeIntellect-ai/prime#818.

`_MAX_SAMPLES_PAYLOAD_BYTES` is the per-sample ceiling `push_traces` (`verifiers/v1/utils/platform.py`) enforces before POSTing eval samples to `/evaluations/{id}/samples`; its comment notes it mirrors the Prime Evals client's request ceiling. prime#818 raises that client ceiling **25 → 100 MiB**, so this mirror is raised to match.

**Why:** computer-use environments (`cua_world_v1`, `osworld_v2_v1`) embed a full 1920×1080 screenshot per step (~1.5–3.5 MiB each), so a **single rollout's sample exceeds 25 MiB** and this check raises, skipping the upload — `uv run eval --push` logs:

- `sample 0 is too large to upload (53564890 > 26214400 bytes)` — cua_world (~51 MiB)
- `sample 0 is too large to upload (78391638 > 26214400 bytes)` — osworld_v2 (~75 MiB @ 50 steps)

so those runs get no hosted rollout link. 100 MiB (with prime#818) gives real headroom for screenshot-heavy rollouts without compressing traces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change with no logic edits; slightly larger HTTP bodies on upload, bounded by the same checks as before.
> 
> **Overview**
> Raises **`_MAX_SAMPLES_PAYLOAD_BYTES`** in `platform.py` from **25 MiB to 100 MiB** so the verifiers `--push` path stays aligned with the Prime Evals client request ceiling (prime#818).
> 
> `push_traces` still uses this constant for per-sample rejection and batch splitting before POSTing to `/evaluations/{id}/samples`; only the ceiling changes, so screenshot-heavy computer-use rollouts that were skipped as “too large” can upload instead of failing the check locally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 066420a101ff9f75b19d1811bc666d5581fa1a79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise eval push payload limit to 100 MiB in `_MAX_SAMPLES_PAYLOAD_BYTES`
> Increases `_MAX_SAMPLES_PAYLOAD_BYTES` in [platform.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2222/files#diff-8644072f827be448db5b0010e0969c6c86d9bbf07191ca00a993f416d123235f) from 25 MiB to 100 MiB to match the limit set in prime#818. Any payload size enforcement using this constant now allows up to 100 MiB.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 066420a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->