### PR TITLE
docs: add "Publishing to the Environments Hub" guide

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -5,6 +5,7 @@
       "group": "Verifiers",
       "pages": [
         "overview",
+        "publishing",
         {
           "group": "Verifiers v1",
           "pages": [

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,0 +1,147 @@
+# Publishing an environment to the Environments Hub
+
+This guide takes you from an empty directory to an environment installable by anyone from the
+[Environments Hub](https://app.primeintellect.ai/dashboard/environments). It covers the **v0
+authoring API** (`load_environment`), which is what the Hub installs and runs today, and ends
+with a short note on the **v1 taskset** migration.
+
+<Note>
+Which API should I write? If your goal is to publish to the Hub now, use the **v0**
+`load_environment` API below — that is what `prime env init`, `vf-eval`, and the Hub currently
+expect. The **v1** taskset API (`verifiers.v1`) is the future of the framework and is covered
+under [Building Tasksets](v1/tasksets.md); it is not yet the Hub's install format. See
+[v0 vs v1](#v0-vs-v1) at the end.
+</Note>
+
+## 1. Prerequisites
+
+```bash
+# uv (package manager)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Prime CLI, authenticated
+uv tool install prime
+prime config set-api-key <api-key>   # from your Prime Intellect account
+```
+
+## 2. Scaffold
+
+```bash
+prime env init my-environment
+cd environments/my_environment
+```
+
+This creates:
+
+```text
+environments/my_environment/
+├── my_environment.py     # implements load_environment()
+├── pyproject.toml        # name, version, dependencies
+├── README.md             # what the env tests, dataset provenance, results
+└── outputs/              # sample eval outputs (committed so reviewers see behavior)
+```
+
+## 3. Implement `load_environment()`
+
+An environment is a dataset of tasks plus a rubric that scores model responses. The minimal
+single-turn shape:
+
+```python
+import verifiers as vf
+from datasets import Dataset
+
+
+def load_environment(**kwargs) -> vf.Environment:
+    dataset = Dataset.from_list(
+        [
+            {"question": "What is 2 + 2?", "answer": "4"},
+            {"question": "What is 3 * 5?", "answer": "15"},
+        ]
+    )
+
+    async def correct_answer(completion, answer) -> float:
+        response = completion[-1]["content"]
+        return 1.0 if answer in response else 0.0
+
+    rubric = vf.Rubric(funcs=[correct_answer])
+    return vf.SingleTurnEnv(dataset=dataset, rubric=rubric)
+```
+
+Each dataset row becomes one **rollout**: the `question` (or a pre-built `prompt` message list)
+is sent to the model, the model's reply becomes the `completion`, and each function in the
+rubric scores it. Use `answer` for a ground-truth string and/or `info` (a dict, or a JSON
+string when rows have differing schemas) for structured metadata.
+
+### Accept configuration through `**kwargs`
+
+Anything a user should be able to vary — split, difficulty, judge model, number of rows —
+should be a keyword argument with a sensible default, so the environment is reusable:
+
+```python
+def load_environment(split: str = "test", max_examples: int = -1, **kwargs) -> vf.Environment:
+    ...
+```
+
+### Multi-step and tool-using environments
+
+- **Tools:** use `vf.ToolEnv` and expose tools as MCP servers when the task needs the model to
+  call functions (search, code execution, an API sandbox).
+- **Custom control flow:** subclass `vf.MultiTurnEnv` to own the rollout loop, stop conditions,
+  and per-turn state.
+
+See [Environments (v0)](v0/environments.md) for rubric composition (multiple reward functions,
+weights, group-based and monitor rubrics), datasets, and the full multi-turn protocol.
+
+## 4. Test locally
+
+```bash
+uv pip install -e .
+uv run vf-eval my-environment                       # runs a few rollouts against a model
+uv run vf-eval my-environment -n 5 -r 3             # 5 tasks, 3 rollouts each
+```
+
+`vf-eval` needs an OpenAI-compatible endpoint. Set `OPENAI_API_KEY` (and `OPENAI_BASE_URL` for
+a non-OpenAI provider) before running. Inspect the sampled rollouts and reward distribution in
+`outputs/` and confirm the reward separates good answers from bad — a reward that returns the
+same value for every completion trains nothing.
+
+<Warning>
+Before publishing, sanity-check that your rubric can't be trivially gamed (e.g. `answer in
+response` rewards a model that echoes every option). Reviewers look for this first.
+</Warning>
+
+## 5. Publish
+
+```bash
+prime env push
+```
+
+Bumping the `version` in `pyproject.toml` triggers CI to build and publish the environment to
+the Hub under the `primeintellect` organization automatically — no manual release step.
+
+## 6. What reviewers look for
+
+- One environment per PR, under `environments/<name>/`.
+- `README.md` states **what capability is tested**, the **dataset source + license**, and shows
+  a **baseline result** (a known model's score) so the reward is calibrated.
+- Committed `outputs/` from a real `vf-eval` run.
+- A reward that is **discriminative** (varies with answer quality) and **not gameable**.
+- Pinned dependencies in `pyproject.toml`; the env installs from a clean checkout.
+
+## v0 vs v1
+
+verifiers is mid-migration. The two APIs differ in shape, not just names:
+
+| | **v0 (Hub today)** | **v1 (`verifiers.v1`, future)** |
+|---|---|---|
+| import | `import verifiers as vf` | `import verifiers.v1 as vf` |
+| unit | `load_environment()` → `vf.Environment` | `vf.Taskset[Task, Config]` with `load()` |
+| data | HF `Dataset` rows | typed `vf.TaskData` per task |
+| scoring | `vf.Rubric(funcs=[...])` | `@vf.reward` methods on a `vf.Task` |
+| scaffold | `prime env init <name>` | `uv run init <name>-v1` |
+| run | `vf-eval <name>` | `uv run eval <taskset-id>` |
+
+The v1 model makes scoring first-class (rewards are methods that see the full `Trace` and can
+execute verification inside the rollout runtime) and separates configurable values onto
+`TasksetConfig` / `TaskConfig`. If you're authoring for the Hub right now, stay on v0; if you're
+contributing to the verifiers repo's `main`, use v1 and follow [Building Tasksets](v1/tasksets.md).


### PR DESCRIPTION
## What

Adds a top-level docs page: **"Publishing an environment to the Environments Hub."**

## Why

The end-to-end flow for authoring an environment and getting it onto the
[Environments Hub](https://app.primeintellect.ai/dashboard/environments) — scaffold →
`load_environment` → `vf-eval` → `prime env push` — is currently documented only in the
`community-environments` README, not in the verifiers docs. A new contributor reading the
verifiers docs site hits `getting_started` (which stops at `uv sync`) and has no path to
publishing.

The page also addresses a concrete drift new contributors hit immediately: `prime env init`
still scaffolds the **v0** `load_environment` template, while the repo's `main` has moved to
**v1** tasksets. The page includes a v0-vs-v1 comparison table so authors know which API to use
for the Hub (v0) vs. for contributing to `main` (v1).

## Contents

- Prerequisites (uv, Prime CLI auth)
- Scaffold, implement `load_environment()`, config via `**kwargs`, tool/multi-turn pointers
- Local testing with `vf-eval` (incl. the `OPENAI_API_KEY` requirement)
- Publishing via `prime env push` / version bump
- A reviewer checklist
- v0 vs v1 comparison

## Notes

- Placed at top level in `docs/mint.json` nav, right after `overview`.
- Links use existing relative paths (`v0/environments.md`, `v1/tasksets.md`).
- Happy to adjust placement, tone, or scope to match maintainer preference.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Adds a new top-level docs page **`publishing`** and wires it into **`docs/mint.json`** immediately after **`overview`**, so the site documents the full Hub publish path instead of leaving it only in community READMEs.
> 
> The new guide walks authors through **v0** Hub workflow: prerequisites, **`prime env init`**, implementing **`load_environment()`**, local **`vf-eval`**, **`prime env push`**, a reviewer checklist, and a **v0 vs v1** table clarifying Hub (v0) vs **`main`** (v1 tasksets). It links to existing **`v0/environments.md`** and **`v1/tasksets.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9a4968fd713da09480951b6c873dd5fae72ab72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add "Publishing to the Environments Hub" guide to docs
> Adds [publishing.md](https://github.com/PrimeIntellect-ai/verifiers/pull/2272/files#diff-84dbb1073803b21c4bad1b65e192bff2ed09ce5944ec79ce2837fe80ee2c124c) with a step-by-step guide for publishing an environment to the Environments Hub. Covers prerequisites, scaffolding, implementing `load_environment`, local testing, publishing steps, reviewer expectations, and a comparison between v0 and v1 APIs. Registers the new page in [mint.json](https://github.com/PrimeIntellect-ai/verifiers/pull/2272/files#diff-c91a604899dfef4b2494c317f4fd39a7f22b79986095f580399347293d534deb).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c9a4968.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->