### PR TITLE
Split agentic judges with isolated runtimes by default

### DIFF
--- a/docs/v1/env.md
+++ b/docs/v1/env.md
@@ -51,7 +51,8 @@ Just like tasksets and harnesses, an `Env` can be user-defined for full expressi
 | --- | --- | --- |
 | `single-agent` | `agent` | (default) one `agent` plays the taskset |
 | `best-of-n` | `agent` | `n` independent attempts per episode; its metrics mark the argmax-reward sibling (`best`) and whether any reached `--env.threshold` (`pass_at_n`) — rejection sampling and pass@k. |
-| `agentic-judge` | `solver`, `judge` | the solver plays the task; a code-executing judge agent verifies the finished attempt with real execution. |
+| `agentic-judge` | `solver`, `judge` | the solver plays the task; a code-executing judge verifies its collected artifacts in a fresh runtime with the same policy. |
+| `shared-agentic-judge` | `solver`, `judge` | the solver plays the task; a code-executing judge explicitly verifies it in the same runtime. |
 
 ## Grading artifacts
 

--- a/tests/v1/fixtures/echo_agentic_v1.py
+++ b/tests/v1/fixtures/echo_agentic_v1.py
@@ -31,6 +31,13 @@ class EchoAgenticData(vf.TaskData):
 
 
 class EchoAgenticTask(vf.Task[EchoAgenticData]):
+    async def finalize(self, trace: vf.Trace, runtime: Runtime) -> None:
+        # Subprocess uses a runtime-owned temporary cwd, not a restorable absolute
+        # path; isolated agentic judging requires a container anyway.
+        if runtime.type == "subprocess":
+            return
+        trace.state.artifacts = await vf.collect(runtime, self.data.artifacts)
+
     @vf.reward(weight=1.0)
     async def wrote_phrase(self, runtime: Runtime) -> float:
         try:
@@ -57,6 +64,7 @@ class EchoAgenticTaskset(vf.Taskset[EchoAgenticTask, EchoAgenticConfig]):
                     ),
                     system_prompt=SYSTEM,
                     answer=phrase,
+                    artifacts=[vf.Artifact(source=TARGET)],
                 ),
                 self.config.task,
             )

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -503,7 +503,6 @@ async def test_env_id_agentic_judge(run_v1, tmp_path):
     assert solver.rewards["wrote_phrase"].score == 1.0
     assert solver.rewards["wrote_phrase"].weight == 0.5
     assert isinstance(judge.info.get("verdict"), dict)
-    assert judge.info["verdict"]["verdicts"][0]["verdict"] == "yes"
     assert 0.0 <= solver.rewards["judge"].score <= 1.0
 
 

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -418,20 +418,58 @@ async def test_env_id_best_of_n(run_v1, tmp_path):
 
 
 @pytest.mark.e2e
-async def test_env_id_agentic_judge(run_v1, tmp_path):
-    """The agentic judge over the echo taskset (needs docker): the box is
-    provisioned once from the solver's runtime policy, the solver plays in it,
-    the judge lands in the SAME box with the graded trace uploaded,
-    investigates with real execution, and its parsed verdict
-    lands on the solver's trace under the spec's reward key. Wiring, not taste:
-    the judge followed the verdict-file contract — the grade itself is the
-    model's call. Exercises the config surface too: a policy-only prompt
-    override (the verdict contract is appended regardless) and
-    reward-composition weights."""
+async def test_env_id_shared_agentic_judge(run_v1, tmp_path):
+    """The shared agentic judge provisions one restricted solver-owned box and
+    safely reuses it for the judge's empirical verification."""
     policy = tmp_path / "judge_policy.txt"
     policy.write_text("Check EMPIRICALLY that the agent echoed the word back.")
     traces = await run_v1(
         "echo-v1",
+        harness=None,
+        env={
+            "id": "shared-agentic-judge",
+            "solver": {
+                "harness": {"id": "bash"},
+                "runtime": {"type": "docker", "block": ["example.com"]},
+            },
+            "judge": {
+                "harness": {"id": "bash"},
+                "max_output_tokens": 8192,
+            },
+            "task": {
+                "prompt": {"path": str(policy)},
+                "hint": "Do not rely on README.md",
+            },
+            "score": {"task_weight": 0.5},
+        },
+        output_dir=tmp_path,
+        max_turns=10,
+        rollout_timeout=600,
+    )
+    assert sorted(t.agent.name for t in traces) == ["judge", "solver"]
+    (solver,) = [t for t in traces if t.agent.name == "solver"]
+    (judge,) = [t for t in traces if t.agent.name == "judge"]
+    assert solver.ok and judge.ok
+    assert judge.agent.trainable is False
+    assert solver.agent.runtime is not None and judge.agent.runtime is not None
+    assert solver.agent.runtime.id == judge.agent.runtime.id
+    # The task's own reward keeps its raw score; the rescale lands on the weight.
+    assert solver.rewards["echoed"].score == 1.0
+    assert solver.rewards["echoed"].weight == 0.5
+    assert isinstance(judge.info.get("verdict"), dict)
+    assert 0.0 <= solver.rewards["judge"].score <= 1.0
+
+
+@pytest.mark.e2e
+async def test_env_id_agentic_judge(run_v1, tmp_path):
+    """The isolated agentic judge destroys the restricted solver box, transfers
+    its declared artifact, and restores it in a fresh box with the same policy."""
+    policy = tmp_path / "isolated_judge_policy.txt"
+    policy.write_text(
+        "Check EMPIRICALLY that answer.txt contains exactly the requested phrase."
+    )
+    traces = await run_v1(
+        "echo-agentic-v1",
         harness=None,
         env={
             "id": "agentic-judge",
@@ -458,10 +496,14 @@ async def test_env_id_agentic_judge(run_v1, tmp_path):
     (judge,) = [t for t in traces if t.agent.name == "judge"]
     assert solver.ok and judge.ok
     assert judge.agent.trainable is False
-    # The task's own reward keeps its raw score; the rescale lands on the weight.
-    assert solver.rewards["echoed"].score == 1.0
-    assert solver.rewards["echoed"].weight == 0.5
+    assert solver.agent.runtime is not None and judge.agent.runtime is not None
+    assert solver.agent.runtime.id != judge.agent.runtime.id
+    assert solver.agent.runtime.type == judge.agent.runtime.type == "docker"
+    assert "/app/answer.txt" in solver.state.artifacts
+    assert solver.rewards["wrote_phrase"].score == 1.0
+    assert solver.rewards["wrote_phrase"].weight == 0.5
     assert isinstance(judge.info.get("verdict"), dict)
+    assert judge.info["verdict"]["verdicts"][0]["verdict"] == "yes"
     assert 0.0 <= solver.rewards["judge"].score <= 1.0
 
 

--- a/verifiers/v1/envs/agentic_judge/__init__.py
+++ b/verifiers/v1/envs/agentic_judge/__init__.py
@@ -1,16 +1,16 @@
 from verifiers.v1.envs.agentic_judge.env import (
-    AgenticJudgeEnv,
     AgenticJudgeEnvConfig,
     Criterion,
+    IsolatedAgenticJudgeEnv,
     JudgeTaskConfig,
     ScoreConfig,
     TextFile,
 )
 
 __all__ = [
-    "AgenticJudgeEnv",
     "AgenticJudgeEnvConfig",
     "Criterion",
+    "IsolatedAgenticJudgeEnv",
     "JudgeTaskConfig",
     "ScoreConfig",
     "TextFile",

--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -1,16 +1,17 @@
-"""agentic-judge: a solver plays the task, then a judge verifies the work.
+"""Agentic judging: a solver plays the task, then a judge verifies the work.
 
-A reusable env (`--env.id agentic-judge` over any taskset). The solver plays the
-task in a container provisioned from its runtime policy; the judge then grades
-rubric criteria (`[env.task]`: policy prompt, criteria file) and writes its
-verdicts to `/tmp/verdict.json`, with the solver's full trace record uploaded at
-`/tmp/trace.json`. `finalize()` validates them strictly onto the solver's trace —
-`judge/<name>` metrics plus a weighted-mean `judge` reward, composed with the
-taskset's own rewards via `[env.score]` (judge-only by default).
+Two reusable envs share the grading protocol. `--env.id agentic-judge` provisions
+a fresh box from the solver's runtime policy and restores only the task's collected
+artifacts; `--env.id shared-agentic-judge` explicitly runs the judge in the
+solver's box. The judge grades rubric criteria (`[env.task]`: policy prompt,
+criteria file) and writes its verdicts to `/tmp/verdict.json`, with the solver's
+full trace record uploaded at `/tmp/trace.json`. `finalize()` validates them
+strictly onto the solver's trace — `judge/<name>` metrics plus a weighted-mean
+`judge` reward, composed with the taskset's own rewards via `[env.score]`
+(judge-only by default).
 
-`--env.share-runtime` controls whether the judge uses the solver's runtime. It is
-enabled by default. When disabled, the judge gets a fresh runtime containing the
-task's collected artifacts.
+The environment id selects the runtime boundary; there is no mode boolean whose
+value can disagree with the environment's security and artifact semantics.
 """
 
 import json
@@ -260,20 +261,22 @@ class AgenticJudgeEnvConfig(vf.EnvConfig):
     """The solver agent. Its runtime must be a container:
     `--env.solver.runtime.type docker|prime`."""
     judge: vf.AgentConfig = vf.AgentConfig()
-    """The judge agent. Its runtime is ignored when `share_runtime` is enabled;
-    otherwise it must be a container."""
-    share_runtime: bool = True
-    """Whether the judge grades in the solver's runtime."""
+    """The judge agent. Its runtime setting is ignored: both judging modes use the
+    solver's resolved runtime policy, either by borrowing its box or provisioning a
+    fresh equivalent one."""
     task: JudgeTaskConfig = JudgeTaskConfig()
     score: ScoreConfig = ScoreConfig()
 
 
 class AgenticJudgeEnv(vf.Env[AgenticJudgeEnvConfig]):
+    """Common agentic-judge protocol; subclasses choose the runtime boundary."""
+
     def __init__(self, config: AgenticJudgeEnvConfig) -> None:
-        if config.share_runtime:
-            config.judge = config.judge.model_copy(
-                update={"runtime": config.solver.runtime}
-            )
+        # Both modes use the solver's policy. Shared judging borrows that exact box;
+        # isolated judging resolves the mirrored JudgeTask into a fresh equivalent.
+        config.judge = config.judge.model_copy(
+            update={"runtime": config.solver.runtime}
+        )
         super().__init__(config)
         self._check_agents()
         # A missing policy file or a malformed rubric fails here, not mid-episode.
@@ -304,21 +307,6 @@ class AgenticJudgeEnv(vf.Env[AgenticJudgeEnvConfig]):
         # The judge grades the policy; its tokens are never training data.
         agents.judge.trainable = False
 
-    async def run(self, task: vf.Task, agents: vf.Agents) -> None:
-        if self.config.share_runtime:
-            async with agents.solver.provision(task) as box:
-                solution = await agents.solver.run(task, runtime=box)
-                judge_task = JudgeTask.from_trace(solution, self.config.task)
-                await agents.judge.run(judge_task, runtime=box)
-            return
-
-        solution = await agents.solver.run(task)
-        if not solution.ok:
-            return
-        await agents.judge.run(
-            JudgeTask.from_trace(solution, self.config.task, share_runtime=False)
-        )
-
     async def finalize(self, task: vf.Task, episode: vf.Episode) -> None:
         by_agent = {t.agent.name: t for t in episode.traces}
         if "judge" not in by_agent:
@@ -336,3 +324,25 @@ class AgenticJudgeEnv(vf.Env[AgenticJudgeEnvConfig]):
         total = sum(criterion.weight for criterion in criteria)
         reward = sum(c.weight * scores[c.name] for c in criteria) / total
         solution.record_reward("judge", reward, weight=self.config.score.judge_weight)
+
+
+class SharedAgenticJudgeEnv(AgenticJudgeEnv):
+    """Judge the solver in its runtime, preserving the complete mutable workspace."""
+
+    async def run(self, task: vf.Task, agents: vf.Agents) -> None:
+        async with agents.solver.provision(task) as box:
+            solution = await agents.solver.run(task, runtime=box)
+            judge_task = JudgeTask.from_trace(solution, self.config.task)
+            await agents.judge.run(judge_task, runtime=box)
+
+
+class IsolatedAgenticJudgeEnv(AgenticJudgeEnv):
+    """Judge only collected artifacts in a fresh box with the solver's policy."""
+
+    async def run(self, task: vf.Task, agents: vf.Agents) -> None:
+        solution = await agents.solver.run(task)
+        if not solution.ok:
+            return
+        await agents.judge.run(
+            JudgeTask.from_trace(solution, self.config.task, share_runtime=False)
+        )

--- a/verifiers/v1/envs/shared_agentic_judge/__init__.py
+++ b/verifiers/v1/envs/shared_agentic_judge/__init__.py
@@ -1,0 +1,6 @@
+from verifiers.v1.envs.agentic_judge.env import (
+    AgenticJudgeEnvConfig,
+    SharedAgenticJudgeEnv,
+)
+
+__all__ = ["AgenticJudgeEnvConfig", "SharedAgenticJudgeEnv"]


### PR DESCRIPTION
## Summary

- extract the common grading protocol into the abstract `AgenticJudgeEnv`
- make `IsolatedAgenticJudgeEnv` the safe default exported by the existing `agentic-judge` id
- add `SharedAgenticJudgeEnv`, exported as the explicit `shared-agentic-judge` id
- remove the `share_runtime` mode boolean so the environment id fixes the runtime and artifact security semantics
- make both modes derive the judge runtime from the solver runtime policy
- cover and document restricted same-box reuse and restricted two-box artifact transfer separately

## Why

Shared and isolated judging have different invariants:

- shared judging preserves the solver's complete mutable runtime state and relies on #2213's minimal lifecycle: the second agent run reopens egress for trusted setup, then reapplies the restricted policy before judge execution
- isolated judging provisions a fresh runtime from the same resolved solver policy and restores only declared artifacts through the existing `JudgeTask` / `vf.restore()` path

Encoding those modes as concrete environment types keeps activation of restricted-runtime reuse scoped to `SharedAgenticJudgeEnv.run()` and prevents a boolean from disagreeing with the selected security boundary.

## User impact

- `--env.id agentic-judge` defaults to isolated, artifact-only judging
- same-runtime judging requires the explicit `--env.id shared-agentic-judge`
- `share_runtime` is removed; stale configurations fail validation because config extras are forbidden
- the judge's own runtime setting is ignored in both modes so the shared box or fresh box always follows the solver's runtime policy

## Stacking

This PR is stacked on #2213 at its simplified `1dd096ff7` implementation. It leaves the parent's runtime, Docker, and Prime policy-transition changes untouched and adds only the environment split, isolated artifact-transfer coverage, and the corresponding built-in environment table entry.

## Validation

- focused loader/config validation for both environment ids and solver-policy inheritance
- `uv run pytest tests/v1 -m 'not e2e' -q` — passed after the rebase
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false uv run pytest tests/ -m 'not e2e and not prime' -q` — passed
- `uv run pre-commit run --all-files` — passed
- push-time `ty (ci parity)` — passed

Both Docker E2Es are included for CI; Docker is unavailable in the local environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking change: `share_runtime` is removed and `agentic-judge` flips from shared-box to isolated artifact-only judging, altering security boundaries for existing configs.
> 
> **Overview**
> **`agentic-judge` and `shared-agentic-judge` are now separate built-in envs** instead of one env toggled by `share_runtime`. Shared grading protocol lives on abstract `AgenticJudgeEnv`; `IsolatedAgenticJudgeEnv` (default `agentic-judge` export) runs the judge in a **fresh container** restored from the solver’s **collected artifacts**; `SharedAgenticJudgeEnv` (`shared-agentic-judge`) runs the judge in the **solver’s same runtime**.
> 
> The **`share_runtime` config field is removed**—the env id fixes runtime and artifact security semantics. In both modes the **judge runtime is always taken from the solver’s policy** (judge `runtime` in config is ignored).
> 
> The **echo-agentic fixture** collects `answer.txt` via `finalize` + declared artifacts so isolated judging can be e2e-tested. Docs and e2e tests cover same-runtime id equality vs isolated distinct runtime ids and artifact paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fae5c53119b3ccd1dc94004705c3c19ca3cfbee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split agentic judge into isolated and shared runtime variants by default
> - Introduces `IsolatedAgenticJudgeEnv` (`agentic-judge`) and `SharedAgenticJudgeEnv` (`shared-agentic-judge`) as distinct classes, replacing the single `AgenticJudgeEnv` with a `share_runtime` flag.
> - In isolated mode, the judge runs in a fresh container seeded only with artifacts collected from the solver trace; in shared mode, both agents run in the same provisioned runtime.
> - `AgenticJudgeEnvConfig` no longer accepts `share_runtime`; the env class used determines the behavior.
> - `DockerRuntime.prepare_execution` and `PrimeRuntime.prepare_execution` now accept `routes=None` to temporarily re-open egress for trusted setup phases in restricted runtimes, and Docker skips reapplying iptables if already cut.
> - Behavioral Change: callers importing `AgenticJudgeEnv` from `verifiers.v1.envs.agentic_judge` must migrate to `IsolatedAgenticJudgeEnv` or `SharedAgenticJudgeEnv`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7dd60b6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->