### PR TITLE
Revert "feat(v1)!: move run info from trace to episode"

### DIFF
--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -10,6 +10,7 @@ from verifiers.v1.cli.dashboard import dashboard
 from verifiers.v1.cli.eval import resume
 from verifiers.v1.cli.output import (
     append_episode,
+    append_trace,
     output_path,
     save_config,
 )
@@ -76,7 +77,8 @@ async def run_eval(env: Env, config: EvalConfig) -> list[Episode]:
     write_lock = asyncio.Lock()
 
     async def on_complete(episode: Episode) -> None:
-        episode.record_run(EvalRunInfo(id=config.uuid))
+        for trace in episode.traces:
+            trace.record_run(EvalRunInfo(id=config.uuid))
         await append_episode(out, episode, write_lock)
 
     # Serving resources (shared tool servers, interception) come up once for the
@@ -256,10 +258,9 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
                 )
             records = []
             for trace in traces:
-                record = Episode.of(trace, env=config.env_id)
-                record.record_run(EvalRunInfo(id=config.uuid))
-                await append_episode(out, record, write_lock)
-                records.append(record)
+                trace.record_run(EvalRunInfo(id=config.uuid))
+                await append_trace(out, trace, write_lock, env=config.env_id)
+                records.append(Episode.of(trace))
             return records
 
         async def run_unit(payload: dict) -> list[Episode]:
@@ -270,7 +271,8 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
                     sampling=config.sampling,
                     **payload,
                 )
-            episode.record_run(EvalRunInfo(id=config.uuid))
+            for trace in episode.traces:
+                trace.record_run(EvalRunInfo(id=config.uuid))
             await append_episode(out, episode, write_lock)
             return [episode]
 

--- a/verifiers/v1/episode.py
+++ b/verifiers/v1/episode.py
@@ -1,14 +1,14 @@
 """The episode — one run's traces plus their shared standing, whole."""
 
 import uuid
-from typing import Any, Generic
+from typing import Generic
 
 from pydantic import BaseModel, Field
 
 from verifiers.v1.configs.agent import WireAgentConfig
 from verifiers.v1.state import State, StateT
 from verifiers.v1.task import DataT, WireTaskData
-from verifiers.v1.trace import AgentConfigT, Error, RunInfo, Trace
+from verifiers.v1.trace import AgentConfigT, Error, Trace
 from verifiers.v1.types import Usage
 
 
@@ -26,19 +26,12 @@ class Episode(BaseModel, Generic[DataT, StateT, AgentConfigT]):
 
     env: EnvInfo = Field(default_factory=EnvInfo)
     """The env that produced this episode."""
-    run: RunInfo | None = None
-    """The run this episode belongs to (eval or train), consumer-stamped. It lives here rather than
-    on each trace because the episode is what a consumer dispatches, and an episode that produced
-    no traces would otherwise have nowhere to say which run it was."""
     ok: bool = False
     """Whether the episode completed successfully."""
     errors: list[Error] = Field(default_factory=list)
     """Every error captured across attempts, oldest to newest."""
     traces: list[Trace[DataT, StateT, AgentConfigT]] = Field(default_factory=list)
     """Every agent's trace, in completion order."""
-    info: dict[str, Any] = Field(default_factory=dict)
-    """Scratch space for episode-level metadata, the counterpart to `Trace.info`. What describes
-    the whole episode belongs here rather than repeated on each of its traces."""
 
     @property
     def last_error(self) -> Error | None:
@@ -78,13 +71,6 @@ class Episode(BaseModel, Generic[DataT, StateT, AgentConfigT]):
         for trace in self.traces:
             grouped.setdefault(trace.agent.name, []).append(trace)
         return grouped
-
-    def record_run(self, run: RunInfo | None = None, **info: Any) -> None:
-        """Record the run identity and any extra metadata about this episode. Both describe the
-        episode as a whole, so they are recorded once here rather than repeated on every trace."""
-        if run is not None:
-            self.run = run
-        self.info.update(info)
 
     @classmethod
     def of(cls, trace: Trace, env: str = "") -> "Episode":

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -321,6 +321,9 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
     """Unique ID for this trace, auto-generated."""
     verifiers: VersionInfo = Field(default_factory=_current_build)
     """The verifiers version that produced this trace."""
+    run: RunInfo | None = None
+    """The run this trace belongs to (eval or train), consumer-stamped."""
+
     task: TraceTask[DataT]
     """The task data that seeded this trace."""
     agent: AgentInfo[AgentConfigT]
@@ -493,6 +496,12 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
         self.info.setdefault("judge", []).append(response.model_dump())
         if response.usage is not None:
             self.extra_usage.append(response.usage)
+
+    def record_run(self, run: RunInfo | None = None, **info: Any) -> None:
+        """Record the run identity (eval / train), and optional extra info."""
+        if run is not None:
+            self.run = run
+        self.info.update(info)
 
     def stop(self, condition: str) -> None:
         """Stop the trace, optionally with a stop condition."""


### PR DESCRIPTION
## Summary

- Reverts #2244: run identity returns to `Trace.run` / `Trace.record_run`, and `Episode.run` / `Episode.info` / `Episode.record_run` are removed.
- The eval runner call sites return to stamping each trace and persisting via the single-trace episode wrapper, as before #2244.

Moving the run onto the episode forced consumers that keep per-trace records (prime-rl's orchestrator) to reconstruct episode shells around traces just to place them, and the episode-level home only pays off with the rest of the episode-first pipeline (#2252 / prime-rl#3206), which we're not taking. Reverting keeps the trace self-describing and makes the prime-rl pin bump trivial.

## Verification

```bash
uv run pytest tests/v1/test_trace.py tests/v1/test_graph.py
ruff check verifiers/v1/trace.py verifiers/v1/episode.py verifiers/v1/cli/eval/runner.py
```

Both pass. Only in-tree users of the episode-level fields were `Episode.record_run` itself and the three eval-runner call sites restored here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move run info from episode level to trace level in v1 eval runner
> - Removes `run` and `info` fields and the `record_run` method from [`Episode`](https://github.com/PrimeIntellect-ai/verifiers/pull/2264/files#diff-ea3591865e4c7653852776e680f3abbf509a3f3a406d518c8dce528669aa0abf); run metadata is no longer stored at the episode level.
> - Adds a `run: RunInfo | None` field and `record_run` method to [`Trace`](https://github.com/PrimeIntellect-ai/verifiers/pull/2264/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e) so each trace carries its own run metadata.
> - Updates [`eval.runner`](https://github.com/PrimeIntellect-ai/verifiers/pull/2264/files#diff-65be4a576330571f2729a3bbcdbe92ac81bbcba450c313597c1bdca3a1c3f2e4) to call `trace.record_run(...)` on each trace within an episode instead of stamping the episode directly.
> - In the group execution path, traces are now persisted individually via `append_trace` and `Episode.of(trace)` is called without an `env` argument, leaving env id empty on returned Episode records.
> - Behavioral Change: `Episode.record_run` is removed; callers must now stamp run info on individual traces.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eaab120.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persisted artifact shape and public v1 APIs (`Episode`/`Trace`); callers that adopted episode-level `run` must migrate back to per-trace stamping.
> 
> **Overview**
> **Reverts** the episode-first run stamping from #2244 so eval and downstream consumers (e.g. prime-rl) can keep **per-trace** records without wrapping traces in episodes just to attach run identity.
> 
> **`Trace`** again has `run: RunInfo | None` and **`record_run`**, which sets run id/type and merges optional metadata into `trace.info`. **`Episode`** drops `run`, `info`, and **`record_run`**—episodes are no longer the place for consumer-stamped run metadata.
> 
> The **v1 eval runner** stamps **`EvalRunInfo`** on **every trace** in an episode (`on_complete`, `run_unit`, and the legacy **`run_group`** path). Group rollouts persist each trace with **`append_trace`** (with `env=config.env_id`) and return **`Episode.of(trace)`** shells for in-memory results; single-rollout paths still use **`append_episode`** after per-trace stamping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eaab12035f728beaa64e659f7ff0c92289a59512. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->