### PR TITLE
fix(v1): de-flake the live E2E suite

### DIFF
--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -164,9 +164,6 @@ def _eval_config(
         seat_cfg.setdefault("max_output_tokens", max_tokens)
         seat_cfg.setdefault("timeout", {"rollout": rollout_timeout, "scoring": 60})
         # Flake resilience: retries are per-agent now (flat RetryConfig).
-        # HarnessError covers live-model harness flakes (an agent ending a turn with
-        # no output, an agent-timeout stall); deterministic failures still fail every
-        # attempt.
         seat_cfg.setdefault(
             "retries",
             {"max_retries": 2, "include": ["ProviderError", "HarnessError"]},

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -164,7 +164,13 @@ def _eval_config(
         seat_cfg.setdefault("max_output_tokens", max_tokens)
         seat_cfg.setdefault("timeout", {"rollout": rollout_timeout, "scoring": 60})
         # Flake resilience: retries are per-agent now (flat RetryConfig).
-        seat_cfg.setdefault("retries", {"max_retries": 2, "include": ["ProviderError"]})
+        # HarnessError covers live-model harness flakes (an agent ending a turn with
+        # no output, an agent-timeout stall); deterministic failures still fail every
+        # attempt.
+        seat_cfg.setdefault(
+            "retries",
+            {"max_retries": 2, "include": ["ProviderError", "HarnessError"]},
+        )
     return EvalConfig(
         env={
             "taskset": taskset_cfg,

--- a/tests/v1/fixtures/echo_tool_v1.py
+++ b/tests/v1/fixtures/echo_tool_v1.py
@@ -37,10 +37,7 @@ class EchoToolTask(vf.Task[vf.TaskData, vf.State, EchoToolTaskConfig]):
 
     @vf.reward(weight=1.0)
     async def echoed(self, trace: vf.Trace) -> float:
-        # A stamped TOOL result proves the model called the MCP tool with the phrase —
-        # wherever in the exchange that happened. Scoring the assistant's relay instead
-        # would grade model obedience (a conversational reply may drop the stamp), not
-        # the tool loop this fixture exists to prove.
+        # A stamped TOOL result proves the tool really ran with the phrase.
         results = (content_text(m.content).lower() for m in trace.tool_messages)
         return float(any(PHRASE in r and ECHO_TOKEN in r for r in results))
 

--- a/tests/v1/fixtures/echo_tool_v1.py
+++ b/tests/v1/fixtures/echo_tool_v1.py
@@ -11,6 +11,7 @@ so it would also serve taskset-scoped (`Taskset.toolsets`).
 """
 
 import verifiers.v1 as vf
+from verifiers.v1.types import content_text
 
 PHRASE = "hello world"
 ECHO_TOKEN = "ok-7f3"  # the tool stamps this; only a real tool call can surface it
@@ -36,11 +37,12 @@ class EchoToolTask(vf.Task[vf.TaskData, vf.State, EchoToolTaskConfig]):
 
     @vf.reward(weight=1.0)
     async def echoed(self, trace: vf.Trace) -> float:
-        # The stamped token surfaces in an ASSISTANT message only if the model called
-        # the MCP tool and relayed its result — wherever in the exchange that happened
-        # (in a conversation the last turn may be a closing pleasantry).
-        replies = ((m.content or "").lower() for m in trace.assistant_messages)
-        return float(any(PHRASE in r and ECHO_TOKEN in r for r in replies))
+        # A stamped TOOL result proves the model called the MCP tool with the phrase —
+        # wherever in the exchange that happened. Scoring the assistant's relay instead
+        # would grade model obedience (a conversational reply may drop the stamp), not
+        # the tool loop this fixture exists to prove.
+        results = (content_text(m.content).lower() for m in trace.tool_messages)
+        return float(any(PHRASE in r and ECHO_TOKEN in r for r in results))
 
 
 class EchoToolConfig(vf.TasksetConfig):

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -141,9 +141,7 @@ def _content_to_wire(content):
 
 def message_to_wire(message: Message) -> dict:
     if message.role == "assistant":
-        # An empty completion records `content=None`; replayed as `"content": null`
-        # without tool calls, strict providers reject the whole request (422) — an
-        # empty string is the lossless wire form.
+        # Strict providers reject `content: null` without tool calls.
         content = message.content
         if content is None and not message.tool_calls:
             content = ""

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -141,7 +141,13 @@ def _content_to_wire(content):
 
 def message_to_wire(message: Message) -> dict:
     if message.role == "assistant":
-        wire: dict = {"role": "assistant", "content": message.content}
+        # An empty completion records `content=None`; replayed as `"content": null`
+        # without tool calls, strict providers reject the whole request (422) — an
+        # empty string is the lossless wire form.
+        content = message.content
+        if content is None and not message.tool_calls:
+            content = ""
+        wire: dict = {"role": "assistant", "content": content}
         if message.provider_state:
             wire["reasoning_details"] = message.provider_state
         elif message.reasoning_content is not None:

--- a/verifiers/v1/envs/user_sim/env.py
+++ b/verifiers/v1/envs/user_sim/env.py
@@ -21,13 +21,14 @@ from pydantic import Field
 
 import verifiers.v1 as vf
 
-PERSONA = """You are role-playing a USER talking to an AI assistant. This is your situation and goal:
+PERSONA = """You are role-playing a USER talking to an AI assistant. This is your situation — what you want the ASSISTANT to do for you:
 
 {scenario}
 
 Rules:
 - Open the conversation with your request, in your own words.
 - Stay in character: short, natural user messages; never act as the assistant.
+- The assistant does the work, not you: never perform the task yourself — any tool call, answer, or output format it asks for must come from the assistant; ask for it instead.
 - Reveal details only when asked, as a real user would.
 - When the assistant has fully met your goal — or you are convinced it cannot — reply with exactly {done} and nothing else."""
 

--- a/verifiers/v1/harnesses/openclaw/harness.py
+++ b/verifiers/v1/harnesses/openclaw/harness.py
@@ -117,12 +117,7 @@ class OpenClawHarness(Harness[OpenClawHarnessConfig]):
         data: TaskData,
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(data)
-        # Reasoning replay is opt-in (`sampling.reasoning_effort`), never guessed from
-        # the model name. With `reasoning` on, OpenClaw asks for
-        # `reasoning.encrypted_content` and replays it from its persisted transcript on
-        # resume — where its secret redaction masks Prime's dotted `<token>.<metadata>`
-        # payloads (they fail OpenClaw's opaque-token allowlist), so every resumed
-        # session then dies on an upstream 400 replaying the mangled token.
+        # Opt-in via sampling: OpenClaw redacts persisted encrypted reasoning, so resumed sessions 400 replaying it.
         reasoning = ctx.sampling.reasoning_effort not in (None, "none")
         directory = OPENCLAW_DIR.format(version=self.config.version)
         state_dir = f".vf-openclaw/{trace.id}"

--- a/verifiers/v1/harnesses/openclaw/harness.py
+++ b/verifiers/v1/harnesses/openclaw/harness.py
@@ -117,10 +117,13 @@ class OpenClawHarness(Harness[OpenClawHarnessConfig]):
         data: TaskData,
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(data)
-        reasoning = ctx.sampling.reasoning_effort not in (
-            None,
-            "none",
-        ) or ctx.model.rsplit("/", 1)[-1].startswith(("gpt-5", "o1", "o3", "o4"))
+        # Reasoning replay is opt-in (`sampling.reasoning_effort`), never guessed from
+        # the model name. With `reasoning` on, OpenClaw asks for
+        # `reasoning.encrypted_content` and replays it from its persisted transcript on
+        # resume — where its secret redaction masks Prime's dotted `<token>.<metadata>`
+        # payloads (they fail OpenClaw's opaque-token allowlist), so every resumed
+        # session then dies on an upstream 400 replaying the mangled token.
+        reasoning = ctx.sampling.reasoning_effort not in (None, "none")
         directory = OPENCLAW_DIR.format(version=self.config.version)
         state_dir = f".vf-openclaw/{trace.id}"
         config_path = f"{state_dir}/openclaw.json"


### PR DESCRIPTION
## Summary

Five targeted fixes for the remaining live-E2E failures on `main` (post #2262). Each was reproduced and diagnosed locally against the real endpoint before fixing.

## 1. `test_acp_resume_with_tool[openclaw-acp-in-docker]` — deterministic upstream 400 on resume

**Root cause** (captured the exact rejected `/responses` body locally): with `reasoning: true`, OpenClaw requests `include: ["reasoning.encrypted_content"]` and replays reasoning items from its **persisted transcript** on session resume. Prime's gateway emits `encrypted_content` in a dotted `<fernet>.<base64-metadata>` format, which fails OpenClaw's opaque-replay-token allowlist (`/^[A-Za-z0-9+/_-]+={0,2}$/` — no dot), so OpenClaw's secret redaction masks the persisted token to `gAAAAA…iA==.<metadata>` (`head6…tail4`). The resumed session replays the mangled token → gateway 400 "Invalid request" → every resumed OpenClaw rollout dies. (Live sessions replay from memory, unredacted — which is why only resume broke.) OpenClaw even has a strip-encrypted-content retry, but it only matches `invalid_encrypted_content` / `thinking_signature_invalid` error codes; the gateway's generic `invalid_request` never triggers it.

**Fix**: OpenClaw `reasoning` now follows the explicit sampling config (`reasoning_effort`), never a model-name guess. The old heuristic force-enabled reasoning replay for `gpt-5*`/`o*` models, which is exactly the broken path on the default (Prime) endpoint.

**Upstream follow-ups worth filing** (out of scope here):
- pinference: dot in `encrypted_content` breaks agents that allowlist OpenAI's dot-free token shape; the opaque 400 also defeats agents' own strip-and-retry fallbacks.
- OpenClaw: allowlist dotted replay tokens (JWT-shaped), or skip redaction for `encrypted_content` fields.

**Validated**: failing 5/5 before (3 CI runs + 2 local), passing 4/4 locally after.

## 2. `test_env_id_user_sim_with_tools` — 422 mode

The CI model occasionally returns a fully-empty completion; it records as `content=None` and `message_to_wire` replays it as `"content": null` in the next segment's initial messages — strict providers reject the request (`content is required unless an assistant message includes tool_calls`). Empty completions now replay as `""`.

## 3. `test_env_id_user_sim_with_tools` — score-0 mode

Local transcript: the tool ran and returned `hello world [ok-7f3]`, but the sim-user paraphrased away the "reply with exactly what it returns" requirement, so the assistant dropped the stamp and the reward scored 0. The `echo-tool-v1` reward now scores the stamped **tool result** — per the fixture's own contract ("reward 1.0 only if the model actually called the tool — trivial when the infra works, impossible when it doesn't") — instead of grading whether the model parrots the stamp verbatim.

**Validated**: failing 4/4 CI runs before; passing 3/3 locally after (2 targeted runs + `test_tool` placement).

## 4. `test_env_id_user_sim_with_tools` — task-leak mode

Local transcript: the sim-user (a strong instruction-follower) reads the scenario's imperative text ("Call the `echo_back` tool … reply inside `<answer></answer>` tags") as its **own** instructions and opens the conversation with `<answer>hello world</answer>` itself — the assistant is never asked to do anything, no tool ever runs (zero TOOL messages, so 3.'s reward fix can't save it), the sim-user closes with `###DONE###`, and the episode scores 0.

**Fix**: harden the `user-sim` PERSONA — frame the scenario as *what you want the ASSISTANT to do for you*, and add an explicit rule that the user seat never performs the task itself (no tool calls, answers, or output formats; it asks the assistant instead).

**Validated**: failing 2/2 locally before (with fixes 1–3 already in-tree); passing 3/3 after, sibling `test_env_id_user_sim` still green.

## 5. `test_single_turn/test_agentic[rlm-*]`, `test_tool_state` — unretried harness flakes

RLM occasionally ends a turn with zero output (`ACP agent produced no visible reply`, survives #2262's grace period — the model genuinely emits nothing), and `test_tool_state` occasionally stalls into its rollout budget (`agent timeout`). Both record as `HarnessError`, which the e2e retry include didn't cover (only `ProviderError`). The conftest now retries `HarnessError` rollouts too; deterministic harness bugs still fail all three attempts.

## Validation

- `uv run pytest tests/v1 -m "not e2e"` — all passed
- `uv run pytest tests/ -m "not e2e"` — all passed
- targeted live e2e: openclaw resume ×4, user_sim ×3, tool[subprocess-colocated] ×1 — all passed
- persona fix: `test_env_id_user_sim_with_tools` ×3 + `test_env_id_user_sim` ×1 — all passed
- `uv run ruff check .`, `ty check verifiers` (3.13), `uv run pre-commit run --all-files` — passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Production paths change OpenClaw reasoning defaults, chat serialization, and user-sim behavior—not just tests—though changes are narrow and aimed at known flake/failure modes.
> 
> **Overview**
> Targets five live-E2E failure modes with small behavioral fixes in harness, dialect, env, and test defaults.
> 
> **OpenClaw resume:** `reasoning` on the intercept model is now driven only by `sampling.reasoning_effort` (not `gpt-5`/`o*` name heuristics), avoiding persisted encrypted-reasoning replay that 400s on session resume.
> 
> **Chat wire:** `message_to_wire` sends `content: ""` instead of `null` for assistant turns with no text and no tool calls, so strict providers accept the next request.
> 
> **User-sim:** The sim-user `PERSONA` frames the scenario as what the assistant should do and forbids the user seat from performing tools, answers, or formatted output itself—fixing cases where the user “completed” the task before the assistant ran tools.
> 
> **Echo-tool fixture:** The `echoed` reward checks stamped text in **tool** messages (via `content_text`), not whether the assistant parroted the stamp.
> 
> **E2E defaults:** Per-seat retries in `conftest` now include `HarnessError` alongside `ProviderError` (still max 2 retries).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de739186c587b9654d04a880cb1a7fc4eca89dcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix flaky live E2E tests by correcting reward logic, retry config, and assistant message handling
> - Adds `HarnessError` to the retry list alongside `ProviderError` in [`_eval_config`](https://github.com/PrimeIntellect-ai/verifiers/pull/2267/files#diff-bc28790d38dc6e7e4f2c44639d40bc33dea724d6c73149abf7ba82b37d14f40b), so transient harness failures no longer fail seats permanently.
> - Fixes the `echoed` reward in [`EchoToolTask`](https://github.com/PrimeIntellect-ai/verifiers/pull/2267/files#diff-cbaa85991c53737ba2194a031e9fe26498f7b5b8c35d0018a9446180f90f91ad) to check tool messages (not assistant messages) for the expected phrase and token, requiring actual tool execution.
> - Sets assistant message `content` to an empty string instead of `null` when there are no tool calls in [`message_to_wire`](https://github.com/PrimeIntellect-ai/verifiers/pull/2267/files#diff-5d2fcbf59a03489b63b0626038a853eee89543b591074597161ee29aab901280), improving provider compatibility.
> - Changes [`OpenClawHarness`](https://github.com/PrimeIntellect-ai/verifiers/pull/2267/files#diff-d7278b9055ef0f18d323c2ac3010b475bc2122a03e99b44977384fab44c24362) to enable reasoning only when `sampling.reasoning_effort` is explicitly set, removing the model-name heuristic.
> - Behavioral Change: `echoed` reward scores will change for any rollout where the assistant relayed the phrase without invoking the tool.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized de73918.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
