### PR TITLE
fix(v1): make the harness MCP tool-call timeout configurable

### DIFF
--- a/verifiers/v1/configs/harness.py
+++ b/verifiers/v1/configs/harness.py
@@ -20,6 +20,8 @@ class HarnessConfig(BaseConfig):
     """Extra program variables; harness-owned variables take precedence."""
     forward_env: list[str] = Field(default_factory=list)
     """Host variables to forward without writing secrets into config; explicit `env` wins."""
+    tool_timeout: float = Field(600.0, gt=0)
+    """Seconds a single MCP tool call may take; raise it for tools that boot a VM."""
     disabled_tools: list[str] | None = None
     skills: list[Path] = Field(default_factory=list)
     """Skill folders to upload into the program's skill discovery directory — each
@@ -33,7 +35,7 @@ class HarnessConfig(BaseConfig):
     @property
     def resolved_env(self) -> dict[str, str]:
         forwarded = {k: os.environ[k] for k in self.forward_env if k in os.environ}
-        return {**forwarded, **self.env}
+        return {**forwarded, "VF_MCP_TIMEOUT": str(self.tool_timeout), **self.env}
 
 
 class WireHarnessConfig(HarnessConfig):

--- a/verifiers/v1/configs/harness.py
+++ b/verifiers/v1/configs/harness.py
@@ -35,7 +35,7 @@ class HarnessConfig(BaseConfig):
     @property
     def resolved_env(self) -> dict[str, str]:
         forwarded = {k: os.environ[k] for k in self.forward_env if k in os.environ}
-        return {**forwarded, **self.env, "VF_MCP_TIMEOUT": str(self.tool_timeout)}
+        return {**forwarded, **self.env}
 
 
 class WireHarnessConfig(HarnessConfig):

--- a/verifiers/v1/configs/harness.py
+++ b/verifiers/v1/configs/harness.py
@@ -35,7 +35,7 @@ class HarnessConfig(BaseConfig):
     @property
     def resolved_env(self) -> dict[str, str]:
         forwarded = {k: os.environ[k] for k in self.forward_env if k in os.environ}
-        return {**forwarded, "VF_MCP_TIMEOUT": str(self.tool_timeout), **self.env}
+        return {**forwarded, **self.env, "VF_MCP_TIMEOUT": str(self.tool_timeout)}
 
 
 class WireHarnessConfig(HarnessConfig):

--- a/verifiers/v1/harnesses/bash/harness.py
+++ b/verifiers/v1/harnesses/bash/harness.py
@@ -101,7 +101,8 @@ class BashHarness(Harness[BashHarnessConfig]):
                 + json.dumps(
                     {
                         "mcpServers": {
-                            name: {"url": url} for name, url in mcp_urls.items()
+                            name: {"url": url, "timeout": self.config.tool_timeout}
+                            for name, url in mcp_urls.items()
                         }
                     }
                 )

--- a/verifiers/v1/harnesses/bash/program.py
+++ b/verifiers/v1/harnesses/bash/program.py
@@ -7,6 +7,7 @@
 import argparse
 import asyncio
 import json
+import os
 import subprocess
 from contextlib import AsyncExitStack, asynccontextmanager, suppress
 from pathlib import Path
@@ -18,7 +19,7 @@ from tenacity import AsyncRetrying, stop_after_attempt, wait_exponential_jitter
 SERPER_URL = "https://google.serper.dev/search"
 
 MCP_CALL_ATTEMPTS = 6
-MCP_TIMEOUT = httpx.Timeout(600.0, connect=5.0)  # the OpenAI SDK client defaults
+MCP_TIMEOUT = httpx.Timeout(float(os.environ.get("VF_MCP_TIMEOUT", "600")), connect=5.0)
 
 
 BASH_TOOL = {

--- a/verifiers/v1/harnesses/bash/program.py
+++ b/verifiers/v1/harnesses/bash/program.py
@@ -7,7 +7,6 @@
 import argparse
 import asyncio
 import json
-import os
 import subprocess
 from contextlib import AsyncExitStack, asynccontextmanager, suppress
 from pathlib import Path
@@ -19,7 +18,7 @@ from tenacity import AsyncRetrying, stop_after_attempt, wait_exponential_jitter
 SERPER_URL = "https://google.serper.dev/search"
 
 MCP_CALL_ATTEMPTS = 6
-MCP_TIMEOUT = httpx.Timeout(float(os.environ.get("VF_MCP_TIMEOUT", "600")), connect=5.0)
+MCP_TIMEOUT = 600.0
 
 
 BASH_TOOL = {
@@ -203,7 +202,8 @@ async def mcp_session(spec: dict):
     try:
         http_client = await stack.enter_async_context(
             create_mcp_http_client(
-                headers=spec.get("headers") or None, timeout=MCP_TIMEOUT
+                headers=spec.get("headers") or None,
+                timeout=httpx.Timeout(spec.get("timeout", MCP_TIMEOUT), connect=5.0),
             )
         )
         read, write, *_ = await stack.enter_async_context(

--- a/verifiers/v1/harnesses/browser_use/harness.py
+++ b/verifiers/v1/harnesses/browser_use/harness.py
@@ -104,7 +104,8 @@ class BrowserUseHarness(Harness[BrowserUseHarnessConfig]):
                 + json.dumps(
                     {
                         "mcpServers": {
-                            name: {"url": url} for name, url in mcp_urls.items()
+                            name: {"url": url, "timeout": self.config.tool_timeout}
+                            for name, url in mcp_urls.items()
                         }
                     }
                 )

--- a/verifiers/v1/harnesses/browser_use/program.py
+++ b/verifiers/v1/harnesses/browser_use/program.py
@@ -36,7 +36,7 @@ from openai import AsyncOpenAI
 from tenacity import AsyncRetrying, stop_after_attempt, wait_exponential_jitter
 
 MCP_CALL_ATTEMPTS = 6
-MCP_TIMEOUT = httpx.Timeout(float(os.environ.get("VF_MCP_TIMEOUT", "600")), connect=5.0)
+MCP_TIMEOUT = 600.0
 
 BROWSER_TOOL_TIMEOUT = 3600
 """Matches the bash harness's command timeout."""
@@ -203,7 +203,8 @@ async def mcp_session(spec: dict):
     try:
         http_client = await stack.enter_async_context(
             create_mcp_http_client(
-                headers=spec.get("headers") or None, timeout=MCP_TIMEOUT
+                headers=spec.get("headers") or None,
+                timeout=httpx.Timeout(spec.get("timeout", MCP_TIMEOUT), connect=5.0),
             )
         )
         read, write, *_ = await stack.enter_async_context(

--- a/verifiers/v1/harnesses/browser_use/program.py
+++ b/verifiers/v1/harnesses/browser_use/program.py
@@ -36,7 +36,7 @@ from openai import AsyncOpenAI
 from tenacity import AsyncRetrying, stop_after_attempt, wait_exponential_jitter
 
 MCP_CALL_ATTEMPTS = 6
-MCP_TIMEOUT = httpx.Timeout(600.0, connect=5.0)  # the OpenAI SDK client defaults
+MCP_TIMEOUT = httpx.Timeout(float(os.environ.get("VF_MCP_TIMEOUT", "600")), connect=5.0)
 
 BROWSER_TOOL_TIMEOUT = 3600
 """Matches the bash harness's command timeout."""

--- a/verifiers/v1/harnesses/codex/harness.py
+++ b/verifiers/v1/harnesses/codex/harness.py
@@ -254,7 +254,7 @@ class CodexHarness(Harness[CodexHarnessConfig]):
                     (
                         f"{json.dumps(name, ensure_ascii=False)}="
                         f"{{url={json.dumps(url, ensure_ascii=False)},required=true,"
-                        "startup_timeout_sec=60.0,tool_timeout_sec=600.0}"
+                        f"startup_timeout_sec=60.0,tool_timeout_sec={self.config.tool_timeout}}}"
                     )
                     for name, url in mcp_urls.items()
                 )

--- a/verifiers/v1/harnesses/null/harness.py
+++ b/verifiers/v1/harnesses/null/harness.py
@@ -53,7 +53,8 @@ class NullHarness(Harness[NullHarnessConfig]):
                 + json.dumps(
                     {
                         "mcpServers": {
-                            name: {"url": url} for name, url in mcp_urls.items()
+                            name: {"url": url, "timeout": self.config.tool_timeout}
+                            for name, url in mcp_urls.items()
                         }
                     }
                 )

--- a/verifiers/v1/harnesses/null/program.py
+++ b/verifiers/v1/harnesses/null/program.py
@@ -7,6 +7,7 @@
 import argparse
 import asyncio
 import json
+import os
 from contextlib import AsyncExitStack, asynccontextmanager, suppress
 from pathlib import Path
 
@@ -15,7 +16,7 @@ from openai import AsyncOpenAI
 from tenacity import AsyncRetrying, stop_after_attempt, wait_exponential_jitter
 
 MCP_CALL_ATTEMPTS = 6
-MCP_TIMEOUT = httpx.Timeout(600.0, connect=5.0)  # the OpenAI SDK client defaults
+MCP_TIMEOUT = httpx.Timeout(float(os.environ.get("VF_MCP_TIMEOUT", "600")), connect=5.0)
 
 
 async def chat(

--- a/verifiers/v1/harnesses/null/program.py
+++ b/verifiers/v1/harnesses/null/program.py
@@ -7,7 +7,6 @@
 import argparse
 import asyncio
 import json
-import os
 from contextlib import AsyncExitStack, asynccontextmanager, suppress
 from pathlib import Path
 
@@ -16,7 +15,7 @@ from openai import AsyncOpenAI
 from tenacity import AsyncRetrying, stop_after_attempt, wait_exponential_jitter
 
 MCP_CALL_ATTEMPTS = 6
-MCP_TIMEOUT = httpx.Timeout(float(os.environ.get("VF_MCP_TIMEOUT", "600")), connect=5.0)
+MCP_TIMEOUT = 600.0
 
 
 async def chat(
@@ -44,7 +43,8 @@ async def mcp_session(spec: dict):
     try:
         http_client = await stack.enter_async_context(
             create_mcp_http_client(
-                headers=spec.get("headers") or None, timeout=MCP_TIMEOUT
+                headers=spec.get("headers") or None,
+                timeout=httpx.Timeout(spec.get("timeout", MCP_TIMEOUT), connect=5.0),
             )
         )
         read, write, *_ = await stack.enter_async_context(

--- a/verifiers/v1/harnesses/openclaw/harness.py
+++ b/verifiers/v1/harnesses/openclaw/harness.py
@@ -166,7 +166,7 @@ class OpenClawHarness(Harness[OpenClawHarnessConfig]):
                         "url": url,
                         "transport": "streamable-http",
                         "connectionTimeoutMs": 60_000,
-                        "requestTimeoutMs": 600_000,
+                        "requestTimeoutMs": int(self.config.tool_timeout * 1000),
                     }
                     for name, url in mcp_urls.items()
                 }


### PR DESCRIPTION
## Problem

`MCP_TIMEOUT` is hardcoded at 600 s in the `null`, `bash`, and `browser_use` programs, and it bounds how long **any single tool call** may take:

```python
MCP_TIMEOUT = httpx.Timeout(600.0, connect=5.0)
```

That is generous for ordinary tools, but a tool server that boots a VM can exceed it. A CUA-World tool server booting a desktop under TCG (prime VM sandboxes have no `/dev/kvm`) takes longer than 10 minutes, so the policy's first tool call is cancelled mid-flight:

```
File ".../mcp/client/session.py", line 401, in call_tool
File ".../anyio/streams/memory.py", line 126, in receive
asyncio.exceptions.CancelledError: Cancelled via cancel scope 7f47b948b6b0
```

Nothing in that traceback indicates a timeout, so it reads as an unexplained cancellation — it took a stopwatch (sandbox up → failure = 11 min 13 s against a 600 s ceiling) to identify the cause.

## Change

A typed **`tool_timeout`** on `HarnessConfig`, defaulting to the current 600 s:

```bash
--harness.tool-timeout 3600
```

It belongs in config rather than the environment: it is harness behaviour, not host state or a secret, and as a field it gets validation (`gt=0`), appears in `-h`, and is recorded in the saved `config.toml`.

The programs are standalone scripts (no `verifiers` import), so the value has to travel to them somehow. It rides the `--mcp-config` the harness already builds — that spec describes how to reach each server (`url`, `headers`), so a per-call timeout sits naturally beside them:

```python
# harness
{"mcpServers": {name: {"url": url, "timeout": self.config.tool_timeout}}}
# program
timeout=httpx.Timeout(spec.get("timeout", MCP_TIMEOUT), connect=5.0)
```

No new argv flag, no module-level global, and no environment variable — `resolved_env` stays purely host/user environment. It is also per-server, which is a better fit than one process-wide constant.

Harnesses that hand their ceiling to an external CLI interpolate the same value — codex (`tool_timeout_sec`) and openclaw (`requestTimeoutMs`, converted to ms). The remaining MCP-capable harnesses (`rlm`, `hermes_agent`, `claude_code`, `kimi_code`, `pi`, `pool`) set no tool-call timeout of their own, so the field is honoured everywhere it means something.

**Default behaviour is unchanged.**

## Verification

```
tool_timeout=None -> spec  600.0 -> client read  600.0, connect 5.0
tool_timeout=3600 -> spec 3600.0 -> client read 3600.0, connect 5.0
resolved_env: {}          (no injected variables)
validation  : rejects <= 0 -> ValidationError
```

Checked through a JSON round-trip, since the spec crosses to the program as an argv string. Lint and format clean.

## Note

Raising the ceiling is a workaround for slow tool startup, not a fix for it. In our case the real cost is TCG emulation; a server needing minutes before its first tool call is better off warming up in the background (which the CUA toolset now does) — but the ceiling still has to be raisable for the boot itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only timeout wiring with the same 600s default; no auth or data-path changes, only how long MCP HTTP clients wait per tool call.
> 
> **Overview**
> Adds **`tool_timeout`** on `HarnessConfig` (default **600s**, validated `> 0`), settable via CLI (e.g. `--harness.tool-timeout 3600`) so long-running MCP tools (e.g. VM boot) are not cut off by a fixed ceiling.
> 
> Harnesses pass the value into each MCP server definition: **bash**, **browser_use**, and **null** add a per-server **`timeout`** in the existing `--mcp-config` JSON; **codex** uses **`tool_timeout_sec`**; **openclaw** sets **`requestTimeoutMs`** from the same field. Standalone harness programs read **`spec["timeout"]`** when opening MCP HTTP clients (still **5s** connect), with **`MCP_TIMEOUT`** reduced to a numeric fallback only.
> 
> **Default behavior is unchanged** when `tool_timeout` is left at 600.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3c633af562e0f7044e0a31643d6a302a78f62d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make MCP tool-call timeout configurable in `HarnessConfig`
> - Adds `tool_timeout: float` (default `600.0`) to [`HarnessConfig`](https://github.com/PrimeIntellect-ai/verifiers/pull/2239/files#diff-c5b409466f272f39cbab9228a91d9b6de6c8a0cdd33ad73f05e7fd690966e478), replacing previously hardcoded 600s timeouts across all harnesses.
> - Each harness (`BashHarness`, `BrowserUseHarness`, `CodexHarness`, `NullHarness`, `OpenClawHarness`) now passes `self.config.tool_timeout` into the MCP server config it sends to child programs.
> - In the `bash`, `browser_use`, and `null` program modules, `MCP_TIMEOUT` is changed from an `httpx.Timeout` object to a plain `float`, and `mcp_session` constructs `httpx.Timeout(spec.get('timeout', MCP_TIMEOUT), connect=5.0)` to honor per-server timeouts from the spec.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c3c633a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->