### PR TITLE
fix(env): a failed agent run fails the episode and skips finalize()

### DIFF
--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -151,8 +151,10 @@ class Env(ABC, Generic[ConfigT]):
     async def run(self, task: Task, agents: Agents) -> None:
         """One episode: how the agents interact on `task`, returning nothing —
         every finished run joins the episode automatically, stamped with its seat's
-        standing. An agent-run failure is data on its trace (this hook decides what
-        it means); an exception raised here is the episode itself failing.
+        standing. An agent run that fails fails the episode: its error is recorded
+        and `finalize()` is skipped, so this hook can read a completed run's trace
+        without guarding it. Raising here fails the episode too, for what the
+        agents' own traces can't say.
         Independent agents are written as such (`asyncio.gather`); how many of them
         actually run at once is the run's bound, not this hook's
         (`--env.max-concurrent-agents`, one at a time by default)."""
@@ -274,6 +276,15 @@ class Env(ABC, Generic[ConfigT]):
                 )
             episode.errors.append(_as_error(e))
             # The completed subset is the crash-safe episode; ok stays False.
+            return episode
+        # `Agent.run` records a failed run on the trace instead of raising, so the
+        # sequence checks here: `finalize()` judges what `run()` produced, and over
+        # a run that never finished it can only fail again, reporting that second
+        # failure instead of the cause.
+        if failed := [trace for trace in episode.traces if not trace.ok]:
+            episode.errors.extend(
+                error for trace in failed if (error := trace.error) is not None
+            )
             return episode
         try:
             async with asyncio.timeout(self.config.timeout.finalize):


### PR DESCRIPTION
## Problem

`run_episode` already treats a raising hook as fatal: if `setup()` or `run()` raises, `finalize()` is skipped and the exception lands on `episode.errors`.

A failed *agent run* took a different path. `Agent.run` records the error on the trace rather than raising — deliberately, so per-agent retries can inspect it — so `env.run()` returns normally, leaving a not-`ok` trace in the episode, and `finalize()` runs anyway.

`finalize()` judges what `run()` produced. Over a run that never finished it can only fail again, and that second failure is the one reported:

- **agentic-judge**: a judge whose provider returned HTTP 400 never reached its own `finalize`, so no verdict was scraped off the box. The env's `finalize` then validated `None`:
  ```
  EnvError: SharedAgenticJudgeEnv.finalize(): ValidationError: 1 validation error for RubricVerdicts
    Input should be a valid dictionary or instance of RubricVerdicts [type=model_type, input_value=None]
  ```
  On the run that prompted this, ~120 rollouts failed and every message named `RubricVerdicts`; the upstream `ProviderError` was only visible by correlating a separate orchestrator log line.
- **best_of_n**: `max(t.reward for t in episode.traces)` over traces that never scored.

Each env could guard its own `finalize()`, but then every env has to remember to, and the failure mode is silent until something downstream trips over half-built state.

## Change

After `run()`, stop if any trace ended not-`ok`: copy those traces' errors onto the episode and return without calling `finalize()` — the same rule already applied to a raising hook.

`run()`'s contract is updated to match: an agent run that fails fails the episode, so the hook can read a completed run's trace without guarding it, and raising is reserved for what the traces themselves can't express.

The episode still carries the completed subset, `ok` stays `False`, and retries are unaffected — `episode_should_retry` already keys off both episode errors and not-`ok` traces.

## Checks

`test_environment.py`, `test_environment_extra.py`, `test_env_group.py`, `test_composable_env.py` pass (102 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Central episode lifecycle change affects every multi-agent env’s `finalize()` visibility on partial failures, though retries and completed-trace semantics are unchanged per existing `episode_should_retry` behavior.
> 
> **Overview**
> **`run_episode`** now treats a non-raising but failed agent run like a hook failure: after **`run()`** returns, if any trace has **`ok=False`**, those traces’ errors are appended to **`episode.errors`** and **`finalize()`** is not called.
> 
> The **`run()`** docstring is updated so env authors know a failed agent run ends the episode and that completed traces in **`run()`** can be read without guarding for failure; raising remains for failures the traces don’t capture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1b8efa0abb697575b32599e1ffb115c288b88cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fail the episode and skip `finalize()` when an agent run fails in `Env`
> When `run()` completes, the episode executor in [env.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2269/files#diff-69be10bd5960e88d88f219d4f261d0bdd16586857f9126451b04d05bac4c2cbb) now checks all traces for `ok == False`. If any failed trace is found, its errors are appended to `episode.errors` and the episode returns early, skipping `finalize()`.
>
> - Behavioral Change: previously, a failed agent run would not propagate to `episode.errors` and `finalize()` would still be called; now it is skipped entirely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c1b8efa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->