### PR TITLE
Respect pyproject package rules for sandboxed MCP tools

### DIFF
--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import importlib.metadata
-import io
 import logging
 import secrets
 import shlex
+import subprocess
 import sys
-import tarfile
+import tempfile
 import uuid
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
@@ -39,8 +38,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Sandboxed servers install the working tree, so only wheel inputs need to cross the boundary.
-VF_BUILD_INPUTS = ("pyproject.toml", "README.md", "LICENSE", "verifiers")
+_SDIST_BUILD_TIMEOUT_SECONDS = 300
 
 # Any HTTP response, including MCP's 406 to a bare GET, proves the server is listening.
 _PROBE = """
@@ -67,30 +65,54 @@ def _source_dir(cls: type) -> str | None:
     return None
 
 
-# These can be gigabytes and are not package source, so uploading them can stall startup.
-_TAR_EXCLUDE = {
-    "__pycache__",
-    ".venv",
-    ".git",
-    ".pytest_cache",
-    ".mypy_cache",
-    ".ruff_cache",
-    "node_modules",
-}
-
-
 @cache
-def _tar_source(src: Path, members: tuple[str, ...] = ()) -> bytes:
-    def keep(info: tarfile.TarInfo) -> tarfile.TarInfo | None:
-        return None if _TAR_EXCLUDE & set(info.name.split("/")) else info
-
-    buf = io.BytesIO()
-    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-        for member in members or ("",):
-            path = src / member if member else src
-            if path.exists():
-                tar.add(path, arcname=f"{src.name}/{member}".rstrip("/"), filter=keep)
-    return buf.getvalue()
+def _build_sdist(src: Path) -> tuple[str, bytes]:
+    """Build a project's source distribution through its declared PEP 517 backend."""
+    with tempfile.TemporaryDirectory(prefix="vf-sdist-") as directory:
+        out = Path(directory)
+        command = [
+            "uv",
+            "build",
+            "--sdist",
+            "--no-create-gitignore",
+            "--color",
+            "never",
+            "--out-dir",
+            str(out),
+            str(src),
+        ]
+        try:
+            result = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=_SDIST_BUILD_TIMEOUT_SECONDS,
+            )
+        except FileNotFoundError as e:
+            raise ToolsetError(
+                f"cannot build source distribution for {src}: uv is not installed"
+            ) from e
+        except subprocess.TimeoutExpired as e:
+            raise ToolsetError(
+                "source distribution build timed out after "
+                f"{_SDIST_BUILD_TIMEOUT_SECONDS}s for {src}"
+            ) from e
+        if result.returncode != 0:
+            detail = "\n".join(
+                part.strip() for part in (result.stdout, result.stderr) if part.strip()
+            )
+            raise ToolsetError(
+                f"source distribution build failed for {src}: {detail[-2000:]}"
+            )
+        artifacts = [path for path in out.iterdir() if path.is_file()]
+        if len(artifacts) != 1:
+            names = ", ".join(sorted(path.name for path in artifacts)) or "none"
+            raise ToolsetError(
+                f"build backend for {src} produced {len(artifacts)} source distributions: {names}"
+            )
+        artifact = artifacts[0]
+        return artifact.name, artifact.read_bytes()
 
 
 def _verifiers_root() -> Path:
@@ -121,27 +143,26 @@ async def _install_in_sandbox(server: ServerBase, runtime: Runtime) -> str:
     temp = str(PurePosixPath(workdir) / ".vf-tmp")
     cache = str(PurePosixPath(workdir) / ".vf-uv-cache")
     vf, env = _verifiers_root(), Path(source_dir)
-    await runtime.write(f"{root}/{vf.name}.tar.gz", _tar_source(vf, VF_BUILD_INPUTS))
-    await runtime.write(f"{root}/{env.name}.tar.gz", _tar_source(env))
+    vf_name, vf_data = await asyncio.to_thread(_build_sdist, vf)
+    if env == vf:
+        env_name, env_data = vf_name, vf_data
+    else:
+        env_name, env_data = await asyncio.to_thread(_build_sdist, env)
+    vf_remote = f"{root}/{vf_name}"
+    env_remote = f"{root}/{env_name}"
+    await runtime.write(vf_remote, vf_data)
+    if env_remote != vf_remote:
+        await runtime.write(env_remote, env_data)
     venv = str(PurePosixPath(workdir) / ".vf-venv")
     root_q, temp_q, cache_q, venv_q = map(shlex.quote, (root, temp, cache, venv))
-    # The upload carries no .git, so hatch-vcs falls back to version 0.0.0 — an env
-    # package's `verifiers>=...` floor would then resolve PyPI verifiers OVER the local
-    # build, silently running the server against a released (older) API. Pretend the
-    # local version so the floor is satisfied by the build we uploaded.
-    vf_version = importlib.metadata.version("verifiers")
     extras = ",".join(type(server).EXTRAS)
-    vf_source = shlex.quote(str(PurePosixPath(root) / vf.name))
-    env_source = shlex.quote(
-        str(PurePosixPath(root) / (env.name + (f"[{extras}]" if extras else "")))
-    )
+    vf_source = shlex.quote(vf_remote)
+    env_source = shlex.quote(env_remote + (f"[{extras}]" if extras else ""))
     setup = (
         f"set -e; mkdir -p {root_q} {temp_q} {cache_q}; "
         f"export TMPDIR={temp_q} UV_CACHE_DIR={cache_q}; "
         f"{_ENSURE_UV}; "
-        f'for t in {root_q}/*.tar.gz; do tar -xzf "$t" -C {root_q}; done && '
         f"uv venv {venv_q} && "
-        f"SETUPTOOLS_SCM_PRETEND_VERSION={shlex.quote(vf_version)} "
         f"uv pip install --python {venv_q} {vf_source} && "
         f"uv pip install --python {venv_q} {env_source}"
     )

--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -8,6 +8,7 @@ import shlex
 import subprocess
 import sys
 import tempfile
+import threading
 import uuid
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
@@ -39,6 +40,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _SDIST_BUILD_TIMEOUT_SECONDS = 300
+_SDIST_BUILD_LOCK = threading.Lock()
 
 # Any HTTP response, including MCP's 406 to a bare GET, proves the server is listening.
 _PROBE = """
@@ -115,6 +117,11 @@ def _build_sdist(src: Path) -> tuple[str, bytes]:
         return artifact.name, artifact.read_bytes()
 
 
+def _locked_sdist(src: Path) -> tuple[str, bytes]:
+    with _SDIST_BUILD_LOCK:
+        return _build_sdist(src)
+
+
 def _verifiers_root() -> Path:
     import verifiers
 
@@ -143,11 +150,11 @@ async def _install_in_sandbox(server: ServerBase, runtime: Runtime) -> str:
     temp = str(PurePosixPath(workdir) / ".vf-tmp")
     cache = str(PurePosixPath(workdir) / ".vf-uv-cache")
     vf, env = _verifiers_root(), Path(source_dir)
-    vf_name, vf_data = await asyncio.to_thread(_build_sdist, vf)
+    vf_name, vf_data = await asyncio.to_thread(_locked_sdist, vf)
     if env == vf:
         env_name, env_data = vf_name, vf_data
     else:
-        env_name, env_data = await asyncio.to_thread(_build_sdist, env)
+        env_name, env_data = await asyncio.to_thread(_locked_sdist, env)
     vf_remote = f"{root}/{vf_name}"
     env_remote = f"{root}/{env_name}"
     await runtime.write(vf_remote, vf_data)


### PR DESCRIPTION
## Context

When v1 launches an MCP tool from local source inside a sandbox, the sandbox needs both the current Verifiers package and the project that defines the tool. It creates a virtual environment, installs Verifiers first, and then installs the tool project with any requested extras.

## Problem

The launcher was not using the projects' normal packaging rules to decide what source to upload. It created tarballs itself:

- Verifiers used a hard-coded list of paths.
- The tool project recursively included its entire directory, apart from a short hard-coded exclusion list.

That meant a project's `pyproject.toml` include/exclude configuration and normal VCS-ignore behavior were bypassed. The archive sent to the sandbox could therefore differ from the source package the project actually defines.

## Change

Build a normal source distribution for each project with `uv build --sdist`, upload those archives, and install them directly in the sandbox.

This delegates file selection and package metadata to each project's declared build backend. It also means source-control-derived versions are recorded while the checkout is still available, instead of requiring a version override after uploading an archive without `.git`.

The cached source-distribution build runs in a worker thread so it does not block concurrent rollouts or the interception server. A five-minute timeout turns a stuck backend build into a clear toolset error.

The existing sandbox behavior remains the same:

- Verifiers is installed before the tool project.
- Tool-project extras are preserved.
- Virtual environment, temporary files, and uv cache stay under the runtime workdir.
- Installing the source archive still builds the installable wheel in the sandbox, as installing the previously extracted source directory did.

Build failures include the backend output so packaging configuration errors are actionable.

## Validation

- Built the repository sdist: `verifiers-0.2.2.dev92.tar.gz`
- Built the v1 fixture sdist: `vf_test_fixtures-0.0.0.tar.gz`
- Verified the build-timeout error path
- `uv run ruff check --fix .`
- `uv run pre-commit run --all-files`
- `uv run --locked --python 3.13 ty check verifiers`
- `uv run pytest tests/`: 912 passed, 72 skipped; one unrelated existing OpenCode shell-expansion test fails while parsing its generated JSON

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Build sdists via PEP 517 to respect pyproject package rules for sandboxed MCP tools
> - Replaces the custom `_tar_source` approach (which uploaded raw source trees) with `_build_sdist` in [launch.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2263/files#diff-989d87123d40d48511f9e1df74594d2e30776e9a99c11eca49d9cc20bf9e2230), which invokes `uv build --sdist` with a 300s timeout to produce a proper source distribution.
> - `_install_in_sandbox` now uploads the built sdist artifact and installs it with `uv pip install`, removing the tar extraction step and the `SETUPTOOLS_SCM_PRETEND_VERSION` override.
> - When the env source dir and verifiers source dir are the same, the sdist is built once and reused to avoid duplicate uploads.
> - `ToolsetError` is raised with specific messages for missing `uv`, timeouts, non-zero exit codes, and unexpected artifact counts.
> - Behavioral Change: package inclusion/exclusion is now governed by the project's declared PEP 517 build backend rather than the previous hardcoded exclusion list (e.g. `__pycache__`, `.venv`, `.git`).
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #2263 opened
>
> - Serialized sdist builds across concurrent sandbox installations using a process-wide lock [2aae03e]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9a80f5a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what source reaches remote sandboxes and how versions resolve at install time, which can surface packaging misconfigurations that the old tarball path hid.
> 
> **Overview**
> Sandboxed MCP launches no longer upload hand-rolled **tar.gz** trees (hard-coded Verifiers paths plus a short exclude list for tool projects). They now build a normal **source distribution** per project with **`uv build --sdist`**, upload those artifacts, and **`uv pip install`** them in the runtime—so include/exclude rules and metadata come from each project’s declared build backend and VCS-aware versioning works without faking **`SETUPTOOLS_SCM_PRETEND_VERSION`** after stripping **`.git`**.
> 
> Sdist builds run under a **thread lock** via **`asyncio.to_thread`** (300s timeout, **`ToolsetError`** on missing **`uv`**, build failure, or wrong artifact count). When the tool project and Verifiers share the same checkout, only one sdist is built and uploaded. The sandbox install sequence (Verifiers first, extras, workdir venv/tmp/uv cache) is unchanged; the in-sandbox **tar extract** step is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2aae03e4d2697b2ef2710fceb9f655a6823d0ae8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->