### PR TITLE
fix(v1): make creation limiters user-global

### DIFF
--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -15,6 +15,7 @@ from verifiers.envs.experimental.utils.git_checkout_cache import (
     validate_git_checkout,
 )
 from verifiers.types import Messages, State, SystemMessage, TrajectoryStep
+from verifiers.utils.path_utils import CACHE_DIR
 
 DEFAULT_RLM_REPO_URL = "github.com/PrimeIntellect-ai/rlm-harness.git"
 DEFAULT_RLM_REF = "main"
@@ -24,9 +25,7 @@ DEFAULT_RLM_MAX_DEPTH = 0
 DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH = "/task/append_to_system_prompt.txt"
 DEFAULT_RLM_CHECKOUT_PATH = "/tmp/rlm-checkout"
 DEFAULT_RLM_CHECKOUT_UPLOAD_NAME = "rlm_checkout"
-DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT = (
-    Path.home() / ".cache" / "verifiers" / "rlm-checkouts"
-)
+DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT = CACHE_DIR / "rlm-checkouts"
 _REQUIRED_CHECKOUT_FILES = ("install.sh", "pyproject.toml")
 
 COMPACTION_BOUNDARY_MARKER = "--- context compacted ---"

--- a/verifiers/envs/experimental/utils/git_checkout_cache.py
+++ b/verifiers/envs/experimental/utils/git_checkout_cache.py
@@ -16,6 +16,7 @@ from verifiers.envs.experimental.utils.file_locks import (
     exclusive_path_lock,
     sibling_lock_path,
 )
+from verifiers.utils.path_utils import CACHE_DIR
 
 _IN_USE_LOCK_SUFFIX = ".in-use.lock"
 
@@ -23,7 +24,7 @@ _IN_USE_LOCK_SUFFIX = ".in-use.lock"
 # resolved checkout's in-use lock file. See ``_acquire_in_use_lock``.
 _held_in_use_locks: dict[Path, IO] = {}
 
-DEFAULT_GIT_CHECKOUT_CACHE_ROOT = Path.home() / ".cache" / "verifiers" / "git-checkouts"
+DEFAULT_GIT_CHECKOUT_CACHE_ROOT = CACHE_DIR / "git-checkouts"
 _FULL_COMMIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
 
 logger = logging.getLogger(__name__)

--- a/verifiers/utils/path_utils.py
+++ b/verifiers/utils/path_utils.py
@@ -9,7 +9,7 @@ from verifiers.types import EvalConfig
 logger = logging.getLogger(__name__)
 
 
-def _home_dir() -> Path:
+def home_dir() -> Path:
     """Best-effort home directory; fall back to the temp dir so import never fails."""
     try:
         return Path.home()
@@ -17,7 +17,7 @@ def _home_dir() -> Path:
         return Path(tempfile.gettempdir())
 
 
-CACHE_DIR = _home_dir() / ".cache" / "verifiers"
+CACHE_DIR = home_dir() / ".cache" / "verifiers"
 """User-local cache root for verifiers-managed state."""
 
 

--- a/verifiers/utils/path_utils.py
+++ b/verifiers/utils/path_utils.py
@@ -9,6 +9,18 @@ from verifiers.types import EvalConfig
 logger = logging.getLogger(__name__)
 
 
+def _home_dir() -> Path:
+    """Best-effort home directory; fall back to the temp dir so import never fails."""
+    try:
+        return Path.home()
+    except RuntimeError:
+        return Path(tempfile.gettempdir())
+
+
+CACHE_DIR = _home_dir() / ".cache" / "verifiers"
+"""User-local cache root for verifiers-managed state."""
+
+
 def write_temp_file(content: str, suffix: str = ".txt") -> str:
     """Write content to a named temporary file and return its path.
 

--- a/verifiers/v1/interception/tunnel/prime.py
+++ b/verifiers/v1/interception/tunnel/prime.py
@@ -13,7 +13,7 @@ from verifiers.v1.runtimes.limiters import creation_limiter
 from verifiers.v1.utils.aio import run_shielded
 
 # The prime_tunnel service caps tunnel starts at 512/min per API token — a property of the
-# tunnel service, shared by every process on the host that opens one. One host-global
+# tunnel service, shared by every process for the user that opens one. One user-global
 # limiter, not a per-runtime config knob.
 _TUNNELS_PER_MIN = 512
 TUNNEL_LIMITER = creation_limiter(_TUNNELS_PER_MIN / 60, "prime-tunnel")
@@ -30,7 +30,7 @@ class PrimeTunnel(Tunnel[PrimeTunnelConfig]):
     @contextlib.asynccontextmanager
     async def expose(self, port: int) -> AsyncIterator[str]:
         """Bridge the host `port` to a public URL via prime_tunnel (frpc). Tunnel creation
-        is network-bound and globally rate-capped (512/min, host-wide via the shared
+        is network-bound and globally rate-capped (512/min, user-wide via the shared
         `TUNNEL_LIMITER`), so transient failures are retried; a terminal one raises
         `TunnelError`. The tunnel is torn down on exit."""
         from prime_tunnel import Tunnel as TunnelClient

--- a/verifiers/v1/runtimes/limiters.py
+++ b/verifiers/v1/runtimes/limiters.py
@@ -1,7 +1,8 @@
 """User-global creation-rate limiters for the remote runtimes.
 
-A leaky bucket backed by a lock file under ``~/.cache/verifiers``, so a provider's per-account
-creation rate (Modal sandboxes, Prime tunnels) is enforced across EVERY process for the user —
+A leaky bucket backed by a lock file under the user cache (``~/.cache/verifiers``, falling
+back to the temp dir when no home is resolvable), so a provider's per-account creation rate
+(Modal sandboxes, Prime tunnels) is enforced across EVERY process for the user —
 the single-process eval and all the elastically-spawned env-server worker processes alike — not
 just within one process. Keyed by name: one bucket file per name, shared by every process (and
 run) for the user.
@@ -11,10 +12,11 @@ import asyncio
 import fcntl
 import os
 import time
-from pathlib import Path
 from typing import Self
 
-_LIMITER_DIR = Path.home() / ".cache" / "verifiers" / "limiter"
+from verifiers.utils.path_utils import CACHE_DIR
+
+LIMITER_DIR = CACHE_DIR / "limiter"
 
 
 class CreationLimiter:
@@ -26,17 +28,18 @@ class CreationLimiter:
 
     def __init__(self, name: str, per_sec: float) -> None:
         self._interval = 1 / per_sec
-        self._path = _LIMITER_DIR / f"{name}.bucket"
+        self._path = LIMITER_DIR / f"{name}.bucket"
 
     def _reserve(self) -> float:
-        os.makedirs(_LIMITER_DIR, exist_ok=True)
-        # monotonic is host-wide on Linux, so the cursor is comparable across processes.
+        os.makedirs(LIMITER_DIR, exist_ok=True)
+        # Wall clock persists across reboots (monotonic does not), so a cursor left in
+        # ~/.cache from a previous boot cannot turn into a huge stale wait.
         with open(self._path, "a+") as f:
             fcntl.flock(f.fileno(), fcntl.LOCK_EX)
             try:
                 f.seek(0)
                 data = f.read().strip()
-                now = time.monotonic()
+                now = time.time()
                 slot = max(now, float(data) if data else 0.0)
                 f.seek(0)
                 f.truncate()

--- a/verifiers/v1/runtimes/limiters.py
+++ b/verifiers/v1/runtimes/limiters.py
@@ -1,31 +1,32 @@
-"""Host-global creation-rate limiters for the remote runtimes.
+"""User-global creation-rate limiters for the remote runtimes.
 
-A leaky bucket backed by a lock file, so a provider's per-account creation rate (Modal
-sandboxes, Prime tunnels) is enforced across EVERY process on the host — the single-process
-eval and all the elastically-spawned env-server worker processes alike — not just within one
-process. So the configured rate is the actual account-wide rate (assuming one env-server
-host). Keyed by name: one bucket file per name, shared by every process (and run) on the host.
+A leaky bucket backed by a lock file under ``~/.cache/verifiers``, so a provider's per-account
+creation rate (Modal sandboxes, Prime tunnels) is enforced across EVERY process for the user —
+the single-process eval and all the elastically-spawned env-server worker processes alike — not
+just within one process. Keyed by name: one bucket file per name, shared by every process (and
+run) for the user.
 """
 
 import asyncio
 import fcntl
 import os
-import tempfile
 import time
+from pathlib import Path
 from typing import Self
 
-_LIMITER_DIR = os.path.join(tempfile.gettempdir(), "vf-rate-limiters")
+_LIMITER_DIR = Path.home() / ".cache" / "verifiers" / "limiter"
 
 
 class CreationLimiter:
     """An async leaky bucket shared across processes via a lock file: each `async with`
     reserves the next `1/per_sec`-spaced slot (advancing the on-disk cursor under an exclusive
-    flock) and sleeps until it, so the aggregate creation rate across all host processes stays
-    at `per_sec`. The reservation runs off the event loop; the wait does not hold the lock."""
+    flock) and sleeps until it, so the aggregate creation rate across all of the user's
+    processes stays at `per_sec`. The reservation runs off the event loop; the wait does not
+    hold the lock."""
 
     def __init__(self, name: str, per_sec: float) -> None:
         self._interval = 1 / per_sec
-        self._path = os.path.join(_LIMITER_DIR, f"{name}.bucket")
+        self._path = _LIMITER_DIR / f"{name}.bucket"
 
     def _reserve(self) -> float:
         os.makedirs(_LIMITER_DIR, exist_ok=True)
@@ -59,7 +60,7 @@ _creation_limiters: dict[str, CreationLimiter] = {}
 
 
 def creation_limiter(per_sec: float | None, name: str) -> CreationLimiter | None:
-    """A host-global limiter pacing `name`'s creation to `per_sec`/s (None/<= 0 disables).
+    """A user-global limiter pacing `name`'s creation to `per_sec`/s (None/<= 0 disables).
 
     All callers (and processes) sharing a `name` share one bucket, so use one rate per name."""
     if not per_sec or per_sec <= 0:

--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -53,7 +53,7 @@ class ModalConfig(BaseConfig):
     """Disk in GB. Modal sandboxes have no disk knob, so this is accepted (so a task can
     declare it without a warning) but not enforced."""
     creates_per_sec: float | None = 40.0
-    """Pace sandbox creation to this many per second, enforced host-wide across every
+    """Pace sandbox creation to this many per second, enforced user-wide across every
     env-server worker process (None/<= 0 disables it)."""
 
 

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -66,7 +66,7 @@ class PrimeConfig(NetworkPolicyConfig):
     idle_timeout: float | None = 3600
     """Seconds of inactivity before the sandbox self-deletes (None disables)."""
     creates_per_min: int | None = None
-    """Pace sandbox creation to this many per minute, enforced host-wide across every
+    """Pace sandbox creation to this many per minute, enforced user-wide across every
     env-server worker process (None/<= 0 disables it). (Tunnel creation is limited separately
     and globally — see interception.tunnel.prime.TUNNEL_LIMITER.)"""
 


### PR DESCRIPTION
## Summary
- Add a shared `CACHE_DIR` (`~/.cache/verifiers`, with a temp-dir fallback if `Path.home()` cannot resolve) in `verifiers/utils/path_utils.py`.
- Move v1 creation-limiter bucket files from the shared temp dir to `CACHE_DIR / "limiter"` (`LIMITER_DIR`).
- Reuse `CACHE_DIR` for the existing verifiers git/RLM checkout cache roots.
- Persist wall-clock (`time.time()`) reservation cursors instead of `time.monotonic()` so cached limiter state survives reboots without huge stale waits.
- Update the surrounding comments/config docs from host-global/host-wide to user-global/user-wide.

## Why
The previous `tempfile.gettempdir()/vf-rate-limiters` location can collide across users on shared cluster hosts. These limiters are meant to coordinate one user's eval process plus env-server workers, not every user on the machine.

## Validation
- `uv run ruff check --fix verifiers/utils/path_utils.py verifiers/v1/runtimes/limiters.py verifiers/envs/experimental/utils/git_checkout_cache.py verifiers/envs/experimental/composable/harnesses/rlm.py`
- `MPLBACKEND=Agg uv run pre-commit run --files verifiers/utils/path_utils.py verifiers/v1/runtimes/limiters.py verifiers/envs/experimental/utils/git_checkout_cache.py verifiers/envs/experimental/composable/harnesses/rlm.py`
- `MPLBACKEND=Agg uv run pytest tests/ -q -m "not e2e"`

Not run: local-only prime/modal e2e rows.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix creation limiters to use user-global scope via a shared cache directory
> - Moves limiter state files from the system temp directory to `~/.cache/verifiers/limiter` (via a new `CACHE_DIR` constant in [`path_utils.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/2265/files#diff-1210e91e402ed01fbe542ddb72ac6447918395403c0b02e9e727f7766056302c)), scoping rate-limit enforcement to the user rather than the host.
> - Switches `CreationLimiter._reserve` from `time.monotonic()` to `time.time()` so slot windows survive reboots and stale waits are avoided.
> - Adds a `home_dir()` helper that falls back to `tempfile.gettempdir()` when `Path.home()` raises `RuntimeError`, used as the base for `CACHE_DIR`.
> - Updates default cache roots for git and RLM checkouts to use `CACHE_DIR` instead of hardcoded `Path.home() / ".cache" / "verifiers"` paths.
> - Behavioral Change: limiter and checkout cache paths will differ from previous locations for users whose home directory was previously available.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4d21872.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cross-process rate limiting paths and timing semantics for Modal/Prime creation, which can briefly alter effective throttling on shared hosts until new bucket files are used; scope is infrastructure coordination rather than auth or data handling.
> 
> **Overview**
> Introduces a shared **`CACHE_DIR`** (`~/.cache/verifiers`, with **`home_dir()`** falling back to the system temp dir when home cannot be resolved) and routes verifiers-managed on-disk state through it.
> 
> **Creation limiters** move from **`tempfile.gettempdir()/vf-rate-limiters`** to **`CACHE_DIR / "limiter"`**, so Modal/Prime creation buckets coordinate across a **user’s** processes instead of every user on a shared host. Reservation cursors now use **`time.time()`** instead of **`time.monotonic()`** so persisted bucket state after reboot does not cause long stale waits.
> 
> **Git checkout caches** (default git-checkouts and RLM checkouts) use the same **`CACHE_DIR`** instead of duplicating `Path.home() / ".cache" / "verifiers"`. Docs/comments for limiters and tunnels are updated from **host-global** to **user-global**; existing temp-dir limiter files are **not** migrated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d21872540796b7b69e3df9eb557c54c8e5c379f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->