### PR TITLE
Keep MCP services alive in Prime runtimes

### DIFF
--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -308,14 +308,21 @@ class PrimeRuntime(Runtime):
     async def run_background(
         self, argv: list[str], env: dict[str, str], log: str
     ) -> None:
-        # `&` backgrounds inside the sandbox; the job returns immediately, the process
-        # lives until the sandbox is deleted in stop().
-        inner = f"nohup {shlex.join(argv)} > {shlex.quote(log)} 2>&1 &"
-        result = await self.run(["sh", "-c", inner], env)
-        if result.exit_code != 0:
-            raise SandboxError(
-                f"prime background launch failed: {result.stderr.strip()}"
+        # Do not add an inner `sh -c "... &"` layer: it exits after spawning, and
+        # services using PR_SET_PDEATHSIG (including Verifiers' MCP servers) die with
+        # it. `exec` keeps the service in the SDK-managed background job instead.
+        if self._client is None or self.info.id is None:
+            raise SandboxError("prime background launch requires a live sandbox")
+        command = f"exec {shlex.join(argv)} > {shlex.quote(log)} 2>&1"
+        try:
+            await self._client.start_background_job(
+                self.info.id,
+                command,
+                working_dir=self.config.workdir,
+                env=env,
             )
+        except Exception as e:
+            raise SandboxError(f"prime background launch failed: {e}") from e
 
     async def _read(self, path: str) -> bytes:
         # Avoid background-job log limits and base64 overhead by downloading binary data directly.

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -308,11 +308,6 @@ class PrimeRuntime(Runtime):
     async def run_background(
         self, argv: list[str], env: dict[str, str], log: str
     ) -> None:
-        # Do not add an inner `sh -c "... &"` layer: it exits after spawning, and
-        # services using PR_SET_PDEATHSIG (including Verifiers' MCP servers) die with
-        # it. `exec` keeps the service in the SDK-managed background job instead.
-        if self._client is None or self.info.id is None:
-            raise SandboxError("prime background launch requires a live sandbox")
         command = f"exec {shlex.join(argv)} > {shlex.quote(log)} 2>&1"
         try:
             await self._client.start_background_job(


### PR DESCRIPTION
## Summary

- launch Prime background services through `start_background_job()` without an additional detached shell
- use `exec` so the service occupies the SDK-managed job process
- require a live sandbox and translate SDK submission failures to `SandboxError`

## Root cause

`PrimeRuntime.run_background()` previously ran a nested `sh -c "nohup ... &"` through the normal command path. That inner shell exited immediately after spawning the service. Verifiers MCP servers enable `PR_SET_PDEATHSIG`, so the shell's exit could kill the colocated MCP service while leaving the Prime sandbox itself alive.

Submitting `exec <service> > <log> 2>&1` as the SDK background job removes that short-lived parent and keeps the service attached to the SDK-managed job for the sandbox lifetime.

This is infrastructure lifecycle hardening only; it does not change evaluation logic, rewards, task behavior, or Worldsims pipelines.

## Validation

- `uv run ruff check verifiers/v1/runtimes/prime.py` — passed
- `uv run pre-commit run --all-files` — passed
- pre-push Ruff, formatting, and ty hooks — passed

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep MCP services alive in Prime runtimes using SDK background jobs
> - Rewrites `PrimeRuntime.run_background` in [prime.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2261/files#diff-d22d61279ff7587a2b14c72ab1a0fc9d3f805a735338a70f8efc7fe19aaa8502) to call `self._client.start_background_job` instead of spawning a detached shell via `sh -c 'nohup ... &'`.
> - The new implementation constructs an `exec <argv>` command with stdout/stderr redirected to the provided log file, passing `working_dir` and `env` to the SDK call.
> - Behavioral Change: `run_background` now raises `SandboxError` immediately if the client or sandbox ID is missing, or if the SDK call fails.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #2261 opened
>
> - Replaced pre-validation guards with exception-based error handling in `PrimeRuntime.run_background` method [abad82c]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c357ba1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only Prime sandbox background service lifecycle, but mis-launch or job API behavior could break colocated MCP/tool servers during eval rollouts.
> 
> **Overview**
> **Prime `run_background` no longer spawns a detached `nohup` shell** that exits right after starting colocated tool/MCP servers.
> 
> It now submits `exec <argv>` with stdout/stderr redirected to the log path through **`start_background_job`**, with `working_dir` and `env` passed to the SDK, so the service runs as the SDK-managed job process for the sandbox lifetime. That avoids a short-lived parent shell exiting and (with MCP servers using `PR_SET_PDEATHSIG`) tearing down the child while the sandbox stays up.
> 
> SDK submission failures are wrapped as **`SandboxError`** with a `prime background launch failed` message instead of checking exit code from a nested `sh -c` run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abad82c9ace8e3d1cd0d6d06139dbbbeb7845089. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->