### PR TITLE
fix(train-client): filter failed tool calls

### DIFF
--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -12,6 +12,7 @@ from typing import Any, ClassVar, TypeVar
 from openai import OpenAIError
 from renderers import OverlongPromptError as RendererOverlongPromptError
 from renderers import RenderedTokens, Renderer, RendererConfig
+from renderers.base import ToolCallParseStatus
 
 from verifiers.v1.clients.base import build_async_openai
 from verifiers.v1.clients.client import SESSION_ID_HEADER, Client
@@ -114,7 +115,16 @@ def response_from_generate(
             else json.dumps(tc.arguments or {}),
         )
         for i, tc in enumerate(result.get("tool_calls") or [])
+        # Only OK-status calls become real tool calls. renderers keeps non-OK
+        # attempts (UNKNOWN_TOOL, MALFORMED_STRUCTURE, INVALID_JSON, ...) on the
+        # response for inspection and withholds the stop->tool_calls finish-reason
+        # promotion for them; vLLM's glm45/glm47 parsers drop the same calls
+        # server-side, so the chat-completions path never sees them. Promoting
+        # them here makes a malformed call a recoverable "unknown tool" turn in
+        # training while the identical bytes end the episode under an engine-side
+        # parser.
         if getattr(tc, "name", None)
+        and getattr(tc, "status", ToolCallParseStatus.OK) == ToolCallParseStatus.OK
     ] or None
     prompt_ids = result.get("prompt_ids") or []
     completion_ids = result.get("completion_ids") or []

--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -115,14 +115,6 @@ def response_from_generate(
             else json.dumps(tc.arguments or {}),
         )
         for i, tc in enumerate(result.get("tool_calls") or [])
-        # Only OK-status calls become real tool calls. renderers keeps non-OK
-        # attempts (UNKNOWN_TOOL, MALFORMED_STRUCTURE, INVALID_JSON, ...) on the
-        # response for inspection and withholds the stop->tool_calls finish-reason
-        # promotion for them; vLLM's glm45/glm47 parsers drop the same calls
-        # server-side, so the chat-completions path never sees them. Promoting
-        # them here makes a malformed call a recoverable "unknown tool" turn in
-        # training while the identical bytes end the episode under an engine-side
-        # parser.
         if getattr(tc, "name", None)
         and getattr(tc, "status", ToolCallParseStatus.OK) == ToolCallParseStatus.OK
     ] or None

--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -116,7 +116,7 @@ def response_from_generate(
         )
         for i, tc in enumerate(result.get("tool_calls") or [])
         if getattr(tc, "name", None)
-        and getattr(tc, "status", ToolCallParseStatus.OK) == ToolCallParseStatus.OK
+        and getattr(tc, "status", None) != ToolCallParseStatus.UNKNOWN_TOOL
     ] or None
     prompt_ids = result.get("prompt_ids") or []
     completion_ids = result.get("completion_ids") or []

--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -116,6 +116,7 @@ def response_from_generate(
         )
         for i, tc in enumerate(result.get("tool_calls") or [])
         if getattr(tc, "name", None)
+        # TODO: we need a better way for renderers to expose this
         and getattr(tc, "status", None) != ToolCallParseStatus.UNKNOWN_TOOL
     ] or None
     prompt_ids = result.get("prompt_ids") or []


### PR DESCRIPTION
## Problem

`response_from_generate` promotes **any** parsed tool call carrying a name into a real `ToolCall`, ignoring `ToolCallParseStatus`:

```python
for i, tc in enumerate(result.get("tool_calls") or [])
if getattr(tc, "name", None)
```

`UNKNOWN_TOOL` exists specifically to mirror the inference engine. From `renderers/parsing.py`:

```python
# vLLM >= 0.24 drops the call entirely here; we keep the
# attempt visible but deny it OK so consumers agree with
# the engine on "no tool was called."
status = ToolCallParseStatus.UNKNOWN_TOOL
```

`renderers/client.py` likewise withholds the `stop` -> `tool_calls` finish-reason promotion for it. The train client ignores both signals and hands the call to the agent anyway.

## Why it matters: train/eval divergence

vLLM's `glm45`/`glm47` parsers run with `validate_tool_names=True` and drop unknown-name calls outright. RL train rollouts go through the renderer client, eval rollouts through chat-completions, so identical model output behaves differently:

| | renderer path (train) | chat-completions path (eval) |
|---|---|---|
| `<tool_call>read\n<arg_key>path</arg_key>…` (tool not declared) | becomes a `ToolCall` -> harness replies `error: unknown tool 'read'` -> **episode continues** | engine drops it -> no tool call -> harness reads the message as final -> **episode ends** |

## Why it's trainable

The malformed emission costs about one wasted turn during training and is invisible in the metrics, so nothing penalises it and it rides along on positively-advantaged trajectories. In a GLM-4.5-Air SWE run the policy's turn-1 malformed-call rate drifted **18% -> 56% over 220 steps** while held-out SWE-bench Verified fell **26% -> 15%** — ~94% of the decline from episodes dying on an unparsed tool call, with the *clean* subset's solve rate flat (45% -> 44%). With the paths realigned the same setup went **22% -> 49%** over 240 steps.

## Scope: only `UNKNOWN_TOOL`

Deliberately **not** filtering every non-OK status. The other statuses describe attempts the engines still emit, so withholding them would make the renderer path *stricter* than chat-completions — the mirror of this bug. Concretely, a call whose argument name isn't in the declared schema parses fine but is marked `INVALID_JSON` by renderers, while vLLM falls back to the raw string and returns the call:

```
undeclared arg 'cmd'  ->  name=bash  status=invalid_json  args={'cmd': 'pwd'}
```

`UNKNOWN_TOOL` is the one status defined as engine parity, and `parse_glm` is currently the only parser that sets it — so this is a no-op for the renderers that don't validate names, and correct for any that adopt it later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Filter out `UNKNOWN_TOOL` tool calls in `response_from_generate`
> In [train.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2266/files#diff-c9bcd6c691890b1de6942fe012d2e74678460b22bf335721a8bba5e939d139c3), `response_from_generate` now excludes tool calls where `tc.status == ToolCallParseStatus.UNKNOWN_TOOL`. If all tool calls are filtered, `Response.tool_calls` is set to `None`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4dc379a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional in train client tool-call mapping; no auth or data changes; behavior change is intentional parity for RL rollouts.
> 
> **Overview**
> **Aligns RL train rollouts with inference/eval** by dropping renderer-parsed tool calls marked `ToolCallParseStatus.UNKNOWN_TOOL` when building `Response.tool_calls` in `response_from_generate`.
> 
> Previously, any parsed call with a **name** was promoted to a `ToolCall`, so unrecognized tools (e.g. GLM parsers with name validation) still reached the harness and extended the episode—unlike vLLM/chat-completions paths that drop them. **Only** `UNKNOWN_TOOL` is filtered; other statuses like `INVALID_JSON` stay, so the renderer path does not become stricter than engines for malformed-but-emitted calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dc379a4e75e14ebf9b5922bc78cdbe89fe43ae4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->