### PR TITLE
fix(v1): stage Harbor environment in workdir

### DIFF
--- a/verifiers/v1/tasksets/harbor/taskset.py
+++ b/verifiers/v1/tasksets/harbor/taskset.py
@@ -104,6 +104,8 @@ class HarborData(TaskData):
     tags: list[str] = Field(default_factory=list)
     task_dir: str = ""
     """Host path to the task dir; used to stage tests/ to verify."""
+    upload_environment: bool = False
+    """Whether to stage environment/ into the workdir."""
     verifier_env: dict[str, str] = Field(default_factory=dict)
     """Raw [verifier.env] entries (literals or `${VAR}`/`${VAR:-default}` templates).
     Resolved against the host environment at scoring time, like `harbor run` — so a
@@ -115,6 +117,27 @@ class HarborData(TaskData):
 
 class HarborTask(Task[HarborData]):
     """Stage and run Harbor's verifier inside the task's live runtime."""
+
+    async def setup(self, runtime: Runtime) -> None:
+        if not self.data.upload_environment:
+            return
+        await runtime.write(
+            "/tmp/environment.tgz",
+            make_tar(Path(self.data.task_dir) / "environment"),
+        )
+        result = await runtime.run(
+            [
+                "sh",
+                "-c",
+                "tar --no-same-owner -xzf /tmp/environment.tgz && rm /tmp/environment.tgz",
+            ],
+            {},
+        )
+        if result.exit_code:
+            raise RuntimeError(
+                f"environment setup failed (exit {result.exit_code}): "
+                f"{(result.stderr or result.stdout).strip()[-500:]}"
+            )
 
     async def finalize(self, trace: Trace, runtime: Runtime) -> None:
         """Run Harbor's collect hooks while the agent's box is still alive.
@@ -313,6 +336,7 @@ def resolve_image(
 
 def parse_task(task_dir: Path, idx: int, harbor_config: HarborConfig) -> HarborData:
     # Harbor is optional, so imports stay deferred until a Harbor task loads.
+    from harbor.environments.definition import should_upload_environment_dir
     from harbor.models.task.config import NetworkMode
     from harbor.models.task.task import Task as HarborModelTask
 
@@ -320,6 +344,11 @@ def parse_task(task_dir: Path, idx: int, harbor_config: HarborConfig) -> HarborD
     parsed = harbor_task.config
     artifacts, collect = parse_verifier_extras(task_dir, parsed)
     environment = parsed.environment
+    environment_dir = task_dir / "environment"
+    upload_environment = should_upload_environment_dir(
+        environment_dir,
+        docker_image=environment.docker_image,
+    )
     network = parsed.agent.explicit_phase_policy() or environment.resolve_baseline()
     task, meta = parsed.task, parsed.metadata
     authors = (
@@ -386,6 +415,7 @@ def parse_task(task_dir: Path, idx: int, harbor_config: HarborConfig) -> HarborD
         category=meta.get("category"),
         tags=meta.get("tags", []),
         task_dir=str(task_dir),
+        upload_environment=upload_environment,
         verifier_env=parsed.verifier.env,
         artifacts=artifacts,
         collect=collect,
@@ -462,9 +492,9 @@ def verifier_env(task: HarborData) -> dict[str, str]:
     return resolve_env_vars(task.verifier_env)
 
 
-# Downloaded test directories are immutable. Cache only the latest archive to
-# bound memory while reusing it across rollouts of the current task.
-@lru_cache(maxsize=1)
+# Downloaded task directories are immutable. Cache the current task's environment
+# and tests to bound memory while reusing both archives across rollouts.
+@lru_cache(maxsize=2)
 def make_tar(directory: Path) -> bytes:
     buffer = io.BytesIO()
     with tarfile.open(fileobj=buffer, mode="w:gz") as tar:


### PR DESCRIPTION
## Summary

- match stock Harbor activation rules for staging `environment/` with prebuilt images
- upload and extract the directory in the resolved runtime workdir before harness setup
- discard host ownership during extraction, matching Harbor file-transfer behavior
- cache the current environment and tests archives across rollouts

## Testing

- `uv run --frozen --extra harbor pytest tests/v1/test_taskset.py tests/test_harbor_env_mcp.py -q`
- `uv run --frozen pre-commit run --all-files`
- local Docker gold validation on two luna-baseline tasks, both improving from verifier score `0.0` to `1.0`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout setup for Harbor tasks with prebuilt images and environment files; mis-staging could break verifiers, but logic is delegated to Harbor’s existing `should_upload_environment_dir` and mirrors `harbor run` behavior.
> 
> **Overview**
> Harbor tasks that use a **prebuilt `docker_image`** and ship files under **`environment/`** (without a local Dockerfile or compose) now get that directory staged into the runtime workdir before the agent runs, matching stock Harbor activation rules.
> 
> **`HarborTask.setup`** uploads a gzipped tar of `environment/` and extracts it with **`tar --no-same-owner`**, failing fast on a non-zero exit. **`parse_task`** sets the new **`upload_environment`** flag via Harbor’s **`should_upload_environment_dir`**. **`make_tar`**’s LRU cache grows from **1 → 2** so environment and tests archives can both be reused across rollouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8ba0d7846f4517472b079c32f689f7b9f8082c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stage Harbor `environment/` directory into workdir before task execution
> - Adds an `upload_environment` field to `HarborData` and a `setup` lifecycle hook to `HarborTask` in [taskset.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2236/files#diff-2bff5dabcb9a41f4d830e8bbb890e8cc6f5b8331ef2ac4c3b19ffad0e046fe00) that conditionally tars and extracts the `environment/` directory into the runtime before execution.
> - `parse_task` calls `should_upload_environment_dir` to decide whether to set `upload_environment=True` based on the task's `environment/` dir and docker image.
> - Raises `RuntimeError` if the extraction command exits non-zero, aborting setup.
> - `make_tar` cache size is increased from 1 to 2 to support caching both the environment and tests directories.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f8ba0d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->