### PR TITLE
Merge agent sampling overrides with run defaults

### DIFF
--- a/skills/evaluate-environments/references/REFERENCE.md
+++ b/skills/evaluate-environments/references/REFERENCE.md
@@ -137,7 +137,7 @@ Per-run caps (turns, tokens, stage timeouts, retries) are agent fields, not env 
 | `runtime` | `RuntimeConfig` | `SubprocessConfig()` | Where the harness runs. Discriminated union — see [Runtime configs](#runtime-configs). Set with `--env.<agent>.runtime.type docker\|prime\|modal`. |
 | `model` | `str \| None` | `None` | Pin a model for this agent (None = the run's `--model`). |
 | `client` | `ClientConfig \| None` | `None` | Pin an endpoint (None = the run's `--client.*`) — route a frozen judge or user sim off the training endpoint. |
-| `sampling` | `SamplingConfig \| None` | `None` | Pin sampling (None = the run's). |
+| `sampling` | `SamplingConfig \| None` | `None` | Override sampling values; unset values inherit from the run's sampling. |
 | `timeout` | `TimeoutConfig` | `TimeoutConfig()` | Per-stage wall-clock timeouts for this agent's runs (`setup`/`rollout`/`finalize`/`scoring`; each stage falls back to the task's own). An interaction spends its rollout budget cumulatively across active harness segments; time awaiting its caller is paused. |
 | `max_turns` / `max_input_tokens` / `max_output_tokens` / `max_total_tokens` | `int \| None` | `None` | Per-agent caps (None = no limit); map onto [`RolloutLimits`](#rollout-limits), each checked between turns (soft by one turn). |
 

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -104,6 +104,7 @@ async def test_single_turn(run_v1, harness, harness_runtime, tmp_path):
         "echo-v1",
         harness=harness,
         runtime={"type": harness_runtime},
+        env={"agent": {"sampling": {"temperature": 0.0}}},
         output_dir=tmp_path,
         max_turns=2,
     )
@@ -112,7 +113,9 @@ async def test_single_turn(run_v1, harness, harness_runtime, tmp_path):
     assert trace.stop_condition == "agent_completed"
     assert trace.reward == 1.0
     # The seat's resolved identity rides the trace (policy metadata for trainers).
-    assert trace.agent is not None and trace.agent.config.sampling.max_tokens == 2048
+    assert trace.agent is not None
+    assert trace.agent.config.sampling.max_tokens == 2048
+    assert trace.agent.config.sampling.temperature == 0.0
     # Every sampled turn has one per-call record, linked to its assistant node.
     sampled = [i for i, n in enumerate(trace.nodes) if n.sampled]
     assert [c.node for c in trace.calls if c.error is None] == sampled

--- a/verifiers/v1/configs/agent.py
+++ b/verifiers/v1/configs/agent.py
@@ -35,7 +35,7 @@ class AgentConfig(BaseConfig):
     client: ClientConfig | None = None
     """Endpoint override (None = the run's client)."""
     sampling: SamplingConfig | None = None
-    """Sampling override (None = the run's sampling)."""
+    """Sampling values merged onto the run's sampling."""
 
     max_turns: int | None = None
     """Max model turns per run (None = no limit)."""

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -32,7 +32,7 @@ from verifiers.v1.mcp import SharedToolServer, serve_shared
 from verifiers.v1.runtimes import SubprocessConfig, runtime_is_local
 from verifiers.v1.task import Task
 from verifiers.v1.trace import Error, Trace
-from verifiers.v1.utils.generic import concrete_type
+from verifiers.v1.utils.generic import concrete_type, deep_merge
 from verifiers.v1.utils.memory import trim_memory_periodically
 from verifiers.v1.utils.retries import run_episode_with_retry
 
@@ -204,15 +204,21 @@ class Env(ABC, Generic[ConfigT]):
 
         def make(name: str, spec: AgentConfig) -> Agent:
             # Unpinned fields fall back to the run's ctx / the taskset's harness.
+            sampling = ctx.sampling
+            if spec.sampling is not None:
+                sampling = sampling.model_copy(
+                    update=deep_merge(
+                        sampling.model_dump(exclude_unset=True),
+                        spec.sampling.model_dump(exclude_unset=True),
+                    )
+                )
             resolved = spec.model_copy(
                 update={
                     "harness": spec.harness
                     if spec.harness is not None
                     else self._default_harness,
                     "model": spec.model if spec.model is not None else ctx.model,
-                    "sampling": spec.sampling
-                    if spec.sampling is not None
-                    else ctx.sampling,
+                    "sampling": sampling,
                 }
             )
             return _EpisodeAgent(


### PR DESCRIPTION
## Overview

Allow role-specific sampling configuration to inherit evaluation-wide defaults while overriding only the values set for that role.

## Details

- Merge agent sampling onto the run model context using the existing V1 deep-merge behavior.
- Preserve nested provider-specific sampling values while letting role-specific values take precedence.
- Keep the resolved sampling configuration attached to each agent trace.
- Document the inheritance behavior and cover it in the existing V1 evaluation path.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Merge agent sampling overrides with run defaults instead of replacing them
> - In [`verifiers/v1/env.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/2226/files#diff-69be10bd5960e88d88f219d4f261d0bdd16586857f9126451b04d05bac4c2cbb), per-agent `sampling` fields are now deep-merged onto the run's `sampling` using `deep_merge`, so only explicitly set fields in the agent config override the run defaults.
> - Previously, providing any agent-level `sampling` would drop all unset run-level sampling fields entirely.
> - Updates the `AgentConfig.sampling` docstring and `REFERENCE.md` to reflect the new merge semantics.
> - Behavioral Change: agents with partial sampling overrides will now inherit unspecified sampling values from the run, rather than losing them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b6aaed8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to sampling resolution in episode agent setup with e2e coverage; behavior shift only when agent sampling is partially set (previously dropped run defaults).
> 
> **Overview**
> **Agent `sampling` is no longer an all-or-nothing replacement** when `--env.<agent>.sampling.*` is set. Episode agent resolution in `Env._episode_agents` now **deep-merges** the agent’s partially set `SamplingConfig` onto the run’s `ctx.sampling` (via `deep_merge` + `model_dump(exclude_unset=True)`), so fields like `max_tokens` can stay from the run while e.g. `temperature` is pinned per role.
> 
> Docs and `AgentConfig` docstrings now describe **inherit unset values from run sampling** instead of treating agent sampling as a full override. The echo **e2e** run sets `env.agent.sampling.temperature: 0.0` and asserts the trace still has run-default `max_tokens` (2048) and the overridden temperature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6aaed8b457257e3d532649d6bae16bf242b0957. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->