### PR TITLE
feat(v1)!: move run info from trace to episode

### DIFF
--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -98,3 +98,35 @@ def test_wire_trace_round_trip():
 
     # the env-server wire form (a plain model_dump) loads too
     assert vf.WireTrace.model_validate(tr.model_dump()).num_branches == 2
+
+
+def test_episode_records_the_run_it_belongs_to():
+    """`Episode.run` is the same identity its traces carry, recorded once on the thing that was
+    actually dispatched — so an episode that produced no traces can still say which run it was."""
+
+    def trace() -> vf.Trace:
+        return vf.Trace(
+            agent=vf.AgentInfo(config=vf.AgentConfig()),
+            task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="hi")),
+        )
+
+    first, second = trace(), trace()
+    episode = vf.Episode(traces=[first, second])
+    assert episode.run is None
+
+    run = vf.TrainRunInfo(id="r1", step=7)
+    episode.record_run(run, env_name="duet")
+    assert episode.run == run
+    assert [t.run for t in episode.traces] == [
+        run,
+        run,
+    ]  # the traces stay in step with it
+    assert all(t.info == {"env_name": "duet"} for t in episode.traces)
+
+    # An episode with nothing in it still carries the run — there is no trace to hold it.
+    empty = vf.Episode()
+    empty.record_run(run)
+    assert empty.run == run and empty.traces == []
+
+    # The single-agent record inherits the run from the trace it wraps.
+    assert vf.Episode.of(first, env="duet-v1").run == run

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -98,35 +98,3 @@ def test_wire_trace_round_trip():
 
     # the env-server wire form (a plain model_dump) loads too
     assert vf.WireTrace.model_validate(tr.model_dump()).num_branches == 2
-
-
-def test_episode_records_the_run_it_belongs_to():
-    """`Episode.run` is the same identity its traces carry, recorded once on the thing that was
-    actually dispatched — so an episode that produced no traces can still say which run it was."""
-
-    def trace() -> vf.Trace:
-        return vf.Trace(
-            agent=vf.AgentInfo(config=vf.AgentConfig()),
-            task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="hi")),
-        )
-
-    first, second = trace(), trace()
-    episode = vf.Episode(traces=[first, second])
-    assert episode.run is None
-
-    run = vf.TrainRunInfo(id="r1", step=7)
-    episode.record_run(run, env_name="duet")
-    assert episode.run == run
-    assert [t.run for t in episode.traces] == [
-        run,
-        run,
-    ]  # the traces stay in step with it
-    assert all(t.info == {"env_name": "duet"} for t in episode.traces)
-
-    # An episode with nothing in it still carries the run — there is no trace to hold it.
-    empty = vf.Episode()
-    empty.record_run(run)
-    assert empty.run == run and empty.traces == []
-
-    # The single-agent record inherits the run from the trace it wraps.
-    assert vf.Episode.of(first, env="duet-v1").run == run

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -10,7 +10,6 @@ from verifiers.v1.cli.dashboard import dashboard
 from verifiers.v1.cli.eval import resume
 from verifiers.v1.cli.output import (
     append_episode,
-    append_trace,
     output_path,
     save_config,
 )
@@ -257,9 +256,12 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
                 )
             records = []
             for trace in traces:
-                await append_trace(out, trace, write_lock, env=config.env_id)
-                record = Episode.of(trace)
+                # Mint the episode once and persist that same object, so the row on disk carries
+                # the run the caller gets back — `append_trace` would wrap the trace in an
+                # episode of its own, which nothing has stamped.
+                record = Episode.of(trace, env=config.env_id)
                 record.record_run(EvalRunInfo(id=config.uuid))
+                await append_episode(out, record, write_lock)
                 records.append(record)
             return records
 

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -256,9 +256,6 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
                 )
             records = []
             for trace in traces:
-                # Mint the episode once and persist that same object, so the row on disk carries
-                # the run the caller gets back — `append_trace` would wrap the trace in an
-                # episode of its own, which nothing has stamped.
                 record = Episode.of(trace, env=config.env_id)
                 record.record_run(EvalRunInfo(id=config.uuid))
                 await append_episode(out, record, write_lock)

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -77,8 +77,7 @@ async def run_eval(env: Env, config: EvalConfig) -> list[Episode]:
     write_lock = asyncio.Lock()
 
     async def on_complete(episode: Episode) -> None:
-        for trace in episode.traces:
-            trace.record_run(EvalRunInfo(id=config.uuid))
+        episode.record_run(EvalRunInfo(id=config.uuid))
         await append_episode(out, episode, write_lock)
 
     # Serving resources (shared tool servers, interception) come up once for the
@@ -258,9 +257,10 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
                 )
             records = []
             for trace in traces:
-                trace.record_run(EvalRunInfo(id=config.uuid))
                 await append_trace(out, trace, write_lock, env=config.env_id)
-                records.append(Episode.of(trace))
+                record = Episode.of(trace)
+                record.record_run(EvalRunInfo(id=config.uuid))
+                records.append(record)
             return records
 
         async def run_unit(payload: dict) -> list[Episode]:
@@ -271,8 +271,7 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
                     sampling=config.sampling,
                     **payload,
                 )
-            for trace in episode.traces:
-                trace.record_run(EvalRunInfo(id=config.uuid))
+            episode.record_run(EvalRunInfo(id=config.uuid))
             await append_episode(out, episode, write_lock)
             return [episode]
 

--- a/verifiers/v1/episode.py
+++ b/verifiers/v1/episode.py
@@ -1,14 +1,14 @@
 """The episode — one run's traces plus their shared standing, whole."""
 
 import uuid
-from typing import Generic
+from typing import Any, Generic
 
 from pydantic import BaseModel, Field
 
 from verifiers.v1.configs.agent import WireAgentConfig
 from verifiers.v1.state import State, StateT
 from verifiers.v1.task import DataT, WireTaskData
-from verifiers.v1.trace import AgentConfigT, Error, Trace
+from verifiers.v1.trace import AgentConfigT, Error, RunInfo, Trace
 from verifiers.v1.types import Usage
 
 
@@ -26,6 +26,10 @@ class Episode(BaseModel, Generic[DataT, StateT, AgentConfigT]):
 
     env: EnvInfo = Field(default_factory=EnvInfo)
     """The env that produced this episode."""
+    run: RunInfo | None = None
+    """The run this episode belongs to (eval or train), consumer-stamped — the same identity its
+    traces carry, recorded once on the thing that was actually dispatched. An episode that produced
+    no traces still has somewhere to say which run it belonged to."""
     ok: bool = False
     """Whether the episode completed successfully."""
     errors: list[Error] = Field(default_factory=list)
@@ -72,10 +76,18 @@ class Episode(BaseModel, Generic[DataT, StateT, AgentConfigT]):
             grouped.setdefault(trace.agent.name, []).append(trace)
         return grouped
 
+    def record_run(self, run: RunInfo, **info: Any) -> None:
+        """Record the run identity on the episode and on every trace it carries. The run and any
+        extra `info` describe the episode as a whole, so stamping it here keeps the two in step
+        rather than leaving each consumer to walk the traces itself."""
+        self.run = run
+        for trace in self.traces:
+            trace.record_run(run, **info)
+
     @classmethod
     def of(cls, trace: Trace, env: str = "") -> "Episode":
         """The single-agent record: one trace as its own episode."""
-        return cls(env=EnvInfo(id=env), traces=[trace], ok=trace.ok)
+        return cls(env=EnvInfo(id=env), run=trace.run, traces=[trace], ok=trace.ok)
 
 
 WireEpisode = Episode[WireTaskData, State, WireAgentConfig]

--- a/verifiers/v1/episode.py
+++ b/verifiers/v1/episode.py
@@ -27,9 +27,9 @@ class Episode(BaseModel, Generic[DataT, StateT, AgentConfigT]):
     env: EnvInfo = Field(default_factory=EnvInfo)
     """The env that produced this episode."""
     run: RunInfo | None = None
-    """The run this episode belongs to (eval or train), consumer-stamped — the same identity its
-    traces carry, recorded once on the thing that was actually dispatched. An episode that produced
-    no traces still has somewhere to say which run it belonged to."""
+    """The run this episode belongs to (eval or train), consumer-stamped. It lives here rather than
+    on each trace because the episode is what a consumer dispatches, and an episode that produced
+    no traces would otherwise have nowhere to say which run it was."""
     ok: bool = False
     """Whether the episode completed successfully."""
     errors: list[Error] = Field(default_factory=list)
@@ -76,18 +76,19 @@ class Episode(BaseModel, Generic[DataT, StateT, AgentConfigT]):
             grouped.setdefault(trace.agent.name, []).append(trace)
         return grouped
 
-    def record_run(self, run: RunInfo, **info: Any) -> None:
-        """Record the run identity on the episode and on every trace it carries. The run and any
-        extra `info` describe the episode as a whole, so stamping it here keeps the two in step
-        rather than leaving each consumer to walk the traces itself."""
-        self.run = run
+    def record_run(self, run: RunInfo | None = None, **info: Any) -> None:
+        """Record the run identity, and optional extra info on every trace it carries. Both
+        describe the episode as a whole, so a consumer stamps once here instead of walking the
+        traces itself."""
+        if run is not None:
+            self.run = run
         for trace in self.traces:
-            trace.record_run(run, **info)
+            trace.info.update(info)
 
     @classmethod
     def of(cls, trace: Trace, env: str = "") -> "Episode":
         """The single-agent record: one trace as its own episode."""
-        return cls(env=EnvInfo(id=env), run=trace.run, traces=[trace], ok=trace.ok)
+        return cls(env=EnvInfo(id=env), traces=[trace], ok=trace.ok)
 
 
 WireEpisode = Episode[WireTaskData, State, WireAgentConfig]

--- a/verifiers/v1/episode.py
+++ b/verifiers/v1/episode.py
@@ -36,6 +36,9 @@ class Episode(BaseModel, Generic[DataT, StateT, AgentConfigT]):
     """Every error captured across attempts, oldest to newest."""
     traces: list[Trace[DataT, StateT, AgentConfigT]] = Field(default_factory=list)
     """Every agent's trace, in completion order."""
+    info: dict[str, Any] = Field(default_factory=dict)
+    """Scratch space for episode-level metadata, the counterpart to `Trace.info`. What describes
+    the whole episode belongs here rather than repeated on each of its traces."""
 
     @property
     def last_error(self) -> Error | None:
@@ -77,13 +80,11 @@ class Episode(BaseModel, Generic[DataT, StateT, AgentConfigT]):
         return grouped
 
     def record_run(self, run: RunInfo | None = None, **info: Any) -> None:
-        """Record the run identity, and optional extra info on every trace it carries. Both
-        describe the episode as a whole, so a consumer stamps once here instead of walking the
-        traces itself."""
+        """Record the run identity and any extra metadata about this episode. Both describe the
+        episode as a whole, so they are recorded once here rather than repeated on every trace."""
         if run is not None:
             self.run = run
-        for trace in self.traces:
-            trace.info.update(info)
+        self.info.update(info)
 
     @classmethod
     def of(cls, trace: Trace, env: str = "") -> "Episode":

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -304,9 +304,6 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
     """Unique ID for this trace, auto-generated."""
     verifiers: VersionInfo = Field(default_factory=_current_build)
     """The verifiers version that produced this trace."""
-    run: RunInfo | None = None
-    """The run this trace belongs to (eval or train), consumer-stamped."""
-
     task: TraceTask[DataT]
     """The task data that seeded this trace."""
     agent: AgentInfo[AgentConfigT]
@@ -479,12 +476,6 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
         self.info.setdefault("judge", []).append(response.model_dump())
         if response.usage is not None:
             self.extra_usage.append(response.usage)
-
-    def record_run(self, run: RunInfo | None = None, **info: Any) -> None:
-        """Record the run identity (eval / train), and optional extra info."""
-        if run is not None:
-            self.run = run
-        self.info.update(info)
 
     def stop(self, condition: str) -> None:
         """Stop the trace, optionally with a stop condition."""


### PR DESCRIPTION
## Summary

`Trace.run` recorded which run (eval or train) a trace belonged to. But the episode is what a consumer actually dispatches, and an episode that produced no traces — cancelled, or a task that raised before reaching the env — had nowhere to record its run at all.

So the run moves up:

- `Episode.run: RunInfo | None`, consumer-stamped, on the unit that was dispatched.
- `Episode.record_run(run, **info)` sets the run and passes any extra `info` down to each trace, so a consumer stamps once instead of walking them.
- `Trace.run` and `Trace.record_run` are removed.

The field stays optional and unstamped by the library — verifiers doesn't own the notion of a run, consumers do. vf's own eval CLI now stamps at the episode level in all three places it used to loop over traces.

## Breaking

- **`Trace.run` is gone** — read `Episode.run`. Traces persisted with a `run` field still load (records parse non-strict), but the value is dropped.
- **`Trace.record_run` is gone** — call `Episode.record_run`, which also forwards `**info` to the traces. A consumer holding only loose traces can set `trace.info` directly.
- A consumer that writes *traces* rather than episodes to disk no longer gets the run recorded in those rows, and should stamp what it needs into `trace.info`.

## Verification

- `uv run pytest tests/v1 -m "not e2e"` green.
- `ruff check` / `ruff format --check`; `ty` reports nothing on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move run metadata from `Trace` to `Episode` in eval runner
> - Adds `run: RunInfo | None` and `info: dict` fields to `Episode`, with a `record_run()` method to set them, mirroring the API previously on `Trace`.
> - Updates `run_eval` and `run_eval_server` in [runner.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2244/files#diff-65be4a576330571f2729a3bbcdbe92ac81bbcba450c313597c1bdca3a1c3f2e4) to call `episode.record_run()` once per episode instead of stamping each trace individually.
> - Removes `run` field and `record_run()` method from `Trace` entirely.
> - Risk: Breaking change — `Trace` serialization no longer includes a `run` field; any consumers reading run metadata from traces will need to read it from the parent `Episode` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1336d48.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Schema and API break for anything reading `Trace.run`; persisted traces may drop the old `run` field on load, but eval output shape stays episode-based.
> 
> **Overview**
> **Breaking:** `Trace.run` and `Trace.record_run` are removed. Consumers should use **`Episode.run`** and **`Episode.record_run`**, so trace-less episodes (cancelled or failed before agents run) can still record which eval/train run they belonged to.
> 
> `Episode` gains optional **`run`**, episode-level **`info`**, and **`record_run(run, **info)`** that sets the run and merges metadata on the episode once instead of on every trace.
> 
> The v1 **eval runner** stamps **`EvalRunInfo`** on the completed episode in all paths (local `on_complete`, env-server `run_unit`, and legacy **`run_group`** where each trace is wrapped with **`Episode.of`** then **`append_episode`** instead of per-trace **`append_trace`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1336d48ef6931035fc71e624e358586e70cdb207. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->