### PR TITLE
Cancel superseded test runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: Test
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     branches: [main]


### PR DESCRIPTION
## Overview

Keep only the newest Test workflow run for each pull request or pushed ref.

## Details

The workflow concurrency group is scoped by workflow and pull request number, so separate pull requests—including members of a stack—continue to run independently. Pushes use their Git ref as the fallback scope.

When a newer run starts in the same scope, GitHub cancels the older run. This reduces duplicate live E2E load and avoids delayed failure notifications from commits that have already been replaced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow configuration with no application or security impact.
> 
> **Overview**
> Adds a **concurrency** block to the **Test** workflow so GitHub keeps only the latest run per scope and cancels older ones (`cancel-in-progress: true`).
> 
> The group key is `${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`, so each PR is isolated (stacked PRs still run in parallel) while pushes fall back to the ref. This cuts duplicate live E2E load and stale failure noise when new commits land quickly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d91e92894bf6284bc9598392c70f46b5f4225fe6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cancel superseded in-progress test runs on new pushes
> Adds a `concurrency` block to [test.yml](.github/workflows/test.yml) that groups runs by workflow name and PR number (or ref), cancelling any in-progress run when a newer one starts in the same group.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d91e928.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->