### PR TITLE
fix(v1): prefer Final Judgment over draft boxed answers in parse_judge_choice

### DIFF
--- a/verifiers/v1/utils/score.py
+++ b/verifiers/v1/utils/score.py
@@ -48,6 +48,16 @@ async def read_answer_file_or_last_reply(
     return answer or trace.last_reply
 
 
+def _choice_on_marker_line(
+    text_upper: str, marker_end: int, choice_re: str
+) -> re.Match[str] | None:
+    """Choice must appear on the verdict marker's line, not later CoT."""
+    remainder = text_upper[marker_end:]
+    line_end = remainder.find("\n")
+    line = remainder if line_end == -1 else remainder[:line_end]
+    return re.search(choice_re, line)
+
+
 def parse_judge_choice(
     content: str | None, choices: Sequence[str] = ("A", "B", "C")
 ) -> str | None:
@@ -55,23 +65,32 @@ def parse_judge_choice(
         return None
 
     text = content.rsplit("</think>", 1)[-1].strip()
-    text = extract_boxed_answer(text, strict=True).strip() or text
-
-    text_upper = text.upper()
     choices_by_upper = {choice.upper(): choice for choice in choices}
     allowed = "|".join(re.escape(choice) for choice in choices_by_upper)
     choice_re = rf"(?<!\w)({allowed})(?!\w)"
-    verdict_re = (
-        r"(?:^|\n)\s*(?:FINAL\s+JUDGMENT|FINAL\s+ANSWER|FINAL\s+VERDICT|"
-        r"JUDGMENT|VERDICT|ANSWER)\s*(?:IS\s*)?[:\-]?\s*"
+    final_verdict_re = (
+        r"(?:^|\n)\s*(?:FINAL\s+JUDGMENT|FINAL\s+ANSWER|FINAL\s+VERDICT)"
+        r"\s*(?:IS\s*)?[:\-]?\s*"
+    )
+    bare_verdict_re = (
+        r"(?:^|\n)\s*(?:JUDGMENT|VERDICT|ANSWER)\s*(?:IS\s*)?[:\-]?\s*"
     )
 
-    verdict = re.search(verdict_re, text_upper)
-    if verdict:
-        match = re.search(choice_re, text_upper[verdict.end() :])
-        return choices_by_upper.get(match.group(1)) if match else None
+    # Prefer explicit Final * markers on the full reply (last wins) so a draft
+    # \boxed{...} cannot shadow a later verdict line. Only accept a choice on the
+    # marker's own line so an empty "Final Judgment:" falls through to boxed.
+    text_upper = text.upper()
+    for verdict_re in (final_verdict_re, bare_verdict_re):
+        for verdict in reversed(list(re.finditer(verdict_re, text_upper))):
+            match = _choice_on_marker_line(text_upper, verdict.end(), choice_re)
+            if match:
+                return choices_by_upper.get(match.group(1))
 
-    matches = re.findall(choice_re, text_upper)
+    # No usable marker choice: keep boxed answers preferred over CoT mentions,
+    # then last match.
+    boxed = extract_boxed_answer(text, strict=True).strip()
+    search_upper = (boxed or text).upper()
+    matches = re.findall(choice_re, search_upper)
     return choices_by_upper.get(matches[-1]) if matches else None
 
 
@@ -101,7 +120,7 @@ def verify_boxed_math_answer(
                 timeout_seconds=timeout_seconds,
             )
         )
-    except (Exception, MathVerifyTimeout):  # noqa: BLE001 - malformed answers score zero
+    except (Exception, MathVerifyTimeout):
         return 0.0
 
 


### PR DESCRIPTION
Supersedes #2008 — same fix, rebased onto current `main` after #2204 moved scoring helpers to `verifiers/v1/utils/score.py`.

## Summary
- `parse_judge_choice` previously unwrapped the last `\boxed{...}` before looking for verdict markers, so a draft box could wipe a later `Final Judgment` / `Final Answer` line and return the wrong choice.
- Search order is now: explicit verdict marker on the full reply → boxed answer (if present) → last choice match.
- If a verdict marker is present but has no choice after it, fall through to boxed / last-match instead of returning `None`.

## Risk
Low. Only flips scores when a reply has both a draft `\boxed{...}` and a later explicit verdict line (or an empty marker that previously failed). Default yes/no-only reference prompts are mostly unaffected.

## Test plan
- [x] Manual: `Draft: \boxed{A}` + `Final Judgment: B` → `B`
- [x] Manual: `Final Judgment:` (empty) + earlier `\boxed{A}` → `A`
- [x] Manual: verdict-marker-only, boxed-only, boxed-over-CoT, last-match, incomplete `<think>` cases

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoring-only change in judge reply parsing; may flip grades when replies mix draft boxes and later verdict lines, with no auth or runtime impact.
> 
> **Overview**
> **`parse_judge_choice`** no longer replaces the post-`</think>` text with a strict `\boxed{...}` extract before hunting verdict lines, so a draft box cannot override a later explicit verdict.
> 
> Parsing order is now: scan the full reply for **`FINAL JUDGMENT` / `FINAL ANSWER` / `FINAL VERDICT`** (then bare **`JUDGMENT` / `VERDICT` / `ANSWER`**), **last marker wins**, and the A/B/C (or custom) choice must sit on **that marker’s line** via new **`_choice_on_marker_line`**. If no marker yields a choice (e.g. empty `Final Judgment:`), it falls back to strict boxed content when present, else the **last** choice token in the text.
> 
> Also drops the **`noqa: BLE001`** on the broad except in **`verify_boxed_math_answer`** (behavior unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08bc1a82e8c8c888b7d6c7edf39b2d55faafb821. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `parse_judge_choice` to prefer Final Judgment markers over draft boxed answers
> - Adds a `_choice_on_marker_line` helper in [score.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2256/files#diff-d7b5bdc04a1f81bad34edd56c57b6adbbb2c5a52979c6a0f4c4320f8e0b4c73a) that restricts choice detection to the same line as a verdict marker, preventing later lines from being matched incorrectly.
> - Reworks `parse_judge_choice` to prefer the last "Final" verdict marker over bare markers, and defers boxed-answer extraction until after marker-based matching so earlier boxed content cannot shadow a later verdict line.
> - Falls back to a boxed answer choice, then to the last choice match in the text, if no marker-based choice is found.
> - Behavioral Change: choices are no longer accepted from lines following a verdict marker; only the marker's own line is scanned.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08bc1a8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->