### PR TITLE
fix(agentic-judge): a failed judge run fails the episode

### DIFF
--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -268,6 +268,20 @@ class AgenticJudgeEnvConfig(vf.EnvConfig):
     score: ScoreConfig = ScoreConfig()
 
 
+def _require_verdict(verdict: vf.Trace) -> None:
+    """A grading env can't grade without its judge, so a failed judge run is the
+    episode failing — raise it here, where the judge's own error is still the
+    thing being reported. Left to `finalize()`, the missing verdict surfaces as a
+    schema error against `None` and buries the cause."""
+    if verdict.ok:
+        return
+    error = verdict.error
+    raise ValueError(
+        "the judge's rollout failed"
+        + (f" — {error.type}: {error.message}" if error else "")
+    )
+
+
 class AgenticJudgeEnv(vf.Env[AgenticJudgeEnvConfig]):
     """Common agentic-judge protocol; subclasses choose the runtime boundary."""
 
@@ -333,7 +347,8 @@ class SharedAgenticJudgeEnv(AgenticJudgeEnv):
         async with agents.solver.provision(task) as box:
             solution = await agents.solver.run(task, runtime=box)
             judge_task = JudgeTask.from_trace(solution, self.config.task)
-            await agents.judge.run(judge_task, runtime=box)
+            verdict = await agents.judge.run(judge_task, runtime=box)
+            _require_verdict(verdict)
 
 
 class IsolatedAgenticJudgeEnv(AgenticJudgeEnv):
@@ -343,6 +358,7 @@ class IsolatedAgenticJudgeEnv(AgenticJudgeEnv):
         solution = await agents.solver.run(task)
         if not solution.ok:
             return
-        await agents.judge.run(
+        verdict = await agents.judge.run(
             JudgeTask.from_trace(solution, self.config.task, share_runtime=False)
         )
+        _require_verdict(verdict)


### PR DESCRIPTION
## Problem

`AgenticJudgeEnv.run()` decides what a failed **solver** means — `if not solution.ok: return`, nothing to grade — but never checks the **judge**.

A judge whose rollout dies (provider error, timeout, lost box) leaves a failed trace. `Agent.run` captures that onto the trace rather than raising, so `run()` returns normally and `finalize()` is called against an episode with no verdict:

```
EnvError: SharedAgenticJudgeEnv.finalize(): ValidationError: 1 validation error for RubricVerdicts
  Input should be a valid dictionary or instance of RubricVerdicts
  [type=model_type, input_value=None, input_type=NoneType]
```

That names the shape and buries the cause. On the run that prompted this, ~120 rollouts failed and every message pointed at `RubricVerdicts`; the judge's actual HTTP 400 was only visible by correlating a separate `ProviderError` line in the orchestrator log.

## Change

Both variants now check the judge's trace and raise if it failed, quoting the judge's own error:

```
ValueError: the judge's rollout failed — ProviderError: upstream 400: ...
```

Per `run()`'s documented contract — *"an agent-run failure is data on its trace (this hook decides what it means); an exception raised here is the episode itself failing"* — a grading env can't grade without its judge, so this env decides it's fatal. Raising in `run()` gets the existing hook behaviour for free: the error lands on `episode.errors` and `finalize()` is skipped, instead of running over state it needs and failing a second time.

Deliberately kept in the env rather than the framework: whether a failed agent run is fatal is the env's call, exactly as the contract says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix failed agent run to raise ValueError instead of continuing silently
> - Adds `_require_verdict` helper in [env.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2268/files#diff-6c0b86ec43e4d94e2bde0d8ed0ac8ff6c3a422e074161c486bb7aa45c9ae1c81) that raises `ValueError` with a descriptive message when a judge verdict indicates failure.
> - `SharedAgenticJudgeEnv.run` and `IsolatedAgenticJudgeEnv.run` now call `_require_verdict` after `agents.judge.run`, stopping the episode before `finalize()` on judge failure.
> - Behavioral Change: previously, a failed judge run would continue silently; it now raises `ValueError`, which will propagate to callers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a7dd76.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->