### PR TITLE
fix(v1): record Harbor diagnostics as metrics

### DIFF
--- a/verifiers/v1/tasksets/harbor/taskset.py
+++ b/verifiers/v1/tasksets/harbor/taskset.py
@@ -13,8 +13,6 @@ image unless ``require_image`` is set.
 import asyncio
 import hashlib
 import io
-import json
-import math
 import shutil
 import subprocess
 import sys
@@ -23,8 +21,9 @@ import tempfile
 from collections.abc import Iterator
 from functools import lru_cache
 from pathlib import Path
+from typing import Annotated
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, ValidationError
 
 from verifiers.v1.configs.taskset import TasksetConfig
 from verifiers.v1.errors import SandboxError
@@ -38,6 +37,10 @@ from verifiers.v1.utils.decorators import reward
 CACHE = Path.home() / ".cache" / "harbor"
 HARBOR_INSTALL_HINT = "uv sync --python 3.12 --extra harbor"
 REWARD_JSON = "/logs/verifier/reward.json"
+REWARD_JSON_ADAPTER = TypeAdapter(
+    float | Annotated[dict[str, float], Field(min_length=1)],
+    config=ConfigDict(strict=True, allow_inf_nan=False),
+)
 
 
 class HarborConfig(TasksetConfig):
@@ -183,22 +186,8 @@ class HarborTask(Task[HarborData]):
     async def _reward_json(self, runtime: Runtime) -> float | dict[str, float] | None:
         """Read Harbor's scalar or keyed JSON reward, if it is valid."""
         try:
-            data = json.loads(await runtime.read(REWARD_JSON))
-            if isinstance(data, bool):
-                return None
-            if isinstance(data, int | float):
-                return float(data) if math.isfinite(data) else None
-            if not isinstance(data, dict) or not data:
-                return None
-            if any(
-                isinstance(value, bool)
-                or not isinstance(value, int | float)
-                or not math.isfinite(value)
-                for value in data.values()
-            ):
-                return None
-            return {key: float(value) for key, value in data.items()}
-        except (SandboxError, OSError, ValueError, OverflowError):
+            return REWARD_JSON_ADAPTER.validate_json(await runtime.read(REWARD_JSON))
+        except (SandboxError, OSError, ValidationError):
             return None
 
 

--- a/verifiers/v1/tasksets/harbor/taskset.py
+++ b/verifiers/v1/tasksets/harbor/taskset.py
@@ -2,7 +2,7 @@
 
 The Harbor CLI downloads and caches each task directory. Its verifier runs in the
 same runtime the harness edited, then writes the score to
-``/logs/verifier/reward.txt``.
+``/logs/verifier/reward.json`` or the legacy ``reward.txt``.
 
 A pullable ``[environment].docker_image`` becomes ``TaskData.image``. Verifiers does
 not build Dockerfile-only environments, so those are rejected unless ``ignore_dockerfile``
@@ -13,6 +13,8 @@ image unless ``require_image`` is set.
 import asyncio
 import hashlib
 import io
+import json
+import math
 import shutil
 import subprocess
 import sys
@@ -35,6 +37,7 @@ from verifiers.v1.utils.decorators import reward
 
 CACHE = Path.home() / ".cache" / "harbor"
 HARBOR_INSTALL_HINT = "uv sync --python 3.12 --extra harbor"
+REWARD_JSON = "/logs/verifier/reward.json"
 
 
 class HarborConfig(TasksetConfig):
@@ -140,7 +143,7 @@ class HarborTask(Task[HarborData]):
         trace.state.artifacts = await collect(runtime, self.data.artifacts)
 
     @reward(weight=1.0)
-    async def solved(self, runtime: Runtime) -> float:
+    async def solved(self, runtime: Runtime, trace: Trace) -> float | dict[str, float]:
         await runtime.write(
             "/tmp/tests.tgz", make_tar(Path(self.data.task_dir) / "tests")
         )
@@ -153,13 +156,50 @@ class HarborTask(Task[HarborData]):
             {},
         )
         await runtime.run(
-            ["sh", "-c", "cd /tests && bash test.sh"], verifier_env(self.data)
+            [
+                "sh",
+                "-c",
+                (
+                    "rm -f /logs/verifier/reward.json /logs/verifier/reward.txt"
+                    " && cd /tests && bash test.sh"
+                ),
+            ],
+            verifier_env(self.data),
         )
+        scores = await self._reward_json(runtime)
+        if scores is not None:
+            if isinstance(scores, dict) and "reward" in scores:
+                trace.record_metrics(
+                    {key: value for key, value in scores.items() if key != "reward"}
+                )
+                return {"reward": scores["reward"]}
+            return scores
         try:
             reward = (await runtime.read("/logs/verifier/reward.txt")).decode().strip()
             return float(reward or 0)
         except (SandboxError, OSError, ValueError):
             return 0.0
+
+    async def _reward_json(self, runtime: Runtime) -> float | dict[str, float] | None:
+        """Read Harbor's scalar or keyed JSON reward, if it is valid."""
+        try:
+            data = json.loads(await runtime.read(REWARD_JSON))
+            if isinstance(data, bool):
+                return None
+            if isinstance(data, int | float):
+                return float(data) if math.isfinite(data) else None
+            if not isinstance(data, dict) or not data:
+                return None
+            if any(
+                isinstance(value, bool)
+                or not isinstance(value, int | float)
+                or not math.isfinite(value)
+                for value in data.values()
+            ):
+                return None
+            return {key: float(value) for key, value in data.items()}
+        except (SandboxError, OSError, ValueError, OverflowError):
+            return None
 
 
 def harbor_cli() -> str:


### PR DESCRIPTION
## Overview

Keep Harbor's scalar `reward` as the only weighted score when `reward.json` also includes diagnostic fields.

Structured Harbor reports can include counters and partial-score details alongside `reward`. The adapter now records those additional values as trace metrics, preserving their observability without adding them to the rollout reward. Keyed reward objects without a `reward` field retain their existing behavior.

This keeps the Harbor report faithful in the trace while ensuring downstream evaluation and training consume the intended scalar reward.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout reward extraction for Harbor tasks and alters what gets weighted vs logged; impact is limited to the Harbor taskset path with fallback to reward.txt.
> 
> **Overview**
> Harbor scoring now prefers **`/logs/verifier/reward.json`** over the legacy **`reward.txt`**, with strict validation for a finite scalar or a non-empty dict of finite numbers.
> 
> When the JSON object includes a **`reward`** key, **`HarborTask.solved`** records every other field on the trace via **`trace.record_metrics`** and returns only **`{"reward": ...}`** so training/evaluation still use the scalar score. Dict-shaped rewards without **`reward`** behave as before.
> 
> Before **`test.sh`** runs, existing **`reward.json`** / **`reward.txt`** files are removed so stale verifier output cannot affect the result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dd919f8a7ddd1d0caef7fbfff588a272461aca4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Record Harbor diagnostics as metrics from reward JSON in `HarborTask.solved`
> - `HarborTask.solved` now reads `/logs/verifier/reward.json` before falling back to the legacy `reward.txt`; if the JSON contains a dict with a `reward` key, all other keys are recorded as metrics on the trace.
> - A new `_reward_json` helper validates the file contents, accepting only finite scalar numbers or dicts of finite numbers.
> - Existing reward files are deleted before tests run to prevent stale results from influencing scoring.
> - Behavioral Change: `solved` may now return a `dict` containing a `'reward'` key instead of always returning a plain `float`; callers that assume a scalar return value may need updating.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #2224 opened
>
> - Replaced manual JSON parsing and validation logic in `HarborTask._reward_json` method with `pydantic.TypeAdapter`-based validation [6dd919f]
> - Added module-level constant `REWARD_JSON_ADAPTER` using `pydantic.TypeAdapter` for reward JSON validation [6dd919f]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized beff3d8. 50 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->