### PR TITLE
Preserve bare MCP tool names in Kimi Code

### DIFF
--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -13,6 +13,7 @@ from dataclasses import field as dataclass_field
 from typing import Any
 
 from openai.types.chat import ChatCompletion
+from pydantic_core import to_json
 
 from verifiers.v1.dialects.base import Dialect, StreamParser, parse_sse_event
 from verifiers.v1.types import (
@@ -48,6 +49,59 @@ FINISH_REASONS = frozenset({"stop", "length", "tool_calls"})
 # `reasoning` (vLLM / Together / OpenRouter), `reasoning_content` (DeepSeek / Qwen / SGLang /
 # Fireworks / Kimi), `reasoning_details` (OpenRouter / MiniMax).
 REASONING_FIELDS = ("reasoning", "reasoning_content", "reasoning_details")
+# Kimi qualifies MCP tools as `mcp__<server>__<tool>`; `TOOL_PREFIX = None`
+# intentionally leaves the server name empty.
+BARE_MCP_TOOL_PREFIX = "mcp____"
+
+
+def replace_chat_tool_names(value: Any, aliases: Mapping[str, str]) -> Any:
+    """Return a chat wire value with matching `name` fields replaced recursively."""
+    if not aliases:
+        return value
+    if isinstance(value, dict):
+        return {
+            key: aliases.get(item, item)
+            if key == "name" and isinstance(item, str)
+            else replace_chat_tool_names(item, aliases)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [replace_chat_tool_names(item, aliases) for item in value]
+    return value
+
+
+def alias_bare_mcp_tool_names(body: dict) -> tuple[dict, dict[str, str]]:
+    """Expose Kimi's empty-server MCP namespace as bare chat tool names."""
+    names = {
+        function["name"]
+        for tool in body.get("tools") or []
+        if isinstance(function := tool.get("function"), dict)
+        and isinstance(function.get("name"), str)
+    }
+    aliases = {
+        name: name.removeprefix(BARE_MCP_TOOL_PREFIX)
+        for name in names
+        if name.startswith(BARE_MCP_TOOL_PREFIX)
+    }
+    if collisions := set(aliases.values()) & (names - aliases.keys()):
+        raise ValueError(
+            f"bare MCP tools collide with harness tools: {', '.join(sorted(collisions))}"
+        )
+    return replace_chat_tool_names(body, aliases), {
+        visible: internal for internal, visible in aliases.items()
+    }
+
+
+def restore_chat_sse_tool_names(raw: bytes, aliases: Mapping[str, str]) -> bytes:
+    """Restore tool names in one complete chat SSE event."""
+    if not aliases:
+        return raw
+    event = parse_sse_event(raw)
+    restored = replace_chat_tool_names(event, aliases)
+    if restored == event:
+        return raw
+    terminator = raw[len(raw.rstrip(b"\r\n")) :]
+    return b"data: " + to_json(restored) + terminator
 
 
 def reasoning_text(data: Mapping[str, Any]) -> str | None:

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -40,6 +40,11 @@ from verifiers.v1.clients import Client, resolve_client
 from verifiers.v1.configs.client import BaseClientConfig
 from verifiers.v1.dialects import DIALECTS, Dialect
 from verifiers.v1.dialects.base import is_sse_done_event
+from verifiers.v1.dialects.chat import (
+    alias_bare_mcp_tool_names,
+    replace_chat_tool_names,
+    restore_chat_sse_tool_names,
+)
 from verifiers.v1.errors import (
     OverlongPromptError,
     ProviderError,
@@ -331,6 +336,10 @@ class InterceptionServer(Interception):
         # alias after parsing so the wire body does not survive model inference.
         request._read_bytes = None
         del raw
+        try:
+            body, tool_aliases = alias_bare_mcp_tool_names(body)
+        except ValueError as e:
+            return web.json_response(dialect.error_body(str(e)), status=400)
         streaming = dialect.streaming(body)
         logger.debug(
             "intercept %s: id=%s stream=%s",
@@ -355,7 +364,15 @@ class InterceptionServer(Interception):
         # coalescing cache, as it was before in-flight retries were introduced.
         if streaming:
             prompt, tools = dialect.parse_request(body)
-            return await self._stream(request, session, dialect, body, prompt, tools)
+            return await self._stream(
+                request,
+                session,
+                dialect,
+                body,
+                prompt,
+                tools,
+                tool_aliases,
+            )
 
         async def coalesced(inflight: "asyncio.Future[dict | None]") -> web.Response:
             # Await the first attempt instead of re-sampling. None means it produced no servable
@@ -385,10 +402,11 @@ class InterceptionServer(Interception):
             # `Response.raw` is the full native provider object (or the renderer's synthesized
             # completion) that the server serializes back to the program.
             session.last_request = req_hash
-            session.last_response = response.raw
+            completion = replace_chat_tool_names(response.raw, tool_aliases)
+            session.last_response = completion
             if not fut.done():
-                fut.set_result(response.raw)
-            return _completion_response(response.raw)
+                fut.set_result(completion)
+            return _completion_response(completion)
 
         try:
             # The proxy preserves native JSON fields except model + sampling. `prompt` is only the
@@ -528,7 +546,8 @@ class InterceptionServer(Interception):
         dialect: Dialect,
         body: dict,
         prompt: Messages,
-        tools: list[Tool] | None = None,
+        tools: list[Tool] | None,
+        tool_aliases: dict[str, str],
     ) -> web.StreamResponse:
         """A streamed (SSE) model turn: relay the provider's stream through to the program,
         incrementally assembling the response to record on the trace (the only client that
@@ -645,9 +664,11 @@ class InterceptionServer(Interception):
                             except Exception as e:  # noqa: BLE001 - defer parser failure
                                 parser_error = e
                         # forwarded after the turn is committed, below
-                        deferred.append(chunk)
+                        deferred.append(
+                            restore_chat_sse_tool_names(chunk, tool_aliases)
+                        )
                         continue
-                    await resp.write(chunk)
+                    await resp.write(restore_chat_sse_tool_names(chunk, tool_aliases))
                     if parser_error is None:
                         try:
                             feed_event(chunk)


### PR DESCRIPTION
## Overview

Preserve `TOOL_PREFIX=None` names when MCP tools are used through the Kimi Code harness, so environments can expose conventional bare entry points such as `submit`.

## Details

- Recognize Kimi's empty-server `mcp____<tool>` namespace at the chat interception boundary.
- Present bare names to the model and trace, then restore Kimi's internal names in streamed and non-streamed responses.
- Reject collisions between bare MCP names and harness-native tools.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the model proxy path for all chat requests (name rewriting on bodies and SSE); mis-aliasing could break tool calls, though scope is limited to tools matching the bare MCP prefix and collisions are rejected.
> 
> **Overview**
> Kimi Code exposes MCP tools with an empty server segment as **`mcp____<tool>`** on the wire. This PR strips that prefix at the chat interception boundary so the model and trace see **bare** names (e.g. `submit`), then maps names back before the harness receives completions.
> 
> New helpers in the chat dialect recursively rewrite `name` fields in request bodies, rebuild SSE `data:` events when tool names change, and **reject** requests where a stripped name would collide with an existing harness tool (**400**). The interception server applies aliasing after parsing the body, passes the aliased request upstream, and runs the reverse map on non-streaming completions (including retry replay cache) and on every forwarded SSE chunk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6560f0cce9656e0838028918692e1ba8d7b1bb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve bare MCP tool names by stripping the `mcp____` prefix in Kimi Code
> - Adds `alias_bare_mcp_tool_names` in [chat.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2270/files#diff-5d2fcbf59a03489b63b0626038a853eee89543b591074597161ee29aab901280) to detect tools prefixed with `mcp____`, strip the prefix to produce bare names, and build a reverse alias map; raises `ValueError` on name collisions.
> - Adds `replace_chat_tool_names` to recursively rewrite `name` fields in chat payloads according to an alias map, and `restore_chat_sse_tool_names` to rewrite tool names back to internal values in streamed SSE events.
> - Integrates aliasing into [server.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2270/files#diff-84e2f8d027d609e8760ef6d533535ec9d99dfc6384d5ddb6111b4001b2010f35): non-streaming responses have tool names rewritten before caching and delivery; streaming responses rewrite each SSE chunk on the fly.
> - Risk: if stripping the prefix would collide with an existing tool name, the endpoint now returns HTTP 400.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e6560f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->