### PR TITLE
fix(v1): preserve optional artifact absence

### DIFF
--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -143,7 +143,7 @@ class JudgeTask(vf.Task):
         self,
         data: vf.TaskData,
         files: dict[str, bytes],
-        artifacts: dict[str, bytes],
+        artifacts: dict[str, bytes | None],
     ) -> None:
         super().__init__(data)
         self.files = files

--- a/verifiers/v1/state.py
+++ b/verifiers/v1/state.py
@@ -9,7 +9,7 @@ from verifiers.v1.utils.generic import concrete_type
 class State(BaseModel):
     model_config = ConfigDict(ser_json_inf_nan="constants")
 
-    artifacts: dict[str, bytes] = Field(default_factory=dict)
+    artifacts: dict[str, bytes | None] = Field(default_factory=dict)
 
 
 StateT = TypeVar("StateT", bound=State, default=State)

--- a/verifiers/v1/tasksets/harbor/taskset.py
+++ b/verifiers/v1/tasksets/harbor/taskset.py
@@ -396,7 +396,11 @@ def parse_verifier_extras(
         # no such directory (the trace is the record) and Harbor never lets destination
         # affect verifier-side placement, so it cannot change any grading outcome.
         artifacts.append(
-            Artifact(source=entry.source, exclude=list(entry.exclude or []))
+            Artifact(
+                source=entry.source,
+                exclude=list(entry.exclude or []),
+                required=False,
+            )
         )
 
     hooks: list[CollectHook] = []

--- a/verifiers/v1/utils/artifacts.py
+++ b/verifiers/v1/utils/artifacts.py
@@ -55,16 +55,40 @@ async def collect(
         for a in artifacts or []
     ]
     convention = PurePosixPath(ARTIFACTS_DIR)
-    sweep = all(PurePosixPath(artifact.source) != convention for artifact in declared)
-    entries = (
-        [Artifact(source=ARTIFACTS_DIR, required=False)] if sweep else []
-    ) + declared
+    declared_paths = [PurePosixPath(artifact.source) for artifact in declared]
+    if convention in declared_paths:
+        entries = declared
+    else:
+        sweep_excludes = [
+            str(path).lstrip("/")
+            for path in declared_paths
+            if path.is_relative_to(convention)
+        ]
+        entries = [
+            Artifact(
+                source=ARTIFACTS_DIR,
+                exclude=sweep_excludes,
+                required=False,
+            )
+        ]
+        for artifact, path in zip(declared, declared_paths, strict=True):
+            if convention.is_relative_to(path):
+                artifact = artifact.model_copy(
+                    update={
+                        "exclude": [
+                            *artifact.exclude,
+                            str(convention).lstrip("/"),
+                        ]
+                    }
+                )
+            entries.append(artifact)
 
     collected: dict[str, bytes | None] = {}
     budget = MAX_ARTIFACT_BYTES
     for artifact in entries:
         source = artifact.source
-        if (await runtime.run(["test", "-e", source], {})).exit_code != 0:
+        exists = f"test -e {shlex.quote(source)} || test -L {shlex.quote(source)}"
+        if (await runtime.run(["sh", "-c", exists], {})).exit_code != 0:
             if not artifact.required:
                 collected[source] = None
                 continue

--- a/verifiers/v1/utils/artifacts.py
+++ b/verifiers/v1/utils/artifacts.py
@@ -29,11 +29,12 @@ class Artifact(BaseModel):
     source: str
     exclude: list[str] = Field(default_factory=list)
     """`tar --exclude` patterns, applied when `source` is a directory."""
+    required: bool = True
 
 
 async def collect(
     runtime: Runtime, artifacts: list[Artifact] | None = None
-) -> dict[str, bytes]:
+) -> dict[str, bytes | None]:
     """Tar the convention dir and every declared path out of `runtime`.
 
     Keyed by source path; the values are tar archives. Insertion order is the order
@@ -54,20 +55,31 @@ async def collect(
         for a in artifacts or []
     ]
     convention = PurePosixPath(ARTIFACTS_DIR)
-    sweep = not any(
-        (p := PurePosixPath(a.source)) == convention
-        or p.is_relative_to(convention)
-        or convention.is_relative_to(p)
-        for a in declared
-    )
-    entries = ([Artifact(source=ARTIFACTS_DIR)] if sweep else []) + declared
+    sweep = True
+    for artifact in declared:
+        source = PurePosixPath(artifact.source)
+        overlaps = (
+            source == convention
+            or source.is_relative_to(convention)
+            or convention.is_relative_to(source)
+        )
+        if overlaps and (
+            artifact.required
+            or (await runtime.run(["test", "-e", artifact.source], {})).exit_code == 0
+        ):
+            sweep = False
+            break
+    entries = (
+        [Artifact(source=ARTIFACTS_DIR, required=False)] if sweep else []
+    ) + declared
 
-    collected: dict[str, bytes] = {}
+    collected: dict[str, bytes | None] = {}
     budget = MAX_ARTIFACT_BYTES
     for artifact in entries:
         source = artifact.source
         if (await runtime.run(["test", "-e", source], {})).exit_code != 0:
-            if sweep and source == ARTIFACTS_DIR:
+            if not artifact.required:
+                collected[source] = None
                 continue
             raise RuntimeError(
                 f"declared artifact {source!r} does not exist in the runtime"
@@ -80,7 +92,7 @@ async def collect(
     return collected
 
 
-async def restore(runtime: Runtime, collected: dict[str, bytes]) -> None:
+async def restore(runtime: Runtime, collected: dict[str, bytes | None]) -> None:
     """Extract `collected` in `runtime` at the original absolute paths."""
     if not collected:
         return
@@ -97,6 +109,8 @@ async def restore(runtime: Runtime, collected: dict[str, bytes]) -> None:
     roots = " ".join(shlex.quote(root) for root in collected)
     await _run(runtime, f"rm -rf -- {roots}", "clear artifact roots")
     for root, archive in collected.items():
+        if archive is None:
+            continue
         path = f"/tmp/vf-artifact-{uuid.uuid4().hex}.tar"
         await runtime.write(path, archive)
         await _run(

--- a/verifiers/v1/utils/artifacts.py
+++ b/verifiers/v1/utils/artifacts.py
@@ -55,20 +55,7 @@ async def collect(
         for a in artifacts or []
     ]
     convention = PurePosixPath(ARTIFACTS_DIR)
-    sweep = True
-    for artifact in declared:
-        source = PurePosixPath(artifact.source)
-        overlaps = (
-            source == convention
-            or source.is_relative_to(convention)
-            or convention.is_relative_to(source)
-        )
-        if overlaps and (
-            artifact.required
-            or (await runtime.run(["test", "-e", artifact.source], {})).exit_code == 0
-        ):
-            sweep = False
-            break
+    sweep = all(PurePosixPath(artifact.source) != convention for artifact in declared)
     entries = (
         [Artifact(source=ARTIFACTS_DIR, required=False)] if sweep else []
     ) + declared


### PR DESCRIPTION
## Overview

Preserve artifact absence across runtime boundaries so isolated graders observe the same filesystem state produced by the agent.

## Details

- Add required and optional semantics to grading artifacts while keeping native declarations strict by default.
- Carry optional missing paths as known-absent entries and clear them during restoration before extracting present artifacts.
- Map Harbor artifact declarations to best-effort outputs so missing deliverables remain gradeable agent outcomes.
- Update agentic-judge typing, Harbor lifecycle documentation, and environment authoring guidance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core grading filesystem handoff (collect/restore) and Harbor artifact semantics; incorrect `None` handling could clear paths or skip restores in isolated judge runs.
> 
> **Overview**
> **Artifact collection and restoration** now distinguish required vs optional paths. `Artifact` gains `required` (default `True`). `collect` returns `dict[str, bytes | None]`; missing optional sources are recorded as `None` instead of failing. `restore` still `rm -rf`s every declared root, then skips tar extraction for `None` entries so an isolated grader sees the same absence the agent left.
> 
> **Convention sweep** (`/logs/artifacts`) is always optional when auto-added. Overlap with declared paths is handled via exclude lists rather than skipping the sweep entirely (only an exact convention path match drops the sweep). Existence checks also treat symlinks as present.
> 
> **Harbor** maps task artifact declarations to `required=False`, so missing deliverables stay gradeable. **`State.artifacts`** and agentic-judge typing align with `bytes | None`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c561282d7e80e466042ea34f26f6c87ef5d6a41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve optional artifact absence in artifact collection and restore
> - Adds a `required: bool = True` field to the `Artifact` model in [artifacts.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2228/files#diff-0d082bad54931be61d7ef55ddce0757034be3013f69ae71cb803cd8416df9138); non-required artifacts that are missing are recorded as `None` instead of raising an error.
> - Updates `collect` to return `dict[str, bytes | None]` and `restore` to skip extraction for `None`-valued entries, clearing their roots without attempting extraction.
> - `ARTIFACTS_DIR` is now always swept as a non-required entry (unless explicitly declared), with excludes to avoid double-collecting declared subpaths.
> - Symlink existence is now checked via `test -e PATH || test -L PATH` so dangling symlinks are treated as present.
> - Artifacts in [harbor/taskset.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2228/files#diff-2bff5dabcb9a41f4d830e8bbb890e8cc6f5b8331ef2ac4c3b19ffad0e046fe00) are now marked `required=False`, and `State.artifacts` and `JudgeTask.artifacts` accept `None` values.
> - Behavioral Change: previously, a missing non-required artifact would raise or be skipped silently; it now produces a `None` entry in the returned dict.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c56128.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->