### PR TITLE
feat(v1): per-token advantages on the node

### DIFF
--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -103,8 +103,7 @@ class MessageNode(BaseModel):
     `mask`; empty for input messages."""
     advantages: list[float] = Field(default_factory=list)
     """Per-token credit over the sampled tokens, same layout as `logprobs`; empty until a
-    consumer's RL algorithm assigns it. It belongs to the node rather than to a branch because
-    branches share nodes: the same generated token cannot be credited two ways."""
+    consumer's RL algorithm assigns it."""
     multi_modal_data: SkipJsonSchema[MultiModalData | None] = None
     """The renderer items for the images this message's content introduces (pixel tensors,
     grids, hashes, placeholders) — the only carrier of the pixels from the env server to the

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -101,9 +101,11 @@ class MessageNode(BaseModel):
     logprobs: list[float] = Field(default_factory=list)
     """Sampling logprobs for the sampled tokens — length equals the number of True entries in
     `mask`; empty for input messages."""
-    advantages: list[float] = Field(default_factory=list)
-    """Per-token credit over the sampled tokens, same layout as `logprobs`; empty until a
-    consumer's RL algorithm assigns it."""
+    advantages: list[float] | None = None
+    """Per-token credit over the sampled tokens, same layout as `logprobs`. `None` until a
+    consumer's RL algorithm assigns it, which is not the same as a credit of zero: a group whose
+    rewards were all equal is assigned zeros and carries no gradient, while an unassigned node was
+    never scored at all."""
     multi_modal_data: SkipJsonSchema[MultiModalData | None] = None
     """The renderer items for the images this message's content introduces (pixel tensors,
     grids, hashes, placeholders) — the only carrier of the pixels from the env server to the

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -101,6 +101,10 @@ class MessageNode(BaseModel):
     logprobs: list[float] = Field(default_factory=list)
     """Sampling logprobs for the sampled tokens — length equals the number of True entries in
     `mask`; empty for input messages."""
+    advantages: list[float] = Field(default_factory=list)
+    """Per-token credit over the sampled tokens, same layout as `logprobs`; empty until a
+    consumer's RL algorithm assigns it. It belongs to the node rather than to a branch because
+    branches share nodes: the same generated token cannot be credited two ways."""
     multi_modal_data: SkipJsonSchema[MultiModalData | None] = None
     """The renderer items for the images this message's content introduces (pixel tensors,
     grids, hashes, placeholders) — the only carrier of the pixels from the env server to the

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -200,12 +200,14 @@ class Branch(BaseModel):
             mask.extend(node.mask)
         return mask
 
-    def spread(self, values: Callable[[MessageNode], list[float]]) -> list[float]:
+    def spread(
+        self, values: Callable[[MessageNode], list[float] | None]
+    ) -> list[float]:
         """A per-sampled-token node field widened to `token_ids`: each node's values land on its
-        sampled positions, 0.0 everywhere else."""
+        sampled positions, 0.0 everywhere else. A node holding nothing contributes zeros."""
         out: list[float] = []
         for node in self.nodes:
-            mask, node_values = node.mask, values(node)
+            mask, node_values = node.mask, values(node) or []
             sampled = sum(mask) if node_values else 0
             # Bulk-fill the canonical unsampled-prefix/sampled-suffix layout.
             if not sampled or all(mask[-sampled:]):
@@ -228,9 +230,13 @@ class Branch(BaseModel):
         return self.spread(lambda node: node.logprobs)
 
     @property
-    def advantages(self) -> list[float]:
-        """Per-token credit aligned to `token_ids`, spread like `logprobs`. Empty-handed nodes
-        contribute 0.0, so a branch whose credit was never assigned reads as all zeros."""
+    def advantages(self) -> list[float] | None:
+        """Per-token credit aligned to `token_ids`, spread like `logprobs` — or `None` when no node
+        on the path was ever assigned any, which a branch of zeros would otherwise be
+        indistinguishable from. A partially assigned path spreads, the unassigned nodes reading
+        0.0."""
+        if all(node.advantages is None for node in self.nodes):
+            return None
         return self.spread(lambda node: node.advantages)
 
     @property

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -200,7 +200,7 @@ class Branch(BaseModel):
             mask.extend(node.mask)
         return mask
 
-    def _spread(self, values: Callable[[MessageNode], list[float]]) -> list[float]:
+    def spread(self, values: Callable[[MessageNode], list[float]]) -> list[float]:
         """A per-sampled-token node field widened to `token_ids`: each node's values land on its
         sampled positions, 0.0 everywhere else."""
         out: list[float] = []
@@ -225,13 +225,13 @@ class Branch(BaseModel):
     def logprobs(self) -> list[float]:
         """Per-token sampling logprobs aligned to `token_ids` — the node logprobs spread onto
         their sampled positions, 0.0 on every non-sampled token."""
-        return self._spread(lambda node: node.logprobs)
+        return self.spread(lambda node: node.logprobs)
 
     @property
     def advantages(self) -> list[float]:
         """Per-token credit aligned to `token_ids`, spread like `logprobs`. Empty-handed nodes
         contribute 0.0, so a branch whose credit was never assigned reads as all zeros."""
-        return self._spread(lambda node: node.advantages)
+        return self.spread(lambda node: node.advantages)
 
     @property
     def multi_modal_data(self) -> MultiModalData | None:

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import time
 import traceback
 import uuid
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Annotated, Any, Generic, Literal
 
 import numpy as np
@@ -200,27 +200,38 @@ class Branch(BaseModel):
             mask.extend(node.mask)
         return mask
 
-    @property
-    def logprobs(self) -> list[float]:
-        """Per-token sampling logprobs aligned to `token_ids` — the node logprobs spread onto
-        their sampled positions, 0.0 on every non-sampled token."""
+    def _spread(self, values: Callable[[MessageNode], list[float]]) -> list[float]:
+        """A per-sampled-token node field widened to `token_ids`: each node's values land on its
+        sampled positions, 0.0 everywhere else."""
         out: list[float] = []
         for node in self.nodes:
-            mask = node.mask
-            sampled = sum(mask) if node.logprobs else 0
+            mask, node_values = node.mask, values(node)
+            sampled = sum(mask) if node_values else 0
             # Bulk-fill the canonical unsampled-prefix/sampled-suffix layout.
             if not sampled or all(mask[-sampled:]):
-                out += [0.0] * (len(mask) - sampled) + node.logprobs[:sampled]
-                out += [0.0] * max(0, sampled - len(node.logprobs))
+                out += [0.0] * (len(mask) - sampled) + node_values[:sampled]
+                out += [0.0] * max(0, sampled - len(node_values))
                 continue
             li = 0
-            for sampled in mask:
-                if sampled:
-                    out.append(node.logprobs[li] if li < len(node.logprobs) else 0.0)
+            for is_sampled in mask:
+                if is_sampled:
+                    out.append(node_values[li] if li < len(node_values) else 0.0)
                     li += 1
                 else:
                     out.append(0.0)
         return out
+
+    @property
+    def logprobs(self) -> list[float]:
+        """Per-token sampling logprobs aligned to `token_ids` — the node logprobs spread onto
+        their sampled positions, 0.0 on every non-sampled token."""
+        return self._spread(lambda node: node.logprobs)
+
+    @property
+    def advantages(self) -> list[float]:
+        """Per-token credit aligned to `token_ids`, spread like `logprobs`. Empty-handed nodes
+        contribute 0.0, so a branch whose credit was never assigned reads as all zeros."""
+        return self._spread(lambda node: node.advantages)
 
     @property
     def multi_modal_data(self) -> MultiModalData | None:


### PR DESCRIPTION
## Summary

Credit assigned by an RL algorithm is token-aligned, so it belongs where the tokens are.

- `MessageNode.advantages: list[float] | None` — per-sampled-token, the same compact layout as `logprobs` (length equals the `True` entries in `mask`).
- `Branch.advantages: list[float] | None` — the node values spread onto `token_ids`, 0.0 on non-sampled positions, exactly like `Branch.logprobs`.
- The spreading both properties do is factored into one `spread` helper rather than written twice.

Nothing in verifiers writes the field — like `Trace.run`, it is consumer-stamped.

### Why the node

Branches share nodes. A consumer holding a flat per-branch advantage stream can give **the same generated token different credit in two branches** of one trace — compaction and subagent forks both produce that shape. On the node it is unrepresentable: one node, one value, every branch through it agrees.

It also means a consumer stops re-implementing the path walk. `branch.advantages` falls out of the same traversal as `token_ids`, `sampled_mask` and `logprobs`, so the alignment is structural rather than asserted by the caller.

### Why nullable

Unassigned credit and zero credit are different facts, and a trainer acts on them differently: a group whose rewards were all equal is assigned zeros and carries no gradient, while a rollout that was never scored ships no advantage stream at all. Storing zeros for both would erase that, so the field is `None` until assigned — at the node, and at the branch when no node on the path holds any:

```
unassigned :  None
zero credit:  [0.0, 0.0, 0.0, 0.0, 0.0]
real credit:  [0.0, 0.0, 0.0, 0.5, 0.5]
```

A partially assigned path spreads, with the unassigned nodes reading 0.0.

## Verification

- `uv run pytest tests/v1 -m "not e2e"` green; `ruff check` / `ruff format --check`; `ty` clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive schema and view-layer refactor with no writers in verifiers; behavior change is limited to new optional fields and deduplicated spread logic for logprobs.
> 
> **Overview**
> Adds **per-token RL credit** on the message graph so trainers can align advantages with the same token layout as `logprobs`.
> 
> **`MessageNode.advantages`** is optional per-sampled-token credit (compact layout matching `mask` / `logprobs`). **`None`** means never scored; **zeros** mean explicit zero credit (e.g. tied rewards)—distinct semantics for downstream RL.
> 
> **`Branch.advantages`** spreads node values onto full `token_ids` like **`Branch.logprobs`**, and stays **`None`** when no node on the path was assigned credit so it is not confused with an all-zero branch.
> 
> **`Branch.spread()`** factors out the shared widening logic; **`logprobs`** now delegates to it. Verifiers does not populate advantages—consumers stamp them after scoring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7eba3e65d2e5df2249519b387f2e7cc6658abf7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-token `advantages` field to `MessageNode` and `Branch`
> - Adds an optional `advantages: list[float] | None` field to [`MessageNode`](https://github.com/PrimeIntellect-ai/verifiers/pull/2245/files#diff-64c9d635eb215902a512c9e8ab316fd9b9967c36db03d4049aacc812cdfbd740) to store per-sampled-token credit assignments.
> - Adds a `Branch.advantages` property in [`trace.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/2245/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e) that aligns node-level advantages to the full token sequence, returning `None` if no nodes have advantages set and `0.0` for unassigned positions otherwise.
> - Refactors `Branch.logprobs` to delegate to a new `Branch.spread` helper, which generalizes widening any per-sampled-token node field to full-token alignment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7eba3e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->