### PR TITLE
Update CI to DeepSeek V4 Flash 0731

### DIFF
--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -129,7 +129,7 @@ def _eval_config(
     runtime: dict | None = None,
     env: dict | None = None,
     pool: dict | None = None,
-    model: str | None = None,
+    model: str | None = "deepseek/deepseek-v4-flash-0731",
     reasoning_effort: str | None = None,
 ) -> EvalConfig:
     """Build the smallest `EvalConfig` that still exercises the path, shared by the in-process
@@ -224,7 +224,7 @@ async def live_ctx():
     client = resolve_client(EvalClientConfig())
     try:
         yield ModelContext(
-            model="deepseek/deepseek-v4-flash",
+            model="deepseek/deepseek-v4-flash-0731",
             client=client,
             sampling=SamplingConfig(max_tokens=2048),
         )


### PR DESCRIPTION
## Overview

Updates the live V1 end-to-end CI suite to use `deepseek/deepseek-v4-flash-0731`.

## Details

- Pins the shared V1 eval fixture to the dated model so in-process and server-backed CI runs use it consistently.
- Aligns the direct-agent `live_ctx` fixture with the same model.
- Keeps the public eval CLI default unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only default model id changes with no production or CLI config impact.
> 
> **Overview**
> **Pins live V1 e2e tests to `deepseek/deepseek-v4-flash-0731`** so CI and local e2e runs hit a single dated DeepSeek V4 Flash build instead of the undated `deepseek/deepseek-v4-flash` id.
> 
> The shared `_eval_config` helper now defaults `model` to the 0731 variant (used by `run_v1` and `run_v1_server`), and the `live_ctx` fixture uses the same id for direct `Agent` tests. The eval CLI’s public default model is **not** changed in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0ef66201504972e062e2f5563cd89b10fa059ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update CI test fixtures to use DeepSeek V4 Flash 0731 model
> Updates the default model in [conftest.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2232/files#diff-bc28790d38dc6e7e4f2c44639d40bc33dea724d6c73149abf7ba82b37d14f40b) from `deepseek/deepseek-v4-flash` to `deepseek/deepseek-v4-flash-0731` in both the `_eval_config` helper default parameter and the `live_ctx` fixture.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e0ef662.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->