### PR TITLE
feat: seed unscored rewards/metrics as None placeholders

### DIFF
--- a/tests/v1/test_judges.py
+++ b/tests/v1/test_judges.py
@@ -461,7 +461,7 @@ async def test_error_attribution(monkeypatch, tmp_path):
         await JudgedTask(trace.task.data, taskset.config.task).score(
             trace, runtime=None
         )
-    assert "reference" not in trace.rewards
+    assert trace.rewards["reference"] is None  # seeded: expected but never scored
     assert len(trace.info["judge"]) == 1  # the billed call is still recorded
 
 

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -71,17 +71,22 @@ def test_wire_trace_round_trip():
         ],
     )
     tr.record_reward("r", 1.0)
+    tr.rewards.setdefault("solved", None)  # seeded: expected but never scored
+    tr.metrics.setdefault("acc", None)
     tr.info = {"build": "ok"}
     tr.stop("done")
 
     # the dump is plain pydantic — derived values are properties, so they're not serialized
     data = json.loads(tr.model_dump_json(exclude_none=True))
     assert "reward" not in data and "is_truncated" not in data
+    # exclude_none drops None FIELDS, not None dict values — unscored seeds survive
+    assert data["rewards"]["solved"] is None and data["metrics"]["acc"] is None
 
     rt = vf.WireTrace.model_validate(data)
     assert rt.num_branches == tr.num_branches == 2  # branch topology survived
     assert rt.num_turns == tr.num_turns == 2
-    assert rt.reward == 1.0  # property recomputed from `rewards`
+    assert rt.reward == 1.0  # property recomputed from `rewards`, seeds contribute 0
+    assert rt.is_scored and rt.rewards["solved"] is None
     assert rt.stop_condition == "done"
     assert rt.info == {"build": "ok"}
     assert (

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -86,7 +86,7 @@ def test_wire_trace_round_trip():
     assert rt.num_branches == tr.num_branches == 2  # branch topology survived
     assert rt.num_turns == tr.num_turns == 2
     assert rt.reward == 1.0  # property recomputed from `rewards`, seeds contribute 0
-    assert rt.is_scored and rt.rewards["solved"] is None
+    assert rt.rewards["solved"] is None
     assert rt.stop_condition == "done"
     assert rt.info == {"build": "ok"}
     assert (

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -557,7 +557,7 @@ def Rows(groups: list[list[RunSlot]], now: float, runtime_type: str) -> Table:
                     result = (
                         t.last_error.type
                         if t.has_error and t.last_error
-                        else (f"reward={t.reward:.2f}" if t.is_scored else "")
+                        else (f"reward={t.reward:.2f}" if t.rewards else "")
                     )
                     if t.has_error:
                         stop = ""  # error shown instead

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -332,8 +332,8 @@ def Progress(
 
 def _score_segments(traces: list[Trace], source: str) -> str | None:
     """`name mean` segments for every reward/metric key seen across `traces`,
-    first-seen order (a trace records only the functions that ran for it, so keys
-    can vary); None when no trace recorded anything."""
+    first-seen order (a trace carries only its own task's signals — unscored ones
+    seeded as `None` — so keys can vary); None when no trace recorded anything."""
     names: list[str] = []
     for trace in traces:
         names.extend(n for n in getattr(trace, source) if n not in names)
@@ -347,11 +347,13 @@ def _score_segments(traces: list[Trace], source: str) -> str | None:
 
 
 def _score(trace: Trace, source: str, name: str) -> float:
-    """Rewards carry raw score + weight; the breakdown shows the raw score."""
+    """Rewards carry raw score + weight; the breakdown shows the raw score. A missing
+    or unscored (seeded `None`) entry reads as 0.0."""
     if source == "rewards":
         reward = trace.rewards.get(name)
         return reward.score if reward is not None else 0.0
-    return trace.metrics.get(name, 0.0)
+    value = trace.metrics.get(name)
+    return value if value is not None else 0.0
 
 
 def _breakdown(scored: list[Trace], done: list[Trace]) -> Table | None:
@@ -555,7 +557,7 @@ def Rows(groups: list[list[RunSlot]], now: float, runtime_type: str) -> Table:
                     result = (
                         t.last_error.type
                         if t.has_error and t.last_error
-                        else (f"reward={t.reward:.2f}" if t.rewards else "")
+                        else (f"reward={t.reward:.2f}" if t.is_scored else "")
                     )
                     if t.has_error:
                         stop = ""  # error shown instead

--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -398,7 +398,8 @@ class AgenticJudgeEnv(vf.Env[AgenticJudgeEnvConfig]):
             solution.record_metric(f"judge/{criterion.name}", scores[criterion.name])
         if self.config.score.task_weight != 1.0:
             for reward in solution.rewards.values():
-                reward.weight *= self.config.score.task_weight
+                if reward is not None:
+                    reward.weight *= self.config.score.task_weight
         total = sum(criterion.weight for criterion in criteria)
         reward = sum(c.weight * scores[c.name] for c in criteria) / total
         solution.record_reward("judge", reward, weight=self.config.score.judge_weight)

--- a/verifiers/v1/gepa/adapter.py
+++ b/verifiers/v1/gepa/adapter.py
@@ -120,5 +120,5 @@ def _episode_score(episode: Episode) -> float:
     """A candidate's score on one episode: the mean reward of the episode's scored
     traces. Seats that recorded no rewards (a reward-less judge) don't dilute the
     signal; an episode with no scored traces scores 0."""
-    scored = [trace.reward for trace in episode.traces if trace.is_scored]
+    scored = [trace.reward for trace in episode.traces if trace.rewards]
     return sum(scored) / len(scored) if scored else 0.0

--- a/verifiers/v1/gepa/adapter.py
+++ b/verifiers/v1/gepa/adapter.py
@@ -120,5 +120,5 @@ def _episode_score(episode: Episode) -> float:
     """A candidate's score on one episode: the mean reward of the episode's scored
     traces. Seats that recorded no rewards (a reward-less judge) don't dilute the
     signal; an episode with no scored traces scores 0."""
-    scored = [trace.reward for trace in episode.traces if trace.rewards]
+    scored = [trace.reward for trace in episode.traces if trace.is_scored]
     return sum(scored) / len(scored) if scored else 0.0

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -12,7 +12,12 @@ from verifiers.v1.errors import HarnessError, SandboxError, boundary
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.types import Messages
-from verifiers.v1.utils.decorators import discover_decorated, invoke_all
+from verifiers.v1.utils.decorators import (
+    discover_decorated,
+    invoke_all,
+    seed,
+    unseed,
+)
 
 if TYPE_CHECKING:
     # Annotation-only: `Trace` appears in signatures only, so this module stays
@@ -155,10 +160,12 @@ class Harness(ABC, Generic[ConfigT]):
         `runtime`) and can read what the harness left behind in the runtime."""
         available = {"task": trace.task.data, "trace": trace, "runtime": runtime}
         fns = discover_decorated(self, "metric")
+        seed(trace.metrics, (fn.__name__ for fn in fns))
         async with boundary(HarnessError, f"harness {self.config.id!r} metric"):
             results = await invoke_all(fns, available)
         for fn, result in zip(fns, results):
             if isinstance(result, Mapping):
+                unseed(trace.metrics, fn.__name__)
                 trace.record_metrics(result)
             else:
                 trace.record_metric(fn.__name__, result)

--- a/verifiers/v1/task.py
+++ b/verifiers/v1/task.py
@@ -23,7 +23,12 @@ from verifiers.v1.errors import TaskError, boundary
 from verifiers.v1.state import StateT
 from verifiers.v1.types import Messages, content_text
 from verifiers.v1.utils.artifacts import Artifact
-from verifiers.v1.utils.decorators import discover_decorated, invoke_all
+from verifiers.v1.utils.decorators import (
+    discover_decorated,
+    invoke_all,
+    seed,
+    unseed,
+)
 from verifiers.v1.utils.generic import concrete_type
 
 if TYPE_CHECKING:
@@ -180,31 +185,36 @@ class Task(Generic[DataT, StateT, ConfigT]):
                     judge for judge in judges if not requires_runtime(judge.score)
                 ]
 
+            seed(trace.metrics, (fn.__name__ for fn in metrics))
+            seed(trace.rewards, (fn.__name__ for fn in rewards))
+            seed(trace.rewards, (judge.reward_name for judge in judges))
+
             metric_results = await invoke_all(metrics, available)
             for fn, result in zip(metrics, metric_results):
                 if isinstance(result, Mapping):
+                    unseed(trace.metrics, fn.__name__)
                     trace.record_metrics(result)
                 else:
                     trace.record_metric(fn.__name__, result)
             reward_results = await invoke_all(rewards, available)
             for fn, result in zip(rewards, reward_results):
                 weight = getattr(fn, "_vf_weight", 1.0)
-                items = (
-                    result.items()
-                    if isinstance(result, Mapping)
-                    else [(fn.__name__, result)]
-                )
+                if isinstance(result, Mapping):
+                    unseed(trace.rewards, fn.__name__)
+                    items = result.items()
+                else:
+                    items = [(fn.__name__, result)]
                 for key, value in items:
                     trace.record_reward(key, value, weight)
             judge_results = await invoke_all(
                 [judge.score for judge in judges], available
             )
             for judge, result in zip(judges, judge_results):
-                items = (
-                    result.items()
-                    if isinstance(result, Mapping)
-                    else [(judge.reward_name, result)]
-                )
+                if isinstance(result, Mapping):
+                    unseed(trace.rewards, judge.reward_name)
+                    items = result.items()
+                else:
+                    items = [(judge.reward_name, result)]
                 for key, value in items:
                     trace.record_reward(key, value, judge.config.weight)
 

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -320,11 +320,10 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
     """Every model call; automatically recorded at intercept time + linked into `nodes`."""
 
     rewards: dict[str, Reward | None] = Field(default_factory=dict)
-    """Named, weighted rewards. Scoring seeds every expected name with `None` before
-    invoking it, so a `None` value means the reward never produced a score; an empty
-    dict means scoring was never attempted."""
+    """Named, weighted rewards; `None` means scoring didn't run (e.g. because of a
+    preceding error)."""
     metrics: dict[str, float | None] = Field(default_factory=dict)
-    """Unweighted, named metrics; `None` and `{}` as in `rewards`."""
+    """Unweighted, named metrics; `None` as in `rewards`."""
     info: dict[str, Any] = Field(default_factory=dict)
     """Scratch space for task-specific metadata."""
     state: StateT = Field(default_factory=State, exclude=True)

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -319,10 +319,12 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
     calls: list[ModelCall] = Field(default_factory=list)
     """Every model call; automatically recorded at intercept time + linked into `nodes`."""
 
-    rewards: dict[str, Reward] = Field(default_factory=dict)
-    """Named, weighted rewards"""
-    metrics: dict[str, float] = Field(default_factory=dict)
-    """Unweighted, named metrics"""
+    rewards: dict[str, Reward | None] = Field(default_factory=dict)
+    """Named, weighted rewards. Scoring seeds every expected name with `None` before
+    invoking it, so a `None` value means the reward never produced a score; an empty
+    dict means scoring was never attempted."""
+    metrics: dict[str, float | None] = Field(default_factory=dict)
+    """Unweighted, named metrics; `None` and `{}` as in `rewards`."""
     info: dict[str, Any] = Field(default_factory=dict)
     """Scratch space for task-specific metadata."""
     state: StateT = Field(default_factory=State, exclude=True)
@@ -346,7 +348,12 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
 
     @property
     def reward(self) -> float:
-        return sum(r.value for r in self.rewards.values())
+        return sum(r.value for r in self.rewards.values() if r is not None)
+
+    @property
+    def is_scored(self) -> bool:
+        """Whether any reward actually produced a score (seeded `None`s don't count)."""
+        return any(r is not None for r in self.rewards.values())
 
     @property
     def has_error(self) -> bool:

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -350,11 +350,6 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
         return sum(r.value for r in self.rewards.values() if r is not None)
 
     @property
-    def is_scored(self) -> bool:
-        """Whether any reward actually produced a score (seeded `None`s don't count)."""
-        return any(r is not None for r in self.rewards.values())
-
-    @property
     def has_error(self) -> bool:
         return not self.ok
 

--- a/verifiers/v1/utils/decorators.py
+++ b/verifiers/v1/utils/decorators.py
@@ -40,9 +40,11 @@ async def invoke_all(
 
 def seed(scores: dict[str, Any], names: Iterable[str]) -> None:
     """Mark every expected scoring key as unscored (`None`) before invocation, so a
-    trace records which signals should have run even when scoring fails midway."""
+    trace records which signals should have run even when scoring fails midway.
+    Overwrites: a re-scoring attempt resets its own names, so stale values from a
+    previous attempt never read as fresh."""
     for name in names:
-        scores.setdefault(name, None)
+        scores[name] = None
 
 
 def unseed(scores: dict[str, Any], name: str) -> None:

--- a/verifiers/v1/utils/decorators.py
+++ b/verifiers/v1/utils/decorators.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import inspect
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from typing import Any, TypeVar, overload
 
 F = TypeVar("F", bound=Callable[..., Any])
@@ -36,6 +36,20 @@ async def invoke_all(
 ) -> list[Any]:
     """Invoke scoring handlers concurrently, including empty and singleton lists."""
     return await asyncio.gather(*(invoke(fn, available) for fn in fns))
+
+
+def seed(scores: dict[str, Any], names: Iterable[str]) -> None:
+    """Mark every expected scoring key as unscored (`None`) before invocation, so a
+    trace records which signals should have run even when scoring fails midway."""
+    for name in names:
+        scores.setdefault(name, None)
+
+
+def unseed(scores: dict[str, Any], name: str) -> None:
+    """Drop a still-unscored seed — a handler returning keyed scores records under
+    its result's keys, not its function name."""
+    if scores.get(name) is None:
+        scores.pop(name, None)
 
 
 def mark(attr: str, **extra: Any) -> Callable[[F], F]:

--- a/verifiers/v1/utils/platform.py
+++ b/verifiers/v1/utils/platform.py
@@ -72,7 +72,7 @@ def trace_to_sample(
         "timing": trace.timing.model_dump(mode="json", exclude_none=True),
         "is_completed": trace.is_completed,
         "is_truncated": trace.is_truncated,
-        "metrics": trace.metrics,
+        "metrics": {k: v for k, v in trace.metrics.items() if v is not None},
         "error": trace.last_error.model_dump(mode="json", exclude_none=True)
         if trace.last_error
         else None,
@@ -93,7 +93,8 @@ def trace_to_sample(
     # Flatten sub-rewards to top-level keys the way v0 does (raw scores, as v0's
     # per-function outputs were); env metrics stay nested.
     for name, reward in trace.rewards.items():
-        sample.setdefault(name, reward.score)
+        if reward is not None:
+            sample.setdefault(name, reward.score)
     return sample
 
 
@@ -128,8 +129,15 @@ def _run_metrics(episodes: list[Episode], traces: list[Trace]) -> dict[str, Any]
     sums: dict[str, float] = {}
     counts: dict[str, int] = {}
     for trace in scored:
-        scores = {name: reward.score for name, reward in trace.rewards.items()}
-        for name, value in {**scores, **trace.metrics}.items():
+        scores = {
+            name: reward.score
+            for name, reward in trace.rewards.items()
+            if reward is not None
+        }
+        metrics = {
+            name: value for name, value in trace.metrics.items() if value is not None
+        }
+        for name, value in {**scores, **metrics}.items():
             sums[name] = sums.get(name, 0.0) + value
             counts[name] = counts.get(name, 0) + 1
     n = len(scored)

--- a/verifiers/v1/utils/platform.py
+++ b/verifiers/v1/utils/platform.py
@@ -72,7 +72,7 @@ def trace_to_sample(
         "timing": trace.timing.model_dump(mode="json", exclude_none=True),
         "is_completed": trace.is_completed,
         "is_truncated": trace.is_truncated,
-        "metrics": {k: v for k, v in trace.metrics.items() if v is not None},
+        "metrics": trace.metrics,
         "error": trace.last_error.model_dump(mode="json", exclude_none=True)
         if trace.last_error
         else None,


### PR DESCRIPTION
## Summary

- Scoring now seeds every discovered `@reward`/`@metric`/judge name with `None` before invoking it (`Task.score`, `Harness.score`), so a trace carries ground truth on which signals *should have* run even when scoring fails midway. Seeding is synchronous before the first await, so it survives scoring timeouts and raising handlers, and it overwrites — a re-scoring attempt resets its own names, so stale values from a previous attempt never read as fresh.
- `Trace.rewards`/`Trace.metrics` values become nullable (`dict[str, Reward | None]` / `dict[str, float | None]`): a `None` value means scoring didn't run for that signal (e.g. because of a preceding error), an empty dict means scoring was never attempted. `exclude_none` serialization keeps `None` dict values, so JSONL records show `"rewards": {"solved": null}` instead of a `{}` that reads as "scored, no reward keys".
- Handlers returning keyed scores record under their result's keys, so their still-`None` function-name seed is dropped on success (`seed`/`unseed` helpers in `utils/decorators.py`); on failure the function name stands in for the unknowable dynamic keys.
- Consumers guard `None` values: platform sample reward flattening and run aggregates skip unscored entries (sample `metrics` upload as-is, nulls included), the eval dashboard reads unscored as 0.0, and `agentic_judge` reweighting skips them.

Context: when scoring errored (e.g. runtime death on scaleswe_v1 SWE-bench Verified), traces ended up with empty reward/metric dicts, indistinguishable from scored-with-no-keys, and downstream per-key aggregation silently dropped them. Companion prime-rl PR makes the `all`-subset reward means count these as 0. Linear: [RES-1210](https://linear.app/primeintellect/issue/RES-1210/handle-empty-rewardmetric-traces-when-scoring-errors-occur)

## Breaking

- `Trace.rewards` / `Trace.metrics` values are now nullable; consumers iterating the dicts must skip `None` values.

## Verification

Before: a reward fn raising mid-scoring left `rewards={}`, indistinguishable from a scored trace with no reward keys. After (task with `@metric acc` + raising `@reward solved`):

```
rewards: {'solved': None}   metrics: {'acc': 1.0}
reward: 0.0
record: "rewards": {"solved": null}
```

`uv run pytest tests/ --ignore=tests/v1/test_e2e.py` passes (only PRIME_API_KEY-gated skips); ruff + pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Nullable `Trace.rewards`/`metrics` values are a breaking contract for external consumers that assumed every dict value was scored; scoring-path changes affect training aggregates and JSONL semantics when scoring errors.
> 
> **Overview**
> **Scoring** now calls `seed`/`unseed` in `Task.score` and `Harness.score` so every discovered `@metric`, `@reward`, and judge name is set to `None` before handlers run; successful keyed results drop the function-name seed via `unseed`. Re-scoring overwrites those keys so stale values cannot masquerade as fresh.
> 
> **Trace model** changes `rewards` and `metrics` to allow `None` values (unscored / aborted for that signal). The aggregate `reward` property ignores `None` entries. JSON serialization keeps `null` dict values under `exclude_none`, so records show e.g. `"solved": null` instead of an empty `{}`.
> 
> **Downstream** treats unscored entries consistently: eval dashboard means count them as **0.0**; platform sample flattening and run aggregates skip `None` rewards/metrics; `agentic_judge` task-weight scaling skips `None` rewards. Tests assert judge failure leaves a seeded `reference: null` and wire round-trips preserve seeded nulls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddb901f6da6417475a07f0f0d64c617012176124. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Seed unscored rewards and metrics as `None` placeholders in `Trace`
> - Adds `seed()` and `unseed()` utilities in [`decorators.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/2235/files#diff-3d8f7306fa2edfd8c2f1beedb8779c90ace86b13067a16425a9f33f43cf594f9) to pre-populate `trace.rewards` and `trace.metrics` with `None` before scoring runs, so expected-but-unscored signals are always present as keys.
> - Updates `Task.score` and `Harness.score` to seed all expected metric, reward, and judge names with `None` before invocation; when a handler returns a `Mapping`, the top-level seed is removed via `unseed()` before recording keyed results.
> - Updates `Trace.reward` to sum only non-`None` reward values, and fixes `AgenticJudgeEnv` to skip `None` entries when scaling rewards by task weight.
> - Fixes metric scoring in the dashboard eval and `platform.py` to treat `None` seeds as `0.0` and exclude them from averages and sample exports respectively.
> - Behavioral Change: `trace.rewards` and `trace.metrics` now contain `None` values for any signal that did not run, rather than omitting the key entirely; downstream consumers must handle `None` values in these dicts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ddb901f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->