### PR TITLE
Fix sandbox sdist build coordination

### DIFF
--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -8,7 +8,6 @@ import shlex
 import subprocess
 import sys
 import tempfile
-import threading
 import uuid
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
@@ -40,7 +39,17 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _SDIST_BUILD_TIMEOUT_SECONDS = 300
-_SDIST_BUILD_LOCK = threading.Lock()
+
+
+@dataclass
+class _SdistBuildState:
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    users: int = 0
+
+
+# Coordination and caching are process-local. Spawned env-server workers each
+# build once; within an event loop, concurrent rollouts share the completed artifact.
+_SDIST_BUILD_STATES: dict[tuple[Path, asyncio.AbstractEventLoop], _SdistBuildState] = {}
 
 # Any HTTP response, including MCP's 406 to a bare GET, proves the server is listening.
 _PROBE = """
@@ -81,11 +90,15 @@ def _build_sdist(src: Path) -> tuple[str, bytes]:
             "never",
             "--out-dir",
             str(out),
-            str(src),
+            ".",
         ]
         try:
+            # Run from the source root so uv discovers this project's workspace,
+            # uv.toml, indexes, constraints, and Python configuration rather than
+            # inheriting configuration from the launcher's working directory.
             result = subprocess.run(
                 command,
+                cwd=src,
                 capture_output=True,
                 text=True,
                 check=False,
@@ -117,9 +130,32 @@ def _build_sdist(src: Path) -> tuple[str, bytes]:
         return artifact.name, artifact.read_bytes()
 
 
-def _locked_sdist(src: Path) -> tuple[str, bytes]:
-    with _SDIST_BUILD_LOCK:
-        return _build_sdist(src)
+async def _cached_sdist(src: Path) -> tuple[str, bytes]:
+    """Build once per source without parking waiters in the thread pool."""
+    src = src.resolve()
+    key = (src, asyncio.get_running_loop())
+    state = _SDIST_BUILD_STATES.get(key)
+    if state is None:
+        state = _SdistBuildState()
+        _SDIST_BUILD_STATES[key] = state
+    state.users += 1
+    try:
+        async with state.lock:
+            # Coordinate before entering the default executor so concurrent
+            # same-source waiters do not occupy executor threads.
+            build = asyncio.create_task(asyncio.to_thread(_build_sdist, src))
+            try:
+                return await asyncio.shield(build)
+            except asyncio.CancelledError:
+                # Cancelling to_thread does not stop its worker. Keep the lock until
+                # that worker exits so a replacement caller cannot overlap the build.
+                with contextlib.suppress(Exception):
+                    await build
+                raise
+    finally:
+        state.users -= 1
+        if state.users == 0 and _SDIST_BUILD_STATES.get(key) is state:
+            del _SDIST_BUILD_STATES[key]
 
 
 def _verifiers_root() -> Path:
@@ -150,11 +186,11 @@ async def _install_in_sandbox(server: ServerBase, runtime: Runtime) -> str:
     temp = str(PurePosixPath(workdir) / ".vf-tmp")
     cache = str(PurePosixPath(workdir) / ".vf-uv-cache")
     vf, env = _verifiers_root(), Path(source_dir)
-    vf_name, vf_data = await asyncio.to_thread(_locked_sdist, vf)
+    vf_name, vf_data = await _cached_sdist(vf)
     if env == vf:
         env_name, env_data = vf_name, vf_data
     else:
-        env_name, env_data = await asyncio.to_thread(_locked_sdist, env)
+        env_name, env_data = await _cached_sdist(env)
     vf_remote = f"{root}/{vf_name}"
     env_remote = f"{root}/{env_name}"
     await runtime.write(vf_remote, vf_data)


### PR DESCRIPTION
## Summary

- run `uv build` from the source root so the tool project's uv/workspace configuration is discovered
- coordinate same-source sdist builds with an async lock before entering the default executor
- document that sdist coordination and caching are process-local, with one build per spawned worker

## Why

This is a follow-up to #2263. Waiting on a `threading.Lock` inside `asyncio.to_thread` parked one default-executor worker per concurrent rollout, which could starve unrelated executor work while a build was in progress. The build subprocess also inherited the launcher's working directory instead of discovering configuration from the source project.

## Validation

- focused regression with 64 concurrent same-source callers: one build, executor remains responsive
- built `vf_test_fixtures-0.0.0.tar.gz` through the updated path
- `uv run ruff check --fix .`
- `uv run ty check verifiers`
- `uv run pre-commit run --all-files`
- `uv run pytest tests/`: 913 passed, 72 skipped


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sandbox sdist build coordination to use asyncio locks and correct working directory
> - Replaces the global `threading.Lock` in `_locked_sdist` with a per-source, per-event-loop `asyncio.Lock` in a new `_cached_sdist` function, so concurrent builds for the same source serialize without blocking executor threads.
> - Changes `_build_sdist` to run `uv build .` with `cwd=src` instead of passing the path as an argument, so the build picks up the project's own workspace and configuration.
> - Cancellation of a waiting coroutine now waits for the in-flight worker to finish before releasing the lock, preventing overlapping builds for the same source.
> - Behavioral Change: sdist builds now always run from the source root directory rather than the caller's working directory.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 588ddab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sandbox install path used when launching remote MCP servers; behavior changes under high concurrency and cancellation, though scoped to build coordination and subprocess cwd.
> 
> **Overview**
> Fixes **sandbox MCP install** sdist builds so many concurrent rollouts no longer tie up the default thread pool while waiting on the same artifact.
> 
> **Coordination:** Replaces a global `threading.Lock` inside `asyncio.to_thread` with per-source, per-event-loop `asyncio.Lock` coordination in `_cached_sdist`. Waiters serialize on the lock *before* entering the executor, so only one thread runs `uv build` per source while others await asynchronously. Cancellation keeps the lock until the background `to_thread` worker finishes, avoiding overlapping builds. State is process-local (documented on `_SDIST_BUILD_STATES`).
> 
> **Build correctness:** `uv build` now runs with `cwd=src` and project path `.` so workspace/`uv.toml`/index config come from the source tree, not the launcher's working directory.
> 
> `_install_in_sandbox` now awaits `_cached_sdist` instead of `_locked_sdist`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 588ddab036ba8dbfd2addcac1ca24ca1d34b5b2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->