### PR TITLE
fix(v1): persist prime-agent ACP sessions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,9 @@ def pytest_configure(config) -> None:
     config.addinivalue_line(
         "markers", "hermes_agent: v1 e2e cases on the hermes-agent harness"
     )
+    config.addinivalue_line(
+        "markers", "prime_agent: v1 e2e cases on the prime-agent harness"
+    )
 
 
 @pytest.fixture

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -26,7 +26,7 @@ Every combination carries its axes' pytest marks, so subsets select with `-m`:
 
 Marks: runtimes `subprocess` / `docker` / `prime` / `modal`, placement `colocated`,
 harnesses `null` / `bash` / `rlm` / `kimi_code` / `pi` / `pool` / `openclaw` / `codex` /
-`claude_code` / `hermes_agent`.
+`claude_code` / `hermes_agent` / `prime_agent`.
 A mark is applied per axis, so it selects every case touching that value on ANY axis; for one exact
 combination use `-k` on the test id (e.g. `-k "harness-in-docker-with-tool-in-subprocess"`).
 prime/modal provision real remote sandboxes (slow, infra-flaky, need setup), so they're local-only.

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -164,7 +164,10 @@ def _eval_config(
         seat_cfg.setdefault("max_output_tokens", max_tokens)
         seat_cfg.setdefault("timeout", {"rollout": rollout_timeout, "scoring": 60})
         # Flake resilience: retries are per-agent now (flat RetryConfig).
-        seat_cfg.setdefault("retries", {"max_retries": 2, "include": ["ProviderError"]})
+        seat_cfg.setdefault(
+            "retries",
+            {"max_retries": 2, "include": ["ProviderError", "HarnessError"]},
+        )
     return EvalConfig(
         env={
             "taskset": taskset_cfg,

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -26,7 +26,7 @@ Every combination carries its axes' pytest marks, so subsets select with `-m`:
 
 Marks: runtimes `subprocess` / `docker` / `prime` / `modal`, placement `colocated`,
 harnesses `null` / `bash` / `rlm` / `kimi_code` / `pi` / `pool` / `openclaw` / `codex` /
-`claude_code` / `hermes_agent`.
+`claude_code` / `hermes_agent` / `prime_agent`.
 A mark is applied per axis, so it selects every case touching that value on ANY axis; for one exact
 combination use `-k` on the test id (e.g. `-k "harness-in-docker-with-tool-in-subprocess"`).
 prime/modal provision real remote sandboxes (slow, infra-flaky, need setup), so they're local-only.
@@ -70,8 +70,8 @@ def tool_runtime(request) -> dict:
 
 
 # Built-in harnesses are bundled in the `harnesses` package; the agent CLIs (`rlm` /
-# `kimi-code` / `openclaw` / `codex` / `claude-code` / `hermes-agent`) install their
-# dependencies at rollout.
+# `kimi-code` / `openclaw` / `codex` / `claude-code` / `hermes-agent` / `prime-agent`)
+# install their dependencies at rollout.
 # `compact` (an example harness) and `terminus-2` (drives the host tmux) are excluded from e2e.
 @pytest.fixture
 def harness(request) -> str:

--- a/tests/v1/fixtures/echo_tool_v1.py
+++ b/tests/v1/fixtures/echo_tool_v1.py
@@ -11,6 +11,7 @@ so it would also serve taskset-scoped (`Taskset.toolsets`).
 """
 
 import verifiers.v1 as vf
+from verifiers.v1.types import content_text
 
 PHRASE = "hello world"
 ECHO_TOKEN = "ok-7f3"  # the tool stamps this; only a real tool call can surface it
@@ -36,11 +37,9 @@ class EchoToolTask(vf.Task[vf.TaskData, vf.State, EchoToolTaskConfig]):
 
     @vf.reward(weight=1.0)
     async def echoed(self, trace: vf.Trace) -> float:
-        # The stamped token surfaces in an ASSISTANT message only if the model called
-        # the MCP tool and relayed its result — wherever in the exchange that happened
-        # (in a conversation the last turn may be a closing pleasantry).
-        replies = ((m.content or "").lower() for m in trace.assistant_messages)
-        return float(any(PHRASE in r and ECHO_TOKEN in r for r in replies))
+        # A stamped TOOL result proves the tool really ran with the phrase.
+        results = (content_text(m.content).lower() for m in trace.tool_messages)
+        return float(any(PHRASE in r and ECHO_TOKEN in r for r in results))
 
 
 class EchoToolConfig(vf.TasksetConfig):

--- a/tests/v1/fixtures/prime_agent_acp_resume_v1.py
+++ b/tests/v1/fixtures/prime_agent_acp_resume_v1.py
@@ -1,0 +1,58 @@
+"""Two-segment Prime Agent exchange that requires live IPython state."""
+
+import verifiers.v1 as vf
+
+
+class PrimeAgentResumeTask(vf.Task):
+    @vf.reward(weight=1.0)
+    async def resumed(self, trace: vf.Trace) -> float:
+        segments = trace.info.get("prime_agent_segments", [])
+        if len(segments) != 2:
+            return 0.0
+        first, second = segments
+        return float(
+            "ready" in first["last_reply"].casefold()
+            and second["last_reply"].strip() == "42"
+        )
+
+
+class PrimeAgentResumeEnv(vf.SingleAgentEnv):
+    async def run(self, task, agents):
+        async with agents.agent.interaction(task) as interaction:
+            first = await interaction.turn(
+                "Use IPython to set vf_acp_counter = 41. Reply with exactly READY."
+            )
+            segments = [first]
+            if not first.terminated:
+                segments.append(
+                    await interaction.turn(
+                        "Use IPython to increment the existing vf_acp_counter by one. "
+                        "Reply with exactly its new integer value."
+                    )
+                )
+            interaction.trace.info["prime_agent_segments"] = [
+                {
+                    "last_reply": segment.last_reply,
+                    "terminated": segment.terminated,
+                }
+                for segment in segments
+            ]
+
+
+class PrimeAgentResumeTaskset(vf.Taskset):
+    def load(self) -> list[PrimeAgentResumeTask]:
+        return [
+            PrimeAgentResumeTask(
+                vf.TaskData(
+                    idx=0,
+                    prompt=None,
+                    system_prompt=(
+                        "Follow each user instruction exactly. Always perform requested "
+                        "IPython operations before replying."
+                    ),
+                )
+            )
+        ]
+
+
+__all__ = ["PrimeAgentResumeEnv", "PrimeAgentResumeTaskset"]

--- a/tests/v1/fixtures/prime_agent_persistence_v1.py
+++ b/tests/v1/fixtures/prime_agent_persistence_v1.py
@@ -1,0 +1,97 @@
+"""Two-segment Prime Agent interaction that requires one live IPython kernel."""
+
+import re
+
+import verifiers.v1 as vf
+
+TOKEN = re.compile(r"\b[0-9a-f]{64}\b")
+FIRST_CELL = "import secrets\n_vf_marker = secrets.token_hex(32)\nprint(_vf_marker)"
+SECOND_CELL = "print(_vf_marker)"
+
+
+def _segment_info(segment: vf.Segment) -> dict:
+    return {
+        "last_reply": segment.last_reply,
+        "tool_outputs": [
+            str(message.content)
+            for message in segment.messages
+            if isinstance(message, vf.ToolMessage)
+        ],
+        "tool_calls": [
+            call.arguments
+            for message in segment.messages
+            if isinstance(message, vf.AssistantMessage)
+            for call in message.tool_calls or []
+        ],
+        "terminated": segment.terminated,
+    }
+
+
+class PrimeAgentPersistenceTask(vf.Task):
+    @vf.reward(weight=1.0)
+    async def persisted(self, trace: vf.Trace) -> float:
+        segments = trace.info.get("prime_agent_segments", [])
+        if len(segments) != 2:
+            return 0.0
+        first, second = segments
+        first_tokens = set(TOKEN.findall("\n".join(first["tool_outputs"])))
+        second_tokens = set(TOKEN.findall("\n".join(second["tool_outputs"])))
+        second_calls = "\n".join(second["tool_calls"])
+        return float(
+            bool(first_tokens & second_tokens)
+            and "_vf_marker" in second_calls
+            and "secrets" not in second_calls
+            and "NameError" not in "\n".join(second["tool_outputs"])
+            and first["last_reply"].strip() == "READY"
+            and not first["terminated"]
+            and not second["terminated"]
+        )
+
+
+class PrimeAgentPersistenceEnv(vf.SingleAgentEnv):
+    async def run(self, task, agents):
+        # Keep the runtime alive after the rollout so cleanup is directly observable.
+        async with agents.agent.provision(task) as runtime:
+            async with agents.agent.interaction(task, runtime=runtime) as interaction:
+                first = await interaction.turn(
+                    "Use IPython to execute exactly this cell:\n\n"
+                    f"{FIRST_CELL}\n\n"
+                    "Then reply with exactly READY. Do not include the printed value."
+                )
+                segments = [first]
+                if not first.terminated:
+                    segments.append(
+                        await interaction.turn(
+                            "Use IPython to execute exactly this cell without defining, "
+                            f"assigning, or reconstructing anything:\n\n{SECOND_CELL}\n\n"
+                            "Then reply with exactly the printed value."
+                        )
+                    )
+                trace = interaction.trace
+                trace.info["prime_agent_segments"] = [
+                    _segment_info(segment) for segment in segments
+                ]
+            state = f".vf-prime-agent-{trace.id}"
+            cleaned = await runtime.run(["test", "!", "-e", state], {})
+            trace.info["prime_agent_state_cleaned"] = cleaned.exit_code == 0
+
+
+class PrimeAgentPersistenceTaskset(
+    vf.Taskset[PrimeAgentPersistenceTask, vf.TasksetConfig]
+):
+    def load(self) -> list[PrimeAgentPersistenceTask]:
+        return [
+            PrimeAgentPersistenceTask(
+                vf.TaskData(
+                    idx=0,
+                    prompt=None,
+                    system_prompt=(
+                        "Follow every instruction exactly. Use IPython when requested, "
+                        "and never reconstruct missing kernel state from conversation text."
+                    ),
+                )
+            )
+        ]
+
+
+__all__ = ["PrimeAgentPersistenceEnv", "PrimeAgentPersistenceTaskset"]

--- a/tests/v1/test_dialects.py
+++ b/tests/v1/test_dialects.py
@@ -1,0 +1,33 @@
+"""Chat dialect wire parsing."""
+
+from verifiers.v1.dialects.chat import ChatStreamParser
+
+
+def test_stream_parser_tolerates_out_of_enum_finish_reason() -> None:
+    """Providers surface upstream failures as `finish_reason: "error"`, outside the SDK's
+    Literal; the assembled completion must still validate, with the out-of-enum value
+    normalized to None like the non-stream path."""
+    parser = ChatStreamParser()
+    parser.feed(
+        b'data: {"id": "cmpl-1", "object": "chat.completion.chunk", "created": 1,'
+        b' "model": "m", "choices": [{"index": 0, "delta": {"content": "partial"}}]}\n\n'
+    )
+    parser.feed(
+        b'data: {"choices": [{"index": 0, "delta": {}, "finish_reason": "error"}]}\n\n'
+    )
+
+    response = parser.finish()
+
+    assert response.finish_reason is None
+    assert response.message.content == "partial"
+
+
+def test_stream_parser_keeps_enum_finish_reasons() -> None:
+    parser = ChatStreamParser()
+    parser.feed(
+        b'data: {"id": "cmpl-2", "object": "chat.completion.chunk", "created": 1,'
+        b' "model": "m", "choices": [{"index": 0, "delta": {"content": "done"},'
+        b' "finish_reason": "stop"}]}\n\n'
+    )
+
+    assert parser.finish().finish_reason == "stop"

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -231,11 +231,12 @@ async def test_acp_resume_with_tool(run_v1, harness, harness_runtime, tmp_path):
     assert trace.ok, trace.errors
     assert trace.stop_condition == "user_closed"
     assert trace.rewards["resumed"].score == 1.0
-    assert trace.tools  # ACP-native tools, or Pi's MCP adapter meta-tool
     segments = trace.info["acp_segments"]
     assert len(segments) == 2
     assert segments[0]["terminated"] is False
     assert segments[1]["terminated"] is False
+    # Native MCP tools need not appear in the intercepted model request that
+    # populates trace.tools; the ACP transcript is the source of truth for use.
     assert "tool" in segments[1]["roles"]
     assert segments[1]["tool_outputs"]
     if harness == "rlm":

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -67,6 +67,7 @@ ACP_RESUME_PLACEMENTS = [
 
 PRIME_AGENT_RESUME_PLACEMENTS = [
     _pair("prime-agent", "docker", "prime-agent-acp-in-docker"),
+    _pair("prime-agent", "prime", "prime-agent-acp-in-prime-vm"),
 ]
 
 # harness runtime x tool placement: every axis value once plus the two-container case
@@ -280,7 +281,10 @@ async def test_prime_agent_acp_resume(run_v1, harness, harness_runtime, tmp_path
     (trace,) = await run_v1(
         "prime-agent-acp-resume-v1",
         harness=harness,
-        runtime={"type": harness_runtime},
+        runtime={
+            "type": harness_runtime,
+            **({"vm": True} if harness_runtime == "prime" else {}),
+        },
         output_dir=tmp_path,
         max_turns=8,
         max_tokens=8192,

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -7,11 +7,11 @@ are local-only (their marks are excluded in CI)."""
 
 import pytest
 
-_m = pytest.mark
+mark = pytest.mark
 
 
-def _pair(a: str, b: str, id: str, *extra_marks):
-    marks = [getattr(_m, a.replace("-", "_")), getattr(_m, b.replace("-", "_"))]
+def pair(a: str, b: str, id: str, *extra_marks):
+    marks = [getattr(mark, a.replace("-", "_")), getattr(mark, b.replace("-", "_"))]
     return pytest.param(a, b, marks=[*marks, *extra_marks], id=id)
 
 
@@ -20,81 +20,83 @@ def _pair(a: str, b: str, id: str, *extra_marks):
 # provider. codex/claude-code are excluded here (unreliable on a no-op echo chat
 # task) — test_agentic covers them.
 CHAT_PLACEMENTS = [
-    _pair("null", "subprocess", "null-harness-in-subprocess"),
-    _pair("bash", "docker", "bash-harness-in-docker"),
-    _pair("rlm", "docker", "rlm-harness-in-docker"),
-    _pair("kimi-code", "docker", "kimi-code-harness-in-docker"),
-    _pair("bash", "prime", "bash-harness-in-prime"),
-    _pair("bash", "modal", "bash-harness-in-modal"),
+    pair("null", "subprocess", "null-harness-in-subprocess"),
+    pair("bash", "docker", "bash-harness-in-docker"),
+    pair("rlm", "docker", "rlm-harness-in-docker"),
+    pair("kimi-code", "docker", "kimi-code-harness-in-docker"),
+    pair("bash", "prime", "bash-harness-in-prime"),
+    pair("bash", "modal", "bash-harness-in-modal"),
 ]
 
 # harness x harness runtime for the shell task: every coding agent once (null is a chat
 # loop with no shell), both local runtimes hit (subprocess only carries bash), one
 # remote row per provider.
 AGENTIC_PLACEMENTS = [
-    _pair("bash", "subprocess", "bash-harness-in-subprocess"),
-    _pair("rlm", "docker", "rlm-harness-in-docker"),
-    _pair("kimi-code", "docker", "kimi-code-harness-in-docker"),
-    _pair("codex", "docker", "codex-harness-in-docker"),
-    _pair("claude-code", "docker", "claude-code-harness-in-docker"),
-    _pair("hermes-agent", "docker", "hermes-agent-harness-in-docker"),
-    _pair("bash", "prime", "bash-harness-in-prime"),
-    _pair("bash", "modal", "bash-harness-in-modal"),
+    pair("bash", "subprocess", "bash-harness-in-subprocess"),
+    pair("rlm", "docker", "rlm-harness-in-docker"),
+    pair("kimi-code", "docker", "kimi-code-harness-in-docker"),
+    pair("codex", "docker", "codex-harness-in-docker"),
+    pair("claude-code", "docker", "claude-code-harness-in-docker"),
+    pair("hermes-agent", "docker", "hermes-agent-harness-in-docker"),
+    pair("bash", "prime", "bash-harness-in-prime"),
+    pair("bash", "modal", "bash-harness-in-modal"),
 ]
 
 # The scripted user runs in the eval process itself (no placement axis); the harness
 # runtime is the exchange's only axis.
 USER_RUNTIMES = [
-    pytest.param("subprocess", marks=[_m.subprocess], id="harness-in-subprocess"),
-    pytest.param("docker", marks=[_m.docker], id="harness-in-docker"),
-    pytest.param("prime", marks=[_m.prime], id="harness-in-prime"),
-    pytest.param("modal", marks=[_m.modal], id="harness-in-modal"),
+    pytest.param("subprocess", marks=[mark.subprocess], id="harness-in-subprocess"),
+    pytest.param("docker", marks=[mark.docker], id="harness-in-docker"),
+    pytest.param("prime", marks=[mark.prime], id="harness-in-prime"),
+    pytest.param("modal", marks=[mark.modal], id="harness-in-modal"),
 ]
 
 # ACP-backed harnesses: each must preserve an exchange across interaction segments and
 # retain MCP access after resuming. Cover every harness in the local container runtime,
 # plus remote placements for the sandbox/tunnel and native-process boundaries.
 ACP_RESUME_PLACEMENTS = [
-    _pair("hermes-agent", "docker", "hermes-agent-acp-in-docker"),
-    _pair("rlm", "docker", "rlm-acp-in-docker"),
-    _pair("kimi-code", "docker", "kimi-code-acp-in-docker"),
-    _pair("pi", "docker", "pi-acp-in-docker"),
-    _pair("pool", "docker", "pool-acp-in-docker"),
-    _pair("openclaw", "docker", "openclaw-acp-in-docker"),
-    _pair("pool", "prime", "pool-acp-in-prime"),
-    _pair("rlm", "prime", "rlm-acp-in-prime-vm"),
+    pair("codex", "docker", "codex-acp-in-docker"),
+    pair("claude-code", "docker", "claude-code-acp-in-docker"),
+    pair("hermes-agent", "docker", "hermes-agent-acp-in-docker"),
+    pair("rlm", "docker", "rlm-acp-in-docker"),
+    pair("kimi-code", "docker", "kimi-code-acp-in-docker"),
+    pair("pi", "docker", "pi-acp-in-docker"),
+    pair("pool", "docker", "pool-acp-in-docker"),
+    pair("openclaw", "docker", "openclaw-acp-in-docker"),
+    pair("pool", "prime", "pool-acp-in-prime"),
+    pair("rlm", "prime", "rlm-acp-in-prime-vm"),
 ]
 
 # harness runtime x tool placement: every axis value once plus the two-container case
 # (harness and tool in separate docker boxes) and a prime-colocated row (a tool in its
 # OWN prime sandbox needs port exposure; colocated rides the harness's box).
 TOOL_PLACEMENTS = [
-    _pair("subprocess", "colocated", "harness-in-subprocess-with-tool-colocated"),
-    _pair("docker", "colocated", "harness-in-docker-with-tool-colocated"),
-    _pair("subprocess", "docker", "harness-in-subprocess-with-tool-in-docker"),
-    _pair("docker", "subprocess", "harness-in-docker-with-tool-in-subprocess"),
-    _pair("docker", "docker", "harness-in-docker-with-tool-in-docker"),
-    _pair("prime", "colocated", "harness-in-prime-with-tool-colocated"),
-    _pair("modal", "colocated", "harness-in-modal-with-tool-colocated"),
-    _pair("subprocess", "modal", "harness-in-subprocess-with-tool-in-modal"),
+    pair("subprocess", "colocated", "harness-in-subprocess-with-tool-colocated"),
+    pair("docker", "colocated", "harness-in-docker-with-tool-colocated"),
+    pair("subprocess", "docker", "harness-in-subprocess-with-tool-in-docker"),
+    pair("docker", "subprocess", "harness-in-docker-with-tool-in-subprocess"),
+    pair("docker", "docker", "harness-in-docker-with-tool-in-docker"),
+    pair("prime", "colocated", "harness-in-prime-with-tool-colocated"),
+    pair("modal", "colocated", "harness-in-modal-with-tool-colocated"),
+    pair("subprocess", "modal", "harness-in-subprocess-with-tool-in-modal"),
 ]
 
 # The state channel rides the same reachability as TOOL_PLACEMENTS; cover each axis
 # value once rather than re-running the whole list.
 TOOL_STATE_PLACEMENTS = [
-    _pair("subprocess", "colocated", "harness-in-subprocess-with-tool-colocated"),
-    _pair("docker", "subprocess", "harness-in-docker-with-tool-in-subprocess"),
-    _pair("subprocess", "docker", "harness-in-subprocess-with-tool-in-docker"),
-    _pair("modal", "colocated", "harness-in-modal-with-tool-colocated"),
+    pair("subprocess", "colocated", "harness-in-subprocess-with-tool-colocated"),
+    pair("docker", "subprocess", "harness-in-docker-with-tool-in-subprocess"),
+    pair("subprocess", "docker", "harness-in-subprocess-with-tool-in-docker"),
+    pair("modal", "colocated", "harness-in-modal-with-tool-colocated"),
 ]
 
 # Shared servers always run in their own runtime (colocation is per-rollout, shared is
 # eval-level): same-runtime pairs plus one cross-boundary row.
 SHARED_TOOL_PLACEMENTS = [
-    _pair("subprocess", "subprocess", "harness-in-subprocess-with-tool-in-subprocess"),
-    _pair("docker", "docker", "harness-in-docker-with-tool-in-docker"),
-    _pair("subprocess", "docker", "harness-in-subprocess-with-tool-in-docker"),
-    _pair("modal", "modal", "harness-in-modal-with-tool-in-modal"),
+    pair("subprocess", "subprocess", "harness-in-subprocess-with-tool-in-subprocess"),
+    pair("docker", "docker", "harness-in-docker-with-tool-in-docker"),
+    pair("subprocess", "docker", "harness-in-subprocess-with-tool-in-docker"),
+    pair("modal", "modal", "harness-in-modal-with-tool-in-modal"),
 ]
 
 

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -63,6 +63,10 @@ ACP_RESUME_PLACEMENTS = [
     _pair("pool", "prime", "pool-acp-in-prime"),
 ]
 
+PRIME_AGENT_RESUME_PLACEMENTS = [
+    _pair("prime-agent", "docker", "prime-agent-acp-in-docker"),
+]
+
 # harness runtime x tool placement: every axis value once plus the two-container case
 # (harness and tool in separate docker boxes) and a prime-colocated row (a tool in its
 # OWN prime sandbox needs port exposure; colocated rides the harness's box).
@@ -231,6 +235,30 @@ async def test_acp_resume_with_tool(run_v1, harness, harness_runtime, tmp_path):
     assert segments[1]["terminated"] is False
     assert "tool" in segments[1]["roles"]
     assert segments[1]["tool_outputs"]
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    "harness,harness_runtime", PRIME_AGENT_RESUME_PLACEMENTS, indirect=True
+)
+async def test_prime_agent_acp_resume(run_v1, harness, harness_runtime, tmp_path):
+    """Prime Agent retains its live IPython kernel across interaction segments."""
+    (trace,) = await run_v1(
+        "prime-agent-acp-resume-v1",
+        harness=harness,
+        runtime={"type": harness_runtime},
+        output_dir=tmp_path,
+        max_turns=8,
+        max_tokens=8192,
+        rollout_timeout=600,
+    )
+    assert trace.ok, trace.errors
+    assert trace.stop_condition == "user_closed"
+    assert trace.rewards["resumed"].score == 1.0
+    segments = trace.info["prime_agent_segments"]
+    assert len(segments) == 2
+    assert segments[0]["terminated"] is False
+    assert segments[1]["terminated"] is False
 
 
 @pytest.mark.e2e

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -241,6 +241,33 @@ async def test_acp_resume_with_tool(run_v1, harness, harness_runtime, tmp_path):
 
 
 @pytest.mark.e2e
+@pytest.mark.docker
+@pytest.mark.prime_agent
+async def test_prime_agent_persists_native_acp_session(run_v1, tmp_path):
+    """Prime Agent retains its native ACP session and cleans its rollout state."""
+    (trace,) = await run_v1(
+        "prime-agent-persistence-v1",
+        harness="prime-agent",
+        runtime={"type": "docker"},
+        output_dir=tmp_path,
+        max_turns=8,
+        max_tokens=8192,
+        rollout_timeout=600,
+    )
+    assert trace.ok, trace.errors
+    assert trace.stop_condition == "user_closed"
+    assert trace.rewards["persisted"].score == 1.0
+    assert trace.info["prime_agent_state_cleaned"] is True
+    # Transcript replay serializes the old assistant turn into a new user prompt;
+    # a live native session keeps it as a distinct assistant message instead.
+    assert not any(
+        isinstance(message.content, str) and "[assistant]\n" in message.content
+        for message in trace.branches[-1].messages
+        if message.role == "user"
+    )
+
+
+@pytest.mark.e2e
 @pytest.mark.parametrize("harness_runtime,tool_runtime", TOOL_PLACEMENTS, indirect=True)
 async def test_tool(run_v1, harness_runtime, tool_runtime, tmp_path):
     """A `vf.Toolset` (an echo tool) across its placement (`tool_runtime`: colocated in

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -278,12 +278,29 @@ async def test_prime_agent_persists_native_acp_session(run_v1, tmp_path):
 )
 async def test_prime_agent_acp_resume(run_v1, harness, harness_runtime, tmp_path):
     """Prime Agent retains its live IPython kernel across interaction segments."""
+    skill = tmp_path / "archive-skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        "---\n"
+        "name: archive-skill\n"
+        "description: Marks the Prime Agent skill archive canary.\n"
+        "---\n\n"
+        "Keep this skill available during the ACP resume test.\n"
+    )
+    reference = skill / "references" / "marker.txt"
+    reference.parent.mkdir()
+    reference.write_text("skill archive marker\n")
     (trace,) = await run_v1(
         "prime-agent-acp-resume-v1",
-        harness=harness,
+        harness=None,
         runtime={
             "type": harness_runtime,
             **({"vm": True} if harness_runtime == "prime" else {}),
+        },
+        env={
+            "agent": {
+                "harness": {"id": harness, "skills": [str(skill)]},
+            }
         },
         output_dir=tmp_path,
         max_turns=8,

--- a/tests/v1/test_prime_agent_harness.py
+++ b/tests/v1/test_prime_agent_harness.py
@@ -1,0 +1,43 @@
+import hashlib
+import os
+import shlex
+import subprocess
+from pathlib import PurePosixPath
+
+import pytest
+
+from verifiers.v1.harnesses.prime_agent.harness import (
+    STATE_ROOT,
+    PrimeAgentHarness,
+    _guarded_install,
+)
+from verifiers.v1.trace import Trace
+
+
+def test_trace_root_encodes_untrusted_trace_id() -> None:
+    trace = Trace.model_construct(id="../../etc")
+
+    root = PurePosixPath(PrimeAgentHarness.trace_root(trace))
+
+    assert root.parent == PurePosixPath(STATE_ROOT)
+    assert root.name == hashlib.sha256(trace.id.encode()).hexdigest()[:32]
+
+
+@pytest.mark.parametrize("owner", [str(os.getpid()), f"{os.getpid()}:0"])
+def test_install_lock_recovers_from_live_reused_pid(tmp_path, owner: str) -> None:
+    lock = tmp_path / "install.lock"
+    marker = tmp_path / "installed"
+    lock.symlink_to(owner)
+    command = f": > {shlex.quote(str(marker))}"
+
+    result = subprocess.run(
+        ["sh", "-c", _guarded_install(str(tmp_path), str(lock), command)],
+        capture_output=True,
+        text=True,
+        timeout=2,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert marker.exists()
+    assert not lock.is_symlink()

--- a/tests/v1/test_prime_agent_harness.py
+++ b/tests/v1/test_prime_agent_harness.py
@@ -7,6 +7,7 @@ from pathlib import PurePosixPath
 import pytest
 
 from verifiers.v1.harnesses.prime_agent.harness import (
+    INSTALL,
     STATE_ROOT,
     PrimeAgentHarness,
     _guarded_install,
@@ -41,3 +42,79 @@ def test_install_lock_recovers_from_live_reused_pid(tmp_path, owner: str) -> Non
     assert result.returncode == 0, result.stderr
     assert marker.exists()
     assert not lock.is_symlink()
+
+
+@pytest.mark.parametrize("failed_move", [0, 1, 2])
+def test_install_activation_is_transactional(tmp_path, failed_move: int) -> None:
+    root = tmp_path / "install"
+    old_bin = root / "node_modules" / ".bin" / "prime-agent"
+    old_bin.parent.mkdir(parents=True)
+    old_bin.write_text("old install")
+    old_bin.chmod(0o700)
+    (root / ".installed").write_text("old digest")
+
+    tarball = tmp_path / "prime-agent.tgz"
+    tarball.write_bytes(b"new package")
+    digest = hashlib.sha256(tarball.read_bytes()).hexdigest()
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+
+    curl = fake_bin / "curl"
+    curl.write_text('#!/bin/sh\ncp "$TEST_TARBALL" "$4"\n')
+    npm = fake_bin / "npm"
+    npm.write_text(
+        "#!/bin/sh\n"
+        'while [ "$#" -gt 0 ]; do\n'
+        '  if [ "$1" = --prefix ]; then prefix=$2; shift 2; else shift; fi\n'
+        "done\n"
+        'mkdir -p "$prefix/node_modules/.bin"\n'
+        'printf %s new-install > "$prefix/node_modules/.bin/prime-agent"\n'
+        'chmod 700 "$prefix/node_modules/.bin/prime-agent"\n'
+    )
+    mv = fake_bin / "mv"
+    mv.write_text(
+        "#!/bin/sh\n"
+        'count=$(cat "$TEST_MV_COUNT" 2>/dev/null || printf 0)\n'
+        "count=$((count + 1))\n"
+        'printf %s "$count" > "$TEST_MV_COUNT"\n'
+        'if [ "$count" -eq "$TEST_FAILED_MOVE" ]; then\n'
+        '  /bin/mv "$@"\n'
+        "  exit 1\n"
+        "fi\n"
+        'exec /bin/mv "$@"\n'
+    )
+    for executable in (curl, npm, mv):
+        executable.chmod(0o700)
+
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "TEST_FAILED_MOVE": str(failed_move),
+        "TEST_MV_COUNT": str(tmp_path / "mv-count"),
+        "TEST_TARBALL": str(tarball),
+        "VF_NODE_BIN_DIR": str(fake_bin),
+        "VF_PRIME_AGENT_BIN": str(old_bin),
+        "VF_PRIME_AGENT_INSTALL_DIR": str(root),
+        "VF_PRIME_AGENT_KERNEL_VENV": str(tmp_path / "kernel"),
+        "VF_PRIME_AGENT_TARBALL": "https://example.invalid/prime-agent.tgz",
+        "VF_PRIME_AGENT_TARBALL_SHA256": digest,
+    }
+    result = subprocess.run(
+        ["sh", "-c", INSTALL],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=False,
+    )
+
+    if failed_move:
+        assert result.returncode != 0
+        assert old_bin.read_text() == "old install"
+        assert (root / ".installed").read_text() == "old digest"
+    else:
+        assert result.returncode == 0, result.stderr
+        assert old_bin.read_text() == "new-install"
+        assert (root / ".installed").read_text() == digest
+    assert not list(tmp_path.glob("install.previous.*"))
+    assert not list(tmp_path.glob("install.staging.*"))

--- a/tests/v1/test_prime_agent_harness.py
+++ b/tests/v1/test_prime_agent_harness.py
@@ -24,6 +24,7 @@ from verifiers.v1.harnesses.prime_agent.harness import (
 )
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
+from verifiers.v1.types import AssistantMessage, UserMessage
 
 
 def test_trace_root_encodes_untrusted_trace_id() -> None:
@@ -247,6 +248,82 @@ async def test_acp_reader_ignores_process_keepalives() -> None:
     result = await session._run(None)
 
     assert result.stdout == "finished"
+
+
+@pytest.mark.asyncio
+async def test_restarted_acp_process_receives_full_transcript() -> None:
+    async def stream(*chunks: bytes):
+        for chunk in chunks:
+            yield chunk
+
+    class Process:
+        def __init__(self, *replies: bytes, exit_code: int) -> None:
+            self.stdout = stream(*replies)
+            self.stderr = stream()
+            self.exit_code = exit_code
+            self.writes: list[bytes] = []
+
+        async def write(self, data: bytes) -> None:
+            self.writes.append(data)
+
+        async def wait(self) -> int:
+            return self.exit_code
+
+        async def terminate(self) -> None:
+            pass
+
+        async def kill(self) -> None:
+            pass
+
+    first = Process(_packet({"ok": True, "reply": "first"}), exit_code=1)
+    replacement = Process(_packet({"ok": True, "reply": "second"}), exit_code=0)
+
+    class Runtime:
+        def __init__(self) -> None:
+            self.processes = [first, replacement]
+
+        async def prepare_uv_script(self, source: str, env: dict[str, str]):
+            del source, env
+            return ["acp-runner"]
+
+        async def open_process(self, argv: list[str], env: dict[str, str]):
+            del argv, env
+            return self.processes.pop(0)
+
+    session = ACPHarnessSession(
+        SimpleNamespace(config=SimpleNamespace(id="prime-agent")),
+        SimpleNamespace(),
+        Trace.model_construct(id="trace"),
+        Runtime(),
+        "http://intercept",
+        "secret",
+        {},
+        TaskData(prompt="hello"),
+        env={},
+        command=["prime-agent", "--mode", "acp"],
+        prompt="hello",
+        system_prompt=None,
+    )
+    transcript = [
+        UserMessage(content="hello"),
+        AssistantMessage(content="first"),
+        UserMessage(content="continue"),
+    ]
+
+    assert (await session._run(None)).stdout == "first"
+    with pytest.raises(EOFError):
+        await session._run(transcript)
+    assert (await session._run(transcript)).stdout == "second"
+
+    packet = replacement.writes[0]
+    size = int.from_bytes(packet[:8], "big")
+    request = json.loads(packet[8 : 8 + size])
+    assert request["config"]["messages"] == [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "first"},
+        {"role": "user", "content": "continue"},
+    ]
+    await session._stop(graceful=False)
 
 
 def _load_acp_runner(monkeypatch: pytest.MonkeyPatch) -> dict:

--- a/tests/v1/test_prime_agent_harness.py
+++ b/tests/v1/test_prime_agent_harness.py
@@ -208,6 +208,61 @@ async def test_acp_eof_reports_process_exit_and_stderr() -> None:
 
 
 @pytest.mark.asyncio
+async def test_acp_stop_releases_the_process_when_its_exit_never_arrives() -> None:
+    # A seat whose command-session stream dies keeps failing wait/terminate/
+    # kill. Teardown must still close the process handle, or its remote stream
+    # pins a gateway HTTP/2 stream slot until the sandbox is deleted.
+    async def stream():
+        return
+        yield b""
+
+    class Process:
+        stdout = stream()
+        stderr = stream()
+
+        def __init__(self) -> None:
+            self.aclosed = False
+
+        async def write(self, data: bytes) -> None:
+            del data
+
+        async def wait(self) -> int:
+            raise RuntimeError("process stream RPC failed (deadline_exceeded)")
+
+        async def terminate(self) -> None:
+            raise RuntimeError("process signal RPC failed (deadline_exceeded)")
+
+        async def kill(self) -> None:
+            raise RuntimeError("process signal RPC failed (deadline_exceeded)")
+
+        async def aclose(self) -> None:
+            self.aclosed = True
+
+    session = ACPHarnessSession(
+        SimpleNamespace(config=SimpleNamespace(id="prime-agent")),
+        SimpleNamespace(),
+        Trace.model_construct(id="trace"),
+        SimpleNamespace(),
+        "http://intercept",
+        "secret",
+        {},
+        TaskData(prompt="hello"),
+        env={},
+        command=["prime-agent", "--mode", "acp"],
+        prompt="hello",
+        system_prompt=None,
+    )
+    process = Process()
+    session._process = process
+
+    exit_code = await session._stop(graceful=False)
+
+    assert exit_code is None
+    assert process.aclosed
+    assert session._process is None
+
+
+@pytest.mark.asyncio
 async def test_acp_reader_ignores_process_keepalives() -> None:
     async def stream():
         yield _packet({"type": "keepalive"}) + _packet(

--- a/tests/v1/test_prime_agent_harness.py
+++ b/tests/v1/test_prime_agent_harness.py
@@ -30,14 +30,16 @@ def test_trace_root_encodes_untrusted_trace_id() -> None:
 
 @pytest.mark.asyncio
 async def test_acp_eof_reports_process_exit_and_stderr() -> None:
-    async def stream(*chunks: bytes):
+    async def stream(*chunks: bytes, delay: float = 0):
+        await asyncio.sleep(delay)
         for chunk in chunks:
             yield chunk
-        await asyncio.sleep(0)
 
     class Process:
         stdout = stream()
-        stderr = stream(b"daemon worker received SIGTERM\n")
+        # Reproduce the remote ordering where stdout and process exit arrive
+        # before the final stderr frame.
+        stderr = stream(b"daemon worker received SIGTERM\n", delay=0.01)
 
         async def write(self, data: bytes) -> None:
             del data

--- a/tests/v1/test_prime_agent_harness.py
+++ b/tests/v1/test_prime_agent_harness.py
@@ -3,12 +3,13 @@ import hashlib
 import os
 import shlex
 import subprocess
+import sys
 from pathlib import PurePosixPath
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
-from verifiers.v1.acp import ACPHarnessSession
+from verifiers.v1.acp import ACP_SOURCE, ACPHarnessSession, _new_segment, _packet
 from verifiers.v1.harnesses.prime_agent.harness import (
     HARNESS_STATE_FILENAME,
     INSTALL,
@@ -140,6 +141,115 @@ async def test_acp_eof_reports_process_exit_and_stderr() -> None:
 
     assert "exit 143" in str(caught.value)
     assert "daemon worker received SIGTERM" in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_acp_reader_ignores_process_keepalives() -> None:
+    async def stream():
+        yield _packet({"type": "keepalive"}) + _packet(
+            {"ok": True, "reply": "finished"}
+        )
+
+    class Process:
+        stdout = stream()
+        stderr = stream()
+
+        async def write(self, data: bytes) -> None:
+            del data
+
+    class Runtime:
+        async def prepare_uv_script(self, source: str, env: dict[str, str]):
+            del source, env
+            return ["acp-runner"]
+
+        async def open_process(self, argv: list[str], env: dict[str, str]):
+            del argv, env
+            return Process()
+
+    session = ACPHarnessSession(
+        SimpleNamespace(config=SimpleNamespace(id="prime-agent")),
+        SimpleNamespace(),
+        Trace.model_construct(id="trace"),
+        Runtime(),
+        "http://intercept",
+        "secret",
+        {},
+        TaskData(prompt="hello"),
+        env={},
+        command=["prime-agent", "--mode", "acp"],
+        prompt="hello",
+        system_prompt=None,
+    )
+
+    result = await session._run(None)
+
+    assert result.stdout == "finished"
+
+
+@pytest.mark.asyncio
+async def test_acp_runner_emits_keepalives_during_silent_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    acp = ModuleType("acp")
+    acp.PROTOCOL_VERSION = 1
+    acp.Client = object
+    acp.RequestError = Exception
+    acp.image_block = lambda *args: args
+    acp.spawn_agent_process = lambda *args, **kwargs: None
+    acp.text_block = lambda value: value
+    schema = ModuleType("acp.schema")
+    for name in (
+        "AgentMessageChunk",
+        "AllowedOutcome",
+        "ClientCapabilities",
+        "DeniedOutcome",
+        "HttpMcpServer",
+        "PermissionOption",
+        "RequestPermissionResponse",
+        "TextContentBlock",
+        "ToolCall",
+        "ToolCallUpdate",
+    ):
+        setattr(schema, name, type(name, (), {}))
+    monkeypatch.setitem(sys.modules, "acp", acp)
+    monkeypatch.setitem(sys.modules, "acp.schema", schema)
+    namespace = {"__name__": "acp_runner_test"}
+    exec(compile(ACP_SOURCE, "acp_runner.py", "exec"), namespace)  # noqa: S102
+    with_keepalives = namespace["with_keepalives"]
+
+    class Stream:
+        def __init__(self) -> None:
+            self.data = bytearray()
+
+        def write(self, data: bytes) -> None:
+            self.data.extend(data)
+
+        def flush(self) -> None:
+            pass
+
+    async def delayed_reply() -> str:
+        await asyncio.sleep(0.03)
+        return "finished"
+
+    stream = Stream()
+    reply = await with_keepalives(delayed_reply(), stream, interval=0.005)
+
+    assert reply == "finished"
+    keepalive = _packet({"type": "keepalive"})
+    assert len(stream.data) >= len(keepalive) * 3
+    assert len(stream.data) % len(keepalive) == 0
+    assert bytes(stream.data) == keepalive * (len(stream.data) // len(keepalive))
+
+
+def test_acp_followup_sends_only_new_message_segment() -> None:
+    messages = [
+        {"role": "system", "content": "rules"},
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "answer"},
+        {"role": "user", "content": "follow-up"},
+    ]
+
+    assert _new_segment(messages) == [{"role": "user", "content": "follow-up"}]
 
 
 def test_install_lock_uses_process_lifetime_lock(tmp_path) -> None:

--- a/tests/v1/test_prime_agent_harness.py
+++ b/tests/v1/test_prime_agent_harness.py
@@ -10,9 +10,12 @@ import pytest
 
 from verifiers.v1.acp import ACPHarnessSession
 from verifiers.v1.harnesses.prime_agent.harness import (
+    HARNESS_STATE_FILENAME,
     INSTALL,
+    REFINEMENT_HISTORY_FILENAME,
     STATE_ROOT,
     PrimeAgentHarness,
+    PrimeAgentHarnessConfig,
     _guarded_install,
 )
 from verifiers.v1.task import TaskData
@@ -26,6 +29,60 @@ def test_trace_root_encodes_untrusted_trace_id() -> None:
 
     assert root.parent == PurePosixPath(STATE_ROOT)
     assert root.name == hashlib.sha256(trace.id.encode()).hexdigest()[:32]
+
+
+@pytest.mark.asyncio
+async def test_harness_state_directory_is_staged(tmp_path) -> None:
+    state = b'{"schema":1,"entries":{},"refinements":[]}\n'
+    history = b'{"id":"ref-1","appliedEdits":[]}\n'
+    (tmp_path / HARNESS_STATE_FILENAME).write_bytes(state)
+    (tmp_path / REFINEMENT_HISTORY_FILENAME).write_bytes(history)
+
+    class Runtime:
+        def __init__(self) -> None:
+            self.writes: dict[str, bytes] = {}
+
+        async def run(self, argv: list[str], env: dict[str, str]):
+            del env
+            if argv[:2] == ["sh", "-c"] and argv[3] == "prime-agent-harness-state":
+                target = argv[4]
+                code = 0 if target in self.writes else 1
+                return SimpleNamespace(exit_code=code, stdout="", stderr="")
+            return SimpleNamespace(exit_code=0, stdout="", stderr="")
+
+        async def write(self, path: str, data: bytes) -> None:
+            self.writes[path] = data
+
+    trace = Trace.model_construct(id="trace")
+    runtime = Runtime()
+    harness = PrimeAgentHarness(PrimeAgentHarnessConfig(harness_state_dir=tmp_path))
+
+    await harness.install_harness_state(runtime, trace)
+
+    root = PrimeAgentHarness.runtime_harness_state_dir(trace)
+    assert runtime.writes == {
+        f"{root}/{HARNESS_STATE_FILENAME}": state,
+        f"{root}/{REFINEMENT_HISTORY_FILENAME}": history,
+    }
+
+    (tmp_path / HARNESS_STATE_FILENAME).write_bytes(b"replacement")
+    await harness.install_harness_state(runtime, trace)
+
+    assert runtime.writes[f"{root}/{HARNESS_STATE_FILENAME}"] == state
+
+
+@pytest.mark.asyncio
+async def test_harness_state_directory_rejects_symlink(tmp_path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(source, target_is_directory=True)
+    harness = PrimeAgentHarness(PrimeAgentHarnessConfig(harness_state_dir=link))
+
+    with pytest.raises(ValueError, match="is not a folder"):
+        await harness.install_harness_state(
+            SimpleNamespace(), Trace.model_construct(id="trace")
+        )
 
 
 @pytest.mark.asyncio
@@ -85,15 +142,15 @@ async def test_acp_eof_reports_process_exit_and_stderr() -> None:
     assert "daemon worker received SIGTERM" in str(caught.value)
 
 
-@pytest.mark.parametrize("owner", [str(os.getpid()), f"{os.getpid()}:0"])
-def test_install_lock_recovers_from_live_reused_pid(tmp_path, owner: str) -> None:
+def test_install_lock_uses_process_lifetime_lock(tmp_path) -> None:
     lock = tmp_path / "install.lock"
     marker = tmp_path / "installed"
-    lock.symlink_to(owner)
+    lock.write_text("a leftover advisory lock file is not held")
     command = f": > {shlex.quote(str(marker))}"
+    script = _guarded_install(str(tmp_path), str(lock), command)
 
     result = subprocess.run(
-        ["sh", "-c", _guarded_install(str(tmp_path), str(lock), command)],
+        ["sh", "-c", script],
         capture_output=True,
         text=True,
         timeout=2,
@@ -102,7 +159,60 @@ def test_install_lock_recovers_from_live_reused_pid(tmp_path, owner: str) -> Non
 
     assert result.returncode == 0, result.stderr
     assert marker.exists()
-    assert not lock.is_symlink()
+    assert "/proc/" not in script
+    assert 'rm -f "$lock"' not in script
+
+
+def test_install_lock_serializes_concurrent_installers(tmp_path) -> None:
+    lock = tmp_path / "install.lock"
+    critical = tmp_path / "critical"
+    visits = tmp_path / "visits"
+    command = (
+        f"mkdir {shlex.quote(str(critical))}; "
+        f"printf x >> {shlex.quote(str(visits))}; "
+        "sleep 0.2; "
+        f"rmdir {shlex.quote(str(critical))}"
+    )
+    script = _guarded_install(str(tmp_path), str(lock), command)
+
+    first = subprocess.Popen(["sh", "-c", script], stderr=subprocess.PIPE, text=True)
+    second = subprocess.Popen(["sh", "-c", script], stderr=subprocess.PIPE, text=True)
+    _, first_error = first.communicate(timeout=3)
+    _, second_error = second.communicate(timeout=3)
+
+    assert first.returncode == 0, first_error
+    assert second.returncode == 0, second_error
+    assert visits.read_text() == "xx"
+
+
+@pytest.mark.parametrize(
+    "version",
+    ["1.2.3", "v1.2.3", "1.2.3-rc.1", "1.2.3-rc.1+build.7"],
+)
+def test_prime_agent_version_accepts_semver(version: str) -> None:
+    config = PrimeAgentHarnessConfig(
+        version=version,
+        tarball_sha256="a" * 64,
+    )
+
+    assert config.version == version.removeprefix("v")
+
+
+@pytest.mark.parametrize(
+    "version",
+    ["01.2.3", "1.02.3", "1.2.03", "1.2.3-01", "1.2.3-.."],
+)
+def test_prime_agent_version_rejects_invalid_semver(version: str) -> None:
+    with pytest.raises(ValueError, match="semantic version"):
+        PrimeAgentHarnessConfig(version=version, tarball_sha256="a" * 64)
+
+
+def test_node_install_is_scoped_to_prime_agent_identity() -> None:
+    first = PrimeAgentHarness(PrimeAgentHarnessConfig(tarball_sha256="a" * 64))
+    second = PrimeAgentHarness(PrimeAgentHarnessConfig(tarball_sha256="b" * 64))
+
+    assert first.node_root() != second.node_root()
+    assert first.node_bin_dir().startswith(first.node_root())
 
 
 @pytest.mark.parametrize("failed_move", [0, 1, 2])

--- a/tests/v1/test_prime_agent_harness.py
+++ b/tests/v1/test_prime_agent_harness.py
@@ -1,17 +1,21 @@
+import asyncio
 import hashlib
 import os
 import shlex
 import subprocess
 from pathlib import PurePosixPath
+from types import SimpleNamespace
 
 import pytest
 
+from verifiers.v1.acp import ACPHarnessSession
 from verifiers.v1.harnesses.prime_agent.harness import (
     INSTALL,
     STATE_ROOT,
     PrimeAgentHarness,
     _guarded_install,
 )
+from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
 
 
@@ -22,6 +26,61 @@ def test_trace_root_encodes_untrusted_trace_id() -> None:
 
     assert root.parent == PurePosixPath(STATE_ROOT)
     assert root.name == hashlib.sha256(trace.id.encode()).hexdigest()[:32]
+
+
+@pytest.mark.asyncio
+async def test_acp_eof_reports_process_exit_and_stderr() -> None:
+    async def stream(*chunks: bytes):
+        for chunk in chunks:
+            yield chunk
+        await asyncio.sleep(0)
+
+    class Process:
+        stdout = stream()
+        stderr = stream(b"daemon worker received SIGTERM\n")
+
+        async def write(self, data: bytes) -> None:
+            del data
+            await asyncio.sleep(0)
+
+        async def wait(self) -> int:
+            return 143
+
+        async def terminate(self) -> None:
+            raise AssertionError("the exited process must not be terminated")
+
+        async def kill(self) -> None:
+            raise AssertionError("the exited process must not be killed")
+
+    class Runtime:
+        async def prepare_uv_script(self, source: str, env: dict[str, str]):
+            del source, env
+            return ["acp-runner"]
+
+        async def open_process(self, argv: list[str], env: dict[str, str]):
+            del argv, env
+            return Process()
+
+    session = ACPHarnessSession(
+        SimpleNamespace(config=SimpleNamespace(id="prime-agent")),
+        SimpleNamespace(),
+        Trace.model_construct(id="trace"),
+        Runtime(),
+        "http://intercept",
+        "secret",
+        {},
+        TaskData(prompt="hello"),
+        env={},
+        command=["prime-agent", "--mode", "acp"],
+        prompt="hello",
+        system_prompt=None,
+    )
+
+    with pytest.raises(EOFError) as caught:
+        await session._run(None)
+
+    assert "exit 143" in str(caught.value)
+    assert "daemon worker received SIGTERM" in str(caught.value)
 
 
 @pytest.mark.parametrize("owner", [str(os.getpid()), f"{os.getpid()}:0"])

--- a/tests/v1/test_prime_agent_harness.py
+++ b/tests/v1/test_prime_agent_harness.py
@@ -1,10 +1,12 @@
 import asyncio
 import hashlib
+import io
 import json
 import os
 import shlex
 import subprocess
 import sys
+import tarfile
 from pathlib import PurePosixPath
 from types import ModuleType, SimpleNamespace
 
@@ -31,6 +33,66 @@ def test_trace_root_encodes_untrusted_trace_id() -> None:
 
     assert root.parent == PurePosixPath(STATE_ROOT)
     assert root.name == hashlib.sha256(trace.id.encode()).hexdigest()[:32]
+
+
+@pytest.mark.asyncio
+async def test_skills_use_one_archive_upload(tmp_path) -> None:
+    first = tmp_path / "first"
+    first.mkdir()
+    (first / "SKILL.md").write_text("first skill")
+    script = first / "scripts" / "run.sh"
+    script.parent.mkdir()
+    script.write_text("#!/bin/sh\nexit 0\n")
+    script.chmod(0o700)
+    second = tmp_path / "second"
+    second.mkdir()
+    (second / "SKILL.md").write_text("second skill")
+
+    class Runtime:
+        def __init__(self) -> None:
+            self.writes: list[tuple[str, bytes]] = []
+            self.runs: list[list[str]] = []
+
+        async def write(self, path: str, data: bytes) -> None:
+            self.writes.append((path, data))
+
+        async def run(self, argv: list[str], env: dict[str, str]):
+            del env
+            self.runs.append(argv)
+            return SimpleNamespace(exit_code=0, stdout="", stderr="")
+
+    runtime = Runtime()
+    harness = PrimeAgentHarness(PrimeAgentHarnessConfig(skills=[first, second]))
+
+    await harness.install_skills(runtime, "/tmp/agent/skills")
+
+    assert len(runtime.writes) == 1
+    archive_path, archive = runtime.writes[0]
+    assert archive_path == "/tmp/agent/skills.tar.gz"
+    with tarfile.open(fileobj=io.BytesIO(archive), mode="r:gz") as packed:
+        assert packed.getnames() == [
+            "first",
+            "first/SKILL.md",
+            "first/scripts",
+            "first/scripts/run.sh",
+            "second",
+            "second/SKILL.md",
+        ]
+        assert packed.extractfile("first/SKILL.md").read() == b"first skill"
+        assert packed.getmember("first/scripts/run.sh").mode == 0o755
+    local_archive = tmp_path / "skills.tar.gz"
+    local_archive.write_bytes(archive)
+    extracted = tmp_path / "extracted"
+    extracted.mkdir()
+    process = await asyncio.create_subprocess_exec(
+        "tar", "-xzf", str(local_archive), "-C", str(extracted)
+    )
+    assert await process.wait() == 0
+    assert (
+        (extracted / "first" / "scripts" / "run.sh").read_text().startswith("#!/bin/sh")
+    )
+    assert len(runtime.runs) == 1
+    assert runtime.runs[0][-2:] == [archive_path, "/tmp/agent/skills"]
 
 
 @pytest.mark.asyncio

--- a/tests/v1/test_prime_agent_harness.py
+++ b/tests/v1/test_prime_agent_harness.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import hashlib
 import io
 import json
@@ -411,11 +412,13 @@ def _load_acp_runner(monkeypatch: pytest.MonkeyPatch) -> dict:
 
 
 @pytest.mark.asyncio
-async def test_acp_runner_emits_keepalives_during_silent_turn(
+async def test_acp_runner_emits_keepalives_while_the_session_lives(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Keepalives must flow between turns too: the gateway reaps connections
+    # that carry no data for ~30 minutes, and idle panel seats sit far longer.
     namespace = _load_acp_runner(monkeypatch)
-    with_keepalives = namespace["with_keepalives"]
+    emit_keepalives = namespace["emit_keepalives"]
 
     class Stream:
         def __init__(self) -> None:
@@ -427,14 +430,13 @@ async def test_acp_runner_emits_keepalives_during_silent_turn(
         def flush(self) -> None:
             pass
 
-    async def delayed_reply() -> str:
-        await asyncio.sleep(0.03)
-        return "finished"
-
     stream = Stream()
-    reply = await with_keepalives(delayed_reply(), stream, interval=0.005)
+    task = asyncio.create_task(emit_keepalives(stream, interval=0.005))
+    await asyncio.sleep(0.03)
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
 
-    assert reply == "finished"
     keepalive = _packet({"type": "keepalive"})
     assert len(stream.data) >= len(keepalive) * 3
     assert len(stream.data) % len(keepalive) == 0

--- a/tests/v1/test_prime_agent_harness.py
+++ b/tests/v1/test_prime_agent_harness.py
@@ -1,5 +1,6 @@
 import asyncio
 import hashlib
+import json
 import os
 import shlex
 import subprocess
@@ -186,10 +187,7 @@ async def test_acp_reader_ignores_process_keepalives() -> None:
     assert result.stdout == "finished"
 
 
-@pytest.mark.asyncio
-async def test_acp_runner_emits_keepalives_during_silent_turn(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def _load_acp_runner(monkeypatch: pytest.MonkeyPatch) -> dict:
     acp = ModuleType("acp")
     acp.PROTOCOL_VERSION = 1
     acp.Client = object
@@ -215,6 +213,14 @@ async def test_acp_runner_emits_keepalives_during_silent_turn(
     monkeypatch.setitem(sys.modules, "acp.schema", schema)
     namespace = {"__name__": "acp_runner_test"}
     exec(compile(ACP_SOURCE, "acp_runner.py", "exec"), namespace)  # noqa: S102
+    return namespace
+
+
+@pytest.mark.asyncio
+async def test_acp_runner_emits_keepalives_during_silent_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    namespace = _load_acp_runner(monkeypatch)
     with_keepalives = namespace["with_keepalives"]
 
     class Stream:
@@ -250,6 +256,115 @@ def test_acp_followup_sends_only_new_message_segment() -> None:
     ]
 
     assert _new_segment(messages) == [{"role": "user", "content": "follow-up"}]
+
+
+@pytest.mark.asyncio
+async def test_acp_session_forwards_empty_tool_reply_policy() -> None:
+    writes: list[bytes] = []
+
+    async def stream():
+        yield _packet({"ok": True, "reply": ""})
+
+    class Process:
+        stdout = stream()
+        stderr = stream()
+
+        async def write(self, data: bytes) -> None:
+            writes.append(data)
+
+    class Runtime:
+        async def prepare_uv_script(self, source: str, env: dict[str, str]):
+            del source, env
+            return ["acp-runner"]
+
+        async def open_process(self, argv: list[str], env: dict[str, str]):
+            del argv, env
+            return Process()
+
+    session = ACPHarnessSession(
+        SimpleNamespace(config=SimpleNamespace(id="prime-agent")),
+        SimpleNamespace(),
+        Trace.model_construct(id="trace"),
+        Runtime(),
+        "http://intercept",
+        "secret",
+        {},
+        TaskData(prompt="hello"),
+        env={},
+        command=["prime-agent", "--mode", "acp"],
+        prompt="hello",
+        system_prompt=None,
+        allow_empty_tool_reply=True,
+    )
+
+    result = await session._run(None)
+
+    size = int.from_bytes(writes[0][:8], "big")
+    request = json.loads(writes[0][8 : 8 + size])
+    assert request["config"]["allow_empty_tool_reply"] is True
+    assert result.stdout == ""
+
+
+@pytest.mark.asyncio
+async def test_acp_runner_accepts_a_completed_tool_only_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Client:
+        def __init__(self) -> None:
+            self.visible_reply = ""
+            self.tool_calls = {"call-1": "completed"}
+
+        def reset(self) -> None:
+            pass
+
+    class Connection:
+        async def prompt(self, **kwargs):
+            assert kwargs["session_id"] == "session"
+            return SimpleNamespace(stop_reason="end_turn")
+
+    reply = await _load_acp_runner(monkeypatch)["prompt"](
+        Client(),
+        Connection(),
+        None,
+        "session",
+        {
+            "messages": [{"role": "user", "content": "finish the task"}],
+            "system_prompt": "",
+            "allow_empty_tool_reply": True,
+        },
+        is_new=True,
+    )
+
+    assert reply == ""
+
+
+@pytest.mark.asyncio
+async def test_prime_agent_allows_completed_tool_only_turns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: dict[str, object] = {}
+
+    async def prepare_run(*args, **kwargs):
+        del args, kwargs
+        return {}, ["prime-agent", "--mode", "acp"]
+
+    async def run(*args, **kwargs):
+        calls.update(kwargs)
+        return SimpleNamespace(exit_code=0, stdout="", stderr="")
+
+    harness = PrimeAgentHarness(PrimeAgentHarnessConfig())
+    monkeypatch.setattr(harness, "prepare_run", prepare_run)
+    monkeypatch.setattr(
+        "verifiers.v1.harnesses.prime_agent.harness.PRIME_AGENT_ACP.run", run
+    )
+    ctx = SimpleNamespace()
+    trace = Trace.model_construct(id="trace")
+    runtime = SimpleNamespace()
+    data = TaskData(prompt="hello")
+
+    await harness.launch(ctx, trace, runtime, "http://intercept", "secret", {}, data)
+
+    assert calls["allow_empty_tool_reply"] is True
 
 
 def test_install_lock_uses_process_lifetime_lock(tmp_path) -> None:

--- a/tests/v1/test_prime_runtime.py
+++ b/tests/v1/test_prime_runtime.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+from verifiers.v1.runtimes.prime import PrimeConfig, PrimeRuntime
+
+
+def test_prime_lifetime_timeout_is_configurable() -> None:
+    config = PrimeConfig(vm=True, lifetime_timeout=600)
+
+    assert config.lifetime_timeout == 600
+    assert config.idle_timeout == 3_600
+
+
+def test_prime_idle_timeout_cannot_exceed_lifetime() -> None:
+    with pytest.raises(ValidationError, match="must not exceed"):
+        PrimeConfig(lifetime_timeout=3_600, idle_timeout=3_601)
+
+
+@pytest.mark.asyncio
+async def test_prime_runtime_uses_configured_lifetime(monkeypatch) -> None:
+    import prime_sandboxes
+
+    class Client:
+        def __init__(self) -> None:
+            self.request = None
+            self.run_timeout = None
+
+        async def create(self, request):
+            self.request = request
+            return SimpleNamespace(id="sandbox", pending_image_build_id=None)
+
+        async def wait_for_creation(self, sandbox_id: str) -> None:
+            assert sandbox_id == "sandbox"
+
+        async def execute_command(self, sandbox_id: str, command: str):
+            del sandbox_id, command
+            return SimpleNamespace(exit_code=0, stdout="", stderr="")
+
+        async def run_background_job(self, sandbox_id: str, command: str, **kwargs):
+            del sandbox_id, command
+            self.run_timeout = kwargs["timeout"]
+            return SimpleNamespace(exit_code=0, stdout="", stderr="")
+
+    client = Client()
+    monkeypatch.setattr(prime_sandboxes, "AsyncSandboxClient", lambda: client)
+    runtime = PrimeRuntime(PrimeConfig(vm=True, lifetime_timeout=43_200), name="test")
+
+    await runtime.start()
+    await runtime.run(["true"], {})
+
+    assert client.request.timeout_minutes == 720
+    assert client.request.idle_timeout_minutes is None
+    assert client.run_timeout == 43_200

--- a/tests/v1/test_prime_runtime.py
+++ b/tests/v1/test_prime_runtime.py
@@ -1,9 +1,10 @@
 from types import SimpleNamespace
+from typing import ClassVar
 
 import pytest
 from pydantic import ValidationError
 
-from verifiers.v1.runtimes.prime import PrimeConfig, PrimeRuntime
+from verifiers.v1.runtimes.prime import PrimeConfig, PrimeProcess, PrimeRuntime
 
 
 def test_prime_lifetime_timeout_is_configurable() -> None:
@@ -53,3 +54,163 @@ async def test_prime_runtime_uses_configured_lifetime(monkeypatch) -> None:
     assert client.request.timeout_minutes == 720
     assert client.request.idle_timeout_minutes is None
     assert client.run_timeout == 43_200
+
+
+class _FakeTransport:
+    instances: ClassVar[list["_FakeTransport"]] = []
+
+    def __init__(self) -> None:
+        self.closed = False
+        _FakeTransport.instances.append(self)
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class _FakeHTTPClient:
+    def __init__(self, transport=None) -> None:
+        self.transport = transport
+
+
+class _FakeConnectClient:
+    unary_transports: ClassVar[list[object]] = []
+
+    def __init__(self, base_url: str, *, http_client=None) -> None:
+        self.base_url = base_url
+        self.http_client = http_client
+
+    def execute_server_stream(self, *, request, method, headers, timeout_ms):
+        del request, method, headers, timeout_ms
+        return SimpleNamespace(kind="stream")
+
+    async def execute_unary(self, *, request, method, headers, timeout_ms):
+        del request, method, headers, timeout_ms
+        _FakeConnectClient.unary_transports.append(self.http_client.transport)
+
+    async def close(self) -> None:
+        pass
+
+
+async def _empty_stream():
+    return
+    yield b""
+
+
+class _FakeSDKProcess:
+    fail_create = False
+
+    def __init__(self, write_stdin) -> None:
+        self.stdout = _empty_stream()
+        self.stderr = _empty_stream()
+        self._write_stdin = write_stdin
+        self.closed = False
+
+    @classmethod
+    async def _create(cls, stream_client, stream, write_stdin, send_signal):
+        del stream, send_signal
+        assert stream_client.http_client is not None
+        if cls.fail_create:
+            raise RuntimeError("process stream refused")
+        return cls(write_stdin)
+
+    async def write_stdin(self, data: bytes) -> None:
+        await self._write_stdin(4242, data)
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def _transport_isolated_runtime(monkeypatch) -> PrimeRuntime:
+    import connectrpc.client
+    import prime_sandboxes.process
+    import pyqwest
+
+    monkeypatch.setattr(pyqwest, "HTTPTransport", _FakeTransport)
+    monkeypatch.setattr(pyqwest, "Client", _FakeHTTPClient)
+    monkeypatch.setattr(connectrpc.client, "ConnectClient", _FakeConnectClient)
+    monkeypatch.setattr(prime_sandboxes.process, "AsyncSandboxProcess", _FakeSDKProcess)
+    _FakeConnectClient.unary_transports = []
+    _FakeSDKProcess.fail_create = False
+    _FakeTransport.instances = []
+
+    class AuthCache:
+        async def get_or_refresh(self, sandbox_id: str) -> dict:
+            assert sandbox_id == "sandbox"
+            return {
+                "gateway_url": "https://gateway.test/",
+                "user_ns": "ns",
+                "job_id": "job",
+                "token": "token",
+            }
+
+    class Client:
+        _auth_cache = AuthCache()
+
+        async def _should_retry_401(self, sandbox_id: str, reauthed: bool) -> bool:
+            del sandbox_id, reauthed
+            return False
+
+    runtime = PrimeRuntime(PrimeConfig(vm=True), name="test")
+    runtime._client = Client()
+    runtime.info.id = "sandbox"
+    return runtime
+
+
+@pytest.mark.asyncio
+async def test_prime_live_processes_get_one_transport_each(monkeypatch) -> None:
+    # The gateway caps one HTTP/2 connection at 100 concurrent streams and the
+    # SDK funnels every command-session RPC over the shared default transport.
+    # Each live process must own its transport, and its stdin RPCs must ride
+    # that same transport, so processes never queue behind each other.
+    runtime = _transport_isolated_runtime(monkeypatch)
+
+    first = await runtime.open_process(["cat"], {})
+    second = await runtime.open_process(["cat"], {})
+
+    assert isinstance(first, PrimeProcess) and isinstance(second, PrimeProcess)
+    assert first._transport is not second._transport
+
+    await first.write(b"ping")
+    await second.write(b"pong")
+    assert _FakeConnectClient.unary_transports == [
+        first._transport,
+        second._transport,
+    ]
+
+    await first.aclose()
+    assert first._process.closed
+    assert first._transport.closed
+    assert not second._transport.closed
+
+
+@pytest.mark.asyncio
+async def test_prime_open_process_closes_its_transport_on_failure(
+    monkeypatch,
+) -> None:
+    from verifiers.v1.errors import SandboxError
+
+    runtime = _transport_isolated_runtime(monkeypatch)
+    _FakeSDKProcess.fail_create = True
+
+    with pytest.raises(SandboxError, match="process stream refused"):
+        await runtime.open_process(["cat"], {})
+
+    assert [transport.closed for transport in _FakeTransport.instances] == [True]
+
+
+@pytest.mark.asyncio
+async def test_prime_process_aclose_releases_transport_when_close_fails() -> None:
+    class SDKProcess:
+        stdout = _empty_stream()
+        stderr = _empty_stream()
+
+        async def aclose(self) -> None:
+            raise RuntimeError("stream already dead")
+
+    transport = _FakeTransport()
+    process = PrimeProcess(SDKProcess(), transport)
+
+    with pytest.raises(RuntimeError, match="stream already dead"):
+        await process.aclose()
+
+    assert transport.closed

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 4
+revision = 3
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'win32'",
@@ -57,7 +57,7 @@ wheels = [
 
 [[package]]
 name = "aiohttp"
-version = "3.14.1"
+version = "3.14.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
@@ -69,67 +69,67 @@ dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/82/78/8ea7308cac6934de8c74a14f3d5f65d1c89287426688be79538d0e5c013d/aiohttp-3.14.1.tar.gz", hash = "sha256:307f2cff90a764d329e77040603fa032db89c5c24fdad50c4c15334cba744035", size = 7955794, upload-time = "2026-06-07T21:09:35.529Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/d9/22ce5786ac0c1653ae8b6c23bded02c1686d11f0dbb45b31ce128e0df985/aiohttp-3.14.3.tar.gz", hash = "sha256:9491196535a88924a60afd5b5f434b5b203b6cc616250878dbdb223a8f7844bc", size = 7971213, upload-time = "2026-07-23T01:57:27.037Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/dd/bf526e6f0a1120dd6f2df2e97bacfe4d358f13d17a0ff5847301a1375a51/aiohttp-3.14.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:aa00140699487bd435fde4342d85c94cb256b7cd3a5b9c3396c67f19922afda2", size = 765225, upload-time = "2026-06-07T21:06:07.957Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/e1/a2872aa55495a70f61310d411541c6ee23812d9a884e000c716e1bc3edbf/aiohttp-3.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1c1af67559445498b502030c35c59db59966f47041ca9de5b4e707f86bd10b5f", size = 518743, upload-time = "2026-06-07T21:06:09.749Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/e7/c60c7b209e509cc787de3cea0550a518538cfc08003e1c1e14c1c63fff71/aiohttp-3.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d44ec478e713ee7f29b439f7eb8dc2b9d4079e11ae114d2c2ac3d5daf30516c8", size = 514139, upload-time = "2026-06-07T21:06:11.26Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/8d/614ace2f579702c9840ab1e1447fd8509e35b0b904f7196418fa2f57b25d/aiohttp-3.14.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d3b1a184a9a8f548a6b73f1e26b96b052193e4b3175ed7342aaf1151a1f00a04", size = 1784088, upload-time = "2026-06-07T21:06:12.887Z" },
-    { url = "https://files.pythonhosted.org/packages/49/e0/726e90f99542bf292f81a96a12cc4847deb86f3ccf62c6f4014a201f4d33/aiohttp-3.14.1-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:5f2504bc0322437c9a1ff6d3333ca56c7477b727c995f036b976ae17b98372c8", size = 1737835, upload-time = "2026-06-07T21:06:14.564Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/4b/d176d5c4db9d33dacf0543102ea59503bc1d528af4cfd0b719949ca49389/aiohttp-3.14.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:73f05ea02013e02512c3bf42714f1208c57168c779cc6fe23516e4543089d0a6", size = 1842801, upload-time = "2026-06-07T21:06:16.228Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/d6/5a99b563690ea0cbed912ae94a2ce33993a5709a651a3a4fe761e7dd973a/aiohttp-3.14.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:797457503c2d426bee06eef808d07b31ede30b65e054444e7de64cad0061b7af", size = 1929992, upload-time = "2026-06-07T21:06:17.947Z" },
-    { url = "https://files.pythonhosted.org/packages/76/7f/a987b14a3859094b3cea3f4825219c3e5536242564af6e3f9c2f6c994eb2/aiohttp-3.14.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b821a1f7dedf7e37450654e620038ac3b2e81e8fa6ea269337e97101978ec730", size = 1786989, upload-time = "2026-06-07T21:06:19.677Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/1a/420e5c85a3e73349372ed22ce0b6af86bfa6ce16a4b20a64a2e94608c781/aiohttp-3.14.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4cd96b5ba05d67ed0cf00b5b405c8cd99586d8e3481e8ee0a831057591af7621", size = 1640129, upload-time = "2026-06-07T21:06:22.558Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/80/18a592ed3be0a402cc03670bd72ee1f8563ddbe1d8d5542dbf868f274136/aiohttp-3.14.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d459b98a932296c6f0e94f87511a0b1b90a8a02c30a50e60a297619cd5a58ee", size = 1756576, upload-time = "2026-06-07T21:06:24.8Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/0b/8b3d5713373858ff71a617daf6e3b0e81ad63e79d09a3cf2f6b6b983939c/aiohttp-3.14.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:764457a7be60825fb770a644852ff717bcbb5042f189f2bd16df61a81b3f6573", size = 1754668, upload-time = "2026-06-07T21:06:26.528Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/49/fd564575cf225821d7ba5a117cb8bc27213d8a7e1811162afb43ae077039/aiohttp-3.14.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f7a16ef45b081454ef844502d87a848876c490c4cb5c650c230f6ec79ed2c1e7", size = 1817019, upload-time = "2026-06-07T21:06:28.297Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/1b/e850c9ae6fc91356552ae668bb6c51e93fa29c8aef13398a10b56678557f/aiohttp-3.14.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:2fbc3ed048b3475b9f0cbcb9978e9d2d3511acd91ead203af26ed9f0056004cf", size = 1631638, upload-time = "2026-06-07T21:06:30.242Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/94/3c337ba72451a89806ace6f75bddc92bafc5b8d53d90115a512858024b63/aiohttp-3.14.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:bedb0cd073cc2dc035e30aeb99444389d3cd2113afe4ef9fcd23d439f5bade85", size = 1835660, upload-time = "2026-06-07T21:06:31.943Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/9c/9c18cf367a0498212d9ba7daf990b504a5e8ae064cda4b504e2647c89c03/aiohttp-3.14.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b6feea921016eb3d4e04d65fc4e9ca402d1a3801f562aef94989f54694917af3", size = 1775698, upload-time = "2026-06-07T21:06:33.72Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/63/a251a9d2a6cb45065b2ddc0bde2b3dd10108740a9a42f632c66405a761a2/aiohttp-3.14.1-cp311-cp311-win32.whl", hash = "sha256:313701e488100074ce99850404ee36e741abf6330179fec908a1944ecf570126", size = 458386, upload-time = "2026-06-07T21:06:35.279Z" },
-    { url = "https://files.pythonhosted.org/packages/17/ca/69274c51dcd6e8947d77b2806cf47a4a15f2c846e2cbeb1882547d3da283/aiohttp-3.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:03ab4530fdcb3a543a122ba4b65ac9919da9fe9f78a03d328a6e38ff962f7aa5", size = 483406, upload-time = "2026-06-07T21:06:36.824Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/8a/c25904f77690c3688ec140f87591ef11a0cfe36bf3d5c0f1f38056fb62b3/aiohttp-3.14.1-cp311-cp311-win_arm64.whl", hash = "sha256:486f7d16ed54c39c2cbd7ca71fd8ba2b8bb7860df65bd7b6ed640bab96a38a8b", size = 452987, upload-time = "2026-06-07T21:06:38.371Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/21/151624b51cd92553d95424daf4bf19f19ce9be9002d19253e7e7ce67197b/aiohttp-3.14.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d35143e27778b4bb0fb189562d7f275bff79c62ab8e98459717c0ea617ff2480", size = 757402, upload-time = "2026-06-07T21:06:40.311Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/82/280619e0bd7bf2454987e19282616e84762255dd9c8468f62382e8c191f1/aiohttp-3.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:bcfb80a2cc36fba2534e5e5b5264dc7ae6fcd9bf15256da3e53d2f499e6fa29d", size = 512310, upload-time = "2026-06-07T21:06:42.207Z" },
-    { url = "https://files.pythonhosted.org/packages/55/b2/2aac325583aaa1353045f96dffa586d8a34e8322e14a7ba49cffeb103ab4/aiohttp-3.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:27fd7c91e51729b4f7e1577865fa6d34c9adccbc39aabe9000285b48af9f0ec2", size = 512448, upload-time = "2026-06-07T21:06:43.813Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/72/a60607cb849faa8af8a356c9329ea2eb6f395d49e82cc82ccba1fd8deb8f/aiohttp-3.14.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:64c567bf9eaf664280116a8688f63016e6b32db2505908e2bdaca1b6438142f2", size = 1766854, upload-time = "2026-06-07T21:06:45.391Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/d3/d9fe1c9ec7557ab4d0d82bebaa728c6418f0b93295ec2f4ab015f7710cc7/aiohttp-3.14.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:f5e6ff2bdbb8f4cd3fbe41f99e25bbcd58e3bf9f13d3dd31a11e7917251cc77a", size = 1740884, upload-time = "2026-06-07T21:06:47.413Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/dc/f2cecfaf9337ba3e63f181500814ff502aa3d00d9c7ec93a9d23d10a27b2/aiohttp-3.14.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2f73e01dc37122325caf079982621262f96d74823c179038a82fddfc50359264", size = 1810034, upload-time = "2026-06-07T21:06:50.165Z" },
-    { url = "https://files.pythonhosted.org/packages/66/d7/2ff65c5e65c0d7476daf7e15c032e0805e36811185b9623e3238ad6c763e/aiohttp-3.14.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bb2c0c80d431c0d03f2c7dbf125150fedd4f0de17366a7ca33f7ccb822391842", size = 1904054, upload-time = "2026-06-07T21:06:52.035Z" },
-    { url = "https://files.pythonhosted.org/packages/20/9c/d445818389df371f56d141d881153ba23183c4735a03f7356ffb43f7757d/aiohttp-3.14.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3e6fc1a85fa7194a1a7d19f44e8609180f4a8eb5fa4c7ed8b4355f080fad235c", size = 1790278, upload-time = "2026-06-07T21:06:54.049Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/aa/bf04cb4d865fc6101c2229a294ad744973b72e513fdc5a6b791e6983d72a/aiohttp-3.14.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:686b6c0d3911ec387b444ddf5dc62fb7f7c0a7d5186a7861626496a5ab4aff95", size = 1591795, upload-time = "2026-06-07T21:06:55.911Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/b4/4dac0038960427ba832f6609dfb4ea5437d7fd80c72001b9e48f834f428b/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c6fa4dc7ad6f8109c70bb1499e589f76b0b792baf39f9b017eb92c8a81d0a199", size = 1728397, upload-time = "2026-06-07T21:06:57.777Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/f9/7cd4e8ad7aa3b75f17d56bb5498dd604a93d4e6eece822ba0568c413fff0/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:87a5eea1b2a5e21e1ebdbb33ad4165359189327e63fc4e4894693e7f821ac817", size = 1766504, upload-time = "2026-06-07T21:07:00.009Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/df/fc01d9fcad0f73fed3f3d361f1f94f975947b50dff82919f6dc2bf4316cc/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1c1421eb01d4fd608d88cc8290211d177a58532b55ad94076fb349c5bf467f0a", size = 1777806, upload-time = "2026-06-07T21:07:02.064Z" },
-    { url = "https://files.pythonhosted.org/packages/41/09/47e2d090bddcc8fb4ccb4c314aadc32d7c5d9bb55f50f6ad1c92fc15d501/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:34b257ec41345c1e8f2df68fa908a7952f5de932723871eb633ecbbff396c9a4", size = 1580707, upload-time = "2026-06-07T21:07:03.942Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/36/f1a4ce904ae0b6930cfe9afc96d0896f7ec1a620c400405d63783bb95a9c/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:de538791a80e5d862addbc183f70f0158ac9b9bb872bb147f1fd2a683691e087", size = 1798121, upload-time = "2026-06-07T21:07:05.987Z" },
-    { url = "https://files.pythonhosted.org/packages/70/0a/e0075ce9ca0279ee1d4f0c0b85f54fea02ebc83c3007651a72bece658fec/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6f71173be42d3241d428f760122febb748de0623f44308a6f120d0dd9ec572e3", size = 1767580, upload-time = "2026-06-07T21:07:07.873Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/61/a0c0a8f327a9c52095cdd8e312391b00d3ed64ab6c72bb5c33d8ec251cf7/aiohttp-3.14.1-cp312-cp312-win32.whl", hash = "sha256:ec8dc383ee57ea3e883477dcca3f11b65d58199f1080acaf4cd6ad9a99698be4", size = 452771, upload-time = "2026-06-07T21:07:09.669Z" },
-    { url = "https://files.pythonhosted.org/packages/df/d9/ea367c75f16ac9c6cdc8febb25e8318fa21a2b1bc8d6514d4b2d890bface/aiohttp-3.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:2aa92c87868cd13674989f9ee83e5f9f7ea4237589b728048e1f0c8f6caa3271", size = 479873, upload-time = "2026-06-07T21:07:11.538Z" },
-    { url = "https://files.pythonhosted.org/packages/03/64/8d96784a7851156db8a4c6c3f6f91042fdf39fb15a4cc38c8b3c14833c45/aiohttp-3.14.1-cp312-cp312-win_arm64.whl", hash = "sha256:2c840c90759922cb5e6dda94596e079a30fb5a5ba548e7e0dc00574703940847", size = 448073, upload-time = "2026-06-07T21:07:13.637Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/97/bd137012dd97e1649162b099135a80e1fd59aaa807b2430fc448d1029aff/aiohttp-3.14.1-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:b3a03285a7f9c7b016324574a6d92a1c895da6b978cb8f1deee3ac72bc6da178", size = 506882, upload-time = "2026-06-07T21:07:15.501Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/79/e5cc690e9d922a66887ceeaca53a8ffd5a7b0be3816142b7abc433742d89/aiohttp-3.14.1-cp313-cp313-android_21_x86_64.whl", hash = "sha256:2a73f487ab8ef5abbb24b7aa9b73e98eaba9e9e031804ff2416f02eca315ccaf", size = 515270, upload-time = "2026-06-07T21:07:17.53Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/22/a73ccbf9dbd6e26dda0b24d5fd5db7da92ee3383a79f47677ffb834c5c5b/aiohttp-3.14.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:915fbb7b41b115192259f8c9ae58f3ddc444d2b5579917270211858e606a4afd", size = 485841, upload-time = "2026-06-07T21:07:19.555Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/b9/57ed8eaf596321c2ad747bd480fb1700dbd7177c60dfc9e4c187f629662e/aiohttp-3.14.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:7fb4bdf95b0561a79f259f9d28fbc109728c5ee7f27aff6391f0ca703a329abe", size = 492088, upload-time = "2026-06-07T21:07:21.581Z" },
-    { url = "https://files.pythonhosted.org/packages/78/c0/5ebe5270a7c140d7c6f79dcb018640225f14d406c149e4eec04a7d82fe71/aiohttp-3.14.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:1b9748363260121d2927704f5d4fc498150669ca3ae93625986ee89c8f80dcd4", size = 501564, upload-time = "2026-06-07T21:07:23.388Z" },
-    { url = "https://files.pythonhosted.org/packages/75/7f/8cdaa24fc7983865e0915153b96a9ac5bcdd3548d64c5a27d17cecccad2d/aiohttp-3.14.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:86a6dab78b0e43e2897a3bbe15745aa60dc5423ca437b7b0b164c069bf91b876", size = 751998, upload-time = "2026-06-07T21:07:25.046Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/f4/c4227aacfacc5cb0cc2d119b65301d177912a6842cd64e120c47af76064f/aiohttp-3.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4dfd6e47d3c44c2279907607f73a4240b88c69eb8b90da7e2441a8045dfd21da", size = 510918, upload-time = "2026-06-07T21:07:27.28Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/01/a2d5f96cd4e74424864d30bc0a7e44d0a12dacdcfa91b5b2d1bd3dca6bf3/aiohttp-3.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:317acd9f8602858dc7d59679812c376c7f0b97bcbbf16e0d6237f54141d8a8a6", size = 508657, upload-time = "2026-06-07T21:07:29.252Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/ed/3c0fb5c500fdd8e7ebc10d1889c04384fffa1a9163eac1356088ca9da1b1/aiohttp-3.14.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd869c427324e5cb15195793de951295710db28be7d818247f3097b4ab5d4b96", size = 1757907, upload-time = "2026-06-07T21:07:31.03Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/ab/d4c924d9bd5be3050c226612413ce68cb54c70d2c31b661bfc8d9a5b6a70/aiohttp-3.14.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:93b032b5ec3255473c143627d21a69ac74ae12f7f33974cb587c564d11b1066f", size = 1737565, upload-time = "2026-06-07T21:07:33.031Z" },
-    { url = "https://files.pythonhosted.org/packages/19/2a/37326821ff779084020cdc33224d20b19f42f4183a500ff92022a739eda7/aiohttp-3.14.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f234b4deb12f3ad59127e037bc57c40c21e45b45282df7d3a55a0f409f595296", size = 1799018, upload-time = "2026-06-07T21:07:35.003Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/4f/6e947ba73e4ce09070761c05ed3a8ceb7c21f5e46798671d8b2aac0e4626/aiohttp-3.14.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9af6779bfb46abf124068327abcdf9ce95c9ef8287a3e8da76ccf2d0f16c28fa", size = 1894416, upload-time = "2026-06-07T21:07:36.956Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/6e/dbf1d0625dc711fb2851f4f3c3055c39ed58bae92082d8c627dbe6013736/aiohttp-3.14.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:faccab372e66bc76d5731525e7f1143c922271725b9d38c9f97edcc66266b451", size = 1783881, upload-time = "2026-06-07T21:07:39.063Z" },
-    { url = "https://files.pythonhosted.org/packages/44/c2/5e25098a67268ed369483ae7d1a58bd0a13d03aab860d2a0e4a6eb25b046/aiohttp-3.14.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f380468b09d2a81633ee863b0ec5648d364bd17bb8ecfb8c2f387f7ac1faf42c", size = 1587572, upload-time = "2026-06-07T21:07:41.058Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/bd/cf9cee17e140f942a3de73e658a543aa8fbf35a5fc67a9d2538d52d77f0b/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:97e704dcd26271f5bda3fa07c3ce0fb76d6d3f8659f4baa1a24442cc9ba177ca", size = 1722137, upload-time = "2026-06-07T21:07:43.014Z" },
-    { url = "https://files.pythonhosted.org/packages/89/6d/5684f8c59045c96f81a18cefbc1fbbd79d25b88f1c622f2a5c5c08fcb632/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:269b76ac5394092b95bc4a098f4fc6c191c083c3bd12775d1e30e663132f6a09", size = 1755953, upload-time = "2026-06-07T21:07:45.933Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/40/35caf3170f8359760740a7d9aa0fff2e344bef98e1d1186f5a0f6dec17e6/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5c0b3e614340c889d575451696374c9d17affd54cd607ca0babed8f8c37b9397", size = 1766479, upload-time = "2026-06-07T21:07:48.047Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/a1/b0c61e7a137f0d81de49a82023a6df73c3c16d6fefb0f8e4a93d21639002/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:5663ee9257cfa1add7253a7da3035a02f31b6600ec48261585e1800a81533080", size = 1580077, upload-time = "2026-06-07T21:07:50.069Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/41/194ea4623693009fcefebef7aef63c141754f153e9cd0d39d3b9e36c175c/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:603a2c834142172ffddc054067f5ec0ca65d57a0aa98a71bc81952573208e345", size = 1791688, upload-time = "2026-06-07T21:07:52.106Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/45/4de841f005cfe1fd63e2a2fe011262c515e2a62aa6994b15947e7d717ac9/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cb21957bb8aca671c1765e32f58164cf0c50e6bf41c0bbbd16da20732ecaf588", size = 1761094, upload-time = "2026-06-07T21:07:54.113Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/ae/dbce10533d3896d544d5053939ed75b7dc31a1b0973d959b1b5ae21028d6/aiohttp-3.14.1-cp313-cp313-win32.whl", hash = "sha256:e509a55f681e6158c20f70f102f9cf61fb20fbc382272bc6d94b7343f2582780", size = 452662, upload-time = "2026-06-07T21:07:56.06Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/d9/0bf1a19362c32f06229da5e7ddfcec91f93474d6307f7a2d3135e9c674dc/aiohttp-3.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:1ac8531b638959718e18c2207fbfe297819875da46a740b29dfa29beba64355a", size = 479748, upload-time = "2026-06-07T21:07:58.319Z" },
-    { url = "https://files.pythonhosted.org/packages/22/0a/62e7232dc9484fbec112ceb32efb6a624cc7994ec6e2b019286f17c4e8f2/aiohttp-3.14.1-cp313-cp313-win_arm64.whl", hash = "sha256:250d14af67f6b6a1a4a811049b1afa69d61d617fca6bf33149b3ab1a6dbcf7b8", size = 447723, upload-time = "2026-06-07T21:08:00.154Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/5c/b3e4ff8ad43a8afef9602c5e90285936da1beaea8b029016b793891f03c3/aiohttp-3.14.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e568e14940c09955aa51f4e645b6daa18a581c5dcfcd73744dcc86a856e3ced3", size = 764250, upload-time = "2026-07-23T01:52:48.525Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/da/f1b384465e51449d844056b75070461da03a9a23e6c1747003695bf4172a/aiohttp-3.14.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:54cfcdee2770dac994417cbb0ee1f3eb0e7cb6b30c79bf44f2c02ff79ec5124a", size = 516281, upload-time = "2026-07-23T01:52:51.047Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/3f/01264f820ee2e3712a827892b1cd6ff80f3300c1fcbffbb45714a915d47a/aiohttp-3.14.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:21c016079415ed3fd676963e9793700a566d85dbbd6bfc564b9b2d209147dcc8", size = 514742, upload-time = "2026-07-23T01:52:53.779Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8d/a71c6f2db52ac1ed142b133f7feddaa6b70539c3f4de24d7e226c95b794c/aiohttp-3.14.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d6088ec9894113802bddb3c09e974929aed2c7b3a8c456219b8aab4481f1a239", size = 1780613, upload-time = "2026-07-23T01:52:56.948Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/11/3dd9b3fb3a170f6ec9011b5291d876a6fab4086714c9e158600edf01b4fd/aiohttp-3.14.3-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:16ea7e24c309fb7c0bbd505d149abe4fe4dccfb8db911db7dbec0921bc889a6f", size = 1737688, upload-time = "2026-07-23T01:52:59.294Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/3e/834c26918be7d88068822b40e0db30fca50b5f4fe79104aa16a93f1d74e6/aiohttp-3.14.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:56f355e79f71aef2a85c80305cc915f894b170dba76de5fe84f6351939b83c06", size = 1845742, upload-time = "2026-07-23T01:53:01.641Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c9/49ab8572df7d66bc13d11e31f781292badb04180dd87ba98733066c6aed7/aiohttp-3.14.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:18c441d0a8fca6de8d1f546849b9f0ab20d435993e2c5b59562b2fae6be2f929", size = 1928412, upload-time = "2026-07-23T01:53:04.018Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/2b8f0c0ce09c87a1daf80fd483431b56b1435d3f62789bc86f572e1245de/aiohttp-3.14.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:53e7b4ce82b54a8bcc71b3b67a5cbd177ca1d7f592cbc92cd38b7349f73482db", size = 1786220, upload-time = "2026-07-23T01:53:06.481Z" },
+    { url = "https://files.pythonhosted.org/packages/85/00/9c45f81de11710460edfa1dc81317b6e882703b160926c879a9d20da9fcc/aiohttp-3.14.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f55119f7bf25f49ed210f6096090715da24f2943c62102448915fde3c62877ce", size = 1637231, upload-time = "2026-07-23T01:53:10.258Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ce/967d628e910756f3539c6107cb7844a1b69440dcb3029a5ee7871b09ab63/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9aa6e61fdf20105c4144e755bd586008ff450791d67b1c8146fdc15959c4d51c", size = 1753161, upload-time = "2026-07-23T01:53:13.817Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b2/0c3d4114f0aee4f580f5b3b4eb71b24d7a23b834ea506a4dfebe76513f35/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:ccd4893707b3e2a13e39c90d43cf80edf2e4d0457935bcc103bf2346214c3f15", size = 1756356, upload-time = "2026-07-23T01:53:16.211Z" },
+    { url = "https://files.pythonhosted.org/packages/63/5d/99e7d91c82f1399d1ae2a854e080bd1493fbc31e5e959dbc4ec33dac3bec/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:b2466434105a4e03113c36ec775cc2ebe6676b62eae326fa670bb607ef788c1c", size = 1819846, upload-time = "2026-07-23T01:53:18.289Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/05/d5e1cb6480eeffd3f901d40a2c5e2d1e7effdc797837da3b490272699f13/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:ba59d59aba08ac02fc03b0c8983ccd5ee39a199d0552ce9e6d2b4845b34d59ae", size = 1628531, upload-time = "2026-07-23T01:53:23.86Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/90/b934682bcaefae18a9e04f3dff5b68522ba810906358ae5029b68110ea3b/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:ed099d105449c4f9e84f24af203cd131349d4761d8813fa7e02c32e7128cd910", size = 1832712, upload-time = "2026-07-23T01:53:27.551Z" },
+    { url = "https://files.pythonhosted.org/packages/21/df/6061679faaf81fac746e7307c7adb71e858071a5d34c27583afefc64f543/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:152516815ef926786a0b6ae2b8f1fd2e0c71582dee0b435636865316fd4891b7", size = 1775014, upload-time = "2026-07-23T01:53:30.223Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/1d/f854878bbc69b88faefe924b619a34a6f59ec05fd387c77690667eaa75eb/aiohttp-3.14.3-cp311-cp311-win32.whl", hash = "sha256:a4af35c443e0b1a1bd6a8af3f3485d7fda15c142751a00f3ff8090f0b93346fa", size = 456006, upload-time = "2026-07-23T01:53:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/73/0c/2af9d1674baccd1dbd47282a93d660a22e57ef6167c856deb24b4214fbab/aiohttp-3.14.3-cp311-cp311-win_amd64.whl", hash = "sha256:e1e74298bab6ee0d6e749ed4fd1901c7e604bdda32c03d787a2cc71c46d0433d", size = 481069, upload-time = "2026-07-23T01:53:39.673Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/76/88401ff3fc95e85c5fc38d588f36f55e61ecb64343b2bc8d69326f453cc0/aiohttp-3.14.3-cp311-cp311-win_arm64.whl", hash = "sha256:03cd2bde3d7f085b64e549c985f4bb928cad7e8ecf5323bfca320db548d81b39", size = 453021, upload-time = "2026-07-23T01:53:43.749Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/eb96299230e20acf2efae207cb8d69051f1f68e357e5ea5e479bf6fb097a/aiohttp-3.14.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:39aded8c7f3b935b54aab1d8d73c70ec0ee2d3ec3b943e0e86611bc150ba47f5", size = 754690, upload-time = "2026-07-23T01:53:47.332Z" },
+    { url = "https://files.pythonhosted.org/packages/88/11/e7a70a209eb9a067c0d3212b518a0134e3484f5178c7533878b6b514d469/aiohttp-3.14.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5bcb6ff3fdab1258a192679ff1a05d44f59626430aa05cd1a9d2447423599228", size = 509484, upload-time = "2026-07-23T01:53:51.159Z" },
+    { url = "https://files.pythonhosted.org/packages/30/07/4bbc222cc8dbe31d4c3e8a5baad2286e4d42026ac0c570027b89afce6344/aiohttp-3.14.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:617105e2c3018ee38d0c8ce5ee3c84f621a6d8b9f723202aacaff28449ca91ee", size = 511949, upload-time = "2026-07-23T01:53:55.083Z" },
+    { url = "https://files.pythonhosted.org/packages/54/b9/42e74c46b7b7c794b995bbc1f573fb48950c38b19d8600c62a6804ee2d67/aiohttp-3.14.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f631fe87a6f30df5fbe6d79640b25e4cffb38c31c7fb6f10871517b84b0f8c1a", size = 1765282, upload-time = "2026-07-23T01:53:59.662Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ed/62bc4d74363ad346d518e0720363a949f63e2e23439a79eb5813d4d29bb3/aiohttp-3.14.3-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a94dbaae5ae27bd849c93570669bff91e0510f33a80805738e3de72a7be0447b", size = 1741511, upload-time = "2026-07-23T01:54:04.063Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9f/181e8a8bc79e47d13c7fc4540bd7a3b729d9505609c61f392a8dd2fbfe55/aiohttp-3.14.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8f2f1c4c032c7cedd7d8da6f54c97b70266c6570c3108d3fdffee7188bb70529", size = 1810680, upload-time = "2026-07-23T01:54:09.882Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/9a/dec94d6ad694552fe3424e3f1928d7a606a5d9d9433a04e7ecdd9d38ae7f/aiohttp-3.14.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ea05e1f97ceea523942d9b2a7d7c0359d781d683d6b043f5943a602b14da4787", size = 1905646, upload-time = "2026-07-23T01:54:13.475Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b7/7cd31f29d6055bd711ae6e669367fba6f5ae9de463910a793e30556a8db7/aiohttp-3.14.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:543906c127fb1d929b95076db19b83fa2d46751006ff1e23b093aa5ac4d8db42", size = 1792122, upload-time = "2026-07-23T01:54:15.752Z" },
+    { url = "https://files.pythonhosted.org/packages/66/73/10b1ef93afa61f4963c746257b70ced619cf31a4798671de5fdb2608501d/aiohttp-3.14.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0a5ff2dfbb9ce645fa5b8ef3e02c6c0b9cc3f6030ff863d0c51fffc50cb5541b", size = 1591127, upload-time = "2026-07-23T01:54:19.489Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ed/3b203fa6de1b338c14acdc06bf6ca9b043b7944f005966958c2ced932cde/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:041badb8f84396357c4d3ad26de6afd7a32b112f43d3c63045c0c8278cfd2043", size = 1725210, upload-time = "2026-07-23T01:54:24.129Z" },
+    { url = "https://files.pythonhosted.org/packages/28/b7/1c2aab8c706436dcc28598452488ac9cd7c409da815237c28c27d58993e6/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:530125ee1163c4219af35dc3aa1206e541e7b31b6efc1a3f93b70a136f65d427", size = 1764848, upload-time = "2026-07-23T01:54:27.973Z" },
+    { url = "https://files.pythonhosted.org/packages/54/50/94c28f08b131c4bf10984ea2c7a536c9920608bb2d6e7f95642c30cc87b7/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c8653fd547c93a61aadc612007790f5555cdd18946fa48cf45e26d8ea4ea473d", size = 1777102, upload-time = "2026-07-23T01:54:31.775Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d4/e7d09ba7d345fb2d74440fd2fa033c5e079fac05552927705986f41a364f/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:89176250f686cb9853c0fb7ead90e639e915b84a6f43eedc2a4e7ec21f1037f0", size = 1580205, upload-time = "2026-07-23T01:54:34.518Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/84/072a91d68e1e1eb587985b54baab94221277f877e8ef274fc213a0ceae28/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:3a26434dafe408229ff3403458ca58de24fb51936504decac49ce6755f77e59d", size = 1797219, upload-time = "2026-07-23T01:54:36.995Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/eb/aad34e897e668424d6e995da5dff8a4a09af93363d3392488772957a63aa/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d1558173930a5a8d3069cee5c92fc91c87c4dbcb099debbb3622053717145a19", size = 1768629, upload-time = "2026-07-23T01:54:40.103Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2b/6bb88ddba0fecd9122aa3ebcad25996cf6c083a4a7040dbb3a4f97972af6/aiohttp-3.14.3-cp312-cp312-win32.whl", hash = "sha256:16100ad3ab8d649fdfbee87602d9d2dcdca9df0b9eda8a1b5fdc0d41f96da559", size = 451481, upload-time = "2026-07-23T01:54:42.547Z" },
+    { url = "https://files.pythonhosted.org/packages/76/9b/f2f8f108da17ecef2cc3efc424e8b7ad3782b1a8360f7b8eae8ced84f6ea/aiohttp-3.14.3-cp312-cp312-win_amd64.whl", hash = "sha256:33a2d7c28d33797a2e99923dffa63f83d908a19b6bf26cfe80fa790aa5e1a75a", size = 476845, upload-time = "2026-07-23T01:54:44.853Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/44/28dac80a8941b604f4da10ce21097614ca1bf905ce93dca28d8d7de9c1e7/aiohttp-3.14.3-cp312-cp312-win_arm64.whl", hash = "sha256:362a3fd481769cac1a824514bcd86fda51c65e8fe6e051099e008fddde6db17c", size = 448050, upload-time = "2026-07-23T01:54:47.087Z" },
+    { url = "https://files.pythonhosted.org/packages/57/be/5afd201cc0ab139029aadb75392efe85a293403d9dd3a3226161c21ce00c/aiohttp-3.14.3-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:2e9878ae68e4a5f1c0abe4dd497dbc3d51946f5837b56759e2a02e78fa90ef86", size = 506269, upload-time = "2026-07-23T01:54:49.075Z" },
+    { url = "https://files.pythonhosted.org/packages/22/09/dec8189d62b45ade009f6792a2264b942a90cb88aeaf181239933cd72c3c/aiohttp-3.14.3-cp313-cp313-android_21_x86_64.whl", hash = "sha256:f3d2669fe7dec7fc359ecdb5984b29b50d85d5d00f8c1cb61de4f4a24ee42627", size = 515166, upload-time = "2026-07-23T01:54:51.894Z" },
+    { url = "https://files.pythonhosted.org/packages/28/24/2854869d29ed8a8b19d74f9ec6629515f7e04d02dd329d9d179201e58e47/aiohttp-3.14.3-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:cc7cb243a68167172f48c1fd43cee91ec4b1d40cefd190edd43369d1a6bc9c82", size = 486263, upload-time = "2026-07-23T01:54:54.223Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/dd/57187c8be2a35aea65eaee3bd2c3dcbbcf0204f5106c89637e3610380cd1/aiohttp-3.14.3-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:78253b573e6ffab5028924fc98bc281aae05445969982a10864bc360dea2016c", size = 492299, upload-time = "2026-07-23T01:54:56.236Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/11/06ae6ed8f0d414edf4068861e233d8fe23ee699bfd4b3ceb8663db948a62/aiohttp-3.14.3-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:7041d52c3a7fa20c9e8c182b534704abb19502c8bdcbde7ab23bfda6f642394f", size = 502235, upload-time = "2026-07-23T01:54:58.377Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/a3/559639c34a345d2cf7c52dff6838119f2eaf29eb508227b5b83f573af813/aiohttp-3.14.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ac74facc01463f138b0da5580329cfcc82818dea5656e83ddcd11268fc12ff80", size = 750883, upload-time = "2026-07-23T01:55:00.65Z" },
+    { url = "https://files.pythonhosted.org/packages/91/cd/41e131f13afd1e7b0172a9d9eda085ef90eb8439f41f0d279db81ed3ae60/aiohttp-3.14.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d6218d92e450824e9b4881f44e8c09f1853b490f9a64130801024a4793b1b3b0", size = 508473, upload-time = "2026-07-23T01:55:02.945Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/6b/e7f13410d391c6e55b4c007a8de024355389d7d459e3d64c42b2d33617e5/aiohttp-3.14.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:11fb37ef075669eee52ab1928fbf6e1741fada40409fa309ebde9607a962aebf", size = 509190, upload-time = "2026-07-23T01:55:05.173Z" },
+    { url = "https://files.pythonhosted.org/packages/97/21/6464573e53d69672cc1eada3e5c5cb2d2efa82701e8305a0f2047a576967/aiohttp-3.14.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55bdcc472aafe2de4a253045cc128007a64f1e0264fb675791e132ea5edaa3bd", size = 1761478, upload-time = "2026-07-23T01:55:07.383Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/81/d217043a4c17fbce360905e3b2bdd20139ebc9a2de836d035d179c4da006/aiohttp-3.14.3-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c39846c3aad97a8530c89d7a3869a8f8e9e3762c6ac0504481e5c80948f7e807", size = 1735092, upload-time = "2026-07-23T01:55:09.803Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/66/e13a02d0eeb1a9a502402a977abb4e4abff9fe4051c26f80558c57a7c975/aiohttp-3.14.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5895ef58c4620afe02fa16044f023dc4dafec08158f9d08874a46a7dbc0341b8", size = 1800546, upload-time = "2026-07-23T01:55:12.012Z" },
+    { url = "https://files.pythonhosted.org/packages/26/5e/57d42fca1d18cb5acc1cad945d017fabc5d6ae71d8a08ad66be8dc3ee544/aiohttp-3.14.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa9467a8113aa69d3d7c55a70ef0b7c636010a40993f3df9d9d0d73b3eb7ef24", size = 1895250, upload-time = "2026-07-23T01:55:14.357Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/1c/7da8d08e74d56f00070822f9638ff3f1c563f8ad87d1efa996c87bfc8644/aiohttp-3.14.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d7d2deec16eeedf55f2c7cf75b521ea3856a5177e123844f8fd0f114ce252cb5", size = 1789289, upload-time = "2026-07-23T01:55:16.668Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/0f/cf16bcf56896981c1a0319f5d5db9337994b5165730c48a8fa07e9b34be6/aiohttp-3.14.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dd54d0e8717de95939766febac482ac0474d8ac3b048115f9f2b1d23a16e7db4", size = 1586706, upload-time = "2026-07-23T01:55:18.913Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/6f/76eac12a7f2480e1e304f842efdb07db33256b0d9165b866b6ef0806c202/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:df82f3787c940c94986b34222d59c9e38843fba85139f36e85255a82ad5355a9", size = 1724652, upload-time = "2026-07-23T01:55:21.296Z" },
+    { url = "https://files.pythonhosted.org/packages/39/b6/19c8c592baeeb94b75f966547d40c02ac7590902306ec5863d5c027cf506/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:42a67efc36300d052fb4508a53e8b6901b9284b599ae63945c377569c5fcc1e1", size = 1756239, upload-time = "2026-07-23T01:55:23.705Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c9/4e9383150296f97f873b680c4de8fb2cd88608fb9f48c79edcb111611abc/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7a75aa63cbf9b21cfaf60dc2657e19df2c2867d91707d653fee171ffeedd1371", size = 1769161, upload-time = "2026-07-23T01:55:26.082Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1e/147bdc6cc5de5f3ab011be8bf5d6e786633249f22c20bae06f85e45f5387/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e92eb8acc45eb6a9f4935071a77edf5b85cc6f8dfad5cd99e97653c26593cdde", size = 1578759, upload-time = "2026-07-23T01:55:28.846Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/31/78388a9d6040ece2e11df62ea229a822cf5e52d238374b220ae9975b2623/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:b014a6ed7cf912e787149fdc529166d3ceabac23f26efeea3158c9aba2354e7e", size = 1792025, upload-time = "2026-07-23T01:55:31.457Z" },
+    { url = "https://files.pythonhosted.org/packages/03/51/a3d29fdf2c25d796746af8ad6fe56a45d6256c38b0a8a2ed752e1160b3a2/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3d4f72af88ac2474bb5bca640030320e3d38a0163a1d7533500e87be458eef71", size = 1768477, upload-time = "2026-07-23T01:55:33.87Z" },
+    { url = "https://files.pythonhosted.org/packages/29/a6/442e18b5afeade534d877a2dc3c3e392aff8d49787890b0cf84790410267/aiohttp-3.14.3-cp313-cp313-win32.whl", hash = "sha256:5f08ec777f35ee70720233b8b9811d3bb5d728137f30ac91b7457709c3261ac0", size = 451069, upload-time = "2026-07-23T01:55:36.121Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/69/3d876ac02659f271cf7f6769f14a8e3de5b6e888ed8b5a7e998086a4cec8/aiohttp-3.14.3-cp313-cp313-win_amd64.whl", hash = "sha256:dff9461ec275f22135650d5ba4b4931a11f3958df7dfbb8db630000d4dee0883", size = 476518, upload-time = "2026-07-23T01:55:38.303Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/0e/50d6e6471cd31edce8b282bdec59375a3a69124d8a989a0b1313355cae52/aiohttp-3.14.3-cp313-cp313-win_arm64.whl", hash = "sha256:ddcac3c6b382e81f1dd0499199d4136b877beb4cb5ef770bbbfba56c4b8f55d2", size = 447676, upload-time = "2026-07-23T01:55:40.451Z" },
 ]
 
 [[package]]
@@ -159,6 +159,12 @@ name = "alphabet-sort-v1"
 version = "0.1.0"
 source = { editable = "environments/alphabet_sort_v1" }
 dependencies = [
+    { name = "datasets" },
+    { name = "verifiers" },
+]
+
+[package.metadata]
+requires-dist = [
     { name = "datasets" },
     { name = "verifiers" },
 ]
@@ -692,12 +698,21 @@ dependencies = [
     { name = "verifiers" },
 ]
 
+[package.metadata]
+requires-dist = [{ name = "verifiers" }]
+
 [[package]]
 name = "color-codeword-v1"
 version = "0.1.0"
 source = { editable = "environments/color_codeword_v1" }
 dependencies = [
     { name = "pillow" },
+    { name = "verifiers" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pillow", specifier = ">=11.0.0" },
     { name = "verifiers" },
 ]
 
@@ -717,6 +732,9 @@ source = { editable = "environments/compact" }
 dependencies = [
     { name = "verifiers" },
 ]
+
+[package.metadata]
+requires-dist = [{ name = "verifiers" }]
 
 [[package]]
 name = "connect-python"
@@ -951,6 +969,9 @@ source = { editable = "environments/deepwiki_v1" }
 dependencies = [
     { name = "verifiers" },
 ]
+
+[package.metadata]
+requires-dist = [{ name = "verifiers" }]
 
 [[package]]
 name = "defusedxml"
@@ -1355,6 +1376,9 @@ dependencies = [
     { name = "verifiers" },
 ]
 
+[package.metadata]
+requires-dist = [{ name = "verifiers" }]
+
 [[package]]
 name = "googleapis-common-protos"
 version = "1.75.0"
@@ -1502,6 +1526,9 @@ source = { editable = "environments/gsm8k_v1" }
 dependencies = [
     { name = "datasets" },
 ]
+
+[package.metadata]
+requires-dist = [{ name = "datasets" }]
 
 [[package]]
 name = "h11"
@@ -2060,6 +2087,9 @@ source = { editable = "environments/kuhn_poker_v1" }
 dependencies = [
     { name = "verifiers" },
 ]
+
+[package.metadata]
+requires-dist = [{ name = "verifiers" }]
 
 [[package]]
 name = "latex2sympy2-extended"
@@ -2810,6 +2840,9 @@ dependencies = [
     { name = "verifiers", extra = ["openenv"] },
 ]
 
+[package.metadata]
+requires-dist = [{ name = "verifiers", extras = ["openenv"] }]
+
 [[package]]
 name = "opentelemetry-api"
 version = "1.43.0"
@@ -3249,6 +3282,9 @@ source = { editable = "environments/proposer_solver_v1" }
 dependencies = [
     { name = "verifiers" },
 ]
+
+[package.metadata]
+requires-dist = [{ name = "verifiers" }]
 
 [[package]]
 name = "protobuf"
@@ -4052,6 +4088,9 @@ dependencies = [
     { name = "datasets" },
 ]
 
+[package.metadata]
+requires-dist = [{ name = "datasets" }]
+
 [[package]]
 name = "rich"
 version = "15.0.0"
@@ -4224,6 +4263,9 @@ source = { editable = "environments/scratchpad_v1" }
 dependencies = [
     { name = "verifiers" },
 ]
+
+[package.metadata]
+requires-dist = [{ name = "verifiers" }]
 
 [[package]]
 name = "secretstorage"
@@ -4918,6 +4960,79 @@ examples = [
     { name = "wordle-v1" },
 ]
 
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp", specifier = ">=3.9.0" },
+    { name = "aiolimiter", specifier = ">=1.2.1" },
+    { name = "anthropic", specifier = ">=0.78.0" },
+    { name = "datasets", specifier = ">=3.3.0,<6.0.0" },
+    { name = "gepa", specifier = ">=0.0.6" },
+    { name = "harbor", marker = "python_full_version >= '3.12' and extra == 'harbor'", specifier = "==0.20.0" },
+    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "loguru", specifier = ">=0.7.0" },
+    { name = "math-verify", specifier = ">=0.8.0" },
+    { name = "mcp", specifier = ">=1.24.0,<2" },
+    { name = "modal", marker = "extra == 'modal'", specifier = ">=1.4.0" },
+    { name = "msgpack", specifier = ">=1.1.2" },
+    { name = "nest-asyncio", marker = "extra == 'notebook'", specifier = ">=1.6.0" },
+    { name = "nltk", marker = "extra == 'ta'", specifier = ">=3.9.2" },
+    { name = "numpy", specifier = ">=2.1.0" },
+    { name = "openai", specifier = ">=2.9.0" },
+    { name = "openai-agents", specifier = ">=0.8.2" },
+    { name = "openenv", marker = "extra == 'openenv'", specifier = ">=0.4.1" },
+    { name = "prime-pydantic-config", extras = ["toml"], specifier = ">=0.4.2" },
+    { name = "prime-sandboxes", specifier = ">=0.2.35" },
+    { name = "prime-tunnel", specifier = ">=0.1.8" },
+    { name = "pydantic", specifier = ">=2.12.3" },
+    { name = "python-dotenv", marker = "extra == 'browser'", specifier = ">=1.0.0" },
+    { name = "pyzmq", specifier = ">=27.1.0" },
+    { name = "reasoning-gym", marker = "extra == 'rg'", specifier = ">=0.1.8" },
+    { name = "renderers", specifier = ">=0.1.9.dev9" },
+    { name = "requests" },
+    { name = "rich", specifier = ">=11.0.0" },
+    { name = "setproctitle", specifier = ">=1.3.0" },
+    { name = "stagehand", marker = "extra == 'browser'", specifier = ">=3.4.0" },
+    { name = "tenacity", specifier = ">=8.5.0" },
+    { name = "textarena", marker = "extra == 'ta'", specifier = "==0.7.4" },
+    { name = "tomli-w", specifier = ">=1.0.0" },
+    { name = "typing-extensions", specifier = ">=4.12.2" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'", specifier = ">=0.21.0" },
+]
+provides-extras = ["browser", "harbor", "modal", "notebook", "openenv", "rg", "ta"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "nest-asyncio", specifier = ">=1.6.0" },
+    { name = "nltk", specifier = ">=3.9.2" },
+    { name = "pre-commit", specifier = ">=2.19.0" },
+    { name = "pytest", specifier = ">=7.0.0,<9.1.0" },
+    { name = "pytest-asyncio", specifier = ">=0.21.0" },
+    { name = "pytest-cov", specifier = ">=4.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "reasoning-gym", specifier = ">=0.1.8" },
+    { name = "ruff", specifier = ">=0.16.0" },
+    { name = "stagehand", specifier = ">=3.4.0" },
+    { name = "textarena", specifier = "==0.7.4" },
+    { name = "ty", specifier = ">=0.0.63" },
+]
+examples = [
+    { name = "alphabet-sort-v1", editable = "environments/alphabet_sort_v1" },
+    { name = "code-golf-v1", editable = "environments/code_golf_v1" },
+    { name = "color-codeword-v1", editable = "environments/color_codeword_v1" },
+    { name = "compact", editable = "environments/compact" },
+    { name = "deepwiki-v1", editable = "environments/deepwiki_v1" },
+    { name = "glossary-v1", editable = "environments/glossary_v1" },
+    { name = "gsm8k-v1", editable = "environments/gsm8k_v1" },
+    { name = "kuhn-poker-v1", editable = "environments/kuhn_poker_v1" },
+    { name = "openenv-wordle-v1", editable = "environments/openenv_wordle_v1" },
+    { name = "proposer-solver-v1", editable = "environments/proposer_solver_v1" },
+    { name = "reverse-text-v1", editable = "environments/reverse_text_v1" },
+    { name = "scratchpad-v1", editable = "environments/scratchpad_v1" },
+    { name = "wiki-search-v1", editable = "environments/wiki_search_v1" },
+    { name = "wordle-v1", editable = "environments/wordle_v1" },
+]
+
 [[package]]
 name = "virtualenv"
 version = "21.6.1"
@@ -5062,6 +5177,13 @@ dependencies = [
     { name = "verifiers" },
 ]
 
+[package.metadata]
+requires-dist = [
+    { name = "chromadb", specifier = ">=0.4.13" },
+    { name = "datasets" },
+    { name = "verifiers" },
+]
+
 [[package]]
 name = "win32-setctime"
 version = "1.2.0"
@@ -5078,6 +5200,9 @@ source = { editable = "environments/wordle_v1" }
 dependencies = [
     { name = "verifiers", extra = ["ta"] },
 ]
+
+[package.metadata]
+requires-dist = [{ name = "verifiers", extras = ["ta"] }]
 
 [[package]]
 name = "xxhash"

--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -15,6 +15,7 @@ from verifiers.envs.experimental.utils.git_checkout_cache import (
     validate_git_checkout,
 )
 from verifiers.types import Messages, State, SystemMessage, TrajectoryStep
+from verifiers.utils.path_utils import CACHE_DIR
 
 DEFAULT_RLM_REPO_URL = "github.com/PrimeIntellect-ai/rlm-harness.git"
 DEFAULT_RLM_REF = "main"
@@ -24,9 +25,7 @@ DEFAULT_RLM_MAX_DEPTH = 0
 DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH = "/task/append_to_system_prompt.txt"
 DEFAULT_RLM_CHECKOUT_PATH = "/tmp/rlm-checkout"
 DEFAULT_RLM_CHECKOUT_UPLOAD_NAME = "rlm_checkout"
-DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT = (
-    Path.home() / ".cache" / "verifiers" / "rlm-checkouts"
-)
+DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT = CACHE_DIR / "rlm-checkouts"
 _REQUIRED_CHECKOUT_FILES = ("install.sh", "pyproject.toml")
 
 COMPACTION_BOUNDARY_MARKER = "--- context compacted ---"

--- a/verifiers/envs/experimental/utils/git_checkout_cache.py
+++ b/verifiers/envs/experimental/utils/git_checkout_cache.py
@@ -16,6 +16,7 @@ from verifiers.envs.experimental.utils.file_locks import (
     exclusive_path_lock,
     sibling_lock_path,
 )
+from verifiers.utils.path_utils import CACHE_DIR
 
 _IN_USE_LOCK_SUFFIX = ".in-use.lock"
 
@@ -23,7 +24,7 @@ _IN_USE_LOCK_SUFFIX = ".in-use.lock"
 # resolved checkout's in-use lock file. See ``_acquire_in_use_lock``.
 _held_in_use_locks: dict[Path, IO] = {}
 
-DEFAULT_GIT_CHECKOUT_CACHE_ROOT = Path.home() / ".cache" / "verifiers" / "git-checkouts"
+DEFAULT_GIT_CHECKOUT_CACHE_ROOT = CACHE_DIR / "git-checkouts"
 _FULL_COMMIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
 
 logger = logging.getLogger(__name__)

--- a/verifiers/utils/path_utils.py
+++ b/verifiers/utils/path_utils.py
@@ -9,6 +9,18 @@ from verifiers.types import EvalConfig
 logger = logging.getLogger(__name__)
 
 
+def home_dir() -> Path:
+    """Best-effort home directory; fall back to the temp dir so import never fails."""
+    try:
+        return Path.home()
+    except RuntimeError:
+        return Path(tempfile.gettempdir())
+
+
+CACHE_DIR = home_dir() / ".cache" / "verifiers"
+"""User-local cache root for verifiers-managed state."""
+
+
 def write_temp_file(content: str, suffix: str = ".txt") -> str:
     """Write content to a named temporary file and return its path.
 

--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -286,6 +286,10 @@ class ACPHarnessSession(HarnessSession):
         process, self._process = self._process, None
         reader, self._reader = self._reader, None
         stderr_task, self._stderr_task = self._stderr_task, None
+        # A replacement process starts a new native ACP session. Its first
+        # request needs the complete transcript, not the suffix used for a
+        # continuation on the old live process.
+        self._completed_turns = 0
         if process is None:
             return None
         failure: BaseException | None = None

--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -47,6 +47,7 @@ class ACP:
         command: list[str],
         prompt: str | Messages | None,
         system_prompt: str | None = None,
+        allow_empty_tool_reply: bool = False,
     ) -> "ACPHarnessSession":
         """Create a persistent ACP-backed handle owned by one rollout."""
         return ACPHarnessSession(
@@ -62,6 +63,7 @@ class ACP:
             command=command,
             prompt=prompt,
             system_prompt=system_prompt,
+            allow_empty_tool_reply=allow_empty_tool_reply,
         )
 
     async def run(
@@ -192,12 +194,14 @@ class ACPHarnessSession(HarnessSession):
         command: list[str],
         prompt: str | Messages | None,
         system_prompt: str | None,
+        allow_empty_tool_reply: bool = False,
     ) -> None:
         super().__init__(harness, ctx, trace, runtime, endpoint, secret, mcp_urls, data)
         self.env = env
         self.command = command
         self.prompt = prompt
         self.system_prompt = system_prompt
+        self.allow_empty_tool_reply = allow_empty_tool_reply
         self._process: RuntimeProcess | None = None
         self._reader: _PacketReader | None = None
         self._stderr_tail = bytearray()
@@ -243,6 +247,7 @@ class ACPHarnessSession(HarnessSession):
             "mcp_urls": self.mcp_urls,
             "system_prompt": self.system_prompt or "",
             "session_path": None,
+            "allow_empty_tool_reply": self.allow_empty_tool_reply,
         }
         async with self._lock:
             if self._closed:

--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -153,10 +153,26 @@ class _PacketReader:
         return data
 
     async def read(self) -> dict:
-        size = int.from_bytes(await self._readexactly(8), "big")
-        if size > MAX_PACKET_BYTES:
-            raise ValueError(f"ACP session packet is too large: {size} bytes")
-        return json.loads((await self._readexactly(size)).decode())
+        while True:
+            size = int.from_bytes(await self._readexactly(8), "big")
+            if size > MAX_PACKET_BYTES:
+                raise ValueError(f"ACP session packet is too large: {size} bytes")
+            packet = json.loads((await self._readexactly(size)).decode())
+            if packet.get("type") != "keepalive":
+                return packet
+
+
+def _new_segment(messages: list[dict]) -> list[dict]:
+    """Return only the messages that follow the last agent reply."""
+    last_assistant = max(
+        (
+            index
+            for index, message in enumerate(messages)
+            if message.get("role") == "assistant"
+        ),
+        default=-1,
+    )
+    return messages[last_assistant + 1 :]
 
 
 class ACPHarnessSession(HarnessSession):
@@ -187,6 +203,7 @@ class ACPHarnessSession(HarnessSession):
         self._stderr_tail = bytearray()
         self._stderr_task: asyncio.Task[None] | None = None
         self._lock = asyncio.Lock()
+        self._completed_turns = 0
 
     async def _start(self) -> None:
         self._stderr_tail.clear()
@@ -216,6 +233,10 @@ class ACPHarnessSession(HarnessSession):
             if isinstance(prompt, str)
             else [message_to_wire(message) for message in prompt]
         )
+        if self._completed_turns:
+            # The live ACP session already owns the preceding conversation. Do
+            # not send it again through the runtime's stdin control RPC.
+            wire_messages = _new_segment(wire_messages)
         config = {
             "command": self.command,
             "messages": wire_messages,
@@ -253,6 +274,7 @@ class ACPHarnessSession(HarnessSession):
             if stderr := self._stderr():
                 detail = f"{detail}\n\nACP process stderr:\n{stderr}"
             raise RuntimeError(detail)
+        self._completed_turns += 1
         return ProgramResult(exit_code=0, stdout=response.get("reply", ""), stderr="")
 
     async def _stop(self, *, graceful: bool) -> int | None:

--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -46,6 +46,7 @@ class ACP:
         command: list[str],
         prompt: str | Messages | None,
         system_prompt: str | None = None,
+        session_meta: dict | None = None,
     ) -> "ACPHarnessSession":
         """Create a persistent ACP-backed handle owned by one rollout."""
         return ACPHarnessSession(
@@ -61,6 +62,7 @@ class ACP:
             command=command,
             prompt=prompt,
             system_prompt=system_prompt,
+            session_meta=session_meta,
         )
 
     async def run(
@@ -73,6 +75,7 @@ class ACP:
         mcp_urls: dict[str, str] | None = None,
         system_prompt: str | None = None,
         session_path: str | None = None,
+        session_meta: dict | None = None,
         allow_empty_tool_reply: bool = False,
     ) -> ProgramResult:
         """Run one ACP segment without retaining its process."""
@@ -84,6 +87,7 @@ class ACP:
             mcp_urls=mcp_urls,
             system_prompt=system_prompt,
             session_path=session_path,
+            session_meta=session_meta,
             allow_empty_tool_reply=allow_empty_tool_reply,
         )
 
@@ -97,6 +101,7 @@ class ACP:
         mcp_urls: dict[str, str] | None = None,
         system_prompt: str | None = None,
         session_path: str | None = None,
+        session_meta: dict | None = None,
         allow_empty_tool_reply: bool = False,
     ) -> ProgramResult:
         if prompt is None:
@@ -112,6 +117,7 @@ class ACP:
             "mcp_urls": mcp_urls or {},
             "system_prompt": system_prompt or "",
             "session_path": session_path,
+            "session_meta": session_meta or {},
             "allow_empty_tool_reply": allow_empty_tool_reply,
         }
         program = await runtime.prepare_uv_script(
@@ -175,12 +181,14 @@ class ACPHarnessSession(HarnessSession):
         command: list[str],
         prompt: str | Messages | None,
         system_prompt: str | None,
+        session_meta: dict | None,
     ) -> None:
         super().__init__(harness, ctx, trace, runtime, endpoint, secret, mcp_urls, data)
         self.env = env
         self.command = command
         self.prompt = prompt
         self.system_prompt = system_prompt
+        self.session_meta = session_meta or {}
         self._process: RuntimeProcess | None = None
         self._reader: _PacketReader | None = None
         self._stderr_tail = bytearray()
@@ -221,6 +229,7 @@ class ACPHarnessSession(HarnessSession):
             "mcp_urls": self.mcp_urls,
             "system_prompt": self.system_prompt or "",
             "session_path": None,
+            "session_meta": self.session_meta,
         }
         async with self._lock:
             if self._closed:

--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -236,6 +236,14 @@ class ACPHarnessSession(HarnessSession):
                     _packet({"operation": "prompt", "config": config})
                 )
                 response = await self._reader.read()
+            except EOFError as error:
+                exit_code = await run_shielded(self._stop(graceful=False))
+                detail = str(error)
+                if exit_code is not None:
+                    detail = f"{detail} (exit {exit_code})"
+                if stderr := self._stderr():
+                    detail = f"{detail}\n\nACP process stderr:\n{stderr}"
+                raise EOFError(detail) from error
             except BaseException:
                 await run_shielded(self._stop(graceful=False))
                 raise
@@ -246,13 +254,14 @@ class ACPHarnessSession(HarnessSession):
             raise RuntimeError(detail)
         return ProgramResult(exit_code=0, stdout=response.get("reply", ""), stderr="")
 
-    async def _stop(self, *, graceful: bool) -> None:
+    async def _stop(self, *, graceful: bool) -> int | None:
         process, self._process = self._process, None
         reader, self._reader = self._reader, None
         stderr_task, self._stderr_task = self._stderr_task, None
         if process is None:
-            return
+            return None
         failure: BaseException | None = None
+        exit_code: int | None = None
         try:
             if graceful and reader is not None:
                 try:
@@ -265,17 +274,19 @@ class ACPHarnessSession(HarnessSession):
                 except BaseException as error:  # noqa: BLE001 - finish teardown if cancelled
                     failure = error
             try:
-                await asyncio.wait_for(process.wait(), timeout=10 if graceful else 0.1)
+                exit_code = await asyncio.wait_for(
+                    process.wait(), timeout=10 if graceful else 0.1
+                )
             except BaseException:  # noqa: BLE001 - cancellation still requires termination
                 with contextlib.suppress(Exception):
                     await asyncio.wait_for(process.terminate(), timeout=5)
                 try:
-                    await asyncio.wait_for(process.wait(), timeout=5)
+                    exit_code = await asyncio.wait_for(process.wait(), timeout=5)
                 except BaseException:  # noqa: BLE001 - cancellation still requires a kill
                     with contextlib.suppress(Exception):
                         await asyncio.wait_for(process.kill(), timeout=5)
                     with contextlib.suppress(BaseException):
-                        await asyncio.wait_for(process.wait(), timeout=5)
+                        exit_code = await asyncio.wait_for(process.wait(), timeout=5)
         finally:
             if stderr_task is not None:
                 if not stderr_task.done():
@@ -287,6 +298,7 @@ class ACPHarnessSession(HarnessSession):
             if stderr := self._stderr():
                 detail = f"{detail}\n\nACP process stderr:\n{stderr}"
             raise RuntimeError(detail) from failure
+        return exit_code
 
     async def close(self) -> None:
         if self._closed:

--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -334,6 +334,13 @@ class ACPHarnessSession(HarnessSession):
                     stderr_task.cancel()
                 with contextlib.suppress(BaseException):
                     await stderr_task
+            # A process abandoned without its exit event still holds its remote
+            # stream open (on Prime, one gateway HTTP/2 stream slot plus its
+            # dedicated connection) until the sandbox dies. Always release it.
+            closer = getattr(process, "aclose", None)
+            if closer is not None:
+                with contextlib.suppress(BaseException):
+                    await closer()
         if failure is not None:
             detail = str(failure)
             if stderr := self._stderr():

--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -19,6 +19,7 @@ from verifiers.v1.utils.aio import run_shielded
 
 ACP_SOURCE = (Path(__file__).resolve().parent / "runner.py").read_text()
 MAX_PACKET_BYTES = 128 * 1024 * 1024
+STDERR_DRAIN_TIMEOUT = 1.0
 
 __all__ = ["ACP"]
 
@@ -289,6 +290,15 @@ class ACPHarnessSession(HarnessSession):
                         exit_code = await asyncio.wait_for(process.wait(), timeout=5)
         finally:
             if stderr_task is not None:
+                if not stderr_task.done():
+                    # Process exit can reach stdout before the remote stderr
+                    # stream flushes its final chunks. Give it a bounded chance
+                    # to close before cancellation discards the crash details.
+                    with contextlib.suppress(BaseException):
+                        await asyncio.wait_for(
+                            asyncio.shield(stderr_task),
+                            timeout=STDERR_DRAIN_TIMEOUT,
+                        )
                 if not stderr_task.done():
                     stderr_task.cancel()
                 with contextlib.suppress(BaseException):

--- a/verifiers/v1/acp/runner.py
+++ b/verifiers/v1/acp/runner.py
@@ -196,28 +196,38 @@ async def run_once(config: dict) -> str:
         *command[1:],
         env=os.environ.copy(),
         transport_kwargs={"stderr": None},
-    ) as (connection, _process):
+    ) as agent_process:
+        connection = agent_process[0]
         initialized = await connection.initialize(
             protocol_version=PROTOCOL_VERSION,
             client_capabilities=ClientCapabilities(),
         )
         capabilities = initialized.agent_capabilities
         session_path = Path(config["session_path"]) if config["session_path"] else None
+        session_meta = config["session_meta"]
         is_new = session_path is None or not session_path.exists()
         servers = mcp_servers(config)
         if is_new:
-            session = await connection.new_session(cwd=os.getcwd(), mcp_servers=servers)
+            session = await connection.new_session(
+                cwd=os.getcwd(), mcp_servers=servers, **session_meta
+            )
             session_id = session.session_id
         else:
             session_id = session_path.read_text().strip()
             session_capabilities = capabilities and capabilities.session_capabilities
             if session_capabilities and session_capabilities.resume is not None:
                 await connection.resume_session(
-                    cwd=os.getcwd(), session_id=session_id, mcp_servers=servers
+                    cwd=os.getcwd(),
+                    session_id=session_id,
+                    mcp_servers=servers,
+                    **session_meta,
                 )
             elif capabilities and capabilities.load_session:
                 await connection.load_session(
-                    cwd=os.getcwd(), session_id=session_id, mcp_servers=servers
+                    cwd=os.getcwd(),
+                    session_id=session_id,
+                    mcp_servers=servers,
+                    **session_meta,
                 )
             else:
                 raise RuntimeError("ACP agent does not support resuming sessions")
@@ -251,12 +261,13 @@ class LiveACPSession:
         self.command: list[str] | None = None
         self.server_urls: dict[str, str] | None = None
         self.system_prompt: str | None = None
+        self.session_meta: dict | None = None
         self.is_new = True
 
     async def start(self, config: dict) -> None:
         command = config["command"]
         try:
-            self.connection, _process = await self.stack.enter_async_context(
+            agent_process = await self.stack.enter_async_context(
                 spawn_agent_process(
                     self.client,
                     command[0],
@@ -265,13 +276,16 @@ class LiveACPSession:
                     transport_kwargs={"stderr": None},
                 )
             )
+            self.connection = agent_process[0]
             initialized = await self.connection.initialize(
                 protocol_version=PROTOCOL_VERSION,
                 client_capabilities=ClientCapabilities(),
             )
             self.capabilities = initialized.agent_capabilities
             session = await self.connection.new_session(
-                cwd=os.getcwd(), mcp_servers=mcp_servers(config)
+                cwd=os.getcwd(),
+                mcp_servers=mcp_servers(config),
+                **config["session_meta"],
             )
         except BaseException:
             with suppress(BaseException):
@@ -282,6 +296,7 @@ class LiveACPSession:
         self.command = command
         self.server_urls = config["mcp_urls"]
         self.system_prompt = config["system_prompt"]
+        self.session_meta = config["session_meta"]
         self.is_new = True
 
     async def run(self, config: dict) -> str:
@@ -291,6 +306,7 @@ class LiveACPSession:
             config["command"] != self.command
             or config["mcp_urls"] != self.server_urls
             or config["system_prompt"] != self.system_prompt
+            or config["session_meta"] != self.session_meta
         ):
             raise RuntimeError("ACP session configuration changed")
         assert self.session_id is not None

--- a/verifiers/v1/acp/runner.py
+++ b/verifiers/v1/acp/runner.py
@@ -10,7 +10,6 @@ import os
 import signal
 import sys
 import traceback
-from collections.abc import Awaitable
 from contextlib import AsyncExitStack, suppress
 from pathlib import Path
 from typing import Any
@@ -383,26 +382,19 @@ def write_packet(stream: Any, value: dict) -> None:
     stream.flush()
 
 
-async def with_keepalives(
-    awaitable: Awaitable[str],
+async def emit_keepalives(
     stream: Any,
     *,
     interval: float = KEEPALIVE_INTERVAL_SECONDS,
-) -> str:
-    """Keep the outer process stream active during a silent agent turn."""
+) -> None:
+    """Keep the outer process stream active while the session lives.
 
-    async def emit() -> None:
-        while True:
-            await asyncio.sleep(interval)
-            write_packet(stream, {"type": "keepalive"})
-
-    task = asyncio.create_task(emit())
-    try:
-        return await awaitable
-    finally:
-        task.cancel()
-        with suppress(asyncio.CancelledError):
-            await task
+    The gateway reaps connections that carry no data for about 30 minutes,
+    and a seat sits idle far longer between panel turns. Keepalives must
+    flow for the whole session, not only during turns."""
+    while True:
+        await asyncio.sleep(interval)
+        write_packet(stream, {"type": "keepalive"})
 
 
 async def serve_stream() -> None:
@@ -413,6 +405,7 @@ async def serve_stream() -> None:
     await asyncio.get_running_loop().connect_read_pipe(
         lambda: protocol, sys.stdin.buffer
     )
+    keepalive = asyncio.create_task(emit_keepalives(sys.stdout.buffer))
     try:
         while request := await read_packet(reader):
             stop = False
@@ -421,9 +414,7 @@ async def serve_stream() -> None:
                 if operation == "prompt":
                     response = {
                         "ok": True,
-                        "reply": await with_keepalives(
-                            session.run(request["config"]), sys.stdout.buffer
-                        ),
+                        "reply": await session.run(request["config"]),
                     }
                 elif operation == "shutdown":
                     await session.close()
@@ -442,6 +433,9 @@ async def serve_stream() -> None:
             if stop:
                 break
     finally:
+        keepalive.cancel()
+        with suppress(asyncio.CancelledError):
+            await keepalive
         if not closed:
             await session.close()
 

--- a/verifiers/v1/acp/runner.py
+++ b/verifiers/v1/acp/runner.py
@@ -10,6 +10,7 @@ import os
 import signal
 import sys
 import traceback
+from collections.abc import Awaitable
 from contextlib import AsyncExitStack, suppress
 from pathlib import Path
 from typing import Any
@@ -36,6 +37,7 @@ from acp.schema import (
 )
 
 MAX_PACKET_BYTES = 128 * 1024 * 1024
+KEEPALIVE_INTERVAL_SECONDS = 15.0
 
 
 class VerifiersACPClient(Client):
@@ -339,9 +341,30 @@ def write_packet(stream: Any, value: dict) -> None:
     data = json.dumps(value, ensure_ascii=False).encode()
     if len(data) > MAX_PACKET_BYTES:
         raise ValueError(f"ACP session packet is too large: {len(data)} bytes")
-    stream.write(len(data).to_bytes(8, "big"))
-    stream.write(data)
+    stream.write(len(data).to_bytes(8, "big") + data)
     stream.flush()
+
+
+async def with_keepalives(
+    awaitable: Awaitable[str],
+    stream: Any,
+    *,
+    interval: float = KEEPALIVE_INTERVAL_SECONDS,
+) -> str:
+    """Keep the outer process stream active during a silent agent turn."""
+
+    async def emit() -> None:
+        while True:
+            await asyncio.sleep(interval)
+            write_packet(stream, {"type": "keepalive"})
+
+    task = asyncio.create_task(emit())
+    try:
+        return await awaitable
+    finally:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
 
 
 async def serve_stream() -> None:
@@ -360,7 +383,9 @@ async def serve_stream() -> None:
                 if operation == "prompt":
                     response = {
                         "ok": True,
-                        "reply": await session.run(request["config"]),
+                        "reply": await with_keepalives(
+                            session.run(request["config"]), sys.stdout.buffer
+                        ),
                     }
                 elif operation == "shutdown":
                     await session.close()

--- a/verifiers/v1/acp/runner.py
+++ b/verifiers/v1/acp/runner.py
@@ -36,6 +36,7 @@ from acp.schema import (
 )
 
 MAX_PACKET_BYTES = 128 * 1024 * 1024
+LATE_UPDATE_GRACE_SECONDS = 1.0
 
 
 class VerifiersACPClient(Client):
@@ -43,6 +44,7 @@ class VerifiersACPClient(Client):
         self.visible_reply = ""
         self.message_id: str | None = None
         self.tool_calls: dict[str, str] = {}
+        self.output_changed = asyncio.Condition()
 
     def reset(self) -> None:
         self.visible_reply = ""
@@ -50,22 +52,23 @@ class VerifiersACPClient(Client):
         self.tool_calls = {}
 
     async def session_update(self, session_id: str, update: Any, **kwargs: Any) -> None:
-        if isinstance(update, ToolCall):
-            self.tool_calls[update.tool_call_id] = update.status or "pending"
-            return
-        if isinstance(update, ToolCallUpdate):
-            if update.status:
-                self.tool_calls[update.tool_call_id] = update.status
-            return
-        if not isinstance(update, AgentMessageChunk) or not isinstance(
-            update.content, TextContentBlock
-        ):
-            return
-        message_id = getattr(update, "message_id", None)
-        if message_id is not None and message_id != self.message_id:
-            self.visible_reply = ""
-            self.message_id = message_id
-        self.visible_reply += update.content.text
+        async with self.output_changed:
+            if isinstance(update, ToolCall):
+                self.tool_calls[update.tool_call_id] = update.status or "pending"
+            elif isinstance(update, ToolCallUpdate):
+                if update.status:
+                    self.tool_calls[update.tool_call_id] = update.status
+            elif isinstance(update, AgentMessageChunk) and isinstance(
+                update.content, TextContentBlock
+            ):
+                message_id = getattr(update, "message_id", None)
+                if message_id is not None and message_id != self.message_id:
+                    self.visible_reply = ""
+                    self.message_id = message_id
+                self.visible_reply += update.content.text
+            else:
+                return
+            self.output_changed.notify_all()
 
     async def request_permission(
         self,
@@ -172,6 +175,25 @@ async def prompt(
     except RequestError as error:
         detail = error.data.get("details") if isinstance(error.data, dict) else None
         raise RuntimeError(detail or str(error)) from error
+
+    # ACP 0.11 dispatches notifications in background tasks but resolves a request
+    # response directly in its receive loop. An agent that sends its final
+    # session/update immediately before session/prompt returns can therefore wake
+    # this coroutine before the update handler has run. Wait specifically for text:
+    # a completed tool update may also arrive first and must not hide a later reply.
+    def has_visible_reply() -> bool:
+        return bool(client.visible_reply.strip())
+
+    if not has_visible_reply():
+        async with client.output_changed:
+            try:
+                await asyncio.wait_for(
+                    client.output_changed.wait_for(has_visible_reply),
+                    timeout=LATE_UPDATE_GRACE_SECONDS,
+                )
+            except asyncio.TimeoutError:  # noqa: UP041 - Python 3.10 compatibility
+                pass
+
     tool_statuses = list(client.tool_calls.values())
     completed_tool_turn = (
         config.get("allow_empty_tool_reply", False)
@@ -179,7 +201,7 @@ async def prompt(
         and bool(tool_statuses)
         and all(status in ("completed", "failed") for status in tool_statuses)
     )
-    if not client.visible_reply.strip() and not completed_tool_turn:
+    if not has_visible_reply() and not completed_tool_turn:
         raise RuntimeError(
             "ACP agent produced no visible reply "
             f"(stop_reason={response.stop_reason}, tool_statuses={tool_statuses})"

--- a/verifiers/v1/cli/eval/main.py
+++ b/verifiers/v1/cli/eval/main.py
@@ -7,7 +7,7 @@ import sys
 from pydantic_config import cli
 
 import verifiers.v1 as vf
-from verifiers.v1.cli.eval.resume import load_resume_config, split_resume
+from verifiers.v1.cli.eval.resume import load_resume_config
 from verifiers.v1.cli.eval.runner import run_eval
 from verifiers.v1.cli.output import output_path, write_config
 from verifiers.v1.cli.resolve import (
@@ -17,6 +17,7 @@ from verifiers.v1.cli.resolve import (
     references_config_file,
     with_positional_taskset,
 )
+from verifiers.v1.cli.resume import split_resume
 from verifiers.v1.configs.cli.eval import EvalConfig
 from verifiers.v1.utils.interrupt import install_interrupt
 from verifiers.v1.utils.logging import setup_logging
@@ -40,7 +41,7 @@ def main(argv: list[str] | None = None) -> None:
                 narrow_config(EvalConfig, argv)
             )  # full option help, narrowed to the given ids
         return
-    resume_dir, rest = split_resume(argv)
+    resume_dir, rest = split_resume(argv, "eval")
     # re-run a previous run's missing/errored rollouts, in place
     if resume_dir is not None:
         if rest:

--- a/verifiers/v1/cli/eval/resume.py
+++ b/verifiers/v1/cli/eval/resume.py
@@ -11,7 +11,6 @@ changed since the interrupted run re-runs, and nothing depends on `data.idx`. Th
 legacy (v0) bridge still matches by row index (`key_of`).
 """
 
-import hashlib
 import json
 import tomllib
 from collections import Counter, defaultdict
@@ -22,48 +21,12 @@ from typing import TypeVar
 from pydantic_core import from_json
 
 from verifiers.v1.cli.output import CONFIG_FILE, TRACES_FILE, sniff_episode
+from verifiers.v1.cli.resume import task_key
 from verifiers.v1.configs.cli.eval import EvalConfig
 from verifiers.v1.episode import Episode, WireEpisode
 from verifiers.v1.trace import WireTrace
 
 K = TypeVar("K", bound=Hashable)
-
-
-def task_key(data: Mapping) -> str:
-    """Content identity of one task's wire data — an `exclude_none` dump, the shape
-    saved rows already have on disk. `sort_keys` so field order can't split identity."""
-    return hashlib.sha256(json.dumps(data, sort_keys=True).encode()).hexdigest()
-
-
-def distribute(
-    selected_keys: list[K], owed: dict[K, int], num_rollouts: int
-) -> list[int]:
-    """Spread each key's owed rollouts over its selection instances, in order —
-    content-identical tasks are interchangeable, so any instance can absorb the
-    debt (capped at `num_rollouts` each). Returns one count per selection."""
-    remaining = dict(owed)
-    counts: list[int] = []
-    for key in selected_keys:
-        take = min(num_rollouts, remaining.get(key, 0))
-        if take:
-            remaining[key] -= take
-        counts.append(take)
-    return counts
-
-
-def split_resume(argv: list[str]) -> tuple[Path | None, list[str]]:
-    """Pull `--resume <dir>` / `--resume=<dir>` out of argv, returning (dir, the other args).
-    The caller rejects any leftover args, since resume re-runs the saved config verbatim."""
-    for i, arg in enumerate(argv):
-        if arg == "--resume":
-            if i + 1 >= len(argv):
-                raise SystemExit(
-                    "--resume needs an output dir: uv run eval --resume <dir>"
-                )
-            return Path(argv[i + 1]), argv[:i] + argv[i + 2 :]
-        if arg.startswith("--resume="):
-            return Path(arg.split("=", 1)[1]), argv[:i] + argv[i + 1 :]
-    return None, argv
 
 
 def load_resume_config(resume_dir: Path) -> EvalConfig:

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -14,6 +14,7 @@ from verifiers.v1.cli.output import (
     output_path,
     save_config,
 )
+from verifiers.v1.cli.resume import distribute, task_key
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.cli.eval import EvalConfig
 from verifiers.v1.env import Env, RunSlot
@@ -48,14 +49,13 @@ async def run_eval(env: Env, config: EvalConfig) -> list[Episode]:
     finished: list[Episode] = []
     if config.resume is not None:
         keys = [
-            resume.task_key(t.data.model_dump(mode="json", exclude_none=True))
-            for t in tasks
+            task_key(t.data.model_dump(mode="json", exclude_none=True)) for t in tasks
         ]
         finished, owed = resume.load(out, keys, config.num_rollouts, env.complete)
         if not owed:  # already complete - report it and exit successfully
             print(resume.nothing_to_resume_msg(out, len(tasks), config.num_rollouts))
             raise SystemExit(0)
-        counts = resume.distribute(keys, owed, config.num_rollouts)
+        counts = distribute(keys, owed, config.num_rollouts)
         plan = [(task, n) for task, n in zip(tasks, counts) if n]
         logger.info(
             "resuming %s: %d task(s), %d rollout(s) owed",
@@ -179,7 +179,7 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
         client = EnvClient(address=address)
         await client.wait_for_server_startup(timeout=600)
         # A v1 run dispatches — and resumes — tasks by content: the client owns them,
-        # and `resume.task_key` is their identity. Only the legacy bridge is addressed
+        # and `task_key` is their identity. Only the legacy bridge is addressed
         # by dataset row (its dataset lives server-side, reported via `info`), and
         # only a legacy env group-scores; a v1 env scores siblings in its own rollout.
         if legacy:
@@ -209,14 +209,14 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
                     whole_task=group_scored,
                     key_of=lambda data: data.get("idx"),
                 )
-                counts = resume.distribute(idxs, owed, config.num_rollouts)
+                counts = distribute(idxs, owed, config.num_rollouts)
             else:
                 keys = [
-                    resume.task_key(t.data.model_dump(mode="json", exclude_none=True))
+                    task_key(t.data.model_dump(mode="json", exclude_none=True))
                     for t in tasks
                 ]
                 finished, owed = resume.load(out, keys, config.num_rollouts)
-                counts = resume.distribute(keys, owed, config.num_rollouts)
+                counts = distribute(keys, owed, config.num_rollouts)
             if not owed:  # already complete - report it and exit successfully
                 print(resume.nothing_to_resume_msg(out, len(plan), config.num_rollouts))
                 raise SystemExit(0)

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -10,6 +10,7 @@ from verifiers.v1.cli.dashboard import dashboard
 from verifiers.v1.cli.eval import resume
 from verifiers.v1.cli.output import (
     append_episode,
+    append_trace,
     output_path,
     save_config,
 )
@@ -76,7 +77,8 @@ async def run_eval(env: Env, config: EvalConfig) -> list[Episode]:
     write_lock = asyncio.Lock()
 
     async def on_complete(episode: Episode) -> None:
-        episode.record_run(EvalRunInfo(id=config.uuid))
+        for trace in episode.traces:
+            trace.record_run(EvalRunInfo(id=config.uuid))
         await append_episode(out, episode, write_lock)
 
     # Serving resources (shared tool servers, interception) come up once for the
@@ -256,10 +258,9 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
                 )
             records = []
             for trace in traces:
-                record = Episode.of(trace, env=config.env_id)
-                record.record_run(EvalRunInfo(id=config.uuid))
-                await append_episode(out, record, write_lock)
-                records.append(record)
+                trace.record_run(EvalRunInfo(id=config.uuid))
+                await append_trace(out, trace, write_lock, env=config.env_id)
+                records.append(Episode.of(trace))
             return records
 
         async def run_unit(payload: dict) -> list[Episode]:
@@ -270,7 +271,8 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
                     sampling=config.sampling,
                     **payload,
                 )
-            episode.record_run(EvalRunInfo(id=config.uuid))
+            for trace in episode.traces:
+                trace.record_run(EvalRunInfo(id=config.uuid))
             await append_episode(out, episode, write_lock)
             return [episode]
 

--- a/verifiers/v1/cli/resume.py
+++ b/verifiers/v1/cli/resume.py
@@ -1,0 +1,42 @@
+"""Resume primitives shared by eval-like CLIs."""
+
+import hashlib
+import json
+from collections.abc import Hashable, Mapping
+from pathlib import Path
+from typing import TypeVar
+
+K = TypeVar("K", bound=Hashable)
+
+
+def task_key(data: Mapping) -> str:
+    """Content identity for task wire data, independent of field order."""
+    return hashlib.sha256(json.dumps(data, sort_keys=True).encode()).hexdigest()
+
+
+def distribute(
+    selected_keys: list[K], owed: dict[K, int], num_results: int
+) -> list[int]:
+    """Spread each key's owed results over its selected instances, in order."""
+    remaining = dict(owed)
+    counts: list[int] = []
+    for key in selected_keys:
+        take = min(num_results, remaining.get(key, 0))
+        if take:
+            remaining[key] -= take
+        counts.append(take)
+    return counts
+
+
+def split_resume(argv: list[str], command: str) -> tuple[Path | None, list[str]]:
+    """Pull ``--resume <dir>`` from argv, returning the dir and other arguments."""
+    for i, arg in enumerate(argv):
+        if arg == "--resume":
+            if i + 1 >= len(argv):
+                raise SystemExit(
+                    f"--resume needs an output dir: uv run {command} --resume <dir>"
+                )
+            return Path(argv[i + 1]), argv[:i] + argv[i + 2 :]
+        if arg.startswith("--resume="):
+            return Path(arg.split("=", 1)[1]), argv[:i] + argv[i + 1 :]
+    return None, argv

--- a/verifiers/v1/cli/validate.py
+++ b/verifiers/v1/cli/validate.py
@@ -2,16 +2,23 @@
 
 import asyncio
 import contextlib
+import json
 import logging
 import sys
 import time
+import tomllib
+from collections import Counter, defaultdict
+from collections.abc import Mapping, Sequence
+from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
 from pydantic_config import cli
+from pydantic_core import from_json
 
 import verifiers.v1 as vf
 from verifiers.v1.cli.dashboard import TaskProgress, validate_dashboard
+from verifiers.v1.cli.output import CONFIG_FILE, write_config
 from verifiers.v1.cli.resolve import (
     extract_id,
     narrow_taskset_config,
@@ -19,11 +26,13 @@ from verifiers.v1.cli.resolve import (
     references_config_file,
     with_positional_taskset,
 )
+from verifiers.v1.cli.resume import distribute, split_resume, task_key
 from verifiers.v1.configs.cli.validate import ValidateConfig
 from verifiers.v1.runtimes import make_runtime
 from verifiers.v1.state import state_cls
 from verifiers.v1.task import Task
 from verifiers.v1.trace import Trace, TraceTask
+from verifiers.v1.utils.aio import run_shielded
 from verifiers.v1.utils.compile import resolve_runtime_config
 from verifiers.v1.utils.decorators import invoke
 from verifiers.v1.utils.interrupt import install_interrupt
@@ -31,10 +40,19 @@ from verifiers.v1.utils.logging import setup_logging
 
 logger = logging.getLogger(__name__)
 
+RESULTS_FILE = "results.jsonl"
+SUMMARY_FILE = "summary.json"
+LOG_FILE = "validate.log"
+FINAL_REASONS = frozenset({"valid", "invalid"})
+REASONS = ("valid", "invalid", "error", "timeout")
+
+ResultRow = dict[str, Any]
+
 USAGE = (
     "usage: uv run validate [<taskset-id>] [--only-setup | --only-gold] "
-    "[--runtime.type subprocess] [options] [@ file.toml]\n"
-    "       runs the gold and setup-only checks per task (no model)"
+    "[-o <output-dir>] [--runtime.type subprocess] [options] [@ file.toml]\n"
+    "       uv run validate --resume <output-dir>\n"
+    "       runs persisted gold and setup-only checks per task (no model)"
 )
 
 
@@ -45,7 +63,149 @@ def _narrow(argv: list[str]) -> type[ValidateConfig]:
     return narrow_taskset_config(ValidateConfig, extract_id(argv, "taskset"))
 
 
-ResultRow = dict[str, Any]
+def validation_mode(config: ValidateConfig) -> str:
+    if config.only_gold:
+        return "gold"
+    if config.only_setup:
+        return "setup"
+    return "all"
+
+
+def output_path(config: ValidateConfig) -> Path:
+    if config.output_dir is not None:
+        return config.output_dir
+    return Path("outputs") / f"{config.name}--validate" / config.uuid
+
+
+def _write_rows(path: Path, rows: Sequence[ResultRow]) -> None:
+    tmp = path.with_suffix(f"{path.suffix}.tmp")
+    with tmp.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, sort_keys=True, separators=(",", ":")) + "\n")
+    tmp.replace(path)
+
+
+def append_result(results_dir: Path, row: ResultRow) -> None:
+    data = json.dumps(row, sort_keys=True, separators=(",", ":")).encode()
+    with (results_dir / RESULTS_FILE).open("ab") as f:
+        f.write(data + b"\n")
+
+
+def _is_final(row: object, key: str, mode: str) -> bool:
+    if not isinstance(row, dict):
+        return False
+    reason = row.get("reason")
+    return (
+        row.get("task_key") == key
+        and row.get("mode") == mode
+        and reason in FINAL_REASONS
+        and row.get("valid") is (reason == "valid")
+    )
+
+
+def load_results(
+    results_dir: Path, selected_keys: list[str], mode: str
+) -> tuple[list[ResultRow], dict[str, int]]:
+    """Keep final rows by eval task-content key; return counts owed per key."""
+    path = results_dir / RESULTS_FILE
+    targets = Counter(selected_keys)
+    good: dict[str, list[ResultRow]] = defaultdict(list)
+    if path.exists():
+        with path.open("rb") as f:
+            for line in f:
+                if not line.strip():
+                    continue
+                try:
+                    row = from_json(line)
+                except ValueError:
+                    try:
+                        row = json.loads(line)
+                    except (json.JSONDecodeError, UnicodeDecodeError):
+                        continue
+                if not isinstance(row, dict):
+                    continue
+                key = row.get("task_key")
+                if (
+                    isinstance(key, str)
+                    and key in targets
+                    and len(good[key]) < targets[key]
+                    and _is_final(row, key, mode)
+                ):
+                    good[key].append(row)
+
+    owed = {
+        key: target - len(good.get(key, []))
+        for key, target in targets.items()
+        if len(good.get(key, [])) < target
+    }
+    # Eval spreads debt over content-identical selected tasks in order. Assign the
+    # interchangeable kept rows to the remaining positions so reporting positions
+    # stay unique even when duplicate task content exists.
+    counts = distribute(selected_keys, owed, 1)
+    rows = []
+    used = Counter()
+    for position, (key, count) in enumerate(zip(selected_keys, counts)):
+        if count:
+            continue
+        row = good[key][used[key]]
+        used[key] += 1
+        rows.append({**row, "task_position": position})
+    _write_rows(path, rows)
+    return rows, owed
+
+
+def summarize(rows: Sequence[ResultRow], total: int, mode: str) -> dict[str, Any]:
+    counts = Counter(row.get("reason") for row in rows)
+    missing = max(0, total - len(rows))
+    outcomes = {reason: counts[reason] for reason in REASONS}
+    outcomes["missing"] = missing
+    terminal = outcomes["valid"] + outcomes["invalid"]
+    summary: dict[str, Any] = {
+        "mode": mode,
+        "total": total,
+        "recorded": len(rows),
+        "terminal": terminal,
+        "owed": missing + outcomes["error"] + outcomes["timeout"],
+        "outcomes": outcomes,
+        "valid_rate": round(outcomes["valid"] / total, 6) if total else None,
+    }
+    if mode == "all":
+        checks: dict[str, dict[str, int]] = {}
+        for check in ("gold", "setup"):
+            check_counts = Counter(
+                row.get(check, {}).get("reason")
+                for row in rows
+                if isinstance(row.get(check), dict)
+            )
+            checks[check] = {reason: check_counts[reason] for reason in REASONS}
+            checks[check]["missing"] = missing
+        summary["checks"] = checks
+    return summary
+
+
+def write_summary(results_dir: Path, summary: Mapping[str, Any]) -> None:
+    path = results_dir / SUMMARY_FILE
+    tmp = path.with_suffix(f"{path.suffix}.tmp")
+    tmp.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+    tmp.replace(path)
+
+
+def save_run(config: ValidateConfig, results_dir: Path, total: int) -> None:
+    write_config(config, results_dir)
+    (results_dir / RESULTS_FILE).write_text("")
+    write_summary(results_dir, summarize([], total, validation_mode(config)))
+
+
+def load_resume_config(resume_dir: Path) -> ValidateConfig:
+    path = resume_dir / CONFIG_FILE
+    if not path.exists():
+        raise SystemExit(
+            f"--resume: no config.toml in {resume_dir} - not a validate output dir"
+        )
+    config = ValidateConfig.model_validate(tomllib.loads(path.read_text()))
+    config.resume = resume_dir
+    config.output_dir = resume_dir
+    return config
 
 
 def _classify(valid: bool, exc: BaseException | None) -> str:
@@ -217,27 +377,64 @@ async def run_validate(config: ValidateConfig) -> list[dict]:
         raise SystemExit(
             "taskset needs a container runtime to validate - pass --runtime.type docker (or prime)"
         )
-    checks = (
-        "gold" if config.only_gold else "setup" if config.only_setup else "gold+setup"
-    )
+    mode = validation_mode(config)
+    checks = "gold+setup" if mode == "all" else mode
+    out = output_path(config)
+    selected_keys = [
+        task_key(task.data.model_dump(mode="json", exclude_none=True)) for task in tasks
+    ]
+    if config.resume is None:
+        save_run(config, out, len(tasks))
+        rows: list[ResultRow] = []
+        counts = [1] * len(tasks)
+    else:
+        rows, owed = load_results(out, selected_keys, mode)
+        counts = distribute(selected_keys, owed, 1)
+        write_summary(out, summarize(rows, len(tasks), mode))
+    plan = [
+        (position, task, key)
+        for position, (task, key, count) in enumerate(zip(tasks, selected_keys, counts))
+        if count
+    ]
     logger.info(
-        "validating %d task(s) from %s on the %s runtime (%s)",
+        "%s %d/%d task(s) from %s on the %s runtime (%s)",
+        "resuming" if config.resume is not None else "validating",
+        len(plan),
         len(tasks),
         config.name,
         config.runtime.type,
         checks,
     )
+    logger.info("results: %s", out)
 
     sem = asyncio.Semaphore(config.max_concurrent) if config.max_concurrent else None
     states = [TaskProgress(idx=t.data.idx, name=t.data.name) for t in tasks]
-    state_by_idx = {s.idx: s for s in states}
+    for row in rows:
+        state = states[row["task_position"]]
+        state.state = row["reason"]
 
-    async def _one(task) -> dict:
-        st = state_by_idx[task.data.idx]
+    write_lock = asyncio.Lock()
+
+    async def _one(position: int, task: Task, key: str) -> ResultRow:
+        st = states[position]
         async with sem or contextlib.nullcontext():
             st.start = time.time()
             st.state = "running"
             row = await _validate_task(task, config)
+        row["task_position"] = position
+        row["task_key"] = key
+
+        async def persist() -> None:
+            async with write_lock:
+                await asyncio.to_thread(append_result, out, row)
+                rows.append(row)
+                await asyncio.to_thread(
+                    write_summary,
+                    out,
+                    summarize(rows, len(tasks), mode),
+                )
+
+        await run_shielded(persist())
         st.end, st.state = time.time(), row["reason"]
         if not config.rich:  # the dashboard shows this live; otherwise log each task
             detail = f" - {row['error']}" if row["error"] else ""
@@ -257,7 +454,17 @@ async def run_validate(config: ValidateConfig) -> list[dict]:
         else contextlib.nullcontext()
     )
     async with display:
-        return await asyncio.gather(*(_one(t) for t in tasks))
+        if not plan:
+            logger.info(
+                "nothing to resume: all %d task(s) are valid or invalid", len(tasks)
+            )
+            return rows
+        await asyncio.gather(
+            *(_one(position, task, key) for position, task, key in plan)
+        )
+    rows.sort(key=lambda row: row["task_position"])
+    write_summary(out, summarize(rows, len(tasks), mode))
+    return rows
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -271,27 +478,46 @@ def main(argv: list[str] | None = None) -> None:
         with plugin_errors():
             cli(_narrow(argv))  # full option help, narrowed to the given taskset
         return
-    if not extract_id(argv, "taskset") and not references_config_file(argv):
-        raise SystemExit(
-            USAGE
-        )  # need a taskset (positional / --taskset.id) or a @ file.toml
+    resume_dir, rest = split_resume(argv, "validate")
+    if resume_dir is not None:
+        if rest:
+            raise SystemExit(
+                f"{USAGE}\n--resume replays the saved config and takes no other arguments"
+            )
+        with plugin_errors():
+            config = load_resume_config(resume_dir)
+    else:
+        if not extract_id(argv, "taskset") and not references_config_file(argv):
+            raise SystemExit(
+                USAGE
+            )  # need a taskset (positional / --taskset.id) or a @ file.toml
 
-    with plugin_errors():
-        config_type = _narrow(argv)
-        sys.argv = [
-            sys.argv[0],
-            *argv,
-        ]  # let prime-pydantic-config render help/errors
-        config = cli(config_type)
-    # Nothing is persisted, so logs are the whole output. Under `--rich` the dashboard owns the
-    # screen, so keep logs off the console (else stray records print over the UI).
-    setup_logging("DEBUG" if config.verbose else "INFO", console=not config.rich)
+        with plugin_errors():
+            config_type = _narrow(argv)
+            sys.argv = [
+                sys.argv[0],
+                *argv,
+            ]  # let prime-pydantic-config render help/errors
+            config = cli(config_type)
+    out = output_path(config)
+    setup_logging(
+        "DEBUG" if config.verbose else "INFO",
+        log_file=str(out / LOG_FILE),
+        console=not config.rich,
+    )
     if config.rich:
         logging.lastResort = None  # drop stdlib records that bypass loguru
     # Graceful shutdown: first Ctrl-C/SIGTERM unwinds each task's teardown `finally`
     # (containers/sandboxes); a second is swallowed so it can't orphan them mid-cleanup.
     install_interrupt()
-    asyncio.run(run_validate(config))
+    try:
+        asyncio.run(run_validate(config))
+    except KeyboardInterrupt:
+        print(f"interrupted; partial results: {out}", file=sys.stderr)
+        raise SystemExit(130)
+    summary = json.loads((out / SUMMARY_FILE).read_text())
+    print(f"results: {out}")
+    print(json.dumps(summary, indent=2, sort_keys=True))
 
 
 if __name__ == "__main__":

--- a/verifiers/v1/configs/cli/validate.py
+++ b/verifiers/v1/configs/cli/validate.py
@@ -1,5 +1,8 @@
 """Configuration for model-free task validation."""
 
+from pathlib import Path
+from uuid import uuid4
+
 from pydantic import AliasChoices, Field, SerializeAsAny, model_validator
 from pydantic_config import BaseConfig
 
@@ -16,6 +19,9 @@ class CheckTimeoutConfig(BaseConfig):
 
 
 class ValidateConfig(BaseConfig):
+    uuid: str = Field(default_factory=lambda: str(uuid4()), exclude=True)
+    """Auto-generated run id — the default output directory leaf. Excluded from the
+    saved config so re-running it starts a fresh run."""
     taskset: SerializeAsAny[TasksetConfig] = TasksetConfig()
     runtime: RuntimeConfig = DockerConfig()
     """Where each task's validation hooks run."""
@@ -40,6 +46,14 @@ class ValidateConfig(BaseConfig):
     """Log at debug level instead of the default info."""
     rich: bool = True
     """Show a live dashboard (one row per task) instead of per-task log lines."""
+    output_dir: Path | None = Field(
+        None, validation_alias=AliasChoices("output_dir", "o")
+    )
+    """Where to write config.toml, results.jsonl, summary.json, and validate.log. None
+    creates a fresh run under outputs/<taskset>--validate/<uuid>."""
+    resume: Path | None = Field(None, exclude=True)
+    """Set by --resume: re-run missing, errored, and timed-out tasks in this directory.
+    The saved config is replayed verbatim, so resume takes no other arguments."""
 
     @property
     def name(self) -> str:

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -141,7 +141,11 @@ def _content_to_wire(content):
 
 def message_to_wire(message: Message) -> dict:
     if message.role == "assistant":
-        wire: dict = {"role": "assistant", "content": message.content}
+        # Strict providers reject `content: null` without tool calls.
+        content = message.content
+        if content is None and not message.tool_calls:
+            content = ""
+        wire: dict = {"role": "assistant", "content": content}
         if message.provider_state:
             wire["reasoning_details"] = message.provider_state
         elif message.reasoning_content is not None:

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -13,6 +13,7 @@ from dataclasses import field as dataclass_field
 from typing import Any
 
 from openai.types.chat import ChatCompletion
+from openai.types.chat.chat_completion import Choice
 
 from verifiers.v1.dialects.base import Dialect, StreamParser, parse_sse_event
 from verifiers.v1.types import (
@@ -33,6 +34,15 @@ from verifiers.v1.types import (
 )
 
 
+class ModdedChoice(Choice):
+    """Providers also emit `finish_reason` values outside the SDK's `Literal` (e.g. `error`
+    when an upstream turn dies mid-stream), which makes `model_validate` reject the whole
+    completion. Widen it to a plain string; `response_from_wire` maps out-of-enum values
+    to `None`."""
+
+    finish_reason: str | None = None  # type: ignore[assignment]
+
+
 class ModdedChatCompletion(ChatCompletion):
     """The OpenAI SDK closes `service_tier` to a fixed `Literal`, but providers return tiers
     outside it (e.g. Prime's `provisioned`), which makes `model_validate` reject an otherwise
@@ -40,6 +50,7 @@ class ModdedChatCompletion(ChatCompletion):
     lenient about the label instead of dropping it."""
 
     service_tier: str | None = None
+    choices: list[ModdedChoice]  # type: ignore[assignment]
 
 
 FINISH_REASONS = frozenset({"stop", "length", "tool_calls"})

--- a/verifiers/v1/envs/user_sim/env.py
+++ b/verifiers/v1/envs/user_sim/env.py
@@ -21,13 +21,14 @@ from pydantic import Field
 
 import verifiers.v1 as vf
 
-PERSONA = """You are role-playing a USER talking to an AI assistant. This is your situation and goal:
+PERSONA = """You are role-playing a USER talking to an AI assistant. This is your situation — what you want the ASSISTANT to do for you:
 
 {scenario}
 
 Rules:
 - Open the conversation with your request, in your own words.
 - Stay in character: short, natural user messages; never act as the assistant.
+- The assistant does the work, not you: never perform the task yourself — any tool call, answer, or output format it asks for must come from the assistant; ask for it instead.
 - Reveal details only when asked, as a real user would.
 - When the assistant has fully met your goal — or you are convinced it cannot — reply with exactly {done} and nothing else."""
 

--- a/verifiers/v1/episode.py
+++ b/verifiers/v1/episode.py
@@ -1,14 +1,14 @@
 """The episode — one run's traces plus their shared standing, whole."""
 
 import uuid
-from typing import Any, Generic
+from typing import Generic
 
 from pydantic import BaseModel, Field
 
 from verifiers.v1.configs.agent import WireAgentConfig
 from verifiers.v1.state import State, StateT
 from verifiers.v1.task import DataT, WireTaskData
-from verifiers.v1.trace import AgentConfigT, Error, RunInfo, Trace
+from verifiers.v1.trace import AgentConfigT, Error, Trace
 from verifiers.v1.types import Usage
 
 
@@ -26,19 +26,12 @@ class Episode(BaseModel, Generic[DataT, StateT, AgentConfigT]):
 
     env: EnvInfo = Field(default_factory=EnvInfo)
     """The env that produced this episode."""
-    run: RunInfo | None = None
-    """The run this episode belongs to (eval or train), consumer-stamped. It lives here rather than
-    on each trace because the episode is what a consumer dispatches, and an episode that produced
-    no traces would otherwise have nowhere to say which run it was."""
     ok: bool = False
     """Whether the episode completed successfully."""
     errors: list[Error] = Field(default_factory=list)
     """Every error captured across attempts, oldest to newest."""
     traces: list[Trace[DataT, StateT, AgentConfigT]] = Field(default_factory=list)
     """Every agent's trace, in completion order."""
-    info: dict[str, Any] = Field(default_factory=dict)
-    """Scratch space for episode-level metadata, the counterpart to `Trace.info`. What describes
-    the whole episode belongs here rather than repeated on each of its traces."""
 
     @property
     def last_error(self) -> Error | None:
@@ -78,13 +71,6 @@ class Episode(BaseModel, Generic[DataT, StateT, AgentConfigT]):
         for trace in self.traces:
             grouped.setdefault(trace.agent.name, []).append(trace)
         return grouped
-
-    def record_run(self, run: RunInfo | None = None, **info: Any) -> None:
-        """Record the run identity and any extra metadata about this episode. Both describe the
-        episode as a whole, so they are recorded once here rather than repeated on every trace."""
-        if run is not None:
-            self.run = run
-        self.info.update(info)
 
     @classmethod
     def of(cls, trace: Trace, env: str = "") -> "Episode":

--- a/verifiers/v1/harnesses/__init__.py
+++ b/verifiers/v1/harnesses/__init__.py
@@ -21,6 +21,10 @@ from verifiers.v1.harnesses.null import NullHarness, NullHarnessConfig
 from verifiers.v1.harnesses.openclaw import OpenClawHarness, OpenClawHarnessConfig
 from verifiers.v1.harnesses.pi import PiHarness, PiHarnessConfig
 from verifiers.v1.harnesses.pool import PoolHarness, PoolHarnessConfig
+from verifiers.v1.harnesses.prime_agent import (
+    PrimeAgentHarness,
+    PrimeAgentHarnessConfig,
+)
 from verifiers.v1.harnesses.rlm import RLMHarness, RLMHarnessConfig
 from verifiers.v1.harnesses.terminus_2 import Terminus2Harness, Terminus2HarnessConfig
 
@@ -47,6 +51,8 @@ __all__ = [
     "PiHarnessConfig",
     "PoolHarness",
     "PoolHarnessConfig",
+    "PrimeAgentHarness",
+    "PrimeAgentHarnessConfig",
     "RLMHarness",
     "RLMHarnessConfig",
     "Terminus2Harness",

--- a/verifiers/v1/harnesses/claude_code/harness.py
+++ b/verifiers/v1/harnesses/claude_code/harness.py
@@ -1,56 +1,116 @@
-"""Run Claude Code against interception as an Anthropic Messages client."""
+"""Run Claude Code through the Claude Agent SDK ACP adapter."""
 
-import json
 import shlex
 
-from pydantic import Field
-
+from verifiers.v1.acp import ACP
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
-from verifiers.v1.harness import Harness
+from verifiers.v1.harness import Harness, HarnessSession
+from verifiers.v1.harnesses.node import NODE_BIN_DIR, ensure_node
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
 
-CLAUDE_HOME = "/tmp/vf-claude-code-{version}"
-CLAUDE_BIN = f"{CLAUDE_HOME}/.local/bin/claude"
-CLAUDE_CONFIG_DIR = ".vf-claude"
-SKILLS_DIR = f"{CLAUDE_CONFIG_DIR}/skills"
-INSTALL = """
+CLAUDE_ACP_DIR = "/var/tmp/vf-claude-agent-acp"
+PACKAGES_DIR = f"{CLAUDE_ACP_DIR}/packages"
+ACP_VERSION = "0.63.0"
+ACP_BIN = f"{PACKAGES_DIR}/node_modules/.bin/claude-agent-acp"
+ACP_COMMAND = [f"{NODE_BIN_DIR}/node", ACP_BIN]
+CLAUDE_CONFIG_ROOT = ".vf-claude"
+SKILLS_DIR = ".claude/skills"
+ACP_INSTALL = r"""
 set -e
-command -v curl >/dev/null || (apt-get update -qq && apt-get install -y -qq curl ca-certificates >/dev/null)
-curl -fsSL https://claude.ai/install.sh | HOME={home} bash -s {version}
+export PATH="/var/tmp/vf-node/bin:$PATH"
+if [ "$(cat /var/tmp/vf-claude-agent-acp/.version 2>/dev/null)" = "$VF_CLAUDE_ACP_VERSION" ] \
+    && [ -x /var/tmp/vf-claude-agent-acp/packages/node_modules/.bin/claude-agent-acp ]; then
+    exit 0
+fi
+npm install --prefix /var/tmp/vf-claude-agent-acp/packages --ignore-scripts --no-audit --no-fund \
+    --omit=dev \
+    "@agentclientprotocol/claude-agent-acp@$VF_CLAUDE_ACP_VERSION" >/dev/null
+printf %s "$VF_CLAUDE_ACP_VERSION" > /var/tmp/vf-claude-agent-acp/.version
 """
+
+CLAUDE_ACP = ACP()
 
 
 class ClaudeCodeHarnessConfig(HarnessConfig):
-    version: str = Field(default="2.1.214", pattern=r"^[A-Za-z0-9._+-]+$")
-    """Claude Code release to install; pinned for reproducibility."""
+    pass
 
 
 class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
     APPENDS_SYSTEM_PROMPT = True
     SUPPORTS_MCP = True
-    # images would require streaming inputs
-    SUPPORTS_RESUME = False
+    SUPPORTS_RESUME = True
     SUPPORTS_SKILLS = True
 
     async def setup(self, runtime: Runtime) -> None:
         await self.install_skills(runtime, SKILLS_DIR)
-        home = CLAUDE_HOME.format(version=self.config.version)
-        binary = CLAUDE_BIN.format(version=self.config.version)
-        script = INSTALL.format(version=self.config.version, home=home)
-        # Cache the pinned binary across local rollouts; Linux has flock, macOS has lockf.
-        install = shlex.quote(f"[ -x {binary} ] || ({script})")
-        guarded = (
-            f"mkdir -p {home} && "
-            f'"$(command -v flock || command -v lockf)" {home}/install.lock '
-            f"bash -o pipefail -c {install}"
+        await ensure_node(runtime)
+        acp_guarded = (
+            f"mkdir -p {CLAUDE_ACP_DIR} && "
+            f'"$(command -v flock || command -v lockf)" {CLAUDE_ACP_DIR}/install.lock '
+            f"sh -c {shlex.quote(ACP_INSTALL)}"
         )
-        result = await runtime.run(["sh", "-c", guarded], self.config.resolved_env)
-        if result.exit_code != 0:
-            detail = (result.stderr or result.stdout).strip()[-500:]
-            raise RuntimeError(f"Claude Code install failed: {detail}")
+        acp_result = await runtime.run(
+            ["sh", "-c", acp_guarded],
+            {
+                **self.config.resolved_env,
+                "VF_CLAUDE_ACP_VERSION": ACP_VERSION,
+            },
+        )
+        if acp_result.exit_code != 0:
+            detail = (acp_result.stderr or acp_result.stdout).strip()[-500:]
+            raise RuntimeError(f"Claude Agent ACP install failed: {detail}")
+        await CLAUDE_ACP.setup(self, runtime)
+
+    async def session(
+        self,
+        ctx: ModelContext,
+        trace: Trace,
+        runtime: Runtime,
+        endpoint: str,
+        secret: str,
+        mcp_urls: dict[str, str],
+        data: TaskData,
+    ) -> HarnessSession:
+        if not runtime.supports_live_processes:
+            return await super().session(
+                ctx, trace, runtime, endpoint, secret, mcp_urls, data
+            )
+        system_prompt, prompt = self.resolve_prompt(data)
+        config_dir = self.config_dir(trace)
+        options: dict[str, object] = {
+            "strictMcpConfig": True,
+            "disallowedTools": self.config.disabled_tools or [],
+        }
+        session_meta: dict[str, object] = {"claudeCode": {"options": options}}
+        if system_prompt:
+            session_meta["systemPrompt"] = {"append": system_prompt}
+        env = {
+            **self.config.resolved_env,
+            "ANTHROPIC_BASE_URL": endpoint.removesuffix("/v1"),
+            "ANTHROPIC_API_KEY": secret,
+            "ANTHROPIC_MODEL": ctx.model,
+            "CLAUDE_CONFIG_DIR": config_dir,
+            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+            "DISABLE_AUTOUPDATER": "1",
+            "IS_SANDBOX": "1",
+        }
+        return CLAUDE_ACP.session(
+            self,
+            ctx,
+            trace,
+            runtime,
+            endpoint,
+            secret,
+            mcp_urls,
+            data,
+            env=env,
+            command=ACP_COMMAND,
+            prompt=prompt or "",
+            session_meta=session_meta,
+        )
 
     async def launch(
         self,
@@ -62,44 +122,44 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
         mcp_urls: dict[str, str],
         data: TaskData,
     ) -> ProgramResult:
-        system_prompt, instruction = self.resolve_text_prompt(data)
+        system_prompt, prompt = self.resolve_prompt(data)
+        config_dir = self.config_dir(trace)
+
+        options: dict[str, object] = {
+            "strictMcpConfig": True,
+            "disallowedTools": self.config.disabled_tools or [],
+        }
+        session_meta: dict[str, object] = {"claudeCode": {"options": options}}
+        if system_prompt:
+            session_meta["systemPrompt"] = {"append": system_prompt}
         env = {
             **self.config.resolved_env,
             # Claude appends /v1/messages; give it the interception root, not the model endpoint.
             "ANTHROPIC_BASE_URL": endpoint.removesuffix("/v1"),
             "ANTHROPIC_API_KEY": secret,
-            "CLAUDE_CONFIG_DIR": CLAUDE_CONFIG_DIR,
+            "ANTHROPIC_MODEL": ctx.model,
+            "CLAUDE_CONFIG_DIR": config_dir,
             "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
             "DISABLE_AUTOUPDATER": "1",
             "IS_SANDBOX": "1",
         }
-        argv = [
-            CLAUDE_BIN.format(version=self.config.version),
-            "--print",
-            "--dangerously-skip-permissions",
-            "--no-session-persistence",
-            "--model",
-            ctx.model,
-        ]
-        if system_prompt:
-            argv += ["--append-system-prompt", system_prompt]
-        argv += [
-            arg
-            for tool in self.config.disabled_tools or []
-            for arg in ("--disallowedTools", tool)
-        ]
-        mcp = {
-            "mcpServers": {
-                name: {"type": "http", "url": url} for name, url in mcp_urls.items()
-            }
-        }
-        mcp_path = f"{CLAUDE_CONFIG_DIR}/mcp.json"
-        await runtime.write(mcp_path, json.dumps(mcp).encode())
-        argv += [
-            "--mcp-config",
-            mcp_path,
-            "--strict-mcp-config",
-            "--",
-            instruction or "",
-        ]
-        return await runtime.run_program(argv, env)
+        return await CLAUDE_ACP.run(
+            runtime,
+            env,
+            ACP_COMMAND,
+            prompt or "",
+            mcp_urls=mcp_urls,
+            session_path=f"{config_dir}/acp-session",
+            session_meta=session_meta,
+        )
+
+    async def cleanup(self, trace: Trace, runtime: Runtime) -> None:
+        result = await runtime.run(["rm", "-rf", self.config_dir(trace)], {})
+        if result.exit_code != 0:
+            raise RuntimeError(
+                f"failed to clean up Claude config: {result.stderr.strip()[-500:]}"
+            )
+
+    @staticmethod
+    def config_dir(trace: Trace) -> str:
+        return f"{CLAUDE_CONFIG_ROOT}/{trace.id}"

--- a/verifiers/v1/harnesses/codex/harness.py
+++ b/verifiers/v1/harnesses/codex/harness.py
@@ -1,9 +1,5 @@
-"""Codex reaches interception as a Responses API provider using the session secret.
+"""Run Codex through its App Server-backed ACP adapter."""
 
-The static musl binary runs in Linux containers without additional runtime dependencies.
-"""
-
-import base64
 import hashlib
 import json
 import logging
@@ -11,39 +7,47 @@ import re
 import shlex
 from collections import Counter
 
+from verifiers.v1.acp import ACP
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
-from verifiers.v1.harness import Harness
+from verifiers.v1.harness import Harness, HarnessSession
+from verifiers.v1.harnesses.node import NODE_BIN_DIR, ensure_node
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
-from verifiers.v1.types import TextContentPart
 
 logger = logging.getLogger(__name__)
 
-# The provider id we register on the fly via `-c` overrides — arbitrary, internal to codex.
 PROVIDER = "intercept"
-# The env var codex reads the provider api key (its bearer = the session secret) from.
 KEY_VAR = "CODEX_INTERCEPT_KEY"
 
-CODEX_DIR = "/tmp/vf-codex"
-CODEX_BIN = f"{CODEX_DIR}/bin/codex"
+CODEX_DIR = "/var/tmp/vf-codex"
+PACKAGES_DIR = f"{CODEX_DIR}/acp"
+CODEX_VERSION = "0.145.0"
+ACP_VERSION = "1.1.7"
+ACP_BIN = f"{PACKAGES_DIR}/node_modules/.bin/codex-acp"
+ACP_COMMAND = [f"{NODE_BIN_DIR}/node", ACP_BIN]
 SKILLS_DIR = ".agents/skills"
 INSTALL = r"""
 set -e
-mkdir -p {dir}/bin
-command -v curl >/dev/null 2>&1 || { apt-get update -qq && apt-get install -y -qq curl >/dev/null; }
-case "$(uname -m)" in aarch64|arm64) arch=aarch64 ;; *) arch=x86_64 ;; esac
-triple="${arch}-unknown-linux-musl"
-curl -fsSL "https://github.com/openai/codex/releases/download/rust-v{version}/codex-${triple}.tar.gz" | tar -xz -C {dir}/bin
-mv "{dir}/bin/codex-${triple}" {bin}
-chmod +x {bin}
+export PATH="/var/tmp/vf-node/bin:$PATH"
+versions="$VF_CODEX_VERSION:$VF_CODEX_ACP_VERSION"
+if [ "$(cat /var/tmp/vf-codex/.versions 2>/dev/null)" = "$versions" ] \
+    && [ -x /var/tmp/vf-codex/acp/node_modules/.bin/codex ] \
+    && [ -x /var/tmp/vf-codex/acp/node_modules/.bin/codex-acp ]; then
+    exit 0
+fi
+npm install --prefix /var/tmp/vf-codex/acp --ignore-scripts --no-audit --no-fund \
+    --omit=dev \
+    "@agentclientprotocol/codex-acp@$VF_CODEX_ACP_VERSION" \
+    "@openai/codex@$VF_CODEX_VERSION" >/dev/null
+printf %s "$versions" > /var/tmp/vf-codex/.versions
 """
+
+CODEX_ACP = ACP()
 
 
 class CodexHarnessConfig(HarnessConfig):
-    version: str = "0.144.5"
-    """Codex release to install (the `rust-v<version>` GitHub release); pinned for reproducibility."""
     multi_agent: bool = False
     """Enable Codex's native multi-agent v2 tools."""
 
@@ -56,20 +60,62 @@ class CodexHarness(Harness[CodexHarnessConfig]):
 
     async def setup(self, runtime: Runtime) -> None:
         await self.install_skills(runtime, SKILLS_DIR)
-        logger.info("codex: ensuring codex %s is installed", self.config.version)
-        script = (
-            INSTALL.replace("{version}", self.config.version)
-            .replace("{dir}", CODEX_DIR)
-            .replace("{bin}", CODEX_BIN)
+        await ensure_node(runtime)
+        logger.info(
+            "codex: ensuring Codex %s and codex-acp %s are installed",
+            CODEX_VERSION,
+            ACP_VERSION,
         )
-        ensure = shlex.quote(f"[ -x {CODEX_BIN} ] || ({script})")
-        # Shared local runtimes may provision concurrently; only the first downloads.
         guarded = (
-            f"mkdir -p {CODEX_DIR} && flock {CODEX_DIR}/install.lock sh -c {ensure}"
+            f"mkdir -p {CODEX_DIR} && "
+            f'"$(command -v flock || command -v lockf)" {CODEX_DIR}/install.lock '
+            f"sh -c {shlex.quote(INSTALL)}"
         )
-        install = await runtime.run(["sh", "-c", guarded], {})
+        install = await runtime.run(
+            ["sh", "-c", guarded],
+            {
+                **self.config.resolved_env,
+                "VF_CODEX_VERSION": CODEX_VERSION,
+                "VF_CODEX_ACP_VERSION": ACP_VERSION,
+            },
+        )
         if install.exit_code != 0:
             raise RuntimeError(f"codex install failed: {install.stderr.strip()[-500:]}")
+        await CODEX_ACP.setup(self, runtime)
+
+    async def session(
+        self,
+        ctx: ModelContext,
+        trace: Trace,
+        runtime: Runtime,
+        endpoint: str,
+        secret: str,
+        mcp_urls: dict[str, str],
+        data: TaskData,
+    ) -> HarnessSession:
+        if not runtime.supports_live_processes:
+            return await super().session(
+                ctx, trace, runtime, endpoint, secret, mcp_urls, data
+            )
+        if data.system_prompt is not None and not isinstance(data.prompt, str):
+            system_prompt, prompt = data.system_prompt, data.prompt
+        else:
+            system_prompt, prompt = self.resolve_prompt(data)
+        env = await self.build_env(ctx, trace, runtime, endpoint, secret, mcp_urls)
+        return CODEX_ACP.session(
+            self,
+            ctx,
+            trace,
+            runtime,
+            endpoint,
+            secret,
+            {},
+            data,
+            env=env,
+            command=ACP_COMMAND,
+            prompt=prompt,
+            system_prompt=system_prompt,
+        )
 
     async def launch(
         self,
@@ -81,76 +127,36 @@ class CodexHarness(Harness[CodexHarnessConfig]):
         mcp_urls: dict[str, str],
         data: TaskData,
     ) -> ProgramResult:
-        task = data
         if (
-            task.system_prompt is not None
-            and task.prompt is not None
-            and not isinstance(task.prompt, str)
+            data.system_prompt is not None
+            and data.prompt is not None
+            and not isinstance(data.prompt, str)
         ):
-            system_prompt, prompt = task.system_prompt, task.prompt
+            system_prompt, prompt = data.system_prompt, data.prompt
         else:
-            system_prompt, prompt = self.resolve_prompt(task)
-        image_args: list[str] = []
-        image_dir = f".vf-codex-images-{trace.id}"
-        if prompt is not None and not isinstance(prompt, str):
-            # Codex seeds one initial turn, so Messages system text joins its prompt.
-            texts = [system_prompt] if system_prompt else []
-            image_index = 0
-            for message in prompt:
-                if message.role not in ("system", "user"):
-                    raise ValueError(
-                        "codex exec only supports system and user initial messages"
-                    )
-                parts = (
-                    [TextContentPart(text=message.content)]
-                    if isinstance(message.content, str)
-                    else message.content
-                )
-                for part in parts:
-                    if isinstance(part, TextContentPart):
-                        texts.append(part.text)
-                        continue
-                    metadata, separator, encoded = part.image_url.url.partition(",")
-                    media_type, *parameters = metadata.removeprefix("data:").split(";")
-                    if (
-                        not separator
-                        or not metadata.startswith("data:image/")
-                        or not any(p.lower() == "base64" for p in parameters)
-                    ):
-                        raise ValueError(
-                            "codex image prompts require base64 data:image URLs"
-                        )
-                    extension = re.sub(
-                        r"[^a-zA-Z0-9]+", "_", media_type.removeprefix("image/")
-                    ).strip("_")
-                    path = f"{image_dir}/image_{image_index}.{extension or 'image'}"
-                    await runtime.write(path, base64.b64decode(encoded))
-                    image_args += ["-i", path]
-                    image_index += 1
-            prompt = "\n\n".join(texts)
-        argv = [
-            CODEX_BIN,
-            "exec",
-            *self._config_args(ctx, endpoint, mcp_urls),
-            *image_args,
-            "--",
+            system_prompt, prompt = self.resolve_prompt(data)
+        env = await self.build_env(ctx, trace, runtime, endpoint, secret, mcp_urls)
+        return await CODEX_ACP.run(
+            runtime,
+            env,
+            ACP_COMMAND,
             prompt,
-        ]
-        try:
-            return await runtime.run_program(
-                argv, await self._env(trace, runtime, secret)
-            )
-        finally:
-            if image_args:
-                try:
-                    await runtime.run(["rm", "-rf", image_dir], {})
-                except Exception:
-                    # Runtime teardown is the fallback; preserve the rollout result.
-                    logger.warning(
-                        "failed to clean up Codex prompt images", exc_info=True
-                    )
+            system_prompt=system_prompt,
+            session_path=f"{self.trace_home(trace)}/acp-session",
+        )
 
-    async def resume(
+    async def cleanup(self, trace: Trace, runtime: Runtime) -> None:
+        result = await runtime.run(["rm", "-rf", self.trace_home(trace)], {})
+        if result.exit_code != 0:
+            raise RuntimeError(
+                f"failed to clean up Codex home: {result.stderr.strip()[-500:]}"
+            )
+
+    @staticmethod
+    def trace_home(trace: Trace) -> str:
+        return f"/tmp/vf-codex-home-{trace.id}"
+
+    async def build_env(
         self,
         ctx: ModelContext,
         trace: Trace,
@@ -158,121 +164,33 @@ class CodexHarness(Harness[CodexHarnessConfig]):
         endpoint: str,
         secret: str,
         mcp_urls: dict[str, str],
-        data: TaskData,
-        messages,
-    ) -> ProgramResult:
-        """Native continuation: `codex exec resume --last` re-opens the session the
-        previous segment recorded — codex's own context, compaction included — and
-        takes the user's next turn. Nothing is replayed into its prompt (replaying
-        our view of the conversation would fight codex's own session state, which is
-        exactly why the default relaunch-resume is wrong for it). The rollout's
-        per-trace `CODEX_HOME` (see `_env`) makes `--last` unambiguous even when a
-        borrowed runtime hosts several rollouts."""
-        texts: list[str] = []
-        for message in messages:
-            if message.role != "user":
-                raise ValueError("codex resume takes user turns only")
-            parts = (
-                [TextContentPart(text=message.content)]
-                if isinstance(message.content, str)
-                else message.content
-            )
-            for part in parts:
-                if not isinstance(part, TextContentPart):
-                    raise TypeError(
-                        "codex resume supports text user turns only (images go in "
-                        "the opening prompt)"
-                    )
-                texts.append(part.text)
-        if trace.num_turns == 0:
-            return await self.launch(
-                ctx,
-                trace,
-                runtime,
-                endpoint,
-                secret,
-                mcp_urls,
-                data.model_copy(update={"prompt": messages}),
-            )
-        argv = [
-            CODEX_BIN,
-            "exec",
-            "resume",
-            "--last",
-            *self._config_args(ctx, endpoint, mcp_urls),
-            "--",
-            "\n\n".join(texts),
-        ]
-        return await runtime.run_program(argv, await self._env(trace, runtime, secret))
-
-    async def cleanup(self, trace: Trace, runtime: Runtime) -> None:
-        home = self._home(trace)
-        result = await runtime.run(["rm", "-rf", home], {})
-        if result.exit_code != 0:
+    ) -> dict[str, str]:
+        home = self.trace_home(trace)
+        created = await runtime.run(["mkdir", "-p", home], {})
+        if created.exit_code != 0:
             raise RuntimeError(
-                f"failed to clean up Codex home: {result.stderr.strip()[-500:]}"
+                f"failed to create Codex home: {created.stderr.strip()[-500:]}"
             )
 
-    @staticmethod
-    def _home(trace: Trace) -> str:
-        return f"/tmp/vf-codex-home-{trace.id}"
-
-    async def _env(self, trace: Trace, runtime: Runtime, secret: str) -> dict[str, str]:
-        # codex authenticates to the interception server with the session secret (its
-        # provider api key) and posts Responses calls to `{endpoint}/responses`. The
-        # per-trace CODEX_HOME scopes its recorded sessions to this rollout, so
-        # `exec resume --last` continues THIS exchange and never a neighbor's.
-        # codex refuses a home that doesn't exist, so make it before every segment.
-        home = self._home(trace)
-        await runtime.run(["mkdir", "-p", home], {})
-        return {
-            **self.config.resolved_env,
-            KEY_VAR: secret,
-            "CODEX_HOME": home,
-        }
-
-    def _config_args(
-        self,
-        ctx: ModelContext,
-        endpoint: str,
-        mcp_urls: dict[str, str],
-    ) -> list[str]:
-        # Values are Codex feature names such as `shell_tool`; Codex owns validation.
-        # https://developers.openai.com/codex/config-reference#features
-        tool_config = [
-            arg
-            for tool in self.config.disabled_tools or []
-            for arg in ("--disable", tool)
-        ]
-        # Set the whole table so dots in quoted server IDs are not interpreted as
-        # `-c` path separators.
         mcp_config = (
-            [
-                "-c",
-                "mcp_servers={"
-                + ",".join(
-                    (
-                        f"{json.dumps(name, ensure_ascii=False)}="
-                        f"{{url={json.dumps(url, ensure_ascii=False)},required=true,"
-                        f"startup_timeout_sec=60.0,tool_timeout_sec={self.config.tool_timeout}}}"
-                    )
-                    for name, url in mcp_urls.items()
-                )
-                + "}",
-            ]
-            if mcp_urls
-            else []
-        )
-
-        # Codex keeps raw server IDs for MCP calls but normalizes the namespaces
-        # exposed to the model. Mirror rust-v0.144.5's per-character replacement,
-        # optional prefix, collision hash, and possible 49-character truncation.
-        namespace_bases: dict[str, str] = {}
-        for name in mcp_urls:
-            namespace = re.sub(r"[^a-zA-Z0-9_]", "_", name) or "_"
-            namespace_bases[name] = (
-                namespace if namespace.startswith("mcp__") else f"mcp__{namespace}"
+            "mcp_servers={"
+            + ",".join(
+                f"{json.dumps(name, ensure_ascii=False)}="
+                f"{{url={json.dumps(url, ensure_ascii=False)},required=true,"
+                f"startup_timeout_sec=60.0,tool_timeout_sec={self.config.tool_timeout}}}"
+                for name, url in mcp_urls.items()
             )
+            + "}"
+            if mcp_urls
+            else ""
+        )
+        await runtime.write(f"{home}/config.toml", mcp_config.encode())
+
+        namespace_bases = {
+            name: (namespace if namespace.startswith("mcp__") else f"mcp__{namespace}")
+            for name in mcp_urls
+            for namespace in (re.sub(r"[^a-zA-Z0-9_]", "_", name) or "_",)
+        }
         namespace_counts = Counter(namespace_bases.values())
         direct_mcp_namespaces: list[str] = []
         for name, namespace in namespace_bases.items():
@@ -286,47 +204,43 @@ class CodexHarness(Harness[CodexHarnessConfig]):
             direct_mcp_namespaces.append(namespace)
             if len(namespace) > 49:
                 direct_mcp_namespaces.append(namespace[:49])
-        direct_mcp_namespaces = list(dict.fromkeys(direct_mcp_namespaces))
-        # `-c` values parse as TOML, falling back to a raw string (so the url / `responses`
-        # come through literally); `requires_openai_auth=false` parses as a bool.
-        return [
-            "--dangerously-bypass-approvals-and-sandbox",
-            "--skip-git-repo-check",
-            # Apps/plugins can flip on remotely and advertise definitions custom providers reject.
-            "--disable",
-            "apps",
-            "--disable",
-            "plugins",
-            "--disable",
-            "multi_agent",
-            # Preserve any user-supplied multi-agent v2 tool and limit settings.
-            "-c",
-            f"features.multi_agent_v2.enabled={str(self.config.multi_agent).lower()}",
-            "-m",
-            ctx.model,
-            "-c",
-            f"model_provider={PROVIDER}",
-            "-c",
-            f"model_providers.{PROVIDER}.name={PROVIDER}",
-            "-c",
-            f"model_providers.{PROVIDER}.base_url={endpoint}",
-            "-c",
-            f"model_providers.{PROVIDER}.env_key={KEY_VAR}",
-            "-c",
-            f"model_providers.{PROVIDER}.wire_api=responses",
-            "-c",
-            f"model_providers.{PROVIDER}.requires_openai_auth=false",
-            *tool_config,
-            *mcp_config,
-            *(
-                [
-                    "-c",
-                    (
-                        "features.code_mode.direct_only_tool_namespaces="
-                        f"{json.dumps(direct_mcp_namespaces)}"
-                    ),
-                ]
-                if direct_mcp_namespaces
-                else []
-            ),
-        ]
+
+        features: dict[str, object] = {
+            "apps": False,
+            "plugins": False,
+            "multi_agent": False,
+            "multi_agent_v2": {"enabled": self.config.multi_agent},
+            **{tool: False for tool in self.config.disabled_tools or []},
+        }
+        if direct_mcp_namespaces:
+            features["code_mode"] = {
+                "direct_only_tool_namespaces": list(
+                    dict.fromkeys(direct_mcp_namespaces)
+                )
+            }
+        config = {
+            "model": ctx.model,
+            "model_provider": PROVIDER,
+            "model_providers": {
+                PROVIDER: {
+                    "name": PROVIDER,
+                    "base_url": endpoint,
+                    "env_key": KEY_VAR,
+                    "wire_api": "responses",
+                    "requires_openai_auth": False,
+                }
+            },
+            "features": features,
+        }
+        return {
+            **self.config.resolved_env,
+            "CODEX_API_KEY": secret,
+            KEY_VAR: secret,
+            "APP_SERVER_LOGS": f"{home}/logs",
+            "CODEX_CONFIG": json.dumps(config),
+            "CODEX_HOME": home,
+            "DEFAULT_AUTH_REQUEST": json.dumps({"methodId": "api-key"}),
+            "INITIAL_AGENT_MODE": "agent-full-access",
+            "MODEL_PROVIDER": PROVIDER,
+            "NO_BROWSER": "1",
+        }

--- a/verifiers/v1/harnesses/node.py
+++ b/verifiers/v1/harnesses/node.py
@@ -1,0 +1,54 @@
+import shlex
+
+from verifiers.v1.runtimes import Runtime
+
+NODE_DIR = "/var/tmp/vf-node"
+NODE_BIN_DIR = f"{NODE_DIR}/bin"
+NODE_VERSION = "22.19.0"
+
+INSTALL = r"""
+set -e
+node=/var/tmp/vf-node
+node_ok() { "$node/bin/node" -e 'const [a,b]=process.versions.node.split(".").map(Number); process.exit(a>22 || a===22 && b>=19 ? 0 : 1)'; }
+
+if [ -f /etc/alpine-release ]; then
+    apk add --no-cache curl ca-certificates nodejs-current npm >/dev/null
+    if ! node -e 'const [a,b]=process.versions.node.split(".").map(Number); process.exit(a>22 || a===22 && b>=19 ? 0 : 1)'; then
+        sed -E -i 's/v[0-9]+\.[0-9]+/v3.22/g' /etc/apk/repositories
+        apk upgrade --available --no-cache >/dev/null
+        apk add --no-cache nodejs-current npm >/dev/null
+    fi
+    mkdir -p "$node/bin"
+    ln -sf "$(command -v node)" "$node/bin/node"
+    ln -sf "$(command -v npm)" "$node/bin/npm"
+else
+    command -v curl >/dev/null 2>&1 \
+        || { apt-get update -qq && apt-get install -y -qq curl ca-certificates >/dev/null; }
+    case "$(uname -s)" in Linux) node_os=linux ;; Darwin) node_os=darwin ;; *) echo "unsupported os: $(uname -s)" >&2; exit 1 ;; esac
+    if [ ! -x "$node/bin/node" ] || [ "$("$node/bin/node" --version 2>/dev/null)" != "v$VF_NODE_VERSION" ]; then
+        case "$(uname -m)" in aarch64|arm64) node_arch=arm64 ;; *) node_arch=x64 ;; esac
+        rm -rf "$node"
+        mkdir -p "$node"
+        curl -fsSL "https://nodejs.org/dist/v$VF_NODE_VERSION/node-v$VF_NODE_VERSION-${node_os}-${node_arch}.tar.gz" \
+            | tar -xz -C "$node" --strip-components=1
+    fi
+fi
+node_ok || { echo "ACP adapters require Node.js 22.19 or newer" >&2; exit 1; }
+"""
+
+
+async def ensure_node(runtime: Runtime) -> None:
+    """Install the shared Node runtime used by ACP adapter harnesses."""
+    lock = f"{NODE_DIR}.install.lock"
+    guarded = (
+        f'until ln -s "$$" {lock} 2>/dev/null; do '
+        f"owner=$(readlink {lock}); "
+        f'if ! kill -0 "$owner" 2>/dev/null; then '
+        f'[ "$(readlink {lock})" != "$owner" ] || rm -f {lock}; fi; '
+        f"sleep 0.1; done; "
+        f'trap \'[ "$(readlink {lock})" != "$$" ] || rm -f {lock}\' EXIT; '
+        f"sh -c {shlex.quote(INSTALL)}"
+    )
+    result = await runtime.run(["sh", "-c", guarded], {"VF_NODE_VERSION": NODE_VERSION})
+    if result.exit_code != 0:
+        raise RuntimeError(f"Node.js install failed: {result.stderr.strip()[-500:]}")

--- a/verifiers/v1/harnesses/openclaw/harness.py
+++ b/verifiers/v1/harnesses/openclaw/harness.py
@@ -117,10 +117,8 @@ class OpenClawHarness(Harness[OpenClawHarnessConfig]):
         data: TaskData,
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(data)
-        reasoning = ctx.sampling.reasoning_effort not in (
-            None,
-            "none",
-        ) or ctx.model.rsplit("/", 1)[-1].startswith(("gpt-5", "o1", "o3", "o4"))
+        # Opt-in via sampling: OpenClaw redacts persisted encrypted reasoning, so resumed sessions 400 replaying it.
+        reasoning = ctx.sampling.reasoning_effort not in (None, "none")
         directory = OPENCLAW_DIR.format(version=self.config.version)
         state_dir = f".vf-openclaw/{trace.id}"
         config_path = f"{state_dir}/openclaw.json"

--- a/verifiers/v1/harnesses/pi/harness.py
+++ b/verifiers/v1/harnesses/pi/harness.py
@@ -8,6 +8,7 @@ from verifiers.v1.acp import ACP
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.harness import Harness
+from verifiers.v1.harnesses.node import NODE_BIN_DIR, ensure_node
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
@@ -18,13 +19,12 @@ PROVIDER = "intercept"
 KEY_VAR = "PI_INTERCEPT_KEY"
 HOME_VAR = "VF_PI_ORIGINAL_HOME"
 
-PI_DIR = "/tmp/vf-pi"
+PI_DIR = "/var/tmp/vf-pi"
 PACKAGES_DIR = f"{PI_DIR}/mcp"
 PI_BIN = f"{PACKAGES_DIR}/node_modules/.bin/pi"
 SKILLS_DIR = ".agents/skills"
 MCP_VERSION = "2.11.0"
 ACP_VERSION = "0.0.31"
-NODE_VERSION = "22.19.0"
 MCP_ADAPTER = f"{PACKAGES_DIR}/node_modules/pi-mcp-adapter/index.ts"
 ACP_BIN = f"{PACKAGES_DIR}/node_modules/.bin/pi-acp"
 ACP_COMMAND = [
@@ -34,39 +34,14 @@ ACP_COMMAND = [
         f'export {HOME_VAR}="$HOME"; '
         'PI_CODING_AGENT_DIR="$PWD/$PI_CODING_AGENT_DIR"; '
         'export PI_CODING_AGENT_DIR HOME="$PI_CODING_AGENT_DIR"; '
-        f'export PATH="{PI_DIR}/node/bin:$PATH"; exec {ACP_BIN}'
+        f'export PATH="{NODE_BIN_DIR}:$PATH"; exec {ACP_BIN}'
     ),
 ]
 
 INSTALL = r"""
 set -e
-packages=/tmp/vf-pi/mcp
-node=/tmp/vf-pi/node
-node_ok() { node -e 'const [a,b]=process.versions.node.split(".").map(Number); process.exit(a>22 || a===22 && b>=19 ? 0 : 1)'; }
-
-if [ -f /etc/alpine-release ]; then
-    apk add --no-cache curl ca-certificates nodejs-current npm >/dev/null
-    if ! node_ok; then
-        sed -E -i 's/v[0-9]+\.[0-9]+/v3.22/g' /etc/apk/repositories
-        apk upgrade --available --no-cache >/dev/null
-        apk add --no-cache nodejs-current npm >/dev/null
-    fi
-    node_bin="$(dirname "$(command -v node)")"
-else
-    command -v curl >/dev/null 2>&1 \
-        || { apt-get update -qq && apt-get install -y -qq curl ca-certificates >/dev/null; }
-    case "$(uname -s)" in Linux) node_os=linux ;; Darwin) node_os=darwin ;; *) echo "unsupported os: $(uname -s)" >&2; exit 1 ;; esac
-    if [ ! -x "$node/bin/node" ] || [ "$("$node/bin/node" --version 2>/dev/null)" != "v$VF_PI_NODE_VERSION" ]; then
-        case "$(uname -m)" in aarch64|arm64) node_arch=arm64 ;; *) node_arch=x64 ;; esac
-        rm -rf "$node"
-        mkdir -p "$node"
-        curl -fsSL "https://nodejs.org/dist/v$VF_PI_NODE_VERSION/node-v$VF_PI_NODE_VERSION-${node_os}-${node_arch}.tar.gz" \
-            | tar -xz -C "$node" --strip-components=1
-    fi
-    node_bin="$node/bin"
-fi
-export PATH="$node_bin:$PATH"
-node_ok || { echo "pi-acp requires Node.js 22.19 or newer" >&2; exit 1; }
+packages=/var/tmp/vf-pi/mcp
+export PATH="/var/tmp/vf-node/bin:$PATH"
 
 versions="$VF_PI_VERSION:$VF_PI_MCP_VERSION:$VF_PI_ACP_VERSION"
 if [ "$(cat "$packages/.versions" 2>/dev/null)" != "$versions" ]; then
@@ -125,6 +100,7 @@ class PiHarness(Harness[PiHarnessConfig]):
 
     async def setup(self, runtime: Runtime) -> None:
         await self.install_skills(runtime, SKILLS_DIR)
+        await ensure_node(runtime)
         logger.info(
             "pi: ensuring Pi %s and pi-acp %s are installed",
             self.config.version,
@@ -147,7 +123,6 @@ class PiHarness(Harness[PiHarnessConfig]):
                 "VF_PI_VERSION": self.config.version,
                 "VF_PI_MCP_VERSION": MCP_VERSION,
                 "VF_PI_ACP_VERSION": ACP_VERSION,
-                "VF_PI_NODE_VERSION": NODE_VERSION,
             },
         )
         if install.exit_code != 0:

--- a/verifiers/v1/harnesses/prime_agent/__init__.py
+++ b/verifiers/v1/harnesses/prime_agent/__init__.py
@@ -1,0 +1,6 @@
+from verifiers.v1.harnesses.prime_agent.harness import (
+    PrimeAgentHarness,
+    PrimeAgentHarnessConfig,
+)
+
+__all__ = ["PrimeAgentHarness", "PrimeAgentHarnessConfig"]

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -107,7 +107,12 @@ class PrimeAgentHarnessConfig(HarnessConfig):
 
 class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
     APPENDS_SYSTEM_PROMPT = True
-    SUPPORTS_MCP = True
+    # prime-agent's ACP mode ignores the `mcpServers` of `session/new`, and its own
+    # MCP integrations are authored Python-backed skills the model imports in its
+    # kernel, not tools an ACP client can inject. Claiming support would let a
+    # tool-bearing taskset run with its tools silently absent, so declare it false
+    # and let `validate_pairing` reject that pairing up front.
+    SUPPORTS_MCP = False
     SUPPORTS_RESUME = True
     SUPPORTS_SKILLS = True
 
@@ -252,6 +257,5 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
             env,
             ["sh", "-c", f'exec "$PWD/{wrapper}"'],
             prompt,
-            mcp_urls=mcp_urls,
             system_prompt=system_prompt,
         )

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -53,11 +53,22 @@ if [ -f /etc/alpine-release ]; then
     fi
     node_bin="$(dirname "$(command -v node)")"
 else
-    command -v curl >/dev/null 2>&1 \
-        || { apt-get update -qq && apt-get install -y -qq curl ca-certificates >/dev/null; }
+    if ! command -v curl >/dev/null 2>&1; then
+        # Only Debian-family images are provisioned here; say so instead of
+        # failing with "apt-get: not found" on a distro this cannot bootstrap.
+        command -v apt-get >/dev/null 2>&1 \
+            || { echo "prime-agent setup needs curl, or apt-get to install it" >&2; exit 1; }
+        apt-get update -qq && apt-get install -y -qq curl ca-certificates >/dev/null
+    fi
     case "$(uname -s)" in Linux) node_os=linux ;; Darwin) node_os=darwin ;; *) echo "unsupported os: $(uname -s)" >&2; exit 1 ;; esac
     if [ ! -x "$node/bin/node" ] || [ "$("$node/bin/node" --version 2>/dev/null)" != "v$VF_PRIME_AGENT_NODE_VERSION" ]; then
-        case "$(uname -m)" in aarch64|arm64) node_arch=arm64 ;; *) node_arch=x64 ;; esac
+        # Reject an unknown machine like the OS check does: guessing x64 would
+        # download an archive whose node cannot exec, failing much later.
+        case "$(uname -m)" in
+            aarch64|arm64) node_arch=arm64 ;;
+            x86_64|amd64) node_arch=x64 ;;
+            *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+        esac
         rm -rf "$node"
         mkdir -p "$node"
         curl -fsSL "https://nodejs.org/dist/v$VF_PRIME_AGENT_NODE_VERSION/node-v$VF_PRIME_AGENT_NODE_VERSION-${node_os}-${node_arch}.tar.gz" \
@@ -246,10 +257,16 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
                 f'export {ENV_AGENT_DIR} HOME="${ENV_AGENT_DIR}"\n'
                 # Substitute the bearer token into models.json here, so the plaintext
                 # credential is only readable by this rollout's own agent process.
+                # Node rewrites the parsed document rather than a text substitution:
+                # a token carrying a backslash, quote, or `sed` metacharacter would
+                # otherwise corrupt the key or abort the wrapper before exec.
                 f'models="${ENV_AGENT_DIR}/models.json"\n'
                 f"umask 077\n"
-                f'sed "s|{APIKEY_PLACEHOLDER}|${KEY_VAR}|" "$models" > "$models.tmp"\n'
-                f'mv "$models.tmp" "$models"\n'
+                "node -e '"
+                'const fs=require("fs"),p=process.argv[1],'
+                'c=JSON.parse(fs.readFileSync(p,"utf8"));'
+                f'c.providers["{PROVIDER}"].apiKey=process.env.{KEY_VAR}||"";'
+                'fs.writeFileSync(p,JSON.stringify(c))\' "$models"\n'
                 f'exec {shlex.join(args)} "$@"\n'
             ).encode(),
         )

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -7,6 +7,7 @@ import json
 import logging
 import re
 import shlex
+from pathlib import Path
 from typing import Literal
 
 from pydantic import Field, field_validator, model_validator
@@ -32,11 +33,20 @@ DEFAULT_TARBALL_SHA256 = (
 )
 INSTALL_ROOT = "/var/tmp/vf-prime-agent"
 STATE_ROOT = "/tmp/vf-prime-agent"
+HARNESS_STATE_FILENAME = "harness_state.json"
+REFINEMENT_HISTORY_FILENAME = "refinements.jsonl"
 NODE_VERSION = "22.19.0"
-NODE_ROOT = f"{INSTALL_ROOT}/node-{NODE_VERSION}"
-NODE_BIN_DIR = f"{NODE_ROOT}/bin"
 THINKING_LEVELS = ("off", "minimal", "low", "medium", "high", "xhigh", "max")
 ThinkingLevel = Literal["off", "minimal", "low", "medium", "high", "xhigh", "max"]
+
+_SEMVER_IDENTIFIER = r"(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)"
+_SEMVER = re.compile(
+    rf"(?:0|[1-9][0-9]*)\."
+    rf"(?:0|[1-9][0-9]*)\."
+    rf"(?:0|[1-9][0-9]*)"
+    rf"(?:-{_SEMVER_IDENTIFIER}(?:\.{_SEMVER_IDENTIFIER})*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+)
 
 INSTALL = r"""
 set -eu
@@ -150,51 +160,38 @@ PRIME_AGENT_ACP = ACP()
 
 
 def _guarded_install(root: str, lock: str, command: str) -> str:
-    """Guard an install with a lock tied to one Linux process lifetime."""
+    """Serialize an install without PID files or stale-lock deletion races."""
     return (
         "set -eu\n"
         f"mkdir -p {shlex.quote(root)}\n"
         f"lock={shlex.quote(lock)}\n"
-        "self_start=$(awk '{print $22}' \"/proc/$$/stat\")\n"
-        'case "$self_start" in\n'
-        "  ''|*[!0-9]*) echo 'prime-agent: cannot identify installer process' >&2; "
-        "exit 1 ;;\n"
-        "esac\n"
-        'owner="$$:$self_start"\n'
-        'while ! ln -s "$owner" "$lock" 2>/dev/null; do\n'
-        '  current=$(readlink "$lock" 2>/dev/null || true)\n'
-        "  stale=0\n"
-        '  case "$current" in\n'
-        "    *:*)\n"
-        "      pid=${current%%:*}\n"
-        "      start=${current#*:}\n"
-        '      case "$pid" in\n'
-        "        ''|*[!0-9]*) stale=1 ;;\n"
-        "      esac\n"
-        '      case "$start" in\n'
-        "        ''|*[!0-9]*) stale=1 ;;\n"
-        "      esac\n"
-        '      if [ "$stale" -eq 0 ]; then\n'
-        "        live_start=$(awk '{print $22}' \"/proc/$pid/stat\" "
-        "2>/dev/null || true)\n"
-        '        [ "$live_start" = "$start" ] || stale=1\n'
-        "      fi\n"
-        "      ;;\n"
-        "    *) stale=1 ;;\n"
-        "  esac\n"
-        '  if [ "$stale" -eq 1 ] \\\n'
-        '      && [ "$(readlink "$lock" 2>/dev/null || true)" = "$current" ]; then\n'
-        '    rm -f "$lock"\n'
-        "  fi\n"
-        "  sleep 0.1\n"
-        "done\n"
-        "release_install_lock() {\n"
-        '  if [ "$(readlink "$lock" 2>/dev/null || true)" = "$owner" ]; then\n'
-        '    rm -f "$lock"\n'
-        "  fi\n"
-        "}\n"
-        "trap release_install_lock EXIT\n"
-        f"{command}\n"
+        "if command -v flock >/dev/null 2>&1; then\n"
+        "  (\n"
+        "    flock -x 9\n"
+        f"    {command}\n"
+        '  ) 9>"$lock"\n'
+        "else\n"
+        '  lock_dir="${lock}.d"\n'
+        "  waited=0\n"
+        '  while ! mkdir "$lock_dir" 2>/dev/null; do\n'
+        '    if [ "$waited" -ge 300 ]; then\n'
+        "      echo 'prime-agent: timed out waiting for install lock' >&2\n"
+        "      exit 1\n"
+        "    fi\n"
+        "    waited=$((waited + 1))\n"
+        "    sleep 1\n"
+        "  done\n"
+        "  release_install_lock() {\n"
+        '    rmdir "$lock_dir" 2>/dev/null || true\n'
+        "  }\n"
+        "  trap release_install_lock EXIT\n"
+        "  trap 'exit 129' HUP\n"
+        "  trap 'exit 130' INT\n"
+        "  trap 'exit 143' TERM\n"
+        f"  {command}\n"
+        '  rmdir "$lock_dir"\n'
+        "  trap - EXIT HUP INT TERM\n"
+        "fi\n"
     )
 
 
@@ -219,6 +216,14 @@ class PrimeAgentHarnessConfig(HarnessConfig):
     save_session: bool = False
     max_depth: int = Field(default=0, strict=True, ge=0)
 
+    harness_state_dir: Path | None = None
+    """Host directory with ``harness_state.json`` and optional refinement history.
+
+    The files seed Prime Agent's global continual harness state for this run. An
+    environment can harvest the corresponding runtime directory before cleanup
+    when it owns cross-run publication.
+    """
+
     autonomous: bool = False
     gates: list[str] = Field(default_factory=list)
     autonomous_gate_retries: int | None = Field(default=None, strict=True, gt=0)
@@ -235,7 +240,7 @@ class PrimeAgentHarnessConfig(HarnessConfig):
     @classmethod
     def normalize_version(cls, value: str) -> str:
         version = value.removeprefix("v")
-        if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?", version):
+        if not _SEMVER.fullmatch(version):
             raise ValueError("version must be a semantic version")
         return version
 
@@ -305,6 +310,13 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
             f"{INSTALL_ROOT}/kernels/{self.config.version}-{self.tarball_sha256()[:16]}"
         )
 
+    def node_root(self) -> str:
+        identity = f"{self.config.version}-{self.tarball_sha256()[:16]}"
+        return f"{INSTALL_ROOT}/nodes/{identity}/node-{NODE_VERSION}"
+
+    def node_bin_dir(self) -> str:
+        return f"{self.node_root()}/bin"
+
     @staticmethod
     def trace_root(trace: Trace) -> str:
         # Keep nested Unix socket paths short while retaining a 128-bit key.
@@ -323,10 +335,73 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
     def temp_dir(cls, trace: Trace) -> str:
         return f"{cls.trace_root(trace)}/tmp"
 
+    @classmethod
+    def runtime_harness_state_dir(cls, trace: Trace) -> str:
+        return f"{cls.agent_dir(trace)}/harness"
+
+    @classmethod
+    def harness_state_path(cls, trace: Trace) -> str:
+        return f"{cls.runtime_harness_state_dir(trace)}/{HARNESS_STATE_FILENAME}"
+
+    @classmethod
+    def refinement_history_path(cls, trace: Trace) -> str:
+        return f"{cls.runtime_harness_state_dir(trace)}/{REFINEMENT_HISTORY_FILENAME}"
+
+    async def install_harness_state(self, runtime: Runtime, trace: Trace) -> None:
+        source = self.config.harness_state_dir
+        if source is None:
+            return
+        if source.is_symlink():
+            raise ValueError(f"harness_state_dir {str(source)!r} is not a folder")
+        source = source.resolve()
+        if not source.is_dir():
+            raise ValueError(f"harness_state_dir {str(source)!r} is not a folder")
+        destination = self.runtime_harness_state_dir(trace)
+        created = await runtime.run(["mkdir", "-p", "-m", "700", destination], {})
+        if created.exit_code != 0:
+            raise RuntimeError(
+                "prime-agent harness state directory failed: "
+                f"{created.stderr.strip()[-500:]}"
+            )
+        for name in (HARNESS_STATE_FILENAME, REFINEMENT_HISTORY_FILENAME):
+            path = source / name
+            if not path.exists():
+                continue
+            if not path.is_file() or path.is_symlink():
+                raise ValueError(f"harness state file {str(path)!r} is not a file")
+            target = f"{destination}/{name}"
+            present = await runtime.run(
+                [
+                    "sh",
+                    "-c",
+                    'if [ -L "$1" ]; then exit 2; fi; [ -e "$1" ]',
+                    "prime-agent-harness-state",
+                    target,
+                ],
+                {},
+            )
+            if present.exit_code == 0:
+                continue
+            if present.exit_code == 2:
+                raise RuntimeError(
+                    f"prime-agent harness state target is a symlink: {target}"
+                )
+            if present.exit_code != 1:
+                raise RuntimeError(
+                    f"prime-agent harness state could not be checked: {target}"
+                )
+            await runtime.write(target, path.read_bytes())
+        restricted = await runtime.run(["chmod", "-R", "go-rwx", destination], {})
+        if restricted.exit_code != 0:
+            raise RuntimeError(
+                "prime-agent harness state permissions failed: "
+                f"{restricted.stderr.strip()[-500:]}"
+            )
+
     async def setup(self, runtime: Runtime) -> None:
         logger.info("prime-agent: ensuring %s is installed", self.config.version)
         install_dir = self.install_dir()
-        lock = f"{install_dir}.install.lock"
+        lock = f"{install_dir}.install.flock"
         guarded = _guarded_install(
             INSTALL_ROOT,
             lock,
@@ -336,8 +411,8 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
             ["sh", "-c", guarded],
             {
                 **self.config.resolved_env,
-                "VF_NODE_BIN_DIR": NODE_BIN_DIR,
-                "VF_NODE_ROOT": NODE_ROOT,
+                "VF_NODE_BIN_DIR": self.node_bin_dir(),
+                "VF_NODE_ROOT": self.node_root(),
                 "VF_NODE_VERSION": NODE_VERSION,
                 "VF_PRIME_AGENT_BIN": self.prime_agent_bin(),
                 "VF_PRIME_AGENT_INSTALL_DIR": install_dir,
@@ -421,6 +496,7 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
 
         skills_dir = f"{agent_dir}/skills"
         await self.install_skills(runtime, skills_dir)
+        await self.install_harness_state(runtime, trace)
         thinking = self.thinking_level(ctx)
         reasoning = thinking not in (None, "off") or (
             thinking is None
@@ -467,7 +543,7 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
             wrapper,
             (
                 "#!/bin/sh\n"
-                f'export PATH="{NODE_BIN_DIR}:$PATH"\n'
+                f'export PATH="{self.node_bin_dir()}:$PATH"\n'
                 f'exec {shlex.quote(self.prime_agent_bin())} "$@"\n'
             ).encode(),
         )

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -1,0 +1,187 @@
+"""Prime Agent harness driving prime-agent's native ACP mode."""
+
+import json
+import logging
+import shlex
+
+from pydantic import Field
+
+from verifiers.v1.acp import ACP
+from verifiers.v1.clients import ModelContext
+from verifiers.v1.configs.harness import HarnessConfig
+from verifiers.v1.harness import Harness
+from verifiers.v1.runtimes import ProgramResult, Runtime
+from verifiers.v1.task import TaskData
+from verifiers.v1.trace import Trace
+
+logger = logging.getLogger(__name__)
+
+# Model traffic is routed through the interception endpoint, which prime-agent
+# sees as an ordinary OpenAI-compatible provider.
+PROVIDER = "intercept"
+KEY_VAR = "PRIME_AGENT_INTERCEPT_KEY"
+
+PRIME_AGENT_DIR = "/tmp/vf-prime-agent"
+PRIME_AGENT_BIN = f"{PRIME_AGENT_DIR}/node_modules/.bin/prime-agent"
+SKILLS_DIR = ".agents/skills"
+INSTALLER_URL = "https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/install.sh"
+
+INSTALL = r"""
+set -e
+if [ -x "$VF_PRIME_AGENT_BIN" ]; then
+    exit 0
+fi
+mkdir -p "$VF_PRIME_AGENT_DIR"
+cd "$VF_PRIME_AGENT_DIR"
+# The published release tarball is a plain npm package, so install it directly
+# instead of running the interactive installer script.
+npm install --no-audit --no-fund --prefix "$VF_PRIME_AGENT_DIR" \
+    "$VF_PRIME_AGENT_TARBALL"
+"""
+
+PRIME_AGENT_ACP = ACP()
+
+
+class PrimeAgentHarnessConfig(HarnessConfig):
+    version: str = "0.5.1"
+    """Prime Agent release to install, pinned for reproducibility."""
+
+    tarball_url: str | None = None
+    """Override the release tarball URL (defaults to the pinned public release)."""
+
+    autonomous: bool = False
+    """Run with `--autonomous`, so the agent continues until its limits or gates stop it."""
+
+    gates: list[str] = Field(default_factory=list)
+    """Autonomous quality-gate commands. Requires `autonomous`."""
+
+
+class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
+    APPENDS_SYSTEM_PROMPT = True
+    SUPPORTS_MCP = True
+    SUPPORTS_RESUME = True
+    SUPPORTS_SKILLS = True
+
+    def _tarball(self) -> str:
+        if self.config.tarball_url:
+            return self.config.tarball_url
+        version = self.config.version
+        base = INSTALLER_URL.rsplit("/", 1)[0]
+        return f"{base}/releases/v{version}/prime-agent-{version}.tgz"
+
+    async def setup(self, runtime: Runtime) -> None:
+        await self.install_skills(runtime, SKILLS_DIR)
+        logger.info("prime-agent: ensuring %s is installed", self.config.version)
+        lock = f"{PRIME_AGENT_DIR}/install.lock"
+        # Concurrent rollouts share one runtime; serialize the install like the
+        # other node-based harnesses do.
+        guarded = (
+            f"mkdir -p {PRIME_AGENT_DIR} && "
+            f'"$(command -v flock || command -v lockf)" {lock} '
+            f"sh -c {shlex.quote(INSTALL)}"
+        )
+        install = await runtime.run(
+            ["sh", "-c", guarded],
+            {
+                "VF_PRIME_AGENT_DIR": PRIME_AGENT_DIR,
+                "VF_PRIME_AGENT_BIN": PRIME_AGENT_BIN,
+                "VF_PRIME_AGENT_TARBALL": self._tarball(),
+            },
+        )
+        if install.exit_code != 0:
+            raise RuntimeError(
+                f"prime-agent install failed: {install.stderr.strip()[-500:]}"
+            )
+        await PRIME_AGENT_ACP.setup(self, runtime)
+
+    async def launch(
+        self,
+        ctx: ModelContext,
+        trace: Trace,
+        runtime: Runtime,
+        endpoint: str,
+        secret: str,
+        mcp_urls: dict[str, str],
+        data: TaskData,
+    ) -> ProgramResult:
+        system_prompt, prompt = self.resolve_prompt(data)
+        agent_dir = f".vf-prime-agent-{trace.id}"
+        reasoning = ctx.sampling.reasoning_effort not in (
+            None,
+            "none",
+        ) or ctx.model.rsplit("/", 1)[-1].startswith(("gpt-5", "o1", "o3", "o4"))
+        models = {
+            "providers": {
+                PROVIDER: {
+                    "baseUrl": endpoint,
+                    "api": "openai-completions",
+                    "apiKey": f"${KEY_VAR}",
+                    "models": [
+                        {
+                            "id": ctx.model,
+                            "reasoning": reasoning,
+                            "input": ["text", "image"],
+                        }
+                    ],
+                }
+            }
+        }
+        await runtime.write(f"{agent_dir}/models.json", json.dumps(models).encode())
+
+        env = {
+            **self.config.resolved_env,
+            KEY_VAR: secret,
+            "PI_CODING_AGENT_DIR": agent_dir,
+            "PI_OFFLINE": "1",
+            "PI_TELEMETRY": "0",
+        }
+
+        args = [
+            PRIME_AGENT_BIN,
+            "--mode",
+            "acp",
+            "--provider",
+            PROVIDER,
+            "--model",
+            ctx.model,
+        ]
+        for skill in self.config.skills:
+            # Resolve like `install_skills` so the path matches what it wrote.
+            args += ["--skill", f"{SKILLS_DIR}/{skill.resolve().name}"]
+        if self.config.disabled_tools:
+            raise ValueError(
+                "prime-agent has no per-tool disable flag; its model-facing tool is "
+                "ipython. Use --no-builtin-tools upstream if that is ever needed."
+            )
+        if self.config.autonomous:
+            args.append("--autonomous")
+            for gate in self.config.gates:
+                args += ["--autonomous-gate", gate]
+        elif self.config.gates:
+            raise ValueError("prime-agent gates require autonomous=true")
+        if system_prompt:
+            args += ["--append-system-prompt", system_prompt]
+
+        # ACP owns stdout, so the agent must be exec'd directly with HOME pinned
+        # to the per-trace agent dir: prime-agent writes sessions and kernel state
+        # under it, and rollouts must not share either.
+        wrapper = f"{agent_dir}/prime-agent"
+        await runtime.write(
+            wrapper,
+            (
+                "#!/bin/sh\n"
+                'PI_CODING_AGENT_DIR="$PWD/$PI_CODING_AGENT_DIR"\n'
+                'export PI_CODING_AGENT_DIR HOME="$PI_CODING_AGENT_DIR"\n'
+                f'exec {shlex.join(args)} "$@"\n'
+            ).encode(),
+        )
+        await runtime.run(["chmod", "+x", wrapper], {})
+
+        return await PRIME_AGENT_ACP.run(
+            runtime,
+            env,
+            ["sh", "-c", f'exec "$PWD/{wrapper}"'],
+            prompt,
+            mcp_urls=mcp_urls,
+            system_prompt=system_prompt,
+        )

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -18,6 +18,11 @@ logger = logging.getLogger(__name__)
 
 # Model traffic is routed through the interception endpoint, which prime-agent
 # sees as an ordinary OpenAI-compatible provider.
+#
+# The agent-dir env var is derived from the package's own piConfig name, so the
+# published prime-agent release reads PRIME_AGENT_CODING_AGENT_DIR, not the
+# upstream PI_ prefix.
+ENV_AGENT_DIR = "PRIME_AGENT_CODING_AGENT_DIR"
 PROVIDER = "intercept"
 KEY_VAR = "PRIME_AGENT_INTERCEPT_KEY"
 
@@ -25,18 +30,43 @@ PRIME_AGENT_DIR = "/tmp/vf-prime-agent"
 PRIME_AGENT_BIN = f"{PRIME_AGENT_DIR}/node_modules/.bin/prime-agent"
 SKILLS_DIR = ".agents/skills"
 INSTALLER_URL = "https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/install.sh"
+NODE_VERSION = "22.19.0"
+NODE_BIN = f"{PRIME_AGENT_DIR}/node/bin"
 
 INSTALL = r"""
 set -e
+node="$VF_PRIME_AGENT_DIR/node"
+node_ok() { node -e 'const [a,b]=process.versions.node.split(".").map(Number); process.exit(a>22 || a===22 && b>=8 ? 0 : 1)'; }
+
+# Containers do not ship Node, and prime-agent requires >=22.8. Prefer the
+# distro package, otherwise fetch the pinned official build.
+if [ -f /etc/alpine-release ]; then
+    apk add --no-cache curl ca-certificates nodejs-current npm >/dev/null
+    node_bin="$(dirname "$(command -v node)")"
+else
+    command -v curl >/dev/null 2>&1 \
+        || { apt-get update -qq && apt-get install -y -qq curl ca-certificates >/dev/null; }
+    case "$(uname -s)" in Linux) node_os=linux ;; Darwin) node_os=darwin ;; *) echo "unsupported os: $(uname -s)" >&2; exit 1 ;; esac
+    if [ ! -x "$node/bin/node" ] || [ "$("$node/bin/node" --version 2>/dev/null)" != "v$VF_PRIME_AGENT_NODE_VERSION" ]; then
+        case "$(uname -m)" in aarch64|arm64) node_arch=arm64 ;; *) node_arch=x64 ;; esac
+        rm -rf "$node"
+        mkdir -p "$node"
+        curl -fsSL "https://nodejs.org/dist/v$VF_PRIME_AGENT_NODE_VERSION/node-v$VF_PRIME_AGENT_NODE_VERSION-${node_os}-${node_arch}.tar.gz" \
+            | tar -xz -C "$node" --strip-components=1
+    fi
+    node_bin="$node/bin"
+fi
+export PATH="$node_bin:$PATH"
+node_ok || { echo "prime-agent requires Node.js 22.8 or newer" >&2; exit 1; }
+
 if [ -x "$VF_PRIME_AGENT_BIN" ]; then
     exit 0
 fi
 mkdir -p "$VF_PRIME_AGENT_DIR"
-cd "$VF_PRIME_AGENT_DIR"
 # The published release tarball is a plain npm package, so install it directly
 # instead of running the interactive installer script.
 npm install --no-audit --no-fund --prefix "$VF_PRIME_AGENT_DIR" \
-    "$VF_PRIME_AGENT_TARBALL"
+    "$VF_PRIME_AGENT_TARBALL" >/dev/null
 """
 
 PRIME_AGENT_ACP = ACP()
@@ -89,6 +119,7 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
                 "VF_PRIME_AGENT_DIR": PRIME_AGENT_DIR,
                 "VF_PRIME_AGENT_BIN": PRIME_AGENT_BIN,
                 "VF_PRIME_AGENT_TARBALL": self._tarball(),
+                "VF_PRIME_AGENT_NODE_VERSION": NODE_VERSION,
             },
         )
         if install.exit_code != 0:
@@ -118,7 +149,10 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
                 PROVIDER: {
                     "baseUrl": endpoint,
                     "api": "openai-completions",
-                    "apiKey": f"${KEY_VAR}",
+                    # prime-agent does NOT expand "$VAR" in models.json: it sends the
+                    # literal string as the bearer token (verified against a capturing
+                    # server). Inline the secret instead of the pi-style indirection.
+                    "apiKey": secret,
                     "models": [
                         {
                             "id": ctx.model,
@@ -134,9 +168,9 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
         env = {
             **self.config.resolved_env,
             KEY_VAR: secret,
-            "PI_CODING_AGENT_DIR": agent_dir,
-            "PI_OFFLINE": "1",
-            "PI_TELEMETRY": "0",
+            ENV_AGENT_DIR: agent_dir,
+            "PRIME_AGENT_OFFLINE": "1",
+            "PRIME_AGENT_TELEMETRY": "0",
         }
 
         args = [
@@ -173,8 +207,10 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
             wrapper,
             (
                 "#!/bin/sh\n"
-                'PI_CODING_AGENT_DIR="$PWD/$PI_CODING_AGENT_DIR"\n'
-                'export PI_CODING_AGENT_DIR HOME="$PI_CODING_AGENT_DIR"\n'
+                # The bundled Node lives beside the install, not on the container PATH.
+                f'export PATH="{NODE_BIN}:$PATH"\n'
+                f'{ENV_AGENT_DIR}="$PWD/${ENV_AGENT_DIR}"\n'
+                f'export {ENV_AGENT_DIR} HOME="${ENV_AGENT_DIR}"\n'
                 f'exec {shlex.join(args)} "$@"\n'
             ).encode(),
         )

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import hashlib
+import io
 import json
 import logging
+import os
 import re
 import shlex
+import tarfile
 from pathlib import Path
 from typing import Literal
 
@@ -397,6 +400,92 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
                 "prime-agent harness state permissions failed: "
                 f"{restricted.stderr.strip()[-500:]}"
             )
+
+    def _skills_archive(self) -> bytes | None:
+        """Pack configured skills for one gateway upload.
+
+        Prime runtime writes require one command RPC and one upload RPC per file.
+        A skill set can contain dozens of small files, so per-file writes can use
+        the full setup budget before Prime Agent starts. The archive contains only
+        regular file data from the configured folders. Symlinks are dereferenced,
+        which matches ``Harness.install_skills``.
+        """
+        if not self.config.skills:
+            return None
+        output = io.BytesIO()
+        with tarfile.open(
+            fileobj=output, mode="w:gz", format=tarfile.PAX_FORMAT
+        ) as tar:
+            for configured in self.config.skills:
+                skill = configured.resolve()
+                if not skill.is_dir():
+                    raise ValueError(f"skill {str(skill)!r} is not a folder")
+                directories = {skill.name}
+                root = tarfile.TarInfo(skill.name)
+                root.type = tarfile.DIRTYPE
+                root.mode = 0o755
+                root.mtime = 0
+                tar.addfile(root)
+                for file in sorted(skill.rglob("*")):
+                    if not file.is_file():
+                        continue
+                    data = file.read_bytes()
+                    relative = file.relative_to(skill).as_posix()
+                    parent = skill.name
+                    for part in file.relative_to(skill).parts[:-1]:
+                        parent = f"{parent}/{part}"
+                        if parent in directories:
+                            continue
+                        directories.add(parent)
+                        directory = tarfile.TarInfo(parent)
+                        directory.type = tarfile.DIRTYPE
+                        directory.mode = 0o755
+                        directory.mtime = 0
+                        tar.addfile(directory)
+                    member = tarfile.TarInfo(f"{skill.name}/{relative}")
+                    member.size = len(data)
+                    member.mode = 0o755 if os.access(file, os.X_OK) else 0o644
+                    member.mtime = 0
+                    member.uid = 0
+                    member.gid = 0
+                    member.uname = ""
+                    member.gname = ""
+                    tar.addfile(member, io.BytesIO(data))
+        return output.getvalue()
+
+    async def install_skills(self, runtime: Runtime, dest: str) -> None:
+        archive = self._skills_archive()
+        if archive is None:
+            return
+        archive_path = f"{dest}.tar.gz"
+        await runtime.write(archive_path, archive)
+        extracted = await runtime.run(
+            [
+                "sh",
+                "-c",
+                (
+                    "set -eu\n"
+                    "archive=$1\n"
+                    "dest=$2\n"
+                    "cleanup_skills_archive() {\n"
+                    "  status=$?\n"
+                    "  trap - EXIT\n"
+                    '  rm -f "$archive"\n'
+                    '  exit "$status"\n'
+                    "}\n"
+                    "trap cleanup_skills_archive EXIT\n"
+                    'mkdir -p -m 700 "$dest"\n'
+                    'tar -xzf "$archive" -C "$dest"\n'
+                ),
+                "prime-agent-skills",
+                archive_path,
+                dest,
+            ],
+            {},
+        )
+        if extracted.exit_code != 0:
+            detail = (extracted.stderr or extracted.stdout).strip()[-1000:]
+            raise RuntimeError(f"prime-agent skill extraction failed: {detail}")
 
     async def setup(self, runtime: Runtime) -> None:
         logger.info("prime-agent: ensuring %s is installed", self.config.version)

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -160,6 +160,12 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
         data: TaskData,
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(data)
+        # A resumed segment replays the accreted conversation, and the ACP runner
+        # renders that transcript into the prompt — including the `[system]` block
+        # it rendered on the first segment. Re-emitting the system prompt here
+        # would hand the model the same instructions twice.
+        if trace.branches and trace.branches[-1].messages:
+            system_prompt = None
         agent_dir = f".vf-prime-agent-{trace.id}"
         reasoning = ctx.sampling.reasoning_effort not in (
             None,

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -31,7 +31,17 @@ KEY_VAR = "PRIME_AGENT_INTERCEPT_KEY"
 PRIME_AGENT_DIR = "/tmp/vf-prime-agent"
 PRIME_AGENT_BIN = f"{PRIME_AGENT_DIR}/node_modules/.bin/prime-agent"
 SKILLS_DIR = ".agents/skills"
-INSTALLER_URL = "https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/install.sh"
+# Release artifacts live under this base; `latest.json` at the root records the
+# current version and each tarball's sha256.
+#
+# This is the artifact base, which is not the same as the user-facing installer at
+# https://app.primeintellect.ai/prime-agent/install.sh. That script is a thin
+# front end: it resolves versions and downloads tarballs from this base, defaulting
+# to it in its own `prime_agent_base_url` and honoring PRIME_AGENT_DOWNLOAD_BASE_URL.
+# The same value is the prime-agent repo's R2_PUBLIC_BASE_URL variable, which its
+# release workflow publishes to. This harness installs the npm tarball directly
+# rather than running that script, so it needs the artifact base.
+RELEASE_BASE_URL = "https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev"
 NODE_VERSION = "22.19.0"
 NODE_BIN = f"{PRIME_AGENT_DIR}/node/bin"
 
@@ -131,8 +141,7 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
         if self.config.tarball_url:
             return self.config.tarball_url
         version = self.config.version
-        base = INSTALLER_URL.rsplit("/", 1)[0]
-        return f"{base}/releases/v{version}/prime-agent-{version}.tgz"
+        return f"{RELEASE_BASE_URL}/releases/v{version}/prime-agent-{version}.tgz"
 
     async def setup(self, runtime: Runtime) -> None:
         await self.install_skills(runtime, SKILLS_DIR)

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -23,7 +23,6 @@ from verifiers.v1.trace import Trace
 logger = logging.getLogger(__name__)
 
 ENV_AGENT_DIR = "PRIME_AGENT_CODING_AGENT_DIR"
-LEGACY_ENV_AGENT_DIR = "PRIME_CODING_AGENT_DIR"
 PROVIDER = "intercept"
 KEY_VAR = "PRIME_AGENT_INTERCEPT_KEY"
 
@@ -67,7 +66,6 @@ fi
 
 export PATH="$VF_NODE_BIN_DIR:$PATH"
 export PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL=1
-export PRIME_AGENT_INSTALL_UV=1
 export PRIME_AGENT_KERNEL_VENV="$VF_PRIME_AGENT_KERNEL_VENV"
 npm install --no-audit --no-fund --prefix "$staging" \
     "$staging/prime-agent.tgz" >/dev/null
@@ -468,10 +466,8 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
             **self.config.resolved_env,
             **({KEY_VAR: secret} if secret is not None else {}),
             ENV_AGENT_DIR: agent_dir,
-            LEGACY_ENV_AGENT_DIR: agent_dir,
             "NO_COLOR": "1",
             "PI_OFFLINE": "1",
-            "PI_SKIP_VERSION_CHECK": "1",
             "PRIME_AGENT_KERNEL_VENV": self.kernel_venv(),
             "RLM_MAX_DEPTH": str(self.config.max_depth),
             "TEMP": temp_dir,

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -43,8 +43,11 @@ PRIME_AGENT_ACP = ACP()
 
 
 class PrimeAgentHarnessConfig(HarnessConfig):
-    version: str = "0.5.1"
-    """Prime Agent release to install, pinned for reproducibility."""
+    version: str = "0.6.0"
+    """Prime Agent release to install, pinned for reproducibility.
+
+    0.6.0 is the first release with native ACP mode (`--mode acp`).
+    """
 
     tarball_url: str | None = None
     """Override the release tarball URL (defaults to the pinned public release)."""

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -44,6 +44,13 @@ node_ok() { node -e 'const [a,b]=process.versions.node.split(".").map(Number); p
 # distro package, otherwise fetch the pinned official build.
 if [ -f /etc/alpine-release ]; then
     apk add --no-cache curl ca-certificates nodejs-current npm >/dev/null
+    if ! node_ok; then
+        # The official Node build is glibc-only, so an Alpine whose own
+        # nodejs-current is too old has to move its repos forward and retry.
+        sed -E -i 's/v[0-9]+\.[0-9]+/v3.22/g' /etc/apk/repositories
+        apk upgrade --available --no-cache >/dev/null
+        apk add --no-cache nodejs-current npm >/dev/null
+    fi
     node_bin="$(dirname "$(command -v node)")"
 else
     command -v curl >/dev/null 2>&1 \
@@ -61,14 +68,21 @@ fi
 export PATH="$node_bin:$PATH"
 node_ok || { echo "prime-agent requires Node.js 22.8 or newer" >&2; exit 1; }
 
-if [ -x "$VF_PRIME_AGENT_BIN" ]; then
+# Concurrent rollouts share the install, so it is keyed on the requested
+# tarball: a changed `version` or `tarball_url` must reinstall rather than
+# silently reuse whatever an earlier rollout left in the shared directory.
+stamp="$VF_PRIME_AGENT_DIR/.installed"
+if [ -x "$VF_PRIME_AGENT_BIN" ] && [ "$(cat "$stamp" 2>/dev/null)" = "$VF_PRIME_AGENT_TARBALL" ]; then
     exit 0
 fi
 mkdir -p "$VF_PRIME_AGENT_DIR"
+# Drop the stamp first so a failed install is never mistaken for a good one.
+rm -f "$stamp"
 # The published release tarball is a plain npm package, so install it directly
 # instead of running the interactive installer script.
 npm install --no-audit --no-fund --prefix "$VF_PRIME_AGENT_DIR" \
     "$VF_PRIME_AGENT_TARBALL" >/dev/null
+printf %s "$VF_PRIME_AGENT_TARBALL" > "$stamp"
 """
 
 PRIME_AGENT_ACP = ACP()

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -24,6 +24,8 @@ logger = logging.getLogger(__name__)
 # upstream PI_ prefix.
 ENV_AGENT_DIR = "PRIME_AGENT_CODING_AGENT_DIR"
 PROVIDER = "intercept"
+# Stand-in written to models.json; the launch wrapper swaps in the real secret.
+APIKEY_PLACEHOLDER = "__VF_PRIME_AGENT_KEY__"
 KEY_VAR = "PRIME_AGENT_INTERCEPT_KEY"
 
 PRIME_AGENT_DIR = "/tmp/vf-prime-agent"
@@ -149,10 +151,14 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
                 PROVIDER: {
                     "baseUrl": endpoint,
                     "api": "openai-completions",
-                    # prime-agent does NOT expand "$VAR" in models.json: it sends the
+                    # prime-agent does not expand "$VAR" in models.json: it sends the
                     # literal string as the bearer token (verified against a capturing
-                    # server). Inline the secret instead of the pi-style indirection.
-                    "apiKey": secret,
+                    # server), so the pi-style indirection cannot be used here. The
+                    # secret is substituted by the launch wrapper at exec time instead
+                    # of being written to disk, because concurrent rollouts share a
+                    # runtime and model-executed code could otherwise read another
+                    # rollout's credential out of its models.json.
+                    "apiKey": APIKEY_PLACEHOLDER,
                     "models": [
                         {
                             "id": ctx.model,
@@ -163,7 +169,8 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
                 }
             }
         }
-        await runtime.write(f"{agent_dir}/models.json", json.dumps(models).encode())
+        models_path = f"{agent_dir}/models.json"
+        await runtime.write(models_path, json.dumps(models).encode())
 
         env = {
             **self.config.resolved_env,
@@ -196,8 +203,8 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
                 args += ["--autonomous-gate", gate]
         elif self.config.gates:
             raise ValueError("prime-agent gates require autonomous=true")
-        if system_prompt:
-            args += ["--append-system-prompt", system_prompt]
+        # The ACP runner seeds the system prompt into the conversation itself, so
+        # passing --append-system-prompt as well would apply it twice.
 
         # ACP owns stdout, so the agent must be exec'd directly with HOME pinned
         # to the per-trace agent dir: prime-agent writes sessions and kernel state
@@ -207,14 +214,24 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
             wrapper,
             (
                 "#!/bin/sh\n"
+                "set -e\n"
                 # The bundled Node lives beside the install, not on the container PATH.
                 f'export PATH="{NODE_BIN}:$PATH"\n'
                 f'{ENV_AGENT_DIR}="$PWD/${ENV_AGENT_DIR}"\n'
                 f'export {ENV_AGENT_DIR} HOME="${ENV_AGENT_DIR}"\n'
+                # Substitute the bearer token into models.json here, so the plaintext
+                # credential is only readable by this rollout's own agent process.
+                f'models="${ENV_AGENT_DIR}/models.json"\n'
+                f"umask 077\n"
+                f'sed "s|{APIKEY_PLACEHOLDER}|${KEY_VAR}|" "$models" > "$models.tmp"\n'
+                f'mv "$models.tmp" "$models"\n'
                 f'exec {shlex.join(args)} "$@"\n'
             ).encode(),
         )
         await runtime.run(["chmod", "+x", wrapper], {})
+        # models.json is world-readable as written; restrict it before it holds a secret.
+        await runtime.run(["chmod", "700", agent_dir], {})
+        await runtime.run(["chmod", "600", models_path], {})
 
         return await PRIME_AGENT_ACP.run(
             runtime,

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import re
@@ -81,6 +82,55 @@ trap - EXIT
 """
 
 PRIME_AGENT_ACP = ACP()
+
+
+def _guarded_install(root: str, lock: str, command: str) -> str:
+    """Guard an install with a lock tied to one Linux process lifetime."""
+    return (
+        "set -eu\n"
+        f"mkdir -p {shlex.quote(root)}\n"
+        f"lock={shlex.quote(lock)}\n"
+        "self_start=$(awk '{print $22}' \"/proc/$$/stat\")\n"
+        'case "$self_start" in\n'
+        "  ''|*[!0-9]*) echo 'prime-agent: cannot identify installer process' >&2; "
+        "exit 1 ;;\n"
+        "esac\n"
+        'owner="$$:$self_start"\n'
+        'while ! ln -s "$owner" "$lock" 2>/dev/null; do\n'
+        '  current=$(readlink "$lock" 2>/dev/null || true)\n'
+        "  stale=0\n"
+        '  case "$current" in\n'
+        "    *:*)\n"
+        "      pid=${current%%:*}\n"
+        "      start=${current#*:}\n"
+        '      case "$pid" in\n'
+        "        ''|*[!0-9]*) stale=1 ;;\n"
+        "      esac\n"
+        '      case "$start" in\n'
+        "        ''|*[!0-9]*) stale=1 ;;\n"
+        "      esac\n"
+        '      if [ "$stale" -eq 0 ]; then\n'
+        "        live_start=$(awk '{print $22}' \"/proc/$pid/stat\" "
+        "2>/dev/null || true)\n"
+        '        [ "$live_start" = "$start" ] || stale=1\n'
+        "      fi\n"
+        "      ;;\n"
+        "    *) stale=1 ;;\n"
+        "  esac\n"
+        '  if [ "$stale" -eq 1 ] \\\n'
+        '      && [ "$(readlink "$lock" 2>/dev/null || true)" = "$current" ]; then\n'
+        '    rm -f "$lock"\n'
+        "  fi\n"
+        "  sleep 0.1\n"
+        "done\n"
+        "release_install_lock() {\n"
+        '  if [ "$(readlink "$lock" 2>/dev/null || true)" = "$owner" ]; then\n'
+        '    rm -f "$lock"\n'
+        "  fi\n"
+        "}\n"
+        "trap release_install_lock EXIT\n"
+        f"{command}\n"
+    )
 
 
 class PrimeAgentHarnessConfig(HarnessConfig):
@@ -192,7 +242,9 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
 
     @staticmethod
     def trace_root(trace: Trace) -> str:
-        return f"{STATE_ROOT}-{trace.id}"
+        # Keep nested Unix socket paths short while retaining a 128-bit key.
+        trace_key = hashlib.sha256(trace.id.encode()).hexdigest()[:32]
+        return f"{STATE_ROOT}/{trace_key}"
 
     @classmethod
     def agent_dir(cls, trace: Trace) -> str:
@@ -211,17 +263,10 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
         logger.info("prime-agent: ensuring %s is installed", self.config.version)
         install_dir = self.install_dir()
         lock = f"{install_dir}.install.lock"
-        guarded = (
-            f"mkdir -p {shlex.quote(INSTALL_ROOT)} && "
-            f'until ln -s "$$" {shlex.quote(lock)} 2>/dev/null; do '
-            f"owner=$(readlink {shlex.quote(lock)}); "
-            f'if ! kill -0 "$owner" 2>/dev/null; then '
-            f'[ "$(readlink {shlex.quote(lock)})" != "$owner" ] || '
-            f"rm -f {shlex.quote(lock)}; fi; "
-            f"sleep 0.1; done; "
-            f'trap \'[ "$(readlink {shlex.quote(lock)})" != "$$" ] || '
-            f"rm -f {shlex.quote(lock)}' EXIT; "
-            f"sh -c {shlex.quote(INSTALL)}"
+        guarded = _guarded_install(
+            INSTALL_ROOT,
+            lock,
+            f"sh -c {shlex.quote(INSTALL)}",
         )
         install = await runtime.run(
             ["sh", "-c", guarded],

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -9,7 +9,7 @@ from pydantic import Field
 from verifiers.v1.acp import ACP
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
-from verifiers.v1.harness import Harness
+from verifiers.v1.harness import Harness, HarnessSession
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
@@ -169,7 +169,7 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
             )
         await PRIME_AGENT_ACP.setup(self, runtime)
 
-    async def launch(
+    async def session(
         self,
         ctx: ModelContext,
         trace: Trace,
@@ -178,14 +178,36 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
         secret: str,
         mcp_urls: dict[str, str],
         data: TaskData,
-    ) -> ProgramResult:
+    ) -> HarnessSession:
+        if not runtime.supports_live_processes:
+            return await super().session(
+                ctx, trace, runtime, endpoint, secret, mcp_urls, data
+            )
         system_prompt, prompt = self.resolve_prompt(data)
-        # A resumed segment replays the accreted conversation, and the ACP runner
-        # renders that transcript into the prompt — including the `[system]` block
-        # it rendered on the first segment. Re-emitting the system prompt here
-        # would hand the model the same instructions twice.
-        if trace.branches and trace.branches[-1].messages:
-            system_prompt = None
+        env, command = await self._prepare(ctx, trace, runtime, endpoint, secret)
+        return PRIME_AGENT_ACP.session(
+            self,
+            ctx,
+            trace,
+            runtime,
+            endpoint,
+            secret,
+            mcp_urls,
+            data,
+            env=env,
+            command=command,
+            prompt=prompt,
+            system_prompt=system_prompt,
+        )
+
+    async def _prepare(
+        self,
+        ctx: ModelContext,
+        trace: Trace,
+        runtime: Runtime,
+        endpoint: str,
+        secret: str,
+    ) -> tuple[dict[str, str], list[str]]:
         agent_dir = f".vf-prime-agent-{trace.id}"
         reasoning = ctx.sampling.reasoning_effort not in (
             None,
@@ -283,11 +305,31 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
         # models.json is world-readable as written; restrict it before it holds a secret.
         await runtime.run(["chmod", "700", agent_dir], {})
         await runtime.run(["chmod", "600", models_path], {})
+        return env, ["sh", "-c", f'exec "$PWD/{wrapper}"']
+
+    async def launch(
+        self,
+        ctx: ModelContext,
+        trace: Trace,
+        runtime: Runtime,
+        endpoint: str,
+        secret: str,
+        mcp_urls: dict[str, str],
+        data: TaskData,
+    ) -> ProgramResult:
+        system_prompt, prompt = self.resolve_prompt(data)
+        # A resumed segment replays the accreted conversation, and the ACP runner
+        # renders that transcript into the prompt — including the `[system]` block
+        # it rendered on the first segment. Re-emitting the system prompt here
+        # would hand the model the same instructions twice.
+        if trace.branches and trace.branches[-1].messages:
+            system_prompt = None
+        env, command = await self._prepare(ctx, trace, runtime, endpoint, secret)
 
         return await PRIME_AGENT_ACP.run(
             runtime,
             env,
-            ["sh", "-c", f'exec "$PWD/{wrapper}"'],
+            command,
             prompt,
             system_prompt=system_prompt,
         )

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -49,7 +49,25 @@ fi
 
 staging="${root}.staging.$$"
 backup="${root}.previous.$$"
-trap 'rm -rf "$staging" "$backup"' EXIT
+had_root=0
+committed=0
+cleanup_install() {
+    status=$?
+    trap - EXIT HUP INT TERM
+    rm -rf "$staging"
+    if [ "$committed" -eq 0 ] && [ "$had_root" -eq 1 ] && [ -e "$backup" ]; then
+        rm -rf "$root"
+        mv "$backup" "$root" || \
+            echo "prime-agent: failed to restore previous install" >&2
+    elif [ "$committed" -eq 1 ]; then
+        rm -rf "$backup"
+    fi
+    exit "$status"
+}
+trap cleanup_install EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 rm -rf "$staging" "$backup"
 mkdir -p "$staging"
 
@@ -72,11 +90,13 @@ npm install --no-audit --no-fund --prefix "$staging" \
 printf %s "$package_sha" > "$staging/.installed"
 
 if [ -e "$root" ]; then
+    had_root=1
     mv "$root" "$backup"
 fi
 mv "$staging" "$root"
+committed=1
 rm -rf "$backup"
-trap - EXIT
+trap - EXIT HUP INT TERM
 """
 
 PRIME_AGENT_ACP = ACP()

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -456,6 +456,7 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
             env=env,
             command=command,
             prompt=prompt,
+            allow_empty_tool_reply=True,
         )
 
     async def launch(
@@ -472,7 +473,13 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
         env, command = await self.prepare_run(
             ctx, trace, runtime, endpoint, secret, system_prompt
         )
-        return await PRIME_AGENT_ACP.run(runtime, env, command, prompt)
+        return await PRIME_AGENT_ACP.run(
+            runtime,
+            env,
+            command,
+            prompt,
+            allow_empty_tool_reply=True,
+        )
 
     async def prepare_run(
         self,

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -222,9 +222,9 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
                     # literal string as the bearer token (verified against a capturing
                     # server), so the pi-style indirection cannot be used here. The
                     # secret is substituted by the launch wrapper at exec time instead
-                    # of being written to disk, because concurrent rollouts share a
-                    # runtime and model-executed code could otherwise read another
-                    # rollout's credential out of its models.json.
+                    # of being uploaded in the placeholder config. File modes narrow
+                    # access to the runtime user; same-uid rollout isolation remains a
+                    # runtime-level concern.
                     "apiKey": APIKEY_PLACEHOLDER,
                     "models": [
                         {
@@ -286,8 +286,8 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
                 f'export PATH="{NODE_BIN}:$PATH"\n'
                 f'{ENV_AGENT_DIR}="$PWD/${ENV_AGENT_DIR}"\n'
                 f'export {ENV_AGENT_DIR} HOME="${ENV_AGENT_DIR}"\n'
-                # Substitute the bearer token into models.json here, so the plaintext
-                # credential is only readable by this rollout's own agent process.
+                # Substitute the bearer token into models.json only when the agent
+                # starts, after its directory and file have restrictive permissions.
                 # Node rewrites the parsed document rather than a text substitution:
                 # a token carrying a backslash, quote, or `sed` metacharacter would
                 # otherwise corrupt the key or abort the wrapper before exec.
@@ -333,3 +333,6 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
             prompt,
             system_prompt=system_prompt,
         )
+
+    async def cleanup(self, trace: Trace, runtime: Runtime) -> None:
+        await runtime.run(["rm", "-rf", f".vf-prime-agent-{trace.id}"], {})

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -1,173 +1,276 @@
-"""Prime Agent harness driving prime-agent's native ACP mode."""
+"""Run Prime Agent through its native ACP mode."""
+
+from __future__ import annotations
 
 import json
 import logging
+import re
 import shlex
+from typing import Literal
 
-from pydantic import Field
+from pydantic import Field, field_validator, model_validator
 
 from verifiers.v1.acp import ACP
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
-from verifiers.v1.harness import Harness
+from verifiers.v1.harness import Harness, HarnessSession
+from verifiers.v1.harnesses.node import NODE_BIN_DIR, ensure_node
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
 
 logger = logging.getLogger(__name__)
 
-# Model traffic is routed through the interception endpoint, which prime-agent
-# sees as an ordinary OpenAI-compatible provider.
-#
-# The agent-dir env var is derived from the package's own piConfig name, so the
-# published prime-agent release reads PRIME_AGENT_CODING_AGENT_DIR, not the
-# upstream PI_ prefix.
 ENV_AGENT_DIR = "PRIME_AGENT_CODING_AGENT_DIR"
+LEGACY_ENV_AGENT_DIR = "PRIME_CODING_AGENT_DIR"
 PROVIDER = "intercept"
-# Stand-in written to models.json; the launch wrapper swaps in the real secret.
-APIKEY_PLACEHOLDER = "__VF_PRIME_AGENT_KEY__"
 KEY_VAR = "PRIME_AGENT_INTERCEPT_KEY"
 
-PRIME_AGENT_DIR = "/tmp/vf-prime-agent"
-PRIME_AGENT_BIN = f"{PRIME_AGENT_DIR}/node_modules/.bin/prime-agent"
-SKILLS_DIR = ".agents/skills"
-# Release artifacts live under this base; `latest.json` at the root records the
-# current version and each tarball's sha256.
-#
-# This is the artifact base, which is not the same as the user-facing installer at
-# https://app.primeintellect.ai/prime-agent/install.sh. That script is a thin
-# front end: it resolves versions and downloads tarballs from this base, defaulting
-# to it in its own `prime_agent_base_url` and honoring PRIME_AGENT_DOWNLOAD_BASE_URL.
-# The same value is the prime-agent repo's R2_PUBLIC_BASE_URL variable, which its
-# release workflow publishes to. This harness installs the npm tarball directly
-# rather than running that script, so it needs the artifact base.
 RELEASE_BASE_URL = "https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev"
-NODE_VERSION = "22.19.0"
-NODE_BIN = f"{PRIME_AGENT_DIR}/node/bin"
+DEFAULT_VERSION = "0.7.0"
+DEFAULT_TARBALL_SHA256 = (
+    "88b6578518c72cd51a825bc80f28e0fef9a64c67de4a7d6fd7afd7ca1b34da0b"
+)
+INSTALL_ROOT = "/var/tmp/vf-prime-agent"
+STATE_ROOT = "/tmp/vf-prime-agent"
+THINKING_LEVELS = ("off", "minimal", "low", "medium", "high", "xhigh", "max")
+ThinkingLevel = Literal["off", "minimal", "low", "medium", "high", "xhigh", "max"]
 
 INSTALL = r"""
-set -e
-node="$VF_PRIME_AGENT_DIR/node"
-node_ok() { node -e 'const [a,b]=process.versions.node.split(".").map(Number); process.exit(a>22 || a===22 && b>=8 ? 0 : 1)'; }
+set -eu
+root="$VF_PRIME_AGENT_INSTALL_DIR"
+package_sha="$VF_PRIME_AGENT_TARBALL_SHA256"
+stamp="$root/.installed"
 
-# Containers do not ship Node, and prime-agent requires >=22.8. Prefer the
-# distro package, otherwise fetch the pinned official build.
-if [ -f /etc/alpine-release ]; then
-    apk add --no-cache curl ca-certificates nodejs-current npm >/dev/null
-    if ! node_ok; then
-        # The official Node build is glibc-only, so an Alpine whose own
-        # nodejs-current is too old has to move its repos forward and retry.
-        sed -E -i 's/v[0-9]+\.[0-9]+/v3.22/g' /etc/apk/repositories
-        apk upgrade --available --no-cache >/dev/null
-        apk add --no-cache nodejs-current npm >/dev/null
-    fi
-    node_bin="$(dirname "$(command -v node)")"
-else
-    if ! command -v curl >/dev/null 2>&1; then
-        # Only Debian-family images are provisioned here; say so instead of
-        # failing with "apt-get: not found" on a distro this cannot bootstrap.
-        command -v apt-get >/dev/null 2>&1 \
-            || { echo "prime-agent setup needs curl, or apt-get to install it" >&2; exit 1; }
-        apt-get update -qq && apt-get install -y -qq curl ca-certificates >/dev/null
-    fi
-    case "$(uname -s)" in Linux) node_os=linux ;; Darwin) node_os=darwin ;; *) echo "unsupported os: $(uname -s)" >&2; exit 1 ;; esac
-    if [ ! -x "$node/bin/node" ] || [ "$("$node/bin/node" --version 2>/dev/null)" != "v$VF_PRIME_AGENT_NODE_VERSION" ]; then
-        # Reject an unknown machine like the OS check does: guessing x64 would
-        # download an archive whose node cannot exec, failing much later.
-        case "$(uname -m)" in
-            aarch64|arm64) node_arch=arm64 ;;
-            x86_64|amd64) node_arch=x64 ;;
-            *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
-        esac
-        rm -rf "$node"
-        mkdir -p "$node"
-        curl -fsSL "https://nodejs.org/dist/v$VF_PRIME_AGENT_NODE_VERSION/node-v$VF_PRIME_AGENT_NODE_VERSION-${node_os}-${node_arch}.tar.gz" \
-            | tar -xz -C "$node" --strip-components=1
-    fi
-    node_bin="$node/bin"
-fi
-export PATH="$node_bin:$PATH"
-node_ok || { echo "prime-agent requires Node.js 22.8 or newer" >&2; exit 1; }
-
-# Concurrent rollouts share the install, so it is keyed on the requested
-# tarball: a changed `version` or `tarball_url` must reinstall rather than
-# silently reuse whatever an earlier rollout left in the shared directory.
-stamp="$VF_PRIME_AGENT_DIR/.installed"
-if [ -x "$VF_PRIME_AGENT_BIN" ] && [ "$(cat "$stamp" 2>/dev/null)" = "$VF_PRIME_AGENT_TARBALL" ]; then
+if [ -x "$VF_PRIME_AGENT_BIN" ] \
+    && [ "$(cat "$stamp" 2>/dev/null)" = "$package_sha" ]; then
     exit 0
 fi
-mkdir -p "$VF_PRIME_AGENT_DIR"
-# Drop the stamp first so a failed install is never mistaken for a good one.
-rm -f "$stamp"
-# The published release tarball is a plain npm package, so install it directly
-# instead of running the interactive installer script.
-npm install --no-audit --no-fund --prefix "$VF_PRIME_AGENT_DIR" \
-    "$VF_PRIME_AGENT_TARBALL" >/dev/null
-printf %s "$VF_PRIME_AGENT_TARBALL" > "$stamp"
+
+staging="${root}.staging.$$"
+backup="${root}.previous.$$"
+trap 'rm -rf "$staging" "$backup"' EXIT
+rm -rf "$staging" "$backup"
+mkdir -p "$staging"
+
+curl -fsSL "$VF_PRIME_AGENT_TARBALL" -o "$staging/prime-agent.tgz"
+if command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "$staging/prime-agent.tgz" | cut -d ' ' -f 1)"
+else
+    actual="$(shasum -a 256 "$staging/prime-agent.tgz" | cut -d ' ' -f 1)"
+fi
+if [ "$actual" != "$package_sha" ]; then
+    echo "prime-agent tarball checksum mismatch" >&2
+    exit 1
+fi
+
+export PATH="$VF_NODE_BIN_DIR:$PATH"
+export PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL=1
+export PRIME_AGENT_INSTALL_UV=1
+export PRIME_AGENT_KERNEL_VENV="$VF_PRIME_AGENT_KERNEL_VENV"
+npm install --no-audit --no-fund --prefix "$staging" \
+    "$staging/prime-agent.tgz" >/dev/null
+printf %s "$package_sha" > "$staging/.installed"
+
+if [ -e "$root" ]; then
+    mv "$root" "$backup"
+fi
+mv "$staging" "$root"
+rm -rf "$backup"
+trap - EXIT
 """
 
 PRIME_AGENT_ACP = ACP()
 
 
 class PrimeAgentHarnessConfig(HarnessConfig):
-    version: str = "0.6.0"
-    """Prime Agent release to install, pinned for reproducibility.
+    id: Literal["prime-agent"] = "prime-agent"
 
-    0.6.0 is the first release with native ACP mode (`--mode acp`).
-    """
+    version: str = DEFAULT_VERSION
+    """Prime Agent release to install."""
 
     tarball_url: str | None = None
-    """Override the release tarball URL (defaults to the pinned public release)."""
+    """Override the release tarball URL."""
+
+    tarball_sha256: str | None = None
+    """SHA-256 for a non-default release or custom tarball."""
+
+    thinking_level: ThinkingLevel | None = None
+    """Override the sampling reasoning effort passed to Prime Agent."""
+
+    model_context_window: int = Field(default=128_000, strict=True, gt=0)
+    model_max_tokens: int = Field(default=16_384, strict=True, gt=0)
+    load_context_files: bool = False
+    save_session: bool = False
+    max_depth: int = Field(default=0, strict=True, ge=0)
 
     autonomous: bool = False
-    """Run with `--autonomous`, so the agent continues until its limits or gates stop it."""
-
     gates: list[str] = Field(default_factory=list)
-    """Autonomous quality-gate commands. Requires `autonomous`."""
+    autonomous_gate_retries: int | None = Field(default=None, strict=True, gt=0)
+    autonomous_gate_timeout_ms: int | None = Field(default=None, strict=True, gt=0)
+    autonomous_max_continuations: int | None = Field(default=None, strict=True, gt=0)
+    autonomous_max_turns: int | None = Field(default=None, strict=True, gt=0)
+    autonomous_max_tokens: int | None = Field(default=None, strict=True, gt=0)
+    autonomous_timeout_ms: int | None = Field(default=None, strict=True, gt=0)
+
+    goal: str | None = None
+    goal_token_budget: int | None = Field(default=None, strict=True, gt=0)
+
+    @field_validator("version")
+    @classmethod
+    def normalize_version(cls, value: str) -> str:
+        version = value.removeprefix("v")
+        if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?", version):
+            raise ValueError("version must be a semantic version")
+        return version
+
+    @field_validator("tarball_sha256")
+    @classmethod
+    def normalize_sha256(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        digest = value.lower()
+        if not re.fullmatch(r"[0-9a-f]{64}", digest):
+            raise ValueError("tarball_sha256 must be a 64-character hexadecimal digest")
+        return digest
+
+    @model_validator(mode="after")
+    def validate_options(self) -> PrimeAgentHarnessConfig:
+        if self.tarball_url and not self.tarball_sha256:
+            raise ValueError("tarball_url requires tarball_sha256")
+        if self.version != DEFAULT_VERSION and not self.tarball_sha256:
+            raise ValueError("a non-default version requires tarball_sha256")
+        autonomous_options = (
+            self.gates,
+            self.autonomous_gate_retries,
+            self.autonomous_gate_timeout_ms,
+            self.autonomous_max_continuations,
+            self.autonomous_max_turns,
+            self.autonomous_max_tokens,
+            self.autonomous_timeout_ms,
+        )
+        if not self.autonomous and any(value for value in autonomous_options):
+            raise ValueError("autonomous options require autonomous=true")
+        if any(not gate.strip() for gate in self.gates):
+            raise ValueError("gates must contain non-empty commands")
+        if self.goal is not None and not self.goal.strip():
+            raise ValueError("goal must be non-empty")
+        if self.goal_token_budget is not None and not self.goal:
+            raise ValueError("goal_token_budget requires goal")
+        unknown_tools = set(self.disabled_tools or []) - {"ipython"}
+        if unknown_tools:
+            names = ", ".join(sorted(unknown_tools))
+            raise ValueError(f"prime-agent cannot disable unknown tools: {names}")
+        return self
 
 
 class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
     APPENDS_SYSTEM_PROMPT = True
-    # prime-agent's ACP mode ignores the `mcpServers` of `session/new`, and its own
-    # MCP integrations are authored Python-backed skills the model imports in its
-    # kernel, not tools an ACP client can inject. Claiming support would let a
-    # tool-bearing taskset run with its tools silently absent, so declare it false
-    # and let `validate_pairing` reject that pairing up front.
     SUPPORTS_MCP = False
     SUPPORTS_RESUME = True
     SUPPORTS_SKILLS = True
 
-    def _tarball(self) -> str:
+    def tarball(self) -> str:
         if self.config.tarball_url:
             return self.config.tarball_url
         version = self.config.version
         return f"{RELEASE_BASE_URL}/releases/v{version}/prime-agent-{version}.tgz"
 
+    def tarball_sha256(self) -> str:
+        return self.config.tarball_sha256 or DEFAULT_TARBALL_SHA256
+
+    def install_dir(self) -> str:
+        return f"{INSTALL_ROOT}/{self.config.version}-{self.tarball_sha256()[:16]}"
+
+    def prime_agent_bin(self) -> str:
+        return f"{self.install_dir()}/node_modules/.bin/prime-agent"
+
+    def kernel_venv(self) -> str:
+        return (
+            f"{INSTALL_ROOT}/kernels/{self.config.version}-{self.tarball_sha256()[:16]}"
+        )
+
+    @staticmethod
+    def trace_root(trace: Trace) -> str:
+        return f"{STATE_ROOT}-{trace.id}"
+
+    @classmethod
+    def agent_dir(cls, trace: Trace) -> str:
+        return f"{cls.trace_root(trace)}/agent"
+
+    @classmethod
+    def daemon_socket(cls, trace: Trace) -> str:
+        return f"{cls.trace_root(trace)}/daemon.sock"
+
+    @classmethod
+    def temp_dir(cls, trace: Trace) -> str:
+        return f"{cls.trace_root(trace)}/tmp"
+
     async def setup(self, runtime: Runtime) -> None:
-        await self.install_skills(runtime, SKILLS_DIR)
+        await ensure_node(runtime)
         logger.info("prime-agent: ensuring %s is installed", self.config.version)
-        lock = f"{PRIME_AGENT_DIR}/install.lock"
-        # Concurrent rollouts share one runtime; serialize the install like the
-        # other node-based harnesses do.
+        install_dir = self.install_dir()
+        lock = f"{install_dir}.install.lock"
         guarded = (
-            f"mkdir -p {PRIME_AGENT_DIR} && "
-            f'"$(command -v flock || command -v lockf)" {lock} '
+            f"mkdir -p {shlex.quote(INSTALL_ROOT)} && "
+            f'until ln -s "$$" {shlex.quote(lock)} 2>/dev/null; do '
+            f"owner=$(readlink {shlex.quote(lock)}); "
+            f'if ! kill -0 "$owner" 2>/dev/null; then '
+            f'[ "$(readlink {shlex.quote(lock)})" != "$owner" ] || '
+            f"rm -f {shlex.quote(lock)}; fi; "
+            f"sleep 0.1; done; "
+            f'trap \'[ "$(readlink {shlex.quote(lock)})" != "$$" ] || '
+            f"rm -f {shlex.quote(lock)}' EXIT; "
             f"sh -c {shlex.quote(INSTALL)}"
         )
         install = await runtime.run(
             ["sh", "-c", guarded],
             {
-                "VF_PRIME_AGENT_DIR": PRIME_AGENT_DIR,
-                "VF_PRIME_AGENT_BIN": PRIME_AGENT_BIN,
-                "VF_PRIME_AGENT_TARBALL": self._tarball(),
-                "VF_PRIME_AGENT_NODE_VERSION": NODE_VERSION,
+                **self.config.resolved_env,
+                "VF_NODE_BIN_DIR": NODE_BIN_DIR,
+                "VF_PRIME_AGENT_BIN": self.prime_agent_bin(),
+                "VF_PRIME_AGENT_INSTALL_DIR": install_dir,
+                "VF_PRIME_AGENT_KERNEL_VENV": self.kernel_venv(),
+                "VF_PRIME_AGENT_TARBALL": self.tarball(),
+                "VF_PRIME_AGENT_TARBALL_SHA256": self.tarball_sha256(),
             },
         )
         if install.exit_code != 0:
-            raise RuntimeError(
-                f"prime-agent install failed: {install.stderr.strip()[-500:]}"
-            )
+            detail = (install.stderr or install.stdout).strip()[-1000:]
+            raise RuntimeError(f"prime-agent install failed: {detail}")
         await PRIME_AGENT_ACP.setup(self, runtime)
+
+    async def session(
+        self,
+        ctx: ModelContext,
+        trace: Trace,
+        runtime: Runtime,
+        endpoint: str,
+        secret: str,
+        mcp_urls: dict[str, str],
+        data: TaskData,
+    ) -> HarnessSession:
+        if not runtime.supports_live_processes:
+            return await super().session(
+                ctx, trace, runtime, endpoint, secret, mcp_urls, data
+            )
+        system_prompt, prompt = self.resolve_prompt(data)
+        env, command = await self.prepare_run(
+            ctx, trace, runtime, endpoint, secret, system_prompt
+        )
+        return PRIME_AGENT_ACP.session(
+            self,
+            ctx,
+            trace,
+            runtime,
+            endpoint,
+            secret,
+            {},
+            data,
+            env=env,
+            command=command,
+            prompt=prompt,
+        )
 
     async def launch(
         self,
@@ -180,35 +283,56 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
         data: TaskData,
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(data)
-        # A resumed segment replays the accreted conversation, and the ACP runner
-        # renders that transcript into the prompt — including the `[system]` block
-        # it rendered on the first segment. Re-emitting the system prompt here
-        # would hand the model the same instructions twice.
-        if trace.branches and trace.branches[-1].messages:
-            system_prompt = None
-        agent_dir = f".vf-prime-agent-{trace.id}"
-        reasoning = ctx.sampling.reasoning_effort not in (
-            None,
-            "none",
-        ) or ctx.model.rsplit("/", 1)[-1].startswith(("gpt-5", "o1", "o3", "o4"))
+        env, command = await self.prepare_run(
+            ctx, trace, runtime, endpoint, secret, system_prompt
+        )
+        return await PRIME_AGENT_ACP.run(runtime, env, command, prompt)
+
+    async def prepare_run(
+        self,
+        ctx: ModelContext,
+        trace: Trace,
+        runtime: Runtime,
+        endpoint: str,
+        secret: str,
+        system_prompt: str | None,
+    ) -> tuple[dict[str, str], list[str]]:
+        root = self.trace_root(trace)
+        agent_dir = self.agent_dir(trace)
+        temp_dir = self.temp_dir(trace)
+        created = await runtime.run(
+            ["mkdir", "-p", "-m", "700", root, agent_dir, temp_dir], {}
+        )
+        if created.exit_code != 0:
+            raise RuntimeError(
+                f"prime-agent state directory failed: {created.stderr.strip()[-500:]}"
+            )
+
+        skills_dir = f"{agent_dir}/skills"
+        await self.install_skills(runtime, skills_dir)
+        thinking = self.thinking_level(ctx)
+        reasoning = thinking not in (None, "off") or (
+            thinking is None
+            and ctx.model.rsplit("/", 1)[-1].startswith(("gpt-5", "o1", "o3", "o4"))
+        )
         models = {
             "providers": {
                 PROVIDER: {
                     "baseUrl": endpoint,
                     "api": "openai-completions",
-                    # prime-agent does not expand "$VAR" in models.json: it sends the
-                    # literal string as the bearer token (verified against a capturing
-                    # server), so the pi-style indirection cannot be used here. The
-                    # secret is substituted by the launch wrapper at exec time instead
-                    # of being written to disk, because concurrent rollouts share a
-                    # runtime and model-executed code could otherwise read another
-                    # rollout's credential out of its models.json.
-                    "apiKey": APIKEY_PLACEHOLDER,
+                    "apiKey": KEY_VAR,
                     "models": [
                         {
                             "id": ctx.model,
+                            "name": ctx.model,
                             "reasoning": reasoning,
                             "input": ["text", "image"],
+                            "contextWindow": self.config.model_context_window,
+                            "maxTokens": (
+                                ctx.sampling.max_tokens
+                                if ctx.sampling.max_tokens is not None
+                                else self.config.model_max_tokens
+                            ),
                         }
                     ],
                 }
@@ -216,78 +340,135 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
         }
         models_path = f"{agent_dir}/models.json"
         await runtime.write(models_path, json.dumps(models).encode())
+        restricted = await runtime.run(["chmod", "700", root, agent_dir, temp_dir], {})
+        if restricted.exit_code != 0:
+            raise RuntimeError(
+                f"prime-agent state permissions failed: {restricted.stderr.strip()[-500:]}"
+            )
+        restricted = await runtime.run(["chmod", "600", models_path], {})
+        if restricted.exit_code != 0:
+            raise RuntimeError(
+                f"prime-agent model permissions failed: {restricted.stderr.strip()[-500:]}"
+            )
 
-        env = {
-            **self.config.resolved_env,
-            KEY_VAR: secret,
-            ENV_AGENT_DIR: agent_dir,
-            "PRIME_AGENT_OFFLINE": "1",
-            "PRIME_AGENT_TELEMETRY": "0",
-        }
+        wrapper = f"{root}/prime-agent"
+        await runtime.write(
+            wrapper,
+            (
+                "#!/bin/sh\n"
+                f'export PATH="{NODE_BIN_DIR}:$PATH"\n'
+                f'exec {shlex.quote(self.prime_agent_bin())} "$@"\n'
+            ).encode(),
+        )
+        restricted = await runtime.run(["chmod", "700", wrapper], {})
+        if restricted.exit_code != 0:
+            raise RuntimeError(
+                f"prime-agent wrapper permissions failed: {restricted.stderr.strip()[-500:]}"
+            )
 
+        env = self.run_env(trace, secret)
         args = [
-            PRIME_AGENT_BIN,
+            wrapper,
             "--mode",
             "acp",
+            "--daemon-socket",
+            self.daemon_socket(trace),
             "--provider",
             PROVIDER,
             "--model",
             ctx.model,
         ]
-        for skill in self.config.skills:
-            # Resolve like `install_skills` so the path matches what it wrote.
-            args += ["--skill", f"{SKILLS_DIR}/{skill.resolve().name}"]
+        if thinking is not None:
+            args += ["--thinking", thinking]
+        if not self.config.save_session:
+            args.append("--no-session")
+        if not self.config.load_context_files:
+            args.append("--no-context-files")
         if self.config.disabled_tools:
-            raise ValueError(
-                "prime-agent has no per-tool disable flag; its model-facing tool is "
-                "ipython. Use --no-builtin-tools upstream if that is ever needed."
-            )
+            args.append("--no-builtin-tools")
+        for skill in self.config.skills:
+            args += ["--skill", f"{skills_dir}/{skill.resolve().name}"]
         if self.config.autonomous:
             args.append("--autonomous")
             for gate in self.config.gates:
                 args += ["--autonomous-gate", gate]
-        elif self.config.gates:
-            raise ValueError("prime-agent gates require autonomous=true")
-        # The ACP runner seeds the system prompt into the conversation itself, so
-        # passing --append-system-prompt as well would apply it twice.
+            for flag, value in (
+                ("--autonomous-gate-retries", self.config.autonomous_gate_retries),
+                (
+                    "--autonomous-gate-timeout-ms",
+                    self.config.autonomous_gate_timeout_ms,
+                ),
+                (
+                    "--autonomous-max-continuations",
+                    self.config.autonomous_max_continuations,
+                ),
+                ("--autonomous-max-turns", self.config.autonomous_max_turns),
+                ("--autonomous-max-tokens", self.config.autonomous_max_tokens),
+                ("--autonomous-timeout-ms", self.config.autonomous_timeout_ms),
+            ):
+                if value is not None:
+                    args += [flag, str(value)]
+        if self.config.goal is not None:
+            args += ["--goal", self.config.goal]
+            if self.config.goal_token_budget is not None:
+                args += ["--goal-token-budget", str(self.config.goal_token_budget)]
+        if system_prompt:
+            args += ["--append-system-prompt", system_prompt]
+        return env, args
 
-        # ACP owns stdout, so the agent must be exec'd directly with HOME pinned
-        # to the per-trace agent dir: prime-agent writes sessions and kernel state
-        # under it, and rollouts must not share either.
-        wrapper = f"{agent_dir}/prime-agent"
-        await runtime.write(
-            wrapper,
-            (
-                "#!/bin/sh\n"
-                "set -e\n"
-                # The bundled Node lives beside the install, not on the container PATH.
-                f'export PATH="{NODE_BIN}:$PATH"\n'
-                f'{ENV_AGENT_DIR}="$PWD/${ENV_AGENT_DIR}"\n'
-                f'export {ENV_AGENT_DIR} HOME="${ENV_AGENT_DIR}"\n'
-                # Substitute the bearer token into models.json here, so the plaintext
-                # credential is only readable by this rollout's own agent process.
-                # Node rewrites the parsed document rather than a text substitution:
-                # a token carrying a backslash, quote, or `sed` metacharacter would
-                # otherwise corrupt the key or abort the wrapper before exec.
-                f'models="${ENV_AGENT_DIR}/models.json"\n'
-                f"umask 077\n"
-                "node -e '"
-                'const fs=require("fs"),p=process.argv[1],'
-                'c=JSON.parse(fs.readFileSync(p,"utf8"));'
-                f'c.providers["{PROVIDER}"].apiKey=process.env.{KEY_VAR}||"";'
-                'fs.writeFileSync(p,JSON.stringify(c))\' "$models"\n'
-                f'exec {shlex.join(args)} "$@"\n'
-            ).encode(),
-        )
-        await runtime.run(["chmod", "+x", wrapper], {})
-        # models.json is world-readable as written; restrict it before it holds a secret.
-        await runtime.run(["chmod", "700", agent_dir], {})
-        await runtime.run(["chmod", "600", models_path], {})
+    def run_env(self, trace: Trace, secret: str | None = None) -> dict[str, str]:
+        agent_dir = self.agent_dir(trace)
+        temp_dir = self.temp_dir(trace)
+        return {
+            **self.config.resolved_env,
+            **({KEY_VAR: secret} if secret is not None else {}),
+            ENV_AGENT_DIR: agent_dir,
+            LEGACY_ENV_AGENT_DIR: agent_dir,
+            "NO_COLOR": "1",
+            "PI_OFFLINE": "1",
+            "PI_SKIP_VERSION_CHECK": "1",
+            "PRIME_AGENT_KERNEL_VENV": self.kernel_venv(),
+            "RLM_MAX_DEPTH": str(self.config.max_depth),
+            "TEMP": temp_dir,
+            "TMP": temp_dir,
+            "TMPDIR": temp_dir,
+        }
 
-        return await PRIME_AGENT_ACP.run(
-            runtime,
-            env,
-            ["sh", "-c", f'exec "$PWD/{wrapper}"'],
-            prompt,
-            system_prompt=system_prompt,
+    def thinking_level(self, ctx: ModelContext) -> ThinkingLevel | None:
+        if self.config.thinking_level is not None:
+            return self.config.thinking_level
+        effort = ctx.sampling.reasoning_effort
+        if effort is None:
+            return None
+        normalized = effort.lower()
+        if normalized == "none":
+            return "off"
+        if normalized not in THINKING_LEVELS:
+            supported = ", ".join(("none", *THINKING_LEVELS))
+            raise ValueError(
+                f"prime-agent does not support reasoning_effort={effort!r}; "
+                f"expected one of: {supported}"
+            )
+        return normalized  # type: ignore[return-value]
+
+    async def cleanup(self, trace: Trace, runtime: Runtime) -> None:
+        root = self.trace_root(trace)
+        wrapper = f"{root}/prime-agent"
+        shutdown = await runtime.run(
+            [
+                "sh",
+                "-c",
+                'if [ -x "$1" ]; then "$1" shutdown --force; fi',
+                "prime-agent-cleanup",
+                wrapper,
+            ],
+            self.run_env(trace),
         )
+        if shutdown.exit_code != 0:
+            detail = (shutdown.stderr or shutdown.stdout).strip()[-500:]
+            raise RuntimeError(f"prime-agent daemon shutdown failed: {detail}")
+        removed = await runtime.run(["rm", "-rf", root], {})
+        if removed.exit_code != 0:
+            raise RuntimeError(
+                f"prime-agent state cleanup failed: {removed.stderr.strip()[-500:]}"
+            )

--- a/verifiers/v1/interception/tunnel/prime.py
+++ b/verifiers/v1/interception/tunnel/prime.py
@@ -13,7 +13,7 @@ from verifiers.v1.runtimes.limiters import creation_limiter
 from verifiers.v1.utils.aio import run_shielded
 
 # The prime_tunnel service caps tunnel starts at 512/min per API token — a property of the
-# tunnel service, shared by every process on the host that opens one. One host-global
+# tunnel service, shared by every process for the user that opens one. One user-global
 # limiter, not a per-runtime config knob.
 _TUNNELS_PER_MIN = 512
 TUNNEL_LIMITER = creation_limiter(_TUNNELS_PER_MIN / 60, "prime-tunnel")
@@ -30,7 +30,7 @@ class PrimeTunnel(Tunnel[PrimeTunnelConfig]):
     @contextlib.asynccontextmanager
     async def expose(self, port: int) -> AsyncIterator[str]:
         """Bridge the host `port` to a public URL via prime_tunnel (frpc). Tunnel creation
-        is network-bound and globally rate-capped (512/min, host-wide via the shared
+        is network-bound and globally rate-capped (512/min, user-wide via the shared
         `TUNNEL_LIMITER`), so transient failures are retried; a terminal one raises
         `TunnelError`. The tunnel is torn down on exit."""
         from prime_tunnel import Tunnel as TunnelClient

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -77,6 +77,13 @@ class RuntimeProcess(ABC):
     async def kill(self) -> None:
         pass
 
+    async def aclose(self) -> None:
+        """Release transport resources pinned by this process handle.
+
+        Runtimes whose processes hold remote streams or dedicated connections
+        override this. Local processes have nothing to release."""
+        return
+
 
 def parse_gpu(gpu: str | None) -> tuple[str | None, int]:
     """A Modal-style GPU spec -> (type, count) for providers that want them split:

--- a/verifiers/v1/runtimes/limiters.py
+++ b/verifiers/v1/runtimes/limiters.py
@@ -1,41 +1,45 @@
-"""Host-global creation-rate limiters for the remote runtimes.
+"""User-global creation-rate limiters for the remote runtimes.
 
-A leaky bucket backed by a lock file, so a provider's per-account creation rate (Modal
-sandboxes, Prime tunnels) is enforced across EVERY process on the host — the single-process
-eval and all the elastically-spawned env-server worker processes alike — not just within one
-process. So the configured rate is the actual account-wide rate (assuming one env-server
-host). Keyed by name: one bucket file per name, shared by every process (and run) on the host.
+A leaky bucket backed by a lock file under the user cache (``~/.cache/verifiers``, falling
+back to the temp dir when no home is resolvable), so a provider's per-account creation rate
+(Modal sandboxes, Prime tunnels) is enforced across EVERY process for the user —
+the single-process eval and all the elastically-spawned env-server worker processes alike — not
+just within one process. Keyed by name: one bucket file per name, shared by every process (and
+run) for the user.
 """
 
 import asyncio
 import fcntl
 import os
-import tempfile
 import time
 from typing import Self
 
-_LIMITER_DIR = os.path.join(tempfile.gettempdir(), "vf-rate-limiters")
+from verifiers.utils.path_utils import CACHE_DIR
+
+LIMITER_DIR = CACHE_DIR / "limiter"
 
 
 class CreationLimiter:
     """An async leaky bucket shared across processes via a lock file: each `async with`
     reserves the next `1/per_sec`-spaced slot (advancing the on-disk cursor under an exclusive
-    flock) and sleeps until it, so the aggregate creation rate across all host processes stays
-    at `per_sec`. The reservation runs off the event loop; the wait does not hold the lock."""
+    flock) and sleeps until it, so the aggregate creation rate across all of the user's
+    processes stays at `per_sec`. The reservation runs off the event loop; the wait does not
+    hold the lock."""
 
     def __init__(self, name: str, per_sec: float) -> None:
         self._interval = 1 / per_sec
-        self._path = os.path.join(_LIMITER_DIR, f"{name}.bucket")
+        self._path = LIMITER_DIR / f"{name}.bucket"
 
     def _reserve(self) -> float:
-        os.makedirs(_LIMITER_DIR, exist_ok=True)
-        # monotonic is host-wide on Linux, so the cursor is comparable across processes.
+        os.makedirs(LIMITER_DIR, exist_ok=True)
+        # Wall clock persists across reboots (monotonic does not), so a cursor left in
+        # ~/.cache from a previous boot cannot turn into a huge stale wait.
         with open(self._path, "a+") as f:
             fcntl.flock(f.fileno(), fcntl.LOCK_EX)
             try:
                 f.seek(0)
                 data = f.read().strip()
-                now = time.monotonic()
+                now = time.time()
                 slot = max(now, float(data) if data else 0.0)
                 f.seek(0)
                 f.truncate()
@@ -59,7 +63,7 @@ _creation_limiters: dict[str, CreationLimiter] = {}
 
 
 def creation_limiter(per_sec: float | None, name: str) -> CreationLimiter | None:
-    """A host-global limiter pacing `name`'s creation to `per_sec`/s (None/<= 0 disables).
+    """A user-global limiter pacing `name`'s creation to `per_sec`/s (None/<= 0 disables).
 
     All callers (and processes) sharing a `name` share one bucket, so use one rate per name."""
     if not per_sec or per_sec <= 0:

--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -53,7 +53,7 @@ class ModalConfig(BaseConfig):
     """Disk in GB. Modal sandboxes have no disk knob, so this is accepted (so a task can
     declare it without a warning) but not enforced."""
     creates_per_sec: float | None = 40.0
-    """Pace sandbox creation to this many per second, enforced host-wide across every
+    """Pace sandbox creation to this many per second, enforced user-wide across every
     env-server worker process (None/<= 0 disables it)."""
 
 

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -63,6 +63,8 @@ class PrimeConfig(NetworkPolicyConfig):
     """GPU spec, e.g. "A100" or "A100:2" (a bare count = provider-chosen type)."""
     disk: float = 5.0
     """Disk in GB."""
+    lifetime_timeout: float = Field(default=MAX_LIFETIME, gt=0, le=MAX_LIFETIME)
+    """Maximum sandbox lifetime in seconds."""
     idle_timeout: float | None = 3600
     """Seconds of inactivity before the sandbox self-deletes (None disables)."""
     creates_per_min: int | None = None
@@ -88,10 +90,14 @@ class PrimeConfig(NetworkPolicyConfig):
 
     @model_validator(mode="after")
     def _validate_idle_timeout(self) -> "PrimeConfig":
-        if self.idle_timeout is not None and self.idle_timeout > MAX_LIFETIME:
+        if (
+            not self.vm
+            and self.idle_timeout is not None
+            and self.idle_timeout > self.lifetime_timeout
+        ):
             raise ValueError(
                 f"idle_timeout ({self.idle_timeout}s) must not exceed the "
-                f"{MAX_LIFETIME}s ({MAX_LIFETIME // 3600}h) max sandbox lifetime"
+                f"lifetime_timeout ({self.lifetime_timeout}s)"
             )
         return self
 
@@ -158,7 +164,7 @@ class PrimeRuntime(Runtime):
             "memory_gb": self.config.memory,
             "disk_size_gb": self.config.disk,
             "gpu_count": gpu_count,
-            "timeout_minutes": MAX_LIFETIME // 60,
+            "timeout_minutes": max(1, math.ceil(self.config.lifetime_timeout / 60)),
             "idle_timeout_minutes": idle_minutes,
             "gpu_type": gpu_type,
             "region": self.config.region,
@@ -254,7 +260,7 @@ class PrimeRuntime(Runtime):
             result = await self._client.run_background_job(
                 self.info.id,
                 shlex.join(argv),
-                timeout=MAX_LIFETIME,
+                timeout=self.config.lifetime_timeout,
                 working_dir=self.config.workdir,
                 env=env,
                 poll_interval=1,

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -339,7 +339,12 @@ class PrimeRuntime(Runtime):
 
         client = self._client
         sandbox_id = self.info.id
-        transport = HTTPTransport()
+        try:
+            # pyqwest >= 0.7 leaves system CA trust off for bare transports; a
+            # bare HTTPTransport() there fails TLS with "UnknownIssuer".
+            transport = HTTPTransport(tls_include_system_certs=True)
+        except TypeError:  # pyqwest 0.6.x trusts system CAs by default
+            transport = HTTPTransport()
         http_client = HTTPClient(transport=transport)
 
         async def authed_target() -> tuple[str, dict[str, str]]:

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -308,14 +308,16 @@ class PrimeRuntime(Runtime):
     async def run_background(
         self, argv: list[str], env: dict[str, str], log: str
     ) -> None:
-        # `&` backgrounds inside the sandbox; the job returns immediately, the process
-        # lives until the sandbox is deleted in stop().
-        inner = f"nohup {shlex.join(argv)} > {shlex.quote(log)} 2>&1 &"
-        result = await self.run(["sh", "-c", inner], env)
-        if result.exit_code != 0:
-            raise SandboxError(
-                f"prime background launch failed: {result.stderr.strip()}"
+        command = f"exec {shlex.join(argv)} > {shlex.quote(log)} 2>&1"
+        try:
+            await self._client.start_background_job(
+                self.info.id,
+                command,
+                working_dir=self.config.workdir,
+                env=env,
             )
+        except Exception as e:
+            raise SandboxError(f"prime background launch failed: {e}") from e
 
     async def _read(self, path: str) -> bytes:
         # Avoid background-job log limits and base64 overhead by downloading binary data directly.

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -66,7 +66,7 @@ class PrimeConfig(NetworkPolicyConfig):
     idle_timeout: float | None = 3600
     """Seconds of inactivity before the sandbox self-deletes (None disables)."""
     creates_per_min: int | None = None
-    """Pace sandbox creation to this many per minute, enforced host-wide across every
+    """Pace sandbox creation to this many per minute, enforced user-wide across every
     env-server worker process (None/<= 0 disables it). (Tunnel creation is limited separately
     and globally — see interception.tunnel.prime.TUNNEL_LIMITER.)"""
 

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -109,8 +109,9 @@ class PrimeRuntimeInfo(PrimeConfig, BaseRuntimeInfo):
 
 
 class PrimeProcess(RuntimeProcess):
-    def __init__(self, process) -> None:
+    def __init__(self, process, transport=None) -> None:
         self._process = process
+        self._transport = transport
         self.stdout: AsyncIterator[bytes] = process.stdout
         self.stderr: AsyncIterator[bytes] = process.stderr
 
@@ -125,6 +126,18 @@ class PrimeProcess(RuntimeProcess):
 
     async def kill(self) -> None:
         await self._process.kill()
+
+    async def aclose(self) -> None:
+        # The SDK handle owns the command-session stream and its pump task; the
+        # transport owns this process's dedicated connection. Both must go even
+        # when the remote exit event never arrived — an abandoned stream pins a
+        # gateway HTTP/2 stream slot until the sandbox is deleted.
+        try:
+            await self._process.aclose()
+        finally:
+            if self._transport is not None:
+                with contextlib.suppress(Exception):
+                    await self._transport.aclose()
 
 
 class PrimeRuntime(Runtime):
@@ -284,15 +297,122 @@ class PrimeRuntime(Runtime):
                 "set runtime.prime.vm=true"
             )
         try:
-            process = await self._client.open_process(
-                self.info.id,
-                shlex.join(argv),
-                working_dir=self.config.workdir,
-                env=env,
+            process, transport = await self._open_process_on_own_transport(
+                shlex.join(argv), env
             )
         except Exception as e:
             raise SandboxError(f"prime live process failed to start: {e}") from e
-        return PrimeProcess(process)
+        return PrimeProcess(process, transport)
+
+    async def _open_process_on_own_transport(self, command: str, env: dict[str, str]):
+        """Start a live process whose RPCs ride one dedicated HTTP connection.
+
+        The SDK routes every command-session RPC over pyqwest's shared default
+        transport, and the gateway caps one HTTP/2 connection at 100 concurrent
+        streams. Each live process pins one stream for its whole life, so
+        accumulated sessions starve stdin/signal RPCs into their 30s deadline
+        ("deadline_exceeded") and queue new process streams for minutes under
+        the 24h stream timeout. One transport per process keeps a process
+        competing only with itself. Rebuilds the SDK's open_process wiring from
+        prime-sandboxes internals (pinned >=0.2.35); drop this once the SDK
+        isolates its own command-session transports."""
+        from connectrpc.client import ConnectClient
+        from connectrpc.code import Code
+        from connectrpc.errors import ConnectError
+        from prime_sandboxes.core import APIError
+        from prime_sandboxes.process import AsyncSandboxProcess
+        from prime_sandboxes.rpc_command_session import (
+            COMMAND_SESSION_SEND_INPUT_RPC_METHOD,
+            COMMAND_SESSION_SEND_SIGNAL_RPC_METHOD,
+            COMMAND_SESSION_START_RPC_METHOD,
+            build_command_session_send_input_request,
+            build_command_session_send_signal_request,
+            build_command_session_start_request,
+        )
+        from prime_sandboxes.sandbox import (
+            _LIVE_PROCESS_TIMEOUT_MS,
+            _PROCESS_INPUT_TIMEOUT_MS,
+            _PROCESS_SIGNAL_TIMEOUT_MS,
+        )
+        from pyqwest import Client as HTTPClient
+        from pyqwest import HTTPTransport
+
+        client = self._client
+        sandbox_id = self.info.id
+        transport = HTTPTransport()
+        http_client = HTTPClient(transport=transport)
+
+        async def authed_target() -> tuple[str, dict[str, str]]:
+            auth = await client._auth_cache.get_or_refresh(sandbox_id)
+            gateway_url = auth["gateway_url"].rstrip("/")
+            return (
+                f"{gateway_url}/{auth['user_ns']}/{auth['job_id']}",
+                {"Authorization": f"Bearer {auth['token']}"},
+            )
+
+        async def control_rpc(request, method, timeout_ms: int, operation: str) -> None:
+            # Mirrors AsyncSandboxClient._execute_process_control_rpc, including
+            # its error strings, but sends over this process's own transport.
+            reauthed = False
+            while True:
+                base_url, headers = await authed_target()
+                rpc_client = ConnectClient(base_url, http_client=http_client)
+                try:
+                    await rpc_client.execute_unary(
+                        request=request,
+                        method=method,
+                        headers=headers,
+                        timeout_ms=timeout_ms,
+                    )
+                    return
+                except ConnectError as error:
+                    if (
+                        error.code == Code.UNAUTHENTICATED
+                        and await client._should_retry_401(sandbox_id, reauthed)
+                    ):
+                        reauthed = True
+                        continue
+                    raise APIError(
+                        f"process {operation} RPC failed ({error.code.value}): {error.message}"
+                    ) from error
+                finally:
+                    await rpc_client.close()
+
+        async def write_stdin(pid: int, data: bytes) -> None:
+            await control_rpc(
+                build_command_session_send_input_request(pid, data),
+                COMMAND_SESSION_SEND_INPUT_RPC_METHOD,
+                _PROCESS_INPUT_TIMEOUT_MS,
+                "stdin",
+            )
+
+        async def send_signal(pid: int, signal: Literal["terminate", "kill"]) -> None:
+            await control_rpc(
+                build_command_session_send_signal_request(pid, signal),
+                COMMAND_SESSION_SEND_SIGNAL_RPC_METHOD,
+                _PROCESS_SIGNAL_TIMEOUT_MS,
+                "signal",
+            )
+
+        try:
+            base_url, headers = await authed_target()
+            stream_client = ConnectClient(base_url, http_client=http_client)
+            stream = stream_client.execute_server_stream(
+                request=build_command_session_start_request(
+                    command, self.config.workdir, env, stdin=True
+                ),
+                method=COMMAND_SESSION_START_RPC_METHOD,
+                headers=headers,
+                timeout_ms=_LIVE_PROCESS_TIMEOUT_MS,
+            )
+            process = await AsyncSandboxProcess._create(
+                stream_client, stream, write_stdin, send_signal
+            )
+        except BaseException:
+            with contextlib.suppress(Exception):
+                await transport.aclose()
+            raise
+        return process, transport
 
     async def expose(self, port: int) -> str | None:
         # Publish a server hosted IN the sandbox via the SDK's native port exposure → a public

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -321,6 +321,9 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
     """Unique ID for this trace, auto-generated."""
     verifiers: VersionInfo = Field(default_factory=_current_build)
     """The verifiers version that produced this trace."""
+    run: RunInfo | None = None
+    """The run this trace belongs to (eval or train), consumer-stamped."""
+
     task: TraceTask[DataT]
     """The task data that seeded this trace."""
     agent: AgentInfo[AgentConfigT]
@@ -493,6 +496,12 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
         self.info.setdefault("judge", []).append(response.model_dump())
         if response.usage is not None:
             self.extra_usage.append(response.usage)
+
+    def record_run(self, run: RunInfo | None = None, **info: Any) -> None:
+        """Record the run identity (eval / train), and optional extra info."""
+        if run is not None:
+            self.run = run
+        self.info.update(info)
 
     def stop(self, condition: str) -> None:
         """Stop the trace, optionally with a stop condition."""


### PR DESCRIPTION
## Problem

The initial Prime Agent harness is not sufficient for long-lived concurrent rollout seats. It needs stronger trace isolation, safe shared installation, better process diagnostics, and Prime runtime support for persistent ACP streams.

## Change

- Pin and checksum Prime Agent 0.7.0.
- Isolate agent state, daemon socket, temporary files, and continual-harness state per trace.
- Use transactional installation with a process-lifetime lock and batch skill uploads.
- Accept completed tool-only turns.
- Keep ACP streams active between turns and report process exits with stderr.
- Release stalled process transports during teardown.
- Isolate Prime live processes onto dedicated transports and make sandbox lifetime configurable.

## Verification

- `pytest tests/v1 -m "not e2e"`: passes.
- Docker e2e: Prime Agent persistence and ACP resume pass.
- Ruff, format, and ty pass.

This PR is stacked on #2254. The transport implementation is temporary and should be replaced by a prime-sandboxes release containing prime#823.
