### PR TITLE
Fix stale V1 config references

### DIFF
--- a/skills/evaluate-environments/SKILL.md
+++ b/skills/evaluate-environments/SKILL.md
@@ -87,7 +87,7 @@ uv run eval my-task-v1 \
   --help
 ```
 
-For implementation details and defaults, start at `verifiers/v1/configs/cli/eval.py` and follow its fields into `verifiers/v1/configs/`. Client configs live in `verifiers/v1/clients/config.py`, sampling in `verifiers/v1/types.py`, and runtime- and harness-specific configs next to their implementations in `verifiers/v1/runtimes/` and `verifiers/v1/harnesses/`. Custom taskset and env config fields live next to those implementations.
+For implementation details and defaults, start at `verifiers/v1/configs/cli/eval.py` and follow its fields into `verifiers/v1/configs/`. Client configs live in `verifiers/v1/configs/client.py`, sampling in `verifiers/v1/types.py`, and runtime- and harness-specific configs next to their implementations in `verifiers/v1/runtimes/` and `verifiers/v1/harnesses/`. Custom taskset and env config fields live next to those implementations.
 
 ## Typed taskset overrides
 

--- a/verifiers/v1/configs/cli/env.py
+++ b/verifiers/v1/configs/cli/env.py
@@ -4,7 +4,7 @@ config that owns one, and the retired keys such a config refuses.
 A run composes the blocks it needs — `[env]` (what runs, `configs/env.py`),
 `[serve]` (how it's hosted, `configs/serve.py`), `[legacy]` (the v0 bridge,
 `configs/legacy.py`) — plus its own fields. Nothing here is a base class: the eval
-CLI, the `serve` CLI, GEPA and a trainer each declare their blocks and call these.
+CLI, GEPA, and a trainer each declare their blocks and call these.
 
 Declare the env field as `SerializeAsAny[EnvConfig] = Field(default_factory=
 single_agent_env_config)`. The `SerializeAsAny` is load-bearing: pydantic serializes


### PR DESCRIPTION
## Summary

- point the evaluation skill at the relocated V1 client config module
- remove the retired `serve` CLI from the shared env-config plumbing docstring

## Why

The evaluation skill added a source pointer before the client config moved from `verifiers/v1/clients/config.py` to `verifiers/v1/configs/client.py`. A later change removed the standalone serve CLI but left one internal description behind.

This keeps config discovery on a real source file and makes the documentation match the current CLI surface.

## Validation

- `uv run pytest tests/v1/ -q`
- `uv run pre-commit run --files skills/evaluate-environments/SKILL.md verifiers/v1/configs/cli/env.py`
- push hooks: markdownlint, Ruff, format, and ty

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale config path references in documentation and CLI env comments
> Updates the client config path in [SKILL.md](https://github.com/PrimeIntellect-ai/verifiers/pull/2240/files#diff-36d08ee11d380ecaa5beacd5b98cd8bfa0791dfa784b93956b128cafc58dbe0d) from `verifiers/v1/clients/config.py` to `verifiers/v1/configs/client.py`. Also removes a stale reference to the `serve` CLI from the callers list in [env.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2240/files#diff-5017ba92db5a09046903b1bb736fd93f2358730db2735c1e79deab2335cadbf8).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8c87ee4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and skill doc edits only; no runtime or config behavior changes.
> 
> **Overview**
> **Documentation-only** alignment after the V1 client config moved and the standalone `serve` CLI was removed.
> 
> The evaluate-environments skill’s config-discovery section now references **`verifiers/v1/configs/client.py`** instead of the old **`verifiers/v1/clients/config.py`** path.
> 
> The module docstring in **`verifiers/v1/configs/cli/env.py`** no longer lists the **`serve` CLI** among callers of the shared env-field plumbing; it now names the eval CLI, GEPA, and a trainer only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c87ee4f61e7f474765d77f4c84b87d7e3cf99f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->