### PR TITLE
fix(v1): isolate Bash commands from harness venv

### DIFF
--- a/verifiers/v1/harnesses/bash/harness.py
+++ b/verifiers/v1/harnesses/bash/harness.py
@@ -118,6 +118,6 @@ class BashHarness(Harness[BashHarnessConfig]):
             )
             args.append(f"--initial-messages-file={path}")
         program = await runtime.prepare_uv_script(
-            PROGRAM_SOURCE, self.config.resolved_env
+            PROGRAM_SOURCE, self.config.resolved_env, activate=False
         )
         return await runtime.run_program([*program, *args], env)


### PR DESCRIPTION
Fixes #2250

Since #2283 introduced `activate=False`, this PR now uses it when launching the Bash harness, keeping the controller on its uv interpreter while Bash commands use the sandbox env.