### PR TITLE
fix(v1): allow redirecting the sandbox tool-server install off /tmp

### DIFF
--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -112,10 +112,8 @@ async def _install_in_sandbox(server: ServerBase, runtime: Runtime) -> str:
             f"server {server.server_name!r} runs in a {runtime.type} runtime but its module is not "
             "a local package (no pyproject) — sandbox launch needs a local env package to upload"
         )
-    # Not /tmp: sandbox images commonly mount it as a small fixed tmpfs (485 MB on prime
-    # VM boxes), far too little for the server venv, while the workdir is on the real
-    # disk (tens of GB) and is already the cwd `runtime.run` uses.
-    base = (getattr(runtime.config, "workdir", None) or "/tmp").rstrip("/")
+    # Default /tmp; `install_dir` redirects when an image caps it (prime VM boxes: 485 MB tmpfs).
+    base = (getattr(server.config, "install_dir", None) or "/tmp").rstrip("/")
     root = f"{base}/vf-src"
     vf, env = _verifiers_root(), Path(source_dir)
     await runtime.write(f"{root}/{vf.name}.tar.gz", _tar_source(vf, VF_BUILD_INPUTS))
@@ -127,20 +125,28 @@ async def _install_in_sandbox(server: ServerBase, runtime: Runtime) -> str:
     # local version so the floor is satisfied by the build we uploaded.
     vf_version = importlib.metadata.version("verifiers")
     extras = ",".join(type(server).EXTRAS)
+    # Quote every caller-derived path; the glob stays outside the quotes so it still expands.
+    qroot, qvenv = shlex.quote(root), shlex.quote(venv)
     setup = (
         f"{_ENSURE_UV}; set -e; "
-        f'for t in {root}/*.tar.gz; do tar -xzf "$t" -C {root}; done && '
-        f"uv venv {venv} && "
+        f'for t in {qroot}/*.tar.gz; do tar -xzf "$t" -C {qroot}; done && '
+        f"uv venv {qvenv} && "
         f"SETUPTOOLS_SCM_PRETEND_VERSION={shlex.quote(vf_version)} "
-        f"uv pip install --python {venv} {root}/{shlex.quote(vf.name)} && "
-        f"uv pip install --python {venv} "
+        f"uv pip install --python {qvenv} {shlex.quote(f'{root}/{vf.name}')} && "
+        f"uv pip install --python {qvenv} "
         f"{shlex.quote(f'{root}/{env.name}' + (f'[{extras}]' if extras else ''))}"
     )
     result = await runtime.run(["sh", "-c", setup], {})
     if result.exit_code != 0:
+        detail = (result.stderr or result.stdout).strip()[-2000:]
+        hint = (
+            " — the install ran out of space under "
+            f"{base!r}; set `install_dir` to a path on a larger filesystem"
+            if "No space left on device" in detail
+            else ""
+        )
         raise ToolsetError(
-            f"server {server.server_name!r} install failed in runtime: "
-            f"{(result.stderr or result.stdout).strip()[-2000:]}"
+            f"server {server.server_name!r} install failed in runtime{hint}: {detail}"
         )
     return f"{venv}/bin/python"
 

--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -112,11 +112,15 @@ async def _install_in_sandbox(server: ServerBase, runtime: Runtime) -> str:
             f"server {server.server_name!r} runs in a {runtime.type} runtime but its module is not "
             "a local package (no pyproject) — sandbox launch needs a local env package to upload"
         )
-    root = "/tmp/vf-src"
+    # Not /tmp: sandbox images commonly mount it as a small fixed tmpfs (485 MB on prime
+    # VM boxes), far too little for the server venv, while the workdir is on the real
+    # disk (tens of GB) and is already the cwd `runtime.run` uses.
+    base = (getattr(runtime.config, "workdir", None) or "/tmp").rstrip("/")
+    root = f"{base}/vf-src"
     vf, env = _verifiers_root(), Path(source_dir)
     await runtime.write(f"{root}/{vf.name}.tar.gz", _tar_source(vf, VF_BUILD_INPUTS))
     await runtime.write(f"{root}/{env.name}.tar.gz", _tar_source(env))
-    venv = "/tmp/vf-venv"
+    venv = f"{base}/vf-venv"
     # The upload carries no .git, so hatch-vcs falls back to version 0.0.0 — an env
     # package's `verifiers>=...` floor would then resolve PyPI verifiers OVER the local
     # build, silently running the server against a released (older) API. Pretend the

--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -125,7 +125,6 @@ async def _install_in_sandbox(server: ServerBase, runtime: Runtime) -> str:
     # local version so the floor is satisfied by the build we uploaded.
     vf_version = importlib.metadata.version("verifiers")
     extras = ",".join(type(server).EXTRAS)
-    # Quote every caller-derived path; the glob stays outside the quotes so it still expands.
     qroot, qvenv = shlex.quote(root), shlex.quote(venv)
     setup = (
         f"{_ENSURE_UV}; set -e; "

--- a/verifiers/v1/mcp/toolset.py
+++ b/verifiers/v1/mcp/toolset.py
@@ -18,16 +18,12 @@ class ToolsetConfig(BaseConfig):
     runtime: RuntimeConfig = SubprocessConfig()
     url: str | None = None
     install_dir: str | None = None
-    """Where to build the server's venv in a sandboxed runtime (default: under /tmp).
-    Point this at a path on the real disk when the image caps /tmp — prime VM boxes mount
-    it as a 485 MB tmpfs, too small for a server whose dependency closure is large."""
 
 
 class SharedToolsetConfig(BaseConfig):
     runtime: RuntimeConfig = SubprocessConfig()
     url: str | None = None
     install_dir: str | None = None
-    """Where to build the server's venv in a sandboxed runtime (see `ToolsetConfig`)."""
 
 
 class Toolset(ServerBase[ConfigT, StateT]):

--- a/verifiers/v1/mcp/toolset.py
+++ b/verifiers/v1/mcp/toolset.py
@@ -17,11 +17,17 @@ class ToolsetConfig(BaseConfig):
     colocated: bool = False
     runtime: RuntimeConfig = SubprocessConfig()
     url: str | None = None
+    install_dir: str | None = None
+    """Where to build the server's venv in a sandboxed runtime (default: under /tmp).
+    Point this at a path on the real disk when the image caps /tmp — prime VM boxes mount
+    it as a 485 MB tmpfs, too small for a server whose dependency closure is large."""
 
 
 class SharedToolsetConfig(BaseConfig):
     runtime: RuntimeConfig = SubprocessConfig()
     url: str | None = None
+    install_dir: str | None = None
+    """Where to build the server's venv in a sandboxed runtime (see `ToolsetConfig`)."""
 
 
 class Toolset(ServerBase[ConfigT, StateT]):


### PR DESCRIPTION
## Problem

`_install_in_sandbox` creates the sandboxed tool-server venv at a hardcoded path under `/tmp`:

```python
root = "/tmp/vf-src"
venv = "/tmp/vf-venv"
```

Sandbox images commonly mount `/tmp` as a **small fixed tmpfs**. On prime VM boxes it is 485 MB and does not scale with the memory request:

```
tmpfs on /tmp type tmpfs (rw,nosuid,nodev,relatime,size=496548k,nr_inodes=124137)
/dev/root        32G  8.5G   22G  29% /
tmpfs           485M  4.0K  485M   1% /tmp
```

Installing verifiers plus an env package resolves ~100 packages (pyarrow, numpy, pandas, transformers — pulled in transitively via `datasets` and `renderers`), so the install fails:

```
error: Failed to install: pyarrow-25.0.0-cp312-cp312-manylinux_2_28_x86_64.whl
  Caused by: failed to copy ... No space left on device (os error 28)
```

This is not env-specific — **any** MCP tool server whose dependency closure exceeds the tmpfs hits it, and it is invisible until you run one on a VM-backed sandbox.

## Why an env can't work around it

- The paths are string literals with no config field or env-var override, and `uv venv <path>` is an explicit target, so `TMPDIR`/`UV_CACHE_DIR` cannot redirect it.
- `_install_in_sandbox` runs inside `launch()` **before** any env-owned code (`setup`, `setup_task`), so there is no hook to remount `/tmp` first.
- `/tmp` is a runtime mount layered over the image, so rebaking the image does not change it.

## Fix

Install under the runtime's `workdir`, which is on the real disk and is already the cwd `runtime.run` executes in. Falls back to `/tmp` for runtimes that expose no `workdir`, so behaviour is unchanged where the current path already works.

## Verification

On a prime VM sandbox running a tool server that boots a QEMU desktop: the install previously failed after ~8 s with ENOSPC; with this change it completes and the rollout proceeds to the serving stage (zero `No space left on device`, zero `install failed in runtime`).

## Note (not addressed here)

The deeper issue is install *weight*: a tool server serves MCP tools and needs neither `transformers`, `pyarrow`, nor `pandas`, yet it installs the full core closure. A slim `verifiers[server]` extra would cut this class of failure everywhere rather than relying on a large disk. Happy to follow up separately if that's wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow sandbox tool-server install directory to be redirected from `/tmp`
> - Adds an optional `install_dir` field to `ToolsetConfig` and `SharedToolsetConfig` in [toolset.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2238/files#diff-1638e398acc8de97e9696063f280512b575057ce9126369ae93434a75b921c99); when set, installation uses `{install_dir}/vf-src` and `{install_dir}/vf-venv` instead of `/tmp`.
> - Shell-quotes all derived paths in the install script in [launch.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2238/files#diff-989d87123d40d48511f9e1df74594d2e30776e9a99c11eca49d9cc20bf9e2230) to handle spaces or special characters in custom directories.
> - Improves `ToolsetError` messages by appending a hint when stderr contains "No space left on device", surfacing the most likely reason to redirect away from `/tmp`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c75297e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to non-subprocess sandbox install paths with a `/tmp` default; no auth or data-path changes.
> 
> **Overview**
> Sandbox MCP tool-server installs no longer assume `/tmp` for the source extract tree and venv. **`install_dir`** on `ToolsetConfig` and `SharedToolsetConfig` sets the base path (`{base}/vf-src`, `{base}/vf-venv`); when unset, behavior stays **`/tmp`**.
> 
> `_install_in_sandbox` now **shell-quotes** those paths in the install script. On failure it surfaces a **tail of stderr/stdout** and, when the output mentions **no space left on device**, adds a hint to point **`install_dir`** at a larger filesystem (e.g. VM sandboxes with a small `/tmp` tmpfs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c75297e5af005255bae1928d9c0a0640a2690238. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->