### PR TITLE
Reject non-finite tool timeouts

### DIFF
--- a/verifiers/v1/configs/harness.py
+++ b/verifiers/v1/configs/harness.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict, Field, FiniteFloat
 from pydantic_config import BaseConfig
 
 from verifiers.v1.types import ID
@@ -20,7 +20,7 @@ class HarnessConfig(BaseConfig):
     """Extra program variables; harness-owned variables take precedence."""
     forward_env: list[str] = Field(default_factory=list)
     """Host variables to forward without writing secrets into config; explicit `env` wins."""
-    tool_timeout: float = Field(600.0, gt=0)
+    tool_timeout: FiniteFloat = Field(600.0, gt=0)
     """Seconds a single MCP tool call may take; raise it for tools that boot a VM."""
     disabled_tools: list[str] | None = None
     skills: list[Path] = Field(default_factory=list)


### PR DESCRIPTION
## Summary

- validate harness tool-call timeouts as finite numbers
- preserve the existing strictly-positive constraint and default

## Root cause

`HarnessConfig.tool_timeout` used a plain `float` with `gt=0`, which still accepted positive infinity. OpenClaw converts the value to integer milliseconds while building its MCP configuration, so `tool_timeout = inf` raised `OverflowError` during harness setup instead of failing config validation.

## Impact

Invalid non-finite timeout values now fail early with a Pydantic validation error, before any harness-specific conversion or setup.

## Validation

- direct probe for a valid fractional timeout and rejection of `inf`, `-inf`, and `nan`
- `uv run ruff check verifiers/v1/configs/harness.py`
- `uv run ruff format --check verifiers/v1/configs/harness.py`
- `uv run pre-commit run --files verifiers/v1/configs/harness.py`
- `uv run pytest tests/v1 -q --disable-warnings` (credential-gated PRIME tests skipped)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject non-finite values for `HarnessConfig.tool_timeout`
> Changes the `tool_timeout` field type from `float` to `FiniteFloat` in [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2255/files#diff-c5b409466f272f39cbab9228a91d9b6de6c8a0cdd33ad73f05e7fd690966e478), so values like `NaN` and `inf` are now rejected at validation time. The existing `gt=0` constraint and default of `600.0` are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b74ef5d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-field validation tightening in harness config; no auth, data, or runtime behavior change for valid timeouts.
> 
> **Overview**
> **`HarnessConfig.tool_timeout`** is now typed as **`FiniteFloat`** instead of **`float`**, so **`inf`**, **`-inf`**, and **`nan`** fail Pydantic validation at config load. The **`gt=0`** rule and **`600.0`** default are unchanged.
> 
> This avoids harness setup blowing up later (e.g. when a program converts the timeout to integer milliseconds) with an **`OverflowError`** on non-finite values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b74ef5d953278357b6b5dd400096526fd992edea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->