### PR TITLE
Use GPT-5.6 Luna for CI evals

### DIFF
--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -44,6 +44,8 @@ from verifiers.v1.configs.cli.eval import EvalConfig
 from verifiers.v1.trace import Trace
 from verifiers.v1.utils.loaders import load_environment
 
+CI_MODEL = "openai/gpt-5.6-luna"
+
 # Fixture tasksets/envs (echo-v1, echo-agentic-v1, echo-v0, echo-multi-v0) live in
 # tests/v1/fixtures, added to the path via `pythonpath` in pyproject so the v1 loader and the
 # v0 legacy bridge both resolve them by id (no install).
@@ -129,13 +131,12 @@ def _eval_config(
     runtime: dict | None = None,
     env: dict | None = None,
     pool: dict | None = None,
-    model: str | None = "deepseek/deepseek-v4-flash-0731",
     reasoning_effort: str | None = None,
 ) -> EvalConfig:
     """Build the smallest `EvalConfig` that still exercises the path, shared by the in-process
     (`run_v1`) and env-server (`run_v1_server`) fixtures. `taskset_overrides` merges onto the
     `{id: ...}` config; `runtime` places the `agent` seat's harness (an agent field, not a
-    harness one); `model` overrides the default text model (e.g. a VLM for an image task).
+    harness one).
 
     `harness=None` leaves every seat on its own story — the multi-agent case: there
     is no run-level harness, so a single-agent test's `harness` lands on the `agent`
@@ -178,7 +179,7 @@ def _eval_config(
         rich=False,
         output_dir=output_dir,
         **({"serve": {"pool": pool}} if pool else {}),
-        **({"model": model} if model else {}),
+        model=CI_MODEL,
     )
 
 
@@ -223,7 +224,7 @@ async def live_ctx():
 
     # Endpoint config only — each rollout builds and closes its own client.
     yield ModelContext(
-        model="deepseek/deepseek-v4-flash-0731",
+        model=CI_MODEL,
         client=EvalClientConfig(),
         sampling=SamplingConfig(max_tokens=2048),
     )
@@ -244,6 +245,7 @@ def run_v0():
     ) -> list[Trace]:
         config = EvalConfig(
             legacy={"id": env_id, "args": args or {}},
+            model=CI_MODEL,
             num_tasks=1,
             num_rollouts=n,
             sampling={"max_tokens": max_tokens},

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -314,7 +314,6 @@ async def test_tool_response_image(run_v1, tmp_path):
         "tool-response-image-v1",
         harness="null",
         runtime={"type": "subprocess"},
-        model="openai/gpt-5.6-luna",
         reasoning_effort="none",
         output_dir=tmp_path,
         max_turns=4,

--- a/tests/v1/test_envs.py
+++ b/tests/v1/test_envs.py
@@ -47,7 +47,7 @@ def test_eval(taskset: str):
         pytest.skip(f"{taskset} can't run a plain-CI smoke eval")
     if os.getenv("PRIME_API_KEY"):
         model = [
-            "-m", "openai/gpt-4.1-mini",
+            "-m", "openai/gpt-5.6-luna",
             "--client.base-url", "https://api.pinference.ai/api/v1",
             "--client.api-key-var", "PRIME_API_KEY",
         ]  # fmt: skip


### PR DESCRIPTION
## Overview

Use GPT-5.6 Luna as the single Prime-backed model across the CI evaluation suite.

## Details

- define one shared CI model for v1 eval fixtures, direct agent coverage, and the legacy bridge
- use Luna for every example-environment CLI smoke run backed by Prime
- remove the image test's separate model override now that the shared model supports vision
- preserve the direct OpenAI API fallback for local runs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only configuration changes with no production code paths affected.
> 
> **Overview**
> **CI evals now use a single Prime-backed model** (`openai/gpt-5.6-luna`) instead of mixing DeepSeek and per-test overrides.
> 
> `tests/v1/conftest.py` introduces `CI_MODEL` and wires it into `_eval_config`, `live_ctx`, and `run_v0`, dropping the optional `model` argument on the shared eval fixture builder. The tool image e2e test no longer passes its own vision model because the shared default is vision-capable. Prime-backed example taskset CLI smokes in `test_envs.py` switch from `gpt-4.1-mini` to Luna; the direct OpenAI `gpt-4.1-mini` path when only `OPENAI_API_KEY` is set is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9566f903c021a34cbb1905d20efeb2d1fd2acda3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch CI evals to use `openai/gpt-5.6-luna`
> Replaces model references across CI eval fixtures and tests with a new `CI_MODEL` constant set to `"openai/gpt-5.6-luna"`. The constant is defined in [conftest.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2258/files#diff-bc28790d38dc6e7e4f2c44639d40bc33dea724d6c73149abf7ba82b37d14f40b) and applied to `_eval_config`, `live_ctx`, and `run_v0` fixtures, as well as the `PRIME_API_KEY` path in [test_envs.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2258/files#diff-7c694d14edc9f77a0d330e4121024e79ba615b135a5e8f2da634bdd15a52b794). Callers can no longer override the model per-call via `_eval_config` — it always uses `CI_MODEL`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9566f90.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->