### PR TITLE
Connect harness tool interception hooks

### DIFF
--- a/tests/v1/test_scoring.py
+++ b/tests/v1/test_scoring.py
@@ -5,6 +5,9 @@ from verifiers.v1.graph import MessageNode
 from verifiers.v1.types import AssistantMessage, UserMessage
 
 PLUGGED_FNS_PY = """
+from verifiers.v1 import Trace
+
+
 async def reply_length(trace) -> float:
     return float(len(trace.last_reply or ""))
 
@@ -17,7 +20,7 @@ async def marker(trace) -> float:
     return 0.125
 
 
-async def two_turns(trace) -> bool:
+async def two_turns(trace: Trace) -> bool:
     return trace.num_turns >= 2
 """
 

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -80,6 +80,7 @@ from verifiers.v1.trace import (
     Branch,
     Error,
     EvalRunInfo,
+    InterceptRecord,
     ModelCall,
     PolicyEvent,
     Reward,
@@ -103,6 +104,7 @@ from verifiers.v1.types import (
     Message,
     MessageContent,
     Messages,
+    Request,
     Response,
     Sampling,
     SamplingConfig,
@@ -121,7 +123,13 @@ from verifiers.v1.utils.artifacts import (
     collect,
     restore,
 )
-from verifiers.v1.utils.decorators import metric, reward, stop, tool
+from verifiers.v1.utils.decorators import (
+    intercept,
+    metric,
+    reward,
+    stop,
+    tool,
+)
 from verifiers.v1.utils.git import (
     PATCH_CAP_BYTES as PATCH_CAP_BYTES,
 )
@@ -178,6 +186,7 @@ __all__ = [  # noqa: RUF022 - grouped by public API area
     "Message",
     "MessageContent",
     "Messages",
+    "Request",
     "Response",
     "Sampling",
     "SamplingConfig",
@@ -220,10 +229,13 @@ __all__ = [  # noqa: RUF022 - grouped by public API area
     "AgentSpan",
     "Error",
     # decorators
+    "intercept",
     "stop",
     "tool",
     "metric",
     "reward",
+    # interception
+    "InterceptRecord",
     # errors
     "RolloutError",
     "EnvError",

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -465,15 +465,11 @@ class Agent:
         interaction = Interaction(run, gate=self._gate)
         async with self._gate or nullcontext():
             opened = await run.open()
-            if not opened:
+            if not opened and (failure := run.failure) is not None:
                 trace = await run.close()
                 if trace.agent.runtime is not None:
                     trace.agent.runtime.borrowed = runtime is not None
-        if not opened:
-            failure = run.failure
-            if failure is None:  # `open()` returning False always captures one.
-                raise RuntimeError("rollout setup failed without a captured error")
-            raise failure
+                raise failure
         try:
             yield interaction
         except Exception as e:

--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -342,7 +342,9 @@ class TrainClient(Client):
             prompt = turn.prompt
             tools = parse_tools(body.get("tools"))
         else:
-            prompt, tools = dialect.parse_request(body)
+            request = dialect.parse_request(body)
+            prompt = request.messages
+            tools = request.tools
         from renderers.client import generate
 
         wire_tools = [tool_to_wire(t) for t in tools] if tools else None

--- a/verifiers/v1/configs/task.py
+++ b/verifiers/v1/configs/task.py
@@ -40,9 +40,9 @@ class TaskConfig(BaseConfig):
     """Judge plugins run after task rewards, set through `--env.taskset.task.judges`."""
 
     stops: dict[str, DecoratedFunctionConfig] = Field(default_factory=dict)
-    """Stop conditions `(trace) -> bool` plugged by name, merged with the task's
-    `@vf.stop` methods (a plugged function replaces a decorated one with the same
-    name)."""
+    """Typed `Request`, `Response`, or `Trace` stop predicates plugged by name and
+    merged with the task's `@vf.stop` methods (a plugged function replaces a
+    decorated one with the same name)."""
     metrics: dict[str, DecoratedFunctionConfig] = Field(default_factory=dict)
     """Metrics `(task, trace, runtime) -> float` plugged by name, merged with the
     task's `@vf.metric` methods."""

--- a/verifiers/v1/dialects/anthropic.py
+++ b/verifiers/v1/dialects/anthropic.py
@@ -30,6 +30,7 @@ from verifiers.v1.types import (
     ImageUrlContentPart,
     ImageUrlSource,
     Messages,
+    Request,
     Response,
     Sampling,
     SamplingConfig,
@@ -196,6 +197,37 @@ def mediate_content(value, path: str):
             continue
         mediated.append(block)
     return mediated, capabilities
+
+
+def content_to_wire(content) -> str | list[dict]:
+    """Typed text/image content in Anthropic's native request shape."""
+    if isinstance(content, str):
+        return content
+    blocks = []
+    for part in content:
+        if isinstance(part, TextContentPart):
+            blocks.append({"type": "text", "text": part.text})
+            continue
+        metadata, separator, data = part.image_url.url.partition(",")
+        if separator and metadata.startswith("data:") and metadata.endswith(";base64"):
+            blocks.append(
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": metadata[5:-7],
+                        "data": data,
+                    },
+                }
+            )
+        else:
+            blocks.append(
+                {
+                    "type": "image",
+                    "source": {"type": "url", "url": part.image_url.url},
+                }
+            )
+    return blocks
 
 
 def parse_messages(body: dict) -> Messages:
@@ -380,7 +412,9 @@ class AnthropicStreamParser(StreamParser):
         for index, parts in self.partial_json.items():
             self.blocks[index]["input"] = json.loads("".join(parts) or "{}")
         self.message["content"] = [self.blocks[index] for index in sorted(self.blocks)]
-        return response_from_wire(self.validate_response(self.message))
+        response = response_from_wire(self.validate_response(self.message))
+        response.raw = self.message
+        return response
 
 
 class ModdedUsage(AnthropicUsage):
@@ -480,6 +514,12 @@ class AnthropicDialect(Dialect[MessageCreateParams, AnthropicMessage]):
         append_user_notice(mediated.setdefault("messages", []))
         return mediated, capabilities
 
+    def is_terminal_event(self, chunk: bytes) -> bool:
+        return any(
+            line.removeprefix(b"event:").strip() == b"message_stop"
+            for line in chunk.splitlines()
+        )
+
     def auth_headers(self, api_key: str) -> dict[str, str]:
         return {"x-api-key": api_key, "anthropic-version": "2023-06-01"}
 
@@ -493,9 +533,7 @@ class AnthropicDialect(Dialect[MessageCreateParams, AnthropicMessage]):
             "error": {"type": "invalid_request_error", "message": message},
         }
 
-    def parse_request(
-        self, body: MessageCreateParams
-    ) -> tuple[Messages, list[Tool] | None]:
+    def parse_request(self, body: MessageCreateParams) -> Request:
         tools = [
             Tool(
                 name=t["name"],
@@ -505,10 +543,103 @@ class AnthropicDialect(Dialect[MessageCreateParams, AnthropicMessage]):
             for t in body.get("tools") or []
             if "input_schema" in t  # skip server tools (web_search etc.)
         ] or None
-        return parse_messages(body), tools
+        return Request(messages=parse_messages(body), tools=tools)
 
     def parse_response(self, response: AnthropicMessage) -> Response:
         return response_from_wire(response)
+
+    def rewrite_request(self, body: dict, before: Request, after: Request) -> None:
+        original = [
+            m for m in before.messages if isinstance(m, (UserMessage, ToolMessage))
+        ]
+        rewritten = [
+            m for m in after.messages if isinstance(m, (UserMessage, ToolMessage))
+        ]
+        targets: list[tuple[dict, dict | None]] = []
+        for native in body.get("messages", []):
+            if native.get("role") == "assistant":
+                continue
+            content = native.get("content")
+            if isinstance(content, str):
+                targets.append((native, None))
+                continue
+            blocks = content or []
+            targets.extend(
+                (native, block)
+                for block in blocks
+                if block.get("type") == "tool_result"
+            )
+            if any(block.get("type") != "tool_result" for block in blocks):
+                targets.append((native, None))
+
+        for (native, block), old, new in zip(targets, original, rewritten, strict=True):
+            if old == new:
+                continue
+            if block is not None:
+                block["content"] = content_to_wire(new.content)
+                continue
+            replacement = content_to_wire(new.content)
+            if isinstance(native.get("content"), str):
+                native["content"] = replacement
+                continue
+            replacement = (
+                [{"type": "text", "text": replacement}]
+                if isinstance(replacement, str)
+                else replacement
+            )
+            blocks = native.get("content") or []
+            updated = []
+            inserted = False
+            for current in blocks:
+                if current.get("type") == "tool_result":
+                    updated.append(current)
+                elif not inserted:
+                    updated.extend(replacement)
+                    inserted = True
+            native["content"] = updated
+
+    def rewrite_response(self, raw: dict, text: str) -> None:
+        raw["content"] = [{"type": "text", "text": text}]
+        raw["stop_reason"] = "end_turn"
+        raw["stop_sequence"] = None
+
+    def stream_events(self, raw: dict) -> list[bytes]:
+        def event(kind: str, payload: dict) -> bytes:
+            return f"event: {kind}\ndata: {json.dumps(payload)}\n\n".encode()
+
+        text = raw["content"][0]["text"]
+        head = {**raw, "content": [], "stop_reason": None, "stop_sequence": None}
+        if isinstance(usage := head.get("usage"), dict):
+            head["usage"] = {**usage, "output_tokens": 0}
+        return [
+            event("message_start", {"type": "message_start", "message": head}),
+            event(
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {"type": "text", "text": ""},
+                },
+            ),
+            event(
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": text},
+                },
+            ),
+            event("content_block_stop", {"type": "content_block_stop", "index": 0}),
+            event(
+                "message_delta",
+                {
+                    "type": "message_delta",
+                    "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+                    "usage": raw.get("usage") or {},
+                },
+            ),
+            event("message_stop", {"type": "message_stop"}),
+        ]
 
     def stream_parser(self) -> StreamParser:
         return AnthropicStreamParser(self.validate_response)

--- a/verifiers/v1/dialects/base.py
+++ b/verifiers/v1/dialects/base.py
@@ -20,7 +20,7 @@ from typing import ClassVar, Generic, TypeVar
 from pydantic import BaseModel
 from pydantic_core import from_json
 
-from verifiers.v1.types import Messages, Response, Sampling, SamplingConfig, Tool
+from verifiers.v1.types import Request, Response, Sampling, SamplingConfig
 
 ReqT = TypeVar("ReqT")
 RespT = TypeVar("RespT", bound=BaseModel)
@@ -193,8 +193,8 @@ class Dialect(ABC, Generic[ReqT, RespT]):
         content. Returned paths never contain request values."""
 
     @abstractmethod
-    def parse_request(self, body: ReqT) -> tuple[Messages, list[Tool] | None]:
-        """The native request -> vf prompt + tools (for the trace)."""
+    def parse_request(self, body: ReqT) -> Request:
+        """The native request -> the typed model request."""
 
     def parse_sampling(self, body: ReqT) -> Sampling:
         """The native request's call settings -> the canonical `Sampling` (for the
@@ -211,6 +211,18 @@ class Dialect(ABC, Generic[ReqT, RespT]):
     def validate_response(self, raw: dict) -> RespT:
         """Validate a native response, normalizing provider-compatible extensions if needed."""
         return self.response_type.model_validate(raw)
+
+    @abstractmethod
+    def rewrite_request(self, body: ReqT, before: Request, after: Request) -> None:
+        """Patch rewritten user/tool messages into the native conversation."""
+
+    @abstractmethod
+    def rewrite_response(self, raw: dict, text: str) -> None:
+        """Replace the native assistant response with inert text."""
+
+    @abstractmethod
+    def stream_events(self, raw: dict) -> list[bytes]:
+        """Serialize a rewritten response as a minimal native SSE stream."""
 
     @abstractmethod
     def stream_parser(self) -> StreamParser:

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -6,6 +6,7 @@ and responses (`parse_response`). Reasoning extraction mirrors the v0 chat clien
 read them in the same precedence (`reasoning` / `reasoning_content` / `reasoning_details`).
 """
 
+import json
 import time
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -28,6 +29,7 @@ from verifiers.v1.types import (
     FinishReason,
     Message,
     Messages,
+    Request,
     Response,
     Sampling,
     SamplingConfig,
@@ -319,7 +321,9 @@ class ChatStreamParser(StreamParser):
             ],
             "usage": self.usage,
         }
-        return response_from_wire(ModdedChatCompletion.model_validate(completion))
+        response = response_from_wire(ModdedChatCompletion.model_validate(completion))
+        response.raw = completion
+        return response
 
 
 class ChatDialect(Dialect[CompletionCreateParams, ChatCompletion]):
@@ -473,9 +477,9 @@ class ChatDialect(Dialect[CompletionCreateParams, ChatCompletion]):
         append_user_notice(mediated.setdefault("messages", []))
         return mediated, capabilities
 
-    def parse_request(
-        self, body: CompletionCreateParams
-    ) -> tuple[Messages, list[Tool] | None]:
+    def parse_request(self, body: CompletionCreateParams) -> Request:
+        if body.get("n", 1) != 1:
+            raise ValueError("chat completions require n=1")
         messages: Messages = []
         tool_names: dict[str, str] = {}
         for raw in body.get("messages", []):
@@ -488,7 +492,7 @@ class ChatDialect(Dialect[CompletionCreateParams, ChatCompletion]):
             if isinstance(message, AssistantMessage):
                 for call in message.tool_calls or []:
                     tool_names[call.id] = call.name
-        return messages, parse_tools(body.get("tools"))
+        return Request(messages=messages, tools=parse_tools(body.get("tools")))
 
     def parse_sampling(self, body: CompletionCreateParams) -> Sampling:
         settings = {k: v for k, v in body.items() if k in self.sampling_fields}
@@ -500,6 +504,41 @@ class ChatDialect(Dialect[CompletionCreateParams, ChatCompletion]):
 
     def parse_response(self, response: ChatCompletion) -> Response:
         return response_from_wire(response)
+
+    def rewrite_request(self, body: dict, before: Request, after: Request) -> None:
+        for native, original, rewritten in zip(
+            body.get("messages", []), before.messages, after.messages, strict=True
+        ):
+            if rewritten != original:
+                native["content"] = message_to_wire(rewritten)["content"]
+                if isinstance(rewritten, ToolMessage):
+                    if rewritten.name is None:
+                        native.pop("name", None)
+                    else:
+                        native["name"] = rewritten.name
+
+    def rewrite_response(self, raw: dict, text: str) -> None:
+        for choice in raw.get("choices") or []:
+            if isinstance(choice.get("message"), dict):
+                choice["message"] = {"role": "assistant", "content": text}
+                choice["finish_reason"] = "stop"
+                choice.pop("logprobs", None)
+
+    def stream_events(self, raw: dict) -> list[bytes]:
+        choice = (raw.get("choices") or [{}])[0]
+        chunk = {
+            **{key: value for key, value in raw.items() if key != "choices"},
+            "object": "chat.completion.chunk",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": choice.get("message")
+                    or {"role": "assistant", "content": ""},
+                    "finish_reason": choice.get("finish_reason"),
+                }
+            ],
+        }
+        return [f"data: {json.dumps(chunk)}\n\n".encode(), b"data: [DONE]\n\n"]
 
     def stream_parser(self) -> StreamParser:
         return ChatStreamParser()

--- a/verifiers/v1/dialects/responses.py
+++ b/verifiers/v1/dialects/responses.py
@@ -32,6 +32,7 @@ from verifiers.v1.types import (
     ImageUrlContentPart,
     ImageUrlSource,
     Messages,
+    Request,
     Response,
     Sampling,
     SamplingConfig,
@@ -386,9 +387,11 @@ class ResponsesStreamParser(StreamParser):
         events = self.terminal_events or self.events
         for event in iter_sse_reverse(b"".join(events)):
             if event.get("type") in FINAL_EVENTS:
-                return response_from_wire(
+                response = response_from_wire(
                     OpenAIResponse.model_validate(event["response"])
                 )
+                response.raw = event["response"]
+                return response
         raise ValueError("Responses stream ended without a terminal event")
 
 
@@ -541,9 +544,7 @@ class ResponsesDialect(Dialect[ResponseCreateParams, OpenAIResponse]):
             settings["max_tokens"] = settings.pop("max_output_tokens")
         return Sampling.model_validate(settings)
 
-    def parse_request(
-        self, body: ResponseCreateParams
-    ) -> tuple[Messages, list[Tool] | None]:
+    def parse_request(self, body: ResponseCreateParams) -> Request:
         prompt: Messages = []
         if instructions := body.get("instructions"):
             prompt.append(SystemMessage(content=instructions))
@@ -596,10 +597,126 @@ class ResponsesDialect(Dialect[ResponseCreateParams, OpenAIResponse]):
             for t in body.get("tools") or []
             if t.get("type") == "function"
         ] or None
-        return prompt, tools
+        return Request(messages=prompt, tools=tools)
 
     def parse_response(self, response: OpenAIResponse) -> Response:
         return response_from_wire(response)
+
+    def rewrite_request(self, body: dict, before: Request, after: Request) -> None:
+        original = [
+            m for m in before.messages if isinstance(m, (UserMessage, ToolMessage))
+        ]
+        rewritten = [
+            m for m in after.messages if isinstance(m, (UserMessage, ToolMessage))
+        ]
+        items = body.get("input")
+        if isinstance(items, str):
+            if original != rewritten:
+                message = rewritten[0]
+                content = (
+                    message.content
+                    if isinstance(message.content, str)
+                    else [
+                        {"type": "input_text", "text": part.text}
+                        if isinstance(part, TextContentPart)
+                        else {
+                            "type": "input_image",
+                            "image_url": part.image_url.url,
+                        }
+                        for part in message.content
+                    ]
+                )
+                body["input"] = (
+                    content
+                    if isinstance(content, str)
+                    else [{"role": "user", "content": content}]
+                )
+            return
+
+        targets = []
+        for item in items or []:
+            role = item.get("role")
+            kind = item.get("type") or ""
+            assistant = role == "assistant" or (
+                role is None and not kind.endswith(("_output", "_response"))
+            )
+            if assistant or role in ("system", "developer"):
+                continue
+            targets.append(item)
+        for item, old, new in zip(targets, original, rewritten, strict=True):
+            if old == new:
+                continue
+            content = (
+                new.content
+                if isinstance(new.content, str)
+                else [
+                    {"type": "input_text", "text": part.text}
+                    if isinstance(part, TextContentPart)
+                    else {
+                        "type": "input_image",
+                        "image_url": part.image_url.url,
+                    }
+                    for part in new.content
+                ]
+            )
+            item["output" if isinstance(new, ToolMessage) else "content"] = content
+
+    def rewrite_response(self, raw: dict, text: str) -> None:
+        original = next(
+            (
+                item
+                for item in raw.get("output") or []
+                if isinstance(item, dict) and item.get("type") == "message"
+            ),
+            {},
+        )
+        raw["output"] = [
+            {
+                "type": "message",
+                "id": original.get("id") or "msg_intercepted",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": text, "annotations": []}],
+            }
+        ]
+        raw.update(status="completed", error=None, incomplete_details=None)
+        raw.pop("required_action", None)
+        if "output_text" in raw:
+            raw["output_text"] = text
+
+    def stream_events(self, raw: dict) -> list[bytes]:
+        item = raw["output"][0]
+        part = item["content"][0]
+        common = {"output_index": 0, "item_id": item["id"], "content_index": 0}
+        head = {
+            **raw,
+            "status": "in_progress",
+            "output": [],
+            "completed_at": None,
+        }
+        events = [
+            ("response.created", {"response": head}),
+            (
+                "response.output_item.added",
+                {"output_index": 0, "item": {**item, "content": []}},
+            ),
+            (
+                "response.content_part.added",
+                {**common, "part": {**part, "text": ""}},
+            ),
+            ("response.output_text.delta", {**common, "delta": part["text"]}),
+            ("response.output_text.done", {**common, "text": part["text"]}),
+            ("response.content_part.done", {**common, "part": part}),
+            ("response.output_item.done", {"output_index": 0, "item": item}),
+            ("response.completed", {"response": raw}),
+        ]
+        return [
+            *(
+                f"data: {json.dumps({'type': kind, 'sequence_number': i, **data})}\n\n".encode()
+                for i, (kind, data) in enumerate(events)
+            ),
+            b"data: [DONE]\n\n",
+        ]
 
     def stream_parser(self) -> StreamParser:
         return ResponsesStreamParser()

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -375,6 +375,18 @@ class PendingTurn:
             self.trace.tools = tools
         return assistant_id
 
+    def commit_prompt(self, tools: list[Tool] | None = None) -> None:
+        """Record an input that terminated before model inference."""
+        parent = self.prefix_node_ids[-1] if self.prefix_node_ids else None
+        index = _head_index(self.trace)
+        for message in self.tail:
+            previous = parent
+            self.trace.nodes.append(MessageNode(parent=parent, message=message))
+            parent = len(self.trace.nodes) - 1
+            index[(previous, message_hash(message))] = parent
+        if tools:
+            self.trace.tools = tools
+
 
 def prepare_turn(trace: Trace, prompt: list[Message]) -> PendingTurn:
     """Resolve `prompt` against the trace graph without mutating it."""

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -34,6 +34,7 @@ class Harness(ABC, Generic[ConfigT]):
     APPENDS_SYSTEM_PROMPT: ClassVar[bool] = False
     """Emit `TaskData.system_prompt` separately instead of folding it into the user prompt."""
     SUPPORTS_MCP: ClassVar[bool] = False
+    SUPPORTS_TOOL_INTERCEPTION: ClassVar[bool] = False
     SUPPORTS_RESUME: ClassVar[bool] = False
     """Whether the default `resume()` can relaunch this harness from the
     accumulated Messages transcript."""
@@ -168,6 +169,7 @@ class Harness(ABC, Generic[ConfigT]):
         secret: str,
         mcp_urls: dict[str, str],
         data: TaskData,
+        tool_interception_url: str | None = None,
     ) -> HarnessSession:
         """Create the rollout-scoped handle that drives this harness.
 
@@ -176,7 +178,15 @@ class Harness(ABC, Generic[ConfigT]):
         connection, or native session for the rollout's full interaction.
         """
         return HarnessSession(
-            self, ctx, trace, runtime, endpoint, secret, mcp_urls, data
+            self,
+            ctx,
+            trace,
+            runtime,
+            endpoint,
+            secret,
+            mcp_urls,
+            data,
+            tool_interception_url,
         )
 
     async def score(self, trace: Trace, runtime: Runtime) -> None:
@@ -205,6 +215,7 @@ class Harness(ABC, Generic[ConfigT]):
         mcp_urls: dict[str, str],
         data: TaskData,
         messages: Messages,
+        tool_interception_url: str | None = None,
     ) -> ProgramResult:
         """Run the next segment of an exchange this trace already carries: the user
         spoke (`messages`), the program answers — with the whole conversation behind
@@ -228,6 +239,11 @@ class Harness(ABC, Generic[ConfigT]):
             *(m for m in branch if m.role != "system" or data.system_prompt is None),
             *messages,
         ]
+        kwargs = (
+            {"tool_interception_url": tool_interception_url}
+            if self.SUPPORTS_TOOL_INTERCEPTION
+            else {}
+        )
         return await self.launch(
             ctx,
             trace,
@@ -236,6 +252,7 @@ class Harness(ABC, Generic[ConfigT]):
             secret,
             mcp_urls,
             data.model_copy(update={"prompt": conversation}),
+            **kwargs,
         )
 
     async def cleanup(self, trace: Trace, runtime: Runtime) -> None:
@@ -285,6 +302,7 @@ class HarnessSession:
         secret: str,
         mcp_urls: dict[str, str],
         data: TaskData,
+        tool_interception_url: str | None = None,
     ) -> None:
         self.harness = harness
         self.ctx = ctx
@@ -294,6 +312,7 @@ class HarnessSession:
         self.secret = secret
         self.mcp_urls = mcp_urls
         self.data = data
+        self.tool_interception_url = tool_interception_url
         self._closed = False
 
     async def turn(self, messages: Messages | None = None) -> None:
@@ -308,6 +327,11 @@ class HarnessSession:
 
     async def _run(self, messages: Messages | None) -> ProgramResult:
         if messages is None:
+            kwargs = (
+                {"tool_interception_url": self.tool_interception_url}
+                if self.harness.SUPPORTS_TOOL_INTERCEPTION
+                else {}
+            )
             return await self.harness.launch(
                 self.ctx,
                 self.trace,
@@ -316,6 +340,7 @@ class HarnessSession:
                 self.secret,
                 self.mcp_urls,
                 self.data,
+                **kwargs,
             )
         return await self.harness.resume(
             self.ctx,
@@ -326,6 +351,7 @@ class HarnessSession:
             self.mcp_urls,
             self.data,
             messages,
+            self.tool_interception_url,
         )
 
     async def close(self) -> None:

--- a/verifiers/v1/harnesses/bash/harness.py
+++ b/verifiers/v1/harnesses/bash/harness.py
@@ -42,6 +42,7 @@ class BashHarness(Harness[BashHarnessConfig]):
     APPENDS_SYSTEM_PROMPT = True
     SUPPORTS_MCP = True
     SUPPORTS_RESUME = True
+    SUPPORTS_TOOL_INTERCEPTION = True
     NEEDS_CONTAINER = False
 
     async def setup(self, runtime: Runtime) -> None:
@@ -56,6 +57,7 @@ class BashHarness(Harness[BashHarnessConfig]):
         secret: str,
         mcp_urls: dict[str, str],
         data: TaskData,
+        tool_interception_url: str | None = None,
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(data)
         fragments = [BASH_SYSTEM_PROMPT]
@@ -73,6 +75,8 @@ class BashHarness(Harness[BashHarnessConfig]):
             f"--model={ctx.model}",
             f"--system-prompt={system_prompt}",
         ]
+        if tool_interception_url:
+            args.append(f"--tool-interception-url={tool_interception_url}")
         if self.config.edit:
             args.append("--edit")
         if self.config.search:

--- a/verifiers/v1/harnesses/bash/program.py
+++ b/verifiers/v1/harnesses/bash/program.py
@@ -299,6 +299,25 @@ async def call_mcp(
     return mcp_content_to_chat_content(result.content)
 
 
+async def run_tool_hook(
+    client: httpx.AsyncClient,
+    url: str,
+    api_key: str,
+    phase: str,
+    message: dict,
+) -> dict:
+    response = await client.post(
+        url,
+        headers={"Authorization": f"Bearer {api_key}"},
+        json={"phase": phase, "message": message},
+    )
+    response.raise_for_status()
+    decision = response.json()
+    if decision["action"] == "stop":
+        raise RuntimeError(decision["reason"])
+    return decision
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--base-url", required=True)
@@ -308,6 +327,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--prompt", default="")
     parser.add_argument("--initial-messages-file", default="")
     parser.add_argument("--mcp-config", default="")
+    parser.add_argument("--tool-interception-url", default="")
     parser.add_argument("--edit", action="store_true")
     parser.add_argument("--search", action="store_true")
     parser.add_argument("--serper-key", default="")
@@ -323,6 +343,11 @@ async def main() -> None:
         path.unlink()
         initial = json.loads(payload)
     client = AsyncOpenAI(base_url=args.base_url, api_key=args.api_key)
+    tool_client = (
+        httpx.AsyncClient(timeout=httpx.Timeout(None, connect=5.0))
+        if args.tool_interception_url
+        else None
+    )
     config = json.loads(args.mcp_config or "{}")
     tools = [BASH_TOOL]
     reserved = {"bash"}
@@ -354,53 +379,69 @@ async def main() -> None:
             break
         for call in message.tool_calls:
             name = call.function.name
+            tool_message = {
+                "role": "tool",
+                "tool_call_id": call.id,
+                "content": "",
+                "name": name,
+            }
+            if args.tool_interception_url:
+                assert tool_client is not None
+                decision = await run_tool_hook(
+                    tool_client,
+                    args.tool_interception_url,
+                    args.api_key,
+                    "before",
+                    tool_message,
+                )
+                if decision["action"] == "rewrite":
+                    messages.append(decision["message"])
+                    continue
             try:
                 tool_args = json.loads(call.function.arguments or "{}")
             except json.JSONDecodeError as e:
-                messages.append(
-                    {
-                        "role": "tool",
-                        "tool_call_id": call.id,
-                        "content": f"error: invalid JSON in tool arguments ({e}); resend the call with valid JSON",
-                    }
-                )
-                continue
-            # Valid JSON can still be a non-object (`[]`, `42`, `null`); the `.get(...)` calls
-            # below assume a dict, so reject anything else as a tool error rather than crashing.
-            if not isinstance(tool_args, dict):
-                messages.append(
-                    {
-                        "role": "tool",
-                        "tool_call_id": call.id,
-                        "content": f"error: tool arguments must be a JSON object, got {type(tool_args).__name__}; resend as an object",
-                    }
-                )
-                continue
-            if name in dispatch:
-                content = await call_mcp(servers, dispatch, name, tool_args)
-            elif name == "bash":
-                content = await asyncio.to_thread(
-                    run_bash, tool_args.get("command", "")
-                )
-            elif name == "edit" and args.edit:
-                content = await asyncio.to_thread(
-                    run_edit,
-                    tool_args.get("path"),
-                    tool_args.get("old_str"),
-                    tool_args.get("new_str"),
-                )
-            elif name == "search" and args.search:
-                content = await asyncio.to_thread(
-                    run_search,
-                    tool_args.get("query", ""),
-                    args.serper_key,
-                    tool_args.get("num_results", 5),
-                )
+                content = f"error: invalid JSON in tool arguments ({e}); resend the call with valid JSON"
             else:
-                content = f"error: unknown tool {name!r}"
-            messages.append(
-                {"role": "tool", "tool_call_id": call.id, "content": content}
-            )
+                # Valid JSON can still be a non-object (`[]`, `42`, `null`).
+                if not isinstance(tool_args, dict):
+                    content = f"error: tool arguments must be a JSON object, got {type(tool_args).__name__}; resend as an object"
+                elif name in dispatch:
+                    content = await call_mcp(servers, dispatch, name, tool_args)
+                elif name == "bash":
+                    content = await asyncio.to_thread(
+                        run_bash, tool_args.get("command", "")
+                    )
+                elif name == "edit" and args.edit:
+                    content = await asyncio.to_thread(
+                        run_edit,
+                        tool_args.get("path"),
+                        tool_args.get("old_str"),
+                        tool_args.get("new_str"),
+                    )
+                elif name == "search" and args.search:
+                    content = await asyncio.to_thread(
+                        run_search,
+                        tool_args.get("query", ""),
+                        args.serper_key,
+                        tool_args.get("num_results", 5),
+                    )
+                else:
+                    content = f"error: unknown tool {name!r}"
+            tool_message["content"] = content
+            if args.tool_interception_url:
+                assert tool_client is not None
+                decision = await run_tool_hook(
+                    tool_client,
+                    args.tool_interception_url,
+                    args.api_key,
+                    "after",
+                    tool_message,
+                )
+                if decision["action"] == "rewrite":
+                    tool_message = decision["message"]
+            messages.append(tool_message)
+    if tool_client is not None:
+        await tool_client.aclose()
 
 
 if __name__ == "__main__":

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -29,6 +29,7 @@ import time
 import traceback
 from collections.abc import AsyncIterator, Collection
 from contextlib import asynccontextmanager
+from tempfile import SpooledTemporaryFile
 from typing import Literal
 
 from aiohttp import web
@@ -50,6 +51,7 @@ from verifiers.v1.errors import (
     TaskError,
 )
 from verifiers.v1.interception.base import BaseInterceptionConfig, Interception, Slot
+from verifiers.v1.interception.tool import ToolHookRequest
 from verifiers.v1.interception.tunnel import (
     PrimeTunnelConfig,
     Tunnel,
@@ -58,7 +60,7 @@ from verifiers.v1.interception.tunnel import (
 )
 from verifiers.v1.session import RolloutSession
 from verifiers.v1.trace import Error, ModelCall, PolicyEvent, TimeSpan
-from verifiers.v1.types import FinishReason, Messages, Response, Tool, Usage
+from verifiers.v1.types import FinishReason, Request, Response, Usage
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +72,7 @@ logger = logging.getLogger(__name__)
 _MAX_REQUEST_BODY = 1024**3  # 1 GiB (aiohttp's default is 1 MiB)
 _KEEPALIVE_INTERVAL_SECONDS = 3
 _STREAM_QUEUE_MAXSIZE = 16
+STREAM_MEMORY_BUFFER = 4 * 1024**2
 # blake2b saturates ~1.7 GB/s, so a body up to this size hashes inline in well under a
 # millisecond; a larger one (bodies may reach `_MAX_REQUEST_BODY`) is hashed off the event
 # loop instead — see `_request_digest`.
@@ -221,6 +224,7 @@ class InterceptionServer(Interception):
         # Tool servers use a state-only capability; the model bearer cannot reach these.
         app.router.add_get("/state", self.handle_state_get)
         app.router.add_put("/state", self.handle_state_put)
+        app.router.add_post("/tool", self.handle_tool)
         # A launched tool server fetches its rollout's task here to run `setup_task` — the task
         # is never passed via env, only over this channel, keyed by the state bearer.
         app.router.add_get("/task", self.handle_task_get)
@@ -250,7 +254,7 @@ class InterceptionServer(Interception):
     def _fail(
         self, session: RolloutSession, dialect: Dialect, error: RolloutError
     ) -> web.Response:
-        """Stash a model-turn-adjacent failure (a `@stop` raising) so the rollout
+        """Stash a model-turn-adjacent failure (such as a hook raising) so the rollout
         re-raises it as the real cause, and report it to the harness as an HTTP error."""
         session.error = error
         logger.warning(
@@ -275,6 +279,28 @@ class InterceptionServer(Interception):
                 ",".join(capabilities),
             )
         return mediated, capabilities
+
+    async def handle_tool(self, request: web.Request) -> web.Response:
+        session = self.sessions.get(
+            request.headers.get("Authorization", "").removeprefix("Bearer ")
+        )
+        if session is None:
+            return web.json_response({"error": "unauthorized"}, status=401)
+        session.adopt(asyncio.current_task())
+        if session.released:
+            return web.json_response({"error": "rollout concluded"}, status=409)
+        if session.stopped:
+            return web.json_response(
+                {"action": "stop", "reason": session.trace.stop_condition}
+            )
+        try:
+            hook = ToolHookRequest.model_validate_json(await request.read())
+            return web.json_response(
+                await session.handle_tool(hook.phase, hook.message)
+            )
+        except RolloutError as error:
+            session.error = error
+            return web.json_response({"error": str(error)}, status=400)
 
     def record_call(
         self,
@@ -357,7 +383,6 @@ class InterceptionServer(Interception):
         request._read_bytes = None
         del raw
         body = dialect.apply_overrides(body, session.ctx.model, session.ctx.sampling)
-        body, policy_paths = self.mediate_capabilities(session, dialect, body)
         streaming = dialect.streaming(body)
         logger.debug(
             "intercept %s: id=%s stream=%s",
@@ -377,24 +402,21 @@ class InterceptionServer(Interception):
             logger.debug("intercept replay: id=%s (retried request)", session.trace.id)
             return _completion_response(session.last_response)
 
-        # A streamed response cannot be replayed as a JSON completion without
-        # buffering the full SSE body. Keep streaming outside the non-streaming
-        # coalescing cache, as it was before in-flight retries were introduced.
-        if streaming:
-            prompt, tools = dialect.parse_request(body)
-            return await self._stream(
-                request,
-                session,
-                dialect,
-                body,
-                prompt,
-                tools,
-                policy_paths,
+        try:
+            model_request = dialect.parse_request(body)
+        except ValueError as error:
+            return web.json_response(dialect.error_body(str(error)), status=400)
+        if session.released:
+            return web.json_response(
+                dialect.error_body("rollout concluded"), status=409
+            )
+        if session.stopped:
+            return web.json_response(
+                dialect.error_body(f"rollout stopped: {session.trace.stop_condition}"),
+                status=400,
             )
 
         async def coalesced(inflight: "asyncio.Future[dict | None]") -> web.Response:
-            # Await the first attempt instead of re-sampling. None means it produced no servable
-            # response (it errored/refused), so let the SDK retry afresh.
             logger.debug(
                 "intercept coalesce: id=%s (retry of in-flight turn)", session.trace.id
             )
@@ -405,14 +427,84 @@ class InterceptionServer(Interception):
                 )
             return _completion_response(completion)
 
-        if (inflight := session.inflight.get(req_hash)) is not None:
-            return await coalesced(inflight)
-        # Claim the in-flight slot so a retry arriving mid-flight coalesces onto it (above)
-        # rather than starting a second inference. The get / create / assign run with no
-        # await between them, so two concurrent identical requests can never both become
-        # owner.
-        fut: asyncio.Future[dict | None] = asyncio.get_running_loop().create_future()
-        session.inflight[req_hash] = fut
+        fut: asyncio.Future[dict | None] | None = None
+        if not streaming:
+            if (inflight := session.inflight.get(req_hash)) is not None:
+                return await coalesced(inflight)
+            fut = asyncio.get_running_loop().create_future()
+            session.inflight[req_hash] = fut
+
+        def finish_inflight(completion: dict | None = None) -> None:
+            if fut is None:
+                return
+            if session.inflight.get(req_hash) is fut:
+                session.inflight.pop(req_hash, None)
+            if not fut.done():
+                fut.set_result(completion)
+
+        try:
+            refused = await session.refused()
+            if refused is not None:
+                finish_inflight()
+                return web.json_response(
+                    dialect.error_body(f"rollout stopped: {refused}"), status=400
+                )
+            original_request = model_request
+            model_request, request_rewrites, stopped = await session.rewrite_request(
+                model_request
+            )
+            if request_rewrites:
+                session.trace.request_rewrites.extend(request_rewrites)
+                if stopped is None:
+                    dialect.rewrite_request(body, original_request, model_request)
+        except RolloutError as error:
+            finish_inflight()
+            return self._fail(session, dialect, error)
+        except Exception as error:  # noqa: BLE001 - surface task hook failures
+            finish_inflight()
+            return self._fail(
+                session,
+                dialect,
+                TaskError(
+                    f"model boundary hook failed: {type(error).__name__}: {error}"
+                ),
+            )
+        except BaseException:
+            finish_inflight()
+            raise
+        if stopped is not None:
+            turn = graph.prepare_turn(session.trace, model_request.messages)
+            turn.commit_prompt(model_request.tools)
+            session.trace.stop(stopped)
+            finish_inflight()
+            return web.json_response(
+                dialect.error_body(f"rollout stopped: {stopped}"),
+                status=400,
+            )
+
+        try:
+            body, policy_paths = self.mediate_capabilities(session, dialect, body)
+            model_request = dialect.parse_request(body)
+            turn = graph.prepare_turn(session.trace, model_request.messages)
+        except ValueError as error:
+            finish_inflight()
+            return web.json_response(dialect.error_body(str(error)), status=400)
+        except RolloutError as error:
+            finish_inflight()
+            return self._fail(session, dialect, error)
+
+        inspect_response = bool(session.response_interceptors or session.response_stops)
+        if streaming:
+            return await self._stream(
+                request,
+                session,
+                dialect,
+                body,
+                model_request,
+                turn=turn,
+                inspect_response=inspect_response,
+                policy_paths=policy_paths,
+            )
 
         def serve(response: Response) -> web.Response:
             # Record the served turn and hand it to any coalesced retry, so a retried
@@ -421,42 +513,10 @@ class InterceptionServer(Interception):
             # completion) that the server serializes back to the program.
             session.last_request = req_hash
             session.last_response = response.raw
-            if not fut.done():
-                fut.set_result(response.raw)
+            finish_inflight(response.raw)
             return _completion_response(response.raw)
 
         try:
-            # The proxy preserves native JSON fields except model + sampling. `prompt` is only the
-            # dialect's typed view for building the trace; the renderer re-derives its own from `body`.
-            prompt: Messages
-            # `tools` is recorded onto the trace only when a turn commits (below / in `_stream`):
-            # the request is ground truth for what the model saw, but a refused or failed request
-            # was never seen at all.
-            prompt, tools = dialect.parse_request(body)
-            # The rollout may conclude (deadline, teardown) while this exchange was
-            # upstream: the trace is sealed, so drop the turn instead of mutating it.
-            if session.released:
-                return web.json_response(
-                    dialect.error_body("rollout concluded"), status=409
-                )
-            try:
-                refused = await session.refused()
-            except RolloutError as e:
-                return self._fail(session, dialect, e)
-            except Exception as e:  # noqa: BLE001 - surface any task hook failure
-                return self._fail(
-                    session,
-                    dialect,
-                    TaskError(f"@stop failed: {type(e).__name__}: {e}"),
-                )
-            if refused is not None:
-                # Refuse the model call to halt the harness (it sees an HTTP error;
-                # `HarnessSession.turn` treats a stopped rollout as the clean exit it is).
-                return web.json_response(
-                    dialect.error_body(f"rollout stopped: {refused}"),
-                    status=400,
-                )
-            turn = graph.prepare_turn(session.trace, prompt)
             session.error = None
             call_response: Response | None = None
             node: int | None = None
@@ -483,9 +543,40 @@ class InterceptionServer(Interception):
                         return web.json_response(
                             dialect.error_body("rollout concluded"), status=409
                         )
-                    # One node per new message; branches fall out of walking the
-                    # graph (see Trace.branches / verifiers.v1.graph).
-                    node = turn.commit(call_response, tools)
+                    response_rewrites = []
+                    stopped = None
+                    if session.response_interceptors or session.response_stops:
+                        (
+                            call_response,
+                            response_rewrites,
+                            stopped,
+                        ) = await session.rewrite_response(call_response)
+                        if response_rewrites:
+                            assert call_response.raw is not None
+                            dialect.rewrite_response(
+                                call_response.raw, call_response.message.content or ""
+                            )
+                            raw_response = call_response.raw
+                            call_response = dialect.parse_response(
+                                dialect.validate_response(raw_response)
+                            )
+                            call_response.raw = raw_response
+                    if session.stopped:
+                        return web.json_response(
+                            dialect.error_body(
+                                f"rollout stopped: {session.trace.stop_condition}"
+                            ),
+                            status=400,
+                        )
+                    node = turn.commit(call_response, model_request.tools)
+                    session.consume_prepared(turn.tail)
+                    session.trace.response_rewrites.extend(response_rewrites)
+                    if stopped is not None:
+                        session.trace.stop(stopped)
+                        return web.json_response(
+                            dialect.error_body(f"rollout stopped: {stopped}"),
+                            status=400,
+                        )
                 except OverlongPromptError as e:
                     # An overlong prompt is a budget limit, not a crash: end the rollout
                     # cleanly as a truncation — refuse the call to halt the harness (same
@@ -546,11 +637,7 @@ class InterceptionServer(Interception):
         finally:
             # Free the in-flight slot and unblock any coalesced retry; None signals "no servable
             # response" (an error/refuse return above), so the waiter surfaces a retryable error.
-            # Only clear our own entry — never one a later owner may have installed.
-            if session.inflight.get(req_hash) is fut:
-                session.inflight.pop(req_hash, None)
-            if not fut.done():
-                fut.set_result(None)
+            finish_inflight()
 
     async def _stream(
         self,
@@ -558,35 +645,20 @@ class InterceptionServer(Interception):
         session: RolloutSession,
         dialect: Dialect,
         body: dict,
-        prompt: Messages,
-        tools: list[Tool] | None = None,
+        model_request: Request,
+        *,
+        turn: graph.PendingTurn,
+        inspect_response: bool,
         policy_paths: list[str] | None = None,
     ) -> web.StreamResponse:
         """A streamed (SSE) model turn: relay the provider's stream through to the program,
         incrementally assembling the response to record on the trace (the only client that
         streams is the eval relay)."""
-        if session.released:  # concluded while this request queued — seal holds
-            return web.json_response(
-                dialect.error_body("rollout concluded"), status=409
-            )
-        try:
-            refused = await session.refused()
-        except RolloutError as e:
-            return self._fail(session, dialect, e)
-        except Exception as e:  # noqa: BLE001 - surface any task hook failure
-            return self._fail(
-                session, dialect, TaskError(f"@stop failed: {type(e).__name__}: {e}")
-            )
-        if refused is not None:
-            return web.json_response(
-                dialect.error_body(f"rollout stopped: {refused}"), status=400
-            )
         session.error = None
         reply = None
         response: Response | None = None
         node: int | None = None
         error: Exception | None = None
-        turn = graph.prepare_turn(session.trace, prompt)
         started = time.time()
         try:
             try:
@@ -619,6 +691,97 @@ class InterceptionServer(Interception):
                 error = e
                 logger.warning("model call failed: id=%s %s", session.trace.id, e)
                 return web.json_response(dialect.error_body(str(e)), status=502)
+
+            if inspect_response:
+                buffered = SpooledTemporaryFile(  # noqa: SIM115 - closed before every exit
+                    max_size=STREAM_MEMORY_BUFFER
+                )
+                parser = dialect.stream_parser()
+                saw_terminal = False
+                try:
+                    async for chunk in reply.chunks:
+                        buffered.write(chunk)
+                        saw_terminal |= dialect.is_terminal_event(chunk)
+                        if parser.on_done is not None and is_sse_done_event(chunk):
+                            parser.on_done()
+                        parser.feed(chunk)
+                    if not saw_terminal:
+                        raise ProviderError(
+                            "upstream stream ended before its terminal event"
+                        )
+                    response = parser.finish()
+                    response_rewrites = []
+                    stopped = None
+                    if session.response_interceptors or session.response_stops:
+                        (
+                            response,
+                            response_rewrites,
+                            stopped,
+                        ) = await session.rewrite_response(response)
+                        if response_rewrites:
+                            assert response.raw is not None
+                            dialect.rewrite_response(
+                                response.raw, response.message.content or ""
+                            )
+                            raw_response = response.raw
+                            response = dialect.parse_response(
+                                dialect.validate_response(raw_response)
+                            )
+                            response.raw = raw_response
+                except RolloutError as e:
+                    buffered.close()
+                    error = e
+                    session.error = e
+                    return self._fail(session, dialect, e)
+                except Exception as e:  # noqa: BLE001 - malformed provider stream
+                    buffered.close()
+                    error = ProviderError(str(e))
+                    session.error = error
+                    return self._fail(session, dialect, error)
+                finally:
+                    await reply.close()
+
+                if session.released or session.stopped:
+                    buffered.close()
+                    return web.json_response(
+                        dialect.error_body(
+                            "rollout concluded"
+                            if session.released
+                            else f"rollout stopped: {session.trace.stop_condition}"
+                        ),
+                        status=409 if session.released else 400,
+                    )
+                node = turn.commit(response, model_request.tools)
+                session.consume_prepared(turn.tail)
+                session.trace.response_rewrites.extend(response_rewrites)
+                if stopped is not None:
+                    buffered.close()
+                    session.trace.stop(stopped)
+                    return web.json_response(
+                        dialect.error_body(f"rollout stopped: {stopped}"),
+                        status=400,
+                    )
+
+                resp = web.StreamResponse(
+                    headers={"Cache-Control": "no-cache", "Connection": "keep-alive"}
+                )
+                resp.content_type = reply.content_type.split(";")[0].strip()
+                try:
+                    await resp.prepare(request)
+                    if response_rewrites:
+                        for event in dialect.stream_events(response.raw or {}):
+                            await resp.write(event)
+                    else:
+                        buffered.seek(0)
+                        while chunk := buffered.read(64 * 1024):
+                            await resp.write(chunk)
+                    await resp.write_eof()
+                except ConnectionResetError:
+                    pass
+                finally:
+                    buffered.close()
+                return resp
+
             resp = web.StreamResponse(
                 headers={"Cache-Control": "no-cache", "Connection": "keep-alive"}
             )
@@ -695,9 +858,14 @@ class InterceptionServer(Interception):
                 if parser_error is not None:
                     raise parser_error
                 response = parser.finish()
-                if not session.released:  # concluded mid-stream — seal holds
-                    node = turn.commit(response, tools)
+                if not session.released and not session.stopped:
+                    node = turn.commit(response, model_request.tools)
+                    session.consume_prepared(turn.tail)
                     logger.debug("intercept stream turn: id=%s", session.trace.id)
+                elif session.stopped:
+                    with contextlib.suppress(ConnectionResetError):
+                        await resp.write_eof()
+                    return resp
             finally:
                 # Release the withheld events only now — after the commit — then close.
                 with contextlib.suppress(ConnectionResetError):

--- a/verifiers/v1/interception/tool.py
+++ b/verifiers/v1/interception/tool.py
@@ -1,0 +1,12 @@
+"""Typed wire payload for native harness tool hooks."""
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+from verifiers.v1.types import ToolMessage
+
+
+class ToolHookRequest(BaseModel):
+    phase: Literal["before", "after"]
+    message: ToolMessage

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -27,12 +27,12 @@ from verifiers.v1.runtimes import (
     RuntimeConfig,
     make_runtime,
 )
-from verifiers.v1.session import RolloutLimits, RolloutSession
+from verifiers.v1.session import RolloutLimits, RolloutSession, hook_boundary
 from verifiers.v1.state import state_cls
 from verifiers.v1.task import Task
 from verifiers.v1.trace import AgentInfo, Trace, TraceTask
-from verifiers.v1.types import Messages
-from verifiers.v1.utils.decorators import invoke
+from verifiers.v1.types import Messages, Request, Response, SystemMessage, UserMessage
+from verifiers.v1.utils.decorators import discover_decorated, invoke
 
 logger = logging.getLogger(__name__)
 
@@ -94,6 +94,10 @@ class Rollout:
         )
         if on_trace is not None:
             on_trace(self.trace)
+        interceptors = [
+            (hook_boundary(fn, allow_trace=False), fn)
+            for fn in discover_decorated(task, "intercept")
+        ]
         self._session = RolloutSession(
             ctx=ctx,
             trace=self.trace,
@@ -109,6 +113,12 @@ class Rollout:
             ),
             stops=task.hooks("stop"),
             limits=limits,
+            request_interceptors=[
+                fn for boundary, fn in interceptors if boundary is Request
+            ],
+            response_interceptors=[
+                fn for boundary, fn in interceptors if boundary is Response
+            ],
         )
         self._stack = AsyncExitStack()
         self._failed = False
@@ -249,6 +259,46 @@ class Rollout:
             # execution policy while preserving the framework routes the agent uses.
             await runtime.prepare_execution([self._endpoint, *self._urls.values()])
             async with boundary(HarnessError, "opening harness session"):
+                harness_data = self.trace.task.data
+                if (
+                    self._session.request_interceptors
+                    and harness_data.prompt is not None
+                ):
+                    prompt = harness_data.prompt
+                    system_prompt = harness_data.system_prompt
+                    if isinstance(prompt, str):
+                        system_prompt, prompt = self.harness.resolve_prompt(
+                            harness_data
+                        )
+                    messages = (
+                        [UserMessage(content=prompt)]
+                        if isinstance(prompt, str)
+                        else list(prompt)
+                    )
+                    has_system = system_prompt is not None
+                    if has_system:
+                        messages.insert(0, SystemMessage(content=system_prompt))
+                    prepared, rewrites = await self._session.prepare_users(
+                        Request(messages=messages)
+                    )
+                    messages = prepared.messages
+                    self.trace.request_rewrites.extend(rewrites)
+                    if has_system:
+                        messages = messages[1:]
+                    rewritten_prompt = (
+                        messages[0].content
+                        if isinstance(prompt, str)
+                        and len(messages) == 1
+                        and isinstance(messages[0], UserMessage)
+                        and isinstance(messages[0].content, str)
+                        else messages
+                    )
+                    harness_data = harness_data.model_copy(
+                        update={
+                            "prompt": rewritten_prompt,
+                            "system_prompt": system_prompt,
+                        }
+                    )
                 self._harness_session = await self.harness.session(
                     self.ctx,
                     self.trace,
@@ -256,7 +306,7 @@ class Rollout:
                     self._endpoint,
                     self._secret,
                     self._urls,
-                    self.trace.task.data,
+                    harness_data,
                 )
         except Exception as e:  # noqa: BLE001 - setup boundary records every rollout failure
             self.fail(e)
@@ -295,6 +345,12 @@ class Rollout:
         try:
             async with asyncio.timeout_at(self.deadline_at):
                 assert self._harness_session is not None
+                if messages is not None and self._session.request_interceptors:
+                    prepared, rewrites = await self._session.prepare_users(
+                        Request(messages=messages)
+                    )
+                    messages = prepared.messages
+                    self.trace.request_rewrites.extend(rewrites)
                 await self._harness_session.turn(messages)
         except TimeoutError as e:
             # An expired rollout deadline is the agent breaking its time budget —
@@ -311,6 +367,8 @@ class Rollout:
                 self.fail(e)
             return False
         except Exception as e:  # noqa: BLE001 - harness boundary records every rollout failure
+            if self._session.stopped:
+                return False
             real = self._session.error
             if real is not None and isinstance(e, RolloutError):
                 real.__cause__ = e

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -303,6 +303,15 @@ class Rollout:
                         }
                     )
                 if not self._session.stopped:
+                    session_kwargs = (
+                        {"tool_interception_url": f"{runtime.host_url(base_url)}/tool"}
+                        if self.harness.SUPPORTS_TOOL_INTERCEPTION
+                        and (
+                            self._session.request_interceptors
+                            or self._session.request_stops
+                        )
+                        else {}
+                    )
                     self._harness_session = await self.harness.session(
                         self.ctx,
                         self.trace,
@@ -311,6 +320,7 @@ class Rollout:
                         self._secret,
                         self._urls,
                         harness_data,
+                        **session_kwargs,
                     )
         except Exception as e:  # noqa: BLE001 - setup boundary records every rollout failure
             self.fail(e)

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -98,6 +98,7 @@ class Rollout:
             (hook_boundary(fn, allow_trace=False), fn)
             for fn in discover_decorated(task, "intercept")
         ]
+        stops = [(hook_boundary(fn, allow_trace=True), fn) for fn in task.hooks("stop")]
         self._session = RolloutSession(
             ctx=ctx,
             trace=self.trace,
@@ -111,7 +112,7 @@ class Rollout:
                     else ["*"]
                 )
             ),
-            stops=task.hooks("stop"),
+            trace_stops=[fn for boundary, fn in stops if boundary is Trace],
             limits=limits,
             request_interceptors=[
                 fn for boundary, fn in interceptors if boundary is Request
@@ -119,6 +120,8 @@ class Rollout:
             response_interceptors=[
                 fn for boundary, fn in interceptors if boundary is Response
             ],
+            request_stops=[fn for boundary, fn in stops if boundary is Request],
+            response_stops=[fn for boundary, fn in stops if boundary is Response],
         )
         self._stack = AsyncExitStack()
         self._failed = False
@@ -299,15 +302,16 @@ class Rollout:
                             "system_prompt": system_prompt,
                         }
                     )
-                self._harness_session = await self.harness.session(
-                    self.ctx,
-                    self.trace,
-                    runtime,
-                    self._endpoint,
-                    self._secret,
-                    self._urls,
-                    harness_data,
-                )
+                if not self._session.stopped:
+                    self._harness_session = await self.harness.session(
+                        self.ctx,
+                        self.trace,
+                        runtime,
+                        self._endpoint,
+                        self._secret,
+                        self._urls,
+                        harness_data,
+                    )
         except Exception as e:  # noqa: BLE001 - setup boundary records every rollout failure
             self.fail(e)
             return False
@@ -320,7 +324,7 @@ class Rollout:
         now = time.time()
         self.trace.timing.setup.end = now
         self.trace.timing.agent.start = now
-        return True
+        return not self._session.stopped
 
     async def step(self, messages: Messages | None = None) -> bool:
         """Run ONE segment: the harness program to its exit. With `messages`, the
@@ -351,6 +355,8 @@ class Rollout:
                     )
                     messages = prepared.messages
                     self.trace.request_rewrites.extend(rewrites)
+                    if self._session.stopped:
+                        return False
                 await self._harness_session.turn(messages)
         except TimeoutError as e:
             # An expired rollout deadline is the agent breaking its time budget —

--- a/verifiers/v1/session.py
+++ b/verifiers/v1/session.py
@@ -8,22 +8,54 @@ budget (turns / tokens), checked between turns.
 """
 
 import asyncio
+import inspect
 import logging
+from collections import Counter
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from functools import cached_property
-from typing import TYPE_CHECKING
+from typing import get_origin, get_type_hints
 
 from pydantic import TypeAdapter
 
+from verifiers.v1 import graph
 from verifiers.v1.clients import Client, ModelContext
 from verifiers.v1.configs.runtime import NetworkPolicyConfig
-from verifiers.v1.trace import Trace
-
-if TYPE_CHECKING:
-    from verifiers.v1.errors import RolloutError
+from verifiers.v1.errors import RolloutError, TaskError
+from verifiers.v1.trace import InterceptRecord, Trace
+from verifiers.v1.types import (
+    AssistantMessage,
+    Messages,
+    Request,
+    Response,
+    ToolMessage,
+    UserMessage,
+)
+from verifiers.v1.utils.decorators import invoke
 
 logger = logging.getLogger(__name__)
+
+
+def hook_boundary(handler: Callable, *, allow_trace: bool) -> type:
+    """Select a hook boundary solely from its annotated parameters."""
+    hints = get_type_hints(handler)
+    annotations = [
+        get_origin(hints[name]) or hints[name]
+        for name in inspect.signature(handler).parameters
+        if name in hints
+    ]
+    boundaries = [kind for kind in annotations if kind in (Request, Response)]
+    if len(boundaries) == 1 and annotations.count(Trace) <= 1:
+        return boundaries[0]
+    if not boundaries and allow_trace and annotations.count(Trace) == 1:
+        return Trace
+    expected = "Request, Response, or Trace" if allow_trace else "Request or Response"
+    raise TypeError(f"{handler.__name__} must have exactly one {expected} parameter")
+
+
+async def call_hook(handler: Callable, available: dict[type, object]) -> object:
+    result = invoke(handler, available)
+    return await result if inspect.isawaitable(result) else result
 
 
 @dataclass(frozen=True)
@@ -68,8 +100,12 @@ class RolloutSession:
     trace: Trace
     network_policy: NetworkPolicyConfig = field(default_factory=NetworkPolicyConfig)
     """The resolved execution policy, including task-level restrictions."""
-    stops: list[Callable[[Trace], Awaitable[bool]]] = field(default_factory=list)
+    stops: list[Callable[..., Awaitable[bool] | bool]] = field(default_factory=list)
     limits: RolloutLimits = field(default_factory=RolloutLimits)
+    request_interceptors: list[Callable] = field(default_factory=list)
+    response_interceptors: list[Callable] = field(default_factory=list)
+    request_stops: list[Callable] = field(default_factory=list)
+    response_stops: list[Callable] = field(default_factory=list)
     client: Client | None = None
     """The model client serving this rollout's turns. The interception server assigns it at
     `register` (one server-owned client per distinct endpoint config), so every rollout it
@@ -80,22 +116,12 @@ class RolloutSession:
     harness returns — recording the real `ProviderError` instead of a secondary `HarnessError`.
     Reset before each model turn, so a successful retry clears it."""
     last_request: bytes | None = None
-    """Digest of the most recently served request body; with `last_response`, the replay cache
-    that keeps the message graph atomic under harness-SDK retries. A retry re-sends the
-    byte-identical request; when it matches, the interception server replays the recorded
-    response instead of re-sampling and committing a second turn — which would fork the graph
-    into a dead-end branch. Only a fully served request is cached, so a genuinely failed attempt
-    still re-runs. Turns are issued sequentially (one outstanding request at a time), so a retry
-    is always of the most recent request — keeping only the last one is sufficient and bounded."""
+    """Digest of the most recently served request body. Together with `last_response`, this
+    replays the common SDK retry of the latest completed exchange without re-sampling it."""
     last_response: dict | None = None
     """The response returned for `last_request`, replayed verbatim on a retry."""
     inflight: dict[bytes, "asyncio.Future[dict | None]"] = field(default_factory=dict)
-    """Body digest -> the future of the attempt currently computing it. A retry that arrives
-    while the first attempt is still in flight (a slow turn) awaits this future instead of
-    starting a second inference — the other half of retry atomicity (with `last_response`, which
-    covers a retry after the attempt finished). Because a slow turn is coalesced rather than
-    re-sampled, retries stay safe without an inflated client timeout. The future resolves to the
-    served response, or to None if the attempt produced no servable response (error/refuse)."""
+    """Body digest -> the response currently computing, used to coalesce an in-flight retry."""
     released: bool = False
     """Set when the rollout unregisters the session: the trace is sealed (its conclusion is
     what scored and persisted), so a handler still in flight must not commit turns, record
@@ -104,6 +130,233 @@ class RolloutSession:
     """Handler tasks currently serving this session. aiohttp does not cancel a handler when
     its client disconnects, so a request whose program died at teardown would keep driving
     the exchange (upstream call, simulator turn) — unregistering cancels these instead."""
+    prepared_tool_results: dict[str, ToolMessage] = field(default_factory=dict)
+    prepared_users: Counter[str] = field(default_factory=Counter)
+
+    @property
+    def stopped(self) -> bool:
+        return self.trace.stop_condition is not None
+
+    async def rewrite_request(
+        self, request: Request
+    ) -> tuple[Request, list[InterceptRecord], str | None]:
+        """Run typed request interceptors and stops over one canonical request."""
+        if not self.request_interceptors and not self.request_stops:
+            return request, [], None
+        turn = graph.prepare_turn(self.trace, request.messages)
+        prepared_users = self.prepared_users.copy()
+        prepared: set[int] = set()
+        candidates: set[int] = set()
+        for position in range(turn.tail_start, len(request.messages)):
+            message = request.messages[position]
+            if isinstance(message, UserMessage):
+                candidates.add(position)
+                key = graph.message_hash(message)
+                if prepared_users[key]:
+                    prepared_users[key] -= 1
+                    prepared.add(position)
+            elif isinstance(message, ToolMessage):
+                candidates.add(position)
+                if self.prepared_tool_results.get(message.tool_call_id) == message:
+                    prepared.add(position)
+        if candidates and candidates == prepared:
+            return request, [], None
+
+        current = request
+        records: list[InterceptRecord] = []
+        try:
+            for handler in self.request_interceptors:
+                candidate = current.model_copy(deep=True)
+                result = await call_hook(
+                    handler, {Request: candidate, Trace: self.trace}
+                )
+                if result is None:
+                    continue
+                if not isinstance(result, Request):
+                    raise TypeError(f"expected Request, got {type(result).__name__}")
+                if len(result.messages) != len(current.messages):
+                    raise ValueError(
+                        "request interceptors cannot add or remove messages"
+                    )
+                if result.tools != current.tools:
+                    raise ValueError("request interceptors cannot rewrite tools")
+                for position, (before, after) in enumerate(
+                    zip(current.messages, result.messages, strict=True)
+                ):
+                    if before == after:
+                        continue
+                    if position not in candidates - prepared:
+                        raise ValueError(
+                            "request interceptors can only rewrite new user or tool messages"
+                        )
+                    if type(after) is not type(before):
+                        raise TypeError(
+                            f"expected {type(before).__name__}, got {type(after).__name__}"
+                        )
+                    if (
+                        isinstance(before, ToolMessage)
+                        and after.tool_call_id != before.tool_call_id
+                    ):
+                        raise ValueError(
+                            "request interceptors cannot change a tool-call ID"
+                        )
+                if result != current:
+                    current = result
+                    records.append(InterceptRecord(handler=handler.__name__))
+
+            for stop in self.request_stops:
+                candidate = current.model_copy(deep=True)
+                result = await call_hook(stop, {Request: candidate, Trace: self.trace})
+                if not isinstance(result, bool):
+                    raise TypeError(
+                        f"@stop must return bool, got {type(result).__name__}"
+                    )
+                if result:
+                    return current, records, stop.__name__
+        except RolloutError:
+            raise
+        except Exception as error:
+            raise TaskError(
+                f"request interception failed: {type(error).__name__}: {error}"
+            ) from error
+        return current, records, None
+
+    def consume_prepared(self, messages: Messages) -> None:
+        """Forget pre-harness rewrites only after their model request commits."""
+        for message in messages:
+            if isinstance(message, UserMessage):
+                key = graph.message_hash(message)
+                if self.prepared_users[key]:
+                    self.prepared_users[key] -= 1
+            elif isinstance(message, ToolMessage):
+                self.prepared_tool_results.pop(message.tool_call_id, None)
+
+    async def prepare_users(
+        self, request: Request
+    ) -> tuple[Request, list[InterceptRecord]]:
+        """Intercept caller-owned user turns before the harness stores them."""
+        branch = self.trace.messages
+        rewritten, records, stopped = await self.rewrite_request(
+            Request(messages=[*branch, *request.messages])
+        )
+        tail = rewritten.messages[len(branch) :]
+        if stopped is not None:
+            graph.prepare_turn(self.trace, rewritten.messages).commit_prompt()
+            self.trace.stop(stopped)
+        else:
+            self.prepared_users.update(
+                graph.message_hash(message)
+                for message in tail
+                if isinstance(message, UserMessage)
+            )
+        return Request(messages=tail), records
+
+    async def rewrite_response(
+        self, response: Response
+    ) -> tuple[Response, list[InterceptRecord], str | None]:
+        """Run typed response interceptors and stops before harness delivery."""
+        records: list[InterceptRecord] = []
+        try:
+            for handler in self.response_interceptors:
+                candidate = response.model_copy(deep=True)
+                result = await call_hook(
+                    handler, {Response: candidate, Trace: self.trace}
+                )
+                if result is None:
+                    continue
+                if not isinstance(result, Response):
+                    raise TypeError(f"expected Response, got {type(result).__name__}")
+                if result == response:
+                    continue
+                unchanged = result.model_copy(
+                    update={
+                        "message": response.message,
+                        "finish_reason": response.finish_reason,
+                    }
+                )
+                if unchanged != response:
+                    raise ValueError(
+                        "response interceptors can only replace the assistant message"
+                    )
+                if (
+                    result.message.reasoning_content
+                    or result.message.tool_calls
+                    or result.message.provider_state
+                ):
+                    raise ValueError(
+                        "response interceptors must return an inert text-only message"
+                    )
+                response = result.model_copy(update={"finish_reason": "stop"})
+                records.append(InterceptRecord(handler=handler.__name__))
+
+            for stop in self.response_stops:
+                candidate = response.model_copy(deep=True)
+                result = await call_hook(stop, {Response: candidate, Trace: self.trace})
+                if not isinstance(result, bool):
+                    raise TypeError(
+                        f"@stop must return bool, got {type(result).__name__}"
+                    )
+                if result:
+                    return response, records, stop.__name__
+        except RolloutError:
+            raise
+        except Exception as error:
+            raise TaskError(
+                f"response interception failed: {type(error).__name__}: {error}"
+            ) from error
+        return response, records, None
+
+    async def handle_tool(self, phase: str, message: ToolMessage) -> dict:
+        """Intercept a harness-owned tool result before the harness records it."""
+        branches = [
+            branch
+            for branch in self.trace.branches
+            if branch.nodes
+            and isinstance(branch.nodes[-1].message, AssistantMessage)
+            and any(
+                call.id == message.tool_call_id
+                for call in branch.nodes[-1].message.tool_calls or []
+            )
+        ]
+        if len(branches) != 1:
+            raise TaskError(
+                f"tool call {message.tool_call_id!r} matched {len(branches)} branches"
+            )
+        branch = branches[0]
+        assistant = branch.nodes[-1].message
+        assert isinstance(assistant, AssistantMessage)
+        # Keep earlier results in the hook's trace, but commit them only when the model
+        # request arrives and can supply their token attribution.
+        previous = [
+            self.prepared_tool_results[call.id]
+            for call in assistant.tool_calls or []
+            if call.id in self.prepared_tool_results
+        ]
+        request, records, stopped = await self.rewrite_request(
+            Request(
+                messages=[*branch.messages, *previous, message],
+                tools=self.trace.tools or None,
+            )
+        )
+        candidate = request.messages[-1]
+        assert isinstance(candidate, ToolMessage)
+        self.trace.request_rewrites.extend(records)
+        if stopped is not None:
+            committed = request.messages if phase == "after" else request.messages[:-1]
+            turn = graph.prepare_turn(self.trace, committed)
+            turn.commit_prompt()
+            self.consume_prepared(turn.tail)
+            self.trace.stop(stopped)
+            return {"action": "stop", "reason": stopped}
+        if phase == "before" and candidate == message:
+            return {"action": "allow"}
+        self.prepared_tool_results[candidate.tool_call_id] = candidate
+        if candidate != message:
+            return {
+                "action": "rewrite",
+                "message": candidate.model_dump(exclude_none=True),
+            }
+        return {"action": "allow"}
 
     @cached_property
     def state_adapter(self) -> TypeAdapter:
@@ -140,7 +393,12 @@ class RolloutSession:
             logger.debug("limit %r reached: id=%s", limit, self.trace.id)
             return limit
         for stop in self.stops:
-            if await stop(self.trace):
+            result = stop(self.trace)
+            if inspect.isawaitable(result):
+                result = await result
+            if not isinstance(result, bool):
+                raise TaskError(f"@stop must return bool, got {type(result).__name__}")
+            if result:
                 self.trace.stop(stop.__name__)
                 logger.debug("stop %r fired: id=%s", stop.__name__, self.trace.id)
                 return stop.__name__

--- a/verifiers/v1/session.py
+++ b/verifiers/v1/session.py
@@ -100,7 +100,9 @@ class RolloutSession:
     trace: Trace
     network_policy: NetworkPolicyConfig = field(default_factory=NetworkPolicyConfig)
     """The resolved execution policy, including task-level restrictions."""
-    stops: list[Callable[..., Awaitable[bool] | bool]] = field(default_factory=list)
+    trace_stops: list[Callable[..., Awaitable[bool] | bool]] = field(
+        default_factory=list
+    )
     limits: RolloutLimits = field(default_factory=RolloutLimits)
     request_interceptors: list[Callable] = field(default_factory=list)
     response_interceptors: list[Callable] = field(default_factory=list)
@@ -138,10 +140,10 @@ class RolloutSession:
         return self.trace.stop_condition is not None
 
     async def rewrite_request(
-        self, request: Request
+        self, request: Request, *, run_stops: bool = True
     ) -> tuple[Request, list[InterceptRecord], str | None]:
         """Run typed request interceptors and stops over one canonical request."""
-        if not self.request_interceptors and not self.request_stops:
+        if not self.request_interceptors and (not run_stops or not self.request_stops):
             return request, [], None
         turn = graph.prepare_turn(self.trace, request.messages)
         prepared_users = self.prepared_users.copy()
@@ -159,13 +161,13 @@ class RolloutSession:
                 candidates.add(position)
                 if self.prepared_tool_results.get(message.tool_call_id) == message:
                     prepared.add(position)
-        if candidates and candidates == prepared:
-            return request, [], None
+        already_intercepted = candidates and candidates == prepared
 
         current = request
         records: list[InterceptRecord] = []
         try:
-            for handler in self.request_interceptors:
+            interceptors = [] if already_intercepted else self.request_interceptors
+            for handler in interceptors:
                 candidate = current.model_copy(deep=True)
                 result = await call_hook(
                     handler, {Request: candidate, Trace: self.trace}
@@ -204,7 +206,8 @@ class RolloutSession:
                     current = result
                     records.append(InterceptRecord(handler=handler.__name__))
 
-            for stop in self.request_stops:
+            stops = self.request_stops if run_stops else []
+            for stop in stops:
                 candidate = current.model_copy(deep=True)
                 result = await call_hook(stop, {Request: candidate, Trace: self.trace})
                 if not isinstance(result, bool):
@@ -236,19 +239,15 @@ class RolloutSession:
     ) -> tuple[Request, list[InterceptRecord]]:
         """Intercept caller-owned user turns before the harness stores them."""
         branch = self.trace.messages
-        rewritten, records, stopped = await self.rewrite_request(
-            Request(messages=[*branch, *request.messages])
+        rewritten, records, _ = await self.rewrite_request(
+            Request(messages=[*branch, *request.messages]), run_stops=False
         )
         tail = rewritten.messages[len(branch) :]
-        if stopped is not None:
-            graph.prepare_turn(self.trace, rewritten.messages).commit_prompt()
-            self.trace.stop(stopped)
-        else:
-            self.prepared_users.update(
-                graph.message_hash(message)
-                for message in tail
-                if isinstance(message, UserMessage)
-            )
+        self.prepared_users.update(
+            graph.message_hash(message)
+            for message in tail
+            if isinstance(message, UserMessage)
+        )
         return Request(messages=tail), records
 
     async def rewrite_response(
@@ -392,10 +391,8 @@ class RolloutSession:
             self.trace.stop(limit)
             logger.debug("limit %r reached: id=%s", limit, self.trace.id)
             return limit
-        for stop in self.stops:
-            result = stop(self.trace)
-            if inspect.isawaitable(result):
-                result = await result
+        for stop in self.trace_stops:
+            result = await call_hook(stop, {Trace: self.trace})
             if not isinstance(result, bool):
                 raise TaskError(f"@stop must return bool, got {type(result).__name__}")
             if result:

--- a/verifiers/v1/tasksets/nemo_gym/taskset.py
+++ b/verifiers/v1/tasksets/nemo_gym/taskset.py
@@ -106,12 +106,12 @@ class NeMoGymTaskset(Taskset[NeMoGymTask, NeMoGymConfig]):
             for idx, line in enumerate(filter(str.strip, lines)):
                 found = True
                 row = json.loads(line)
-                prompt, _ = dialect.parse_request(row["responses_create_params"])
+                request = dialect.parse_request(row["responses_create_params"])
                 yield NeMoGymTask(
                     NeMoGymData(
                         idx=idx,
                         name=f"{path.stem}:{idx}",
-                        prompt=prompt,
+                        prompt=request.messages,
                         row=row,
                     ),
                     self.config.task,

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -25,6 +25,7 @@ from verifiers.v1.types import (
     AssistantMessage,
     FinishReason,
     KeptTokens,
+    Message,
     Messages,
     Sampling,
     Tool,
@@ -123,6 +124,10 @@ class TraceTask(BaseModel, Generic[DataT]):
     """The (immutable) row being solved."""
     hash: str | None = None
     """Content hash of `data` (`Task.hash`) — the task's identity across runs."""
+
+
+class InterceptRecord(BaseModel):
+    handler: str
 
 
 class Reward(BaseModel):
@@ -364,6 +369,10 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
     """The message graph; branches are derived views and storage stays linear in turns."""
     calls: list[ModelCall] = Field(default_factory=list)
     """Every model call; automatically recorded at intercept time + linked into `nodes`."""
+    request_rewrites: list[InterceptRecord] = Field(default_factory=list)
+    """Request changes made by `@intercept`, in execution order."""
+    response_rewrites: list[InterceptRecord] = Field(default_factory=list)
+    """Response changes made by `@intercept`, in execution order."""
 
     rewards: dict[str, Reward | None] = Field(default_factory=dict)
     """Named, weighted rewards; `None` means scoring didn't run (e.g. because of a
@@ -449,6 +458,19 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
                 )
             )
         return branches
+
+    @property
+    def messages(self) -> Messages:
+        """Messages on the final branch."""
+        branches = self.branches
+        return branches[-1].messages if branches else []
+
+    @property
+    def last_message(self) -> Message:
+        """The most recently stored message."""
+        if not self.nodes:
+            raise ValueError("trace has no messages")
+        return self.nodes[-1].message
 
     @property
     def num_branches(self) -> int:

--- a/verifiers/v1/types.py
+++ b/verifiers/v1/types.py
@@ -101,6 +101,13 @@ class Tool(BaseModel):
     strict: bool | None = None
 
 
+class Request(BaseModel):
+    """The typed conversation about to cross a model or harness boundary."""
+
+    messages: Messages
+    tools: list[Tool] | None = None
+
+
 FinishReason = Literal["stop", "length", "tool_calls"] | None
 
 

--- a/verifiers/v1/utils/decorators.py
+++ b/verifiers/v1/utils/decorators.py
@@ -3,7 +3,7 @@
 import asyncio
 import inspect
 from collections.abc import Callable, Iterable
-from typing import Any, TypeVar, overload
+from typing import Any, TypeVar, get_origin, get_type_hints, overload
 
 F = TypeVar("F", bound=Callable[..., Any])
 
@@ -26,9 +26,16 @@ def discover_decorated(obj: object, attr: str) -> list[Callable[..., Any]]:
     return methods
 
 
-def invoke(fn: Callable[..., Any], available: dict[str, Any]) -> Any:
+def invoke(fn: Callable[..., Any], available: dict[str | type, Any]) -> Any:
     params = inspect.signature(fn).parameters
-    return fn(**{name: value for name, value in available.items() if name in params})
+    kwargs = {name: available[name] for name in params if name in available}
+    if any(isinstance(key, type) for key in available):
+        hints = get_type_hints(fn)
+        for name in params:
+            annotation = get_origin(hints.get(name)) or hints.get(name)
+            if name not in kwargs and annotation in available:
+                kwargs[name] = available[annotation]
+    return fn(**kwargs)
 
 
 async def invoke_all(
@@ -80,8 +87,18 @@ def stop(func: F, priority: int = 0) -> F: ...
 @overload
 def stop(func: None = None, priority: int = 0) -> Callable[[F], F]: ...
 def stop(func: F | None = None, priority: int = 0) -> F | Callable[[F], F]:
-    """Mark a stop condition `(self, trace) -> bool`."""
+    """Stop when a typed `Request`, `Response`, or `Trace` predicate returns true."""
     decorator = mark("stop", stop_priority=priority)
+    return decorator if func is None else decorator(func)
+
+
+@overload
+def intercept(func: F, priority: int = 0) -> F: ...
+@overload
+def intercept(func: None = None, priority: int = 0) -> Callable[[F], F]: ...
+def intercept(func: F | None = None, priority: int = 0) -> F | Callable[[F], F]:
+    """Inspect a typed boundary; return its replacement or None to leave it unchanged."""
+    decorator = mark("intercept", intercept_priority=priority)
     return decorator if func is None else decorator(func)
 
 


### PR DESCRIPTION
## Overview

Connects harness-owned tool execution to the same typed request interception path. The plumbing is opt-in for each harness; this PR enables it for the Bash harness.

## Behavior

- A supporting harness receives the rollout's tool-interception URL on both launch and resume.
- Immediately before Bash executes a tool, it sends a `vf.Request` whose final message is an empty `ToolMessage`.
- A request interceptor can fill that message with a synthetic result. Bash then skips execution and returns the replacement to the model as ordinary tool output.
- A request stop can end the rollout before the proposed tool executes.
- After a tool executes, its real `ToolMessage` passes through the same request hooks before it is returned to the model. A hook may replace that result.
- Prepared tool results remain canonical across the harness, the next model request, and the trace.
- Harnesses without support, and rollouts without request interceptors or request stops, receive no interception URL and keep their normal path.

## Stack

These PRs are stacked in merge order. Each PR targets the one above it.

| PR | What it adds |
| --- | --- |
| [#2164](https://github.com/PrimeIntellect-ai/verifiers/pull/2164) | Typed transport, native request/response rewriting, buffered inspection, and retry replay |
| [#2165](https://github.com/PrimeIntellect-ai/verifiers/pull/2165) | Public `@vf.intercept` for `vf.Request` and `vf.Response` |
| [#2166](https://github.com/PrimeIntellect-ai/verifiers/pull/2166) | Public `@vf.stop` for `vf.Request`, `vf.Response`, and `vf.Trace` |
| [#2229](https://github.com/PrimeIntellect-ai/verifiers/pull/2229) | Opt-in harness tool hooks, enabled for Bash |
| [#2178](https://github.com/PrimeIntellect-ai/verifiers/pull/2178) | Example environments for response, image, Bash, and native web-search interception |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> When interceptors are configured, Bash tool execution (including shell commands) is gated by remote hook decisions; misconfigured or buggy hooks can block runs or inject tool output, though the path is inactive without request interceptors/stops.
> 
> **Overview**
> Adds **opt-in harness tool interception** so rollout `@intercept` / `@stop` hooks on `vf.Request` can run around **harness-owned** tool calls, not only model HTTP traffic. Harnesses declare `SUPPORTS_TOOL_INTERCEPTION`; the rollout passes a `{base_url}/tool` URL into `session` / `launch` / `resume` only when that flag is set **and** the session has request interceptors or request stops.
> 
> **Bash** is the first enabled harness: it forwards `--tool-interception-url` to `program.py`, which POSTs `before` / `after` hooks (Bearer `api_key`) with a provisional `ToolMessage`. A **`rewrite`** on `before` skips real execution and appends the synthetic tool result; **`stop`** aborts the loop; **`after`** may replace the executed tool output before it goes back to the model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f600f9b673be0dde8a657876e2daaf022edc3ecf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Connect harness tool interception hooks to rollout sessions
> - Introduces an `@intercept` decorator in [decorators.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2229/files#diff-3d8f7306fa2edfd8c2f1beedb8779c90ace86b13067a16425a9f33f43cf594f9) that marks handler functions for execution at request or response boundaries, with optional priority ordering.
> - Expands `RolloutSession` in [session.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2229/files#diff-0eeafa9506eb0d53c459cf476e308ce72a99d147d2f84979affa04baaee79a66) with full interception flow: typed user/tool request rewriting, response rewriting, stop evaluation, and tool hook handling.
> - All three dialects ([chat.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2229/files#diff-5d2fcbf59a03489b63b0626038a853eee89543b591074597161ee29aab901280), [anthropic.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2229/files#diff-abc86b3ad07c2d6ab09cd923f50271c4f6c4cb928a9bb82c12f6e97aac17b04d), [responses.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2229/files#diff-73f89a1b25536fd7a806555e765120f5189cb934eff813f4c7900838efa56b5a)) now implement `rewrite_request`, `rewrite_response`, and `stream_events` to apply interceptor rewrites and stream injected responses over SSE.
> - The bash harness ([harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2229/files#diff-1544e2ee3426241d8c97940a3e8daf25b2eeeeb95f8abb27e88bed4af420e609), [program.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2229/files#diff-d4cd8c8ecce1607fa0d58ad9d6be1b24a81ace7b7dd85521910d4082319a2400)) gains a `--tool-interception-url` argument; the program sends before/after hooks to the interception server and handles stop or rewrite decisions per tool call.
> - `Rollout.open()` now runs request interceptors on the initial prompt before launching the harness, and may return `False` when a stop fires before any inference.
> - Risk: `Rollout.open()` returning `False` is a behavioral change — callers that previously only checked for exceptions must now also handle a `False` return.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f600f9b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->