### PR TITLE
Spool collected artifacts to host disk and stream transfers

### DIFF
--- a/docs/v1/env.md
+++ b/docs/v1/env.md
@@ -73,6 +73,10 @@ class MyTask(vf.Task[MyData]):
 
 Declared paths must exist when collected. The implicit directory is optional.
 
+Collected archives spool to host disk. An env that restores them elsewhere owns
+their lifetime: call `vf.discard(trace.state.artifacts)` once grading has
+consumed them, or they stay on disk until the process exits.
+
 ## Concurrency
 
 Write independent agents as independent (`asyncio.gather`, a `TaskGroup`) — how many actually run at once is the run's call, not the env's. Two knobs bound it, and the **episode is the unit** at the outer one:

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -508,7 +508,8 @@ async def test_env_id_agentic_judge(run_v1, tmp_path):
     assert solver.agent.runtime is not None and judge.agent.runtime is not None
     assert solver.agent.runtime.id != judge.agent.runtime.id
     assert solver.agent.runtime.type == judge.agent.runtime.type == "docker"
-    assert "/app/answer.txt" in solver.state.artifacts
+    # Collected (key present), then discarded after judging (spool file dropped).
+    assert solver.state.artifacts["/app/answer.txt"] is None
     assert solver.rewards["wrote_phrase"].score == 1.0
     assert solver.rewards["wrote_phrase"].weight == 0.5
     assert isinstance(judge.info.get("verdict"), dict)

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -115,6 +115,7 @@ from verifiers.v1.utils.artifacts import (
     ARTIFACTS_DIR,
     Artifact,
     collect,
+    discard,
     restore,
 )
 from verifiers.v1.utils.decorators import metric, reward, stop, tool
@@ -308,6 +309,7 @@ __all__ = [  # noqa: RUF022 - grouped by public API area
     "ARTIFACTS_DIR",
     "Artifact",
     "collect",
+    "discard",
     "restore",
     # scoring
     "compare_stdout_results",

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -32,6 +32,7 @@ from verifiers.v1.mcp import SharedToolServer, serve_shared
 from verifiers.v1.runtimes import SubprocessConfig, runtime_is_local
 from verifiers.v1.task import Task
 from verifiers.v1.trace import Error, Trace
+from verifiers.v1.utils.artifacts import discard as discard_artifacts
 from verifiers.v1.utils.generic import concrete_type, deep_merge
 from verifiers.v1.utils.memory import trim_memory_periodically
 from verifiers.v1.utils.retries import run_episode_with_retry
@@ -317,7 +318,8 @@ class Env(ABC, Generic[ConfigT]):
             live = slot.traces
 
             def discard(trace: Trace) -> None:
-                # A retried agent attempt abandons its trace; drop it from the view.
+                # A retried agent attempt abandons its trace: free its spools and view.
+                discard_artifacts(trace.state.artifacts)
                 with contextlib.suppress(ValueError):
                     live.remove(trace)
 

--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -125,7 +125,7 @@ class JudgeTask(vf.Task):
         self,
         data: vf.TaskData,
         files: dict[str, bytes],
-        artifacts: dict[str, bytes | None],
+        artifacts: dict[str, Path | None],
     ) -> None:
         super().__init__(data)
         self.files = files
@@ -346,3 +346,4 @@ class IsolatedAgenticJudgeEnv(AgenticJudgeEnv):
         await agents.judge.run(
             JudgeTask.from_trace(solution, self.config.task, share_runtime=False)
         )
+        vf.discard(solution.state.artifacts)  # judged; nothing can grade them again

--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -332,6 +332,9 @@ class SharedAgenticJudgeEnv(AgenticJudgeEnv):
     async def run(self, task: vf.Task, agents: vf.Agents) -> None:
         async with agents.solver.provision(task) as box:
             solution = await agents.solver.run(task, runtime=box)
+            # The judge works in the solver's box, where the artifacts already
+            # live on disk — a spooled copy has no consumer here.
+            vf.discard(solution.state.artifacts)
             judge_task = JudgeTask.from_trace(solution, self.config.task)
             await agents.judge.run(judge_task, runtime=box)
 
@@ -341,9 +344,13 @@ class IsolatedAgenticJudgeEnv(AgenticJudgeEnv):
 
     async def run(self, task: vf.Task, agents: vf.Agents) -> None:
         solution = await agents.solver.run(task)
-        if not solution.ok:
-            return
-        await agents.judge.run(
-            JudgeTask.from_trace(solution, self.config.task, share_runtime=False)
-        )
-        vf.discard(solution.state.artifacts)  # judged; nothing can grade them again
+        # The judge is this collection's only consumer, so it ends here either
+        # way: judged, failed solve, or a judge that never got off the ground.
+        try:
+            if not solution.ok:
+                return
+            await agents.judge.run(
+                JudgeTask.from_trace(solution, self.config.task, share_runtime=False)
+            )
+        finally:
+            vf.discard(solution.state.artifacts)

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -12,7 +12,7 @@ import weakref
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import ClassVar, Self
 
 from pydantic import Field, model_validator
@@ -363,6 +363,19 @@ class Runtime(ABC):
     @abstractmethod
     async def write(self, path: str, data: bytes) -> None:
         pass
+
+    async def read_to(self, path: str, local: Path) -> None:
+        """Download `path` into the host file `local`. The default buffers the whole
+        file through `_read`; backends with file transport override it to stream, so
+        a large artifact never has to fit in host memory."""
+        data = await self._read(path)
+        await asyncio.to_thread(local.write_bytes, data)
+
+    async def write_from(self, path: str, local: Path) -> None:
+        """Upload the host file `local` to `path`. Default and overrides mirror
+        `read_to`."""
+        data = await asyncio.to_thread(local.read_bytes)
+        await self.write(path, data)
 
     def host_url(self, url: str) -> str:
         """The URL a program inside this runtime uses to reach a host-bound `url`."""

--- a/verifiers/v1/runtimes/docker/__init__.py
+++ b/verifiers/v1/runtimes/docker/__init__.py
@@ -11,7 +11,7 @@ import sys
 import tempfile
 import uuid
 from collections.abc import AsyncIterator
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import Literal
 from urllib.parse import urlsplit
 
@@ -538,6 +538,51 @@ class DockerRuntime(Runtime):
             stderr=asyncio.subprocess.PIPE,
         )
         _, stderr = await proc.communicate(input=data)
+        if proc.returncode != 0:
+            raise SandboxError(
+                f"write {path!r}: {stderr.decode(errors='replace').strip()}"
+            )
+
+    async def read_to(self, path: str, local: Path) -> None:
+        # `cat` out of the container with stdout redirected straight to the host
+        # file: a large artifact streams through a pipe, never into host memory.
+        with await asyncio.to_thread(open, local, "wb") as f:
+            proc = await asyncio.create_subprocess_exec(
+                "docker",
+                "exec",
+                "--workdir",
+                self.config.workdir,
+                self._container,
+                "cat",
+                path,
+                stdout=f,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, stderr = await proc.communicate()
+        if proc.returncode != 0:
+            raise SandboxError(
+                f"read {path!r}: {stderr.decode(errors='replace').strip()}"
+            )
+
+    async def write_from(self, path: str, local: Path) -> None:
+        # Mirror of `read_to`: the host file rides in on stdin.
+        parent = shlex.quote(str(PurePosixPath(path).parent))
+        with await asyncio.to_thread(open, local, "rb") as f:
+            proc = await asyncio.create_subprocess_exec(
+                "docker",
+                "exec",
+                "-i",
+                "--workdir",
+                self.config.workdir,
+                self._container,
+                "sh",
+                "-c",
+                f"mkdir -p {parent} && cat > {shlex.quote(path)}",
+                stdin=f,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, stderr = await proc.communicate()
         if proc.returncode != 0:
             raise SandboxError(
                 f"write {path!r}: {stderr.decode(errors='replace').strip()}"

--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -13,7 +13,7 @@ import logging
 import shlex
 import uuid
 from collections.abc import AsyncIterator
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import ClassVar, Literal
 
 from pydantic_config import BaseConfig
@@ -278,6 +278,25 @@ class ModalRuntime(Runtime):
                 str(PurePosixPath(target).parent)
             )
             await self._sandbox.filesystem.write_bytes.aio(data, target)
+        except Exception as e:
+            raise SandboxError(f"write {path!r}: {e}") from e
+
+    async def read_to(self, path: str, local: Path) -> None:
+        # `copy_to_local` streams in chunks, so a large artifact lands on host
+        # disk without ever being held whole in host memory.
+        try:
+            await self._sandbox.filesystem.copy_to_local.aio(self._abs(path), local)
+        except Exception as e:
+            raise SandboxError(f"read {path!r}: {e}") from e
+
+    async def write_from(self, path: str, local: Path) -> None:
+        # Mirror of `read_to` via the streaming `copy_from_local`.
+        target = self._abs(path)
+        try:
+            await self._sandbox.filesystem.make_directory.aio(
+                str(PurePosixPath(target).parent)
+            )
+            await self._sandbox.filesystem.copy_from_local.aio(local, target)
         except Exception as e:
             raise SandboxError(f"write {path!r}: {e}") from e
 

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -329,17 +329,16 @@ class PrimeRuntime(Runtime):
     async def _read(self, path: str) -> bytes:
         # Avoid background-job log limits and base64 overhead by downloading binary data directly.
         # The temporary file is removed on every exit, and its byte read stays off the event loop.
-        try:
-            with tempfile.TemporaryDirectory() as directory:
-                download = Path(directory) / "download"
-                await self.read_to(path, download)
-                return await asyncio.to_thread(download.read_bytes)
-        except Exception as e:
-            raise SandboxError(f"read {path!r}: {e}") from e
+        with tempfile.TemporaryDirectory() as directory:
+            download = Path(directory) / "download"
+            await self.read_to(path, download)
+            return await asyncio.to_thread(download.read_bytes)
 
     async def read_to(self, path: str, local: Path) -> None:
-        # The SDK downloads file-to-file, so a large artifact streams to host disk
-        # without ever being held in host memory.
+        # File-to-file via the SDK. NOTE: prime-sandboxes buffers the whole transfer
+        # in memory in transit (no streaming API yet), so this bounds memory to one
+        # transfer at a time rather than eliminating it; the bytes are freed as soon
+        # as the file lands instead of living on the trace.
         target = self._abs(path)
         try:
             await self._client.download_file(self.info.id, target, str(local))
@@ -347,6 +346,7 @@ class PrimeRuntime(Runtime):
             raise SandboxError(f"read {path!r}: {e}") from e
 
     async def write_from(self, path: str, local: Path) -> None:
+        # Same in-transit buffering caveat as `read_to`.
         target = self._abs(path)
         try:
             await self._client.execute_command(

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -319,21 +319,43 @@ class PrimeRuntime(Runtime):
         except Exception as e:
             raise SandboxError(f"prime background launch failed: {e}") from e
 
+    def _abs(self, path: str) -> str:
+        # The gateway's file endpoints do not run in the workdir; resolve a relative
+        # path against it.
+        if path.startswith("/"):
+            return path
+        return f"{self.config.workdir.rstrip('/')}/{path}"
+
     async def _read(self, path: str) -> bytes:
         # Avoid background-job log limits and base64 overhead by downloading binary data directly.
         # The temporary file is removed on every exit, and its byte read stays off the event loop.
-        target = (
-            path
-            if path.startswith("/")
-            else f"{self.config.workdir.rstrip('/')}/{path}"
-        )
         try:
             with tempfile.TemporaryDirectory() as directory:
                 download = Path(directory) / "download"
-                await self._client.download_file(self.info.id, target, str(download))
+                await self.read_to(path, download)
                 return await asyncio.to_thread(download.read_bytes)
         except Exception as e:
             raise SandboxError(f"read {path!r}: {e}") from e
+
+    async def read_to(self, path: str, local: Path) -> None:
+        # The SDK downloads file-to-file, so a large artifact streams to host disk
+        # without ever being held in host memory.
+        target = self._abs(path)
+        try:
+            await self._client.download_file(self.info.id, target, str(local))
+        except Exception as e:
+            raise SandboxError(f"read {path!r}: {e}") from e
+
+    async def write_from(self, path: str, local: Path) -> None:
+        target = self._abs(path)
+        try:
+            await self._client.execute_command(
+                self.info.id,
+                f"mkdir -p {shlex.quote(str(PurePosixPath(target).parent))}",
+            )
+            await self._client.upload_file(self.info.id, target, str(local))
+        except Exception as e:
+            raise SandboxError(f"write {path!r}: {e}") from e
 
     async def write(self, path: str, data: bytes) -> None:
         # Upload via the gateway (multipart) — never inline the bytes on the command line
@@ -341,11 +363,7 @@ class PrimeRuntime(Runtime):
         # fails with ENAMETOOLONG). The upload does NOT run in the workdir, so resolve a
         # relative path against it (and mkdir its parent) — otherwise the sidecar writes
         # it somewhere unwritable ("Operation not permitted").
-        target = (
-            path
-            if path.startswith("/")
-            else f"{self.config.workdir.rstrip('/')}/{path}"
-        )
+        target = self._abs(path)
         try:
             await self._client.execute_command(
                 self.info.id,

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -11,7 +11,9 @@ import contextlib
 import logging
 import math
 import shlex
+import shutil
 import tempfile
+import uuid
 from collections.abc import AsyncIterator
 from pathlib import Path, PurePosixPath
 from typing import ClassVar, Literal
@@ -36,6 +38,26 @@ logger = logging.getLogger(__name__)
 
 MAX_LIFETIME = 24 * 60 * 60
 """Prime's fixed cap (seconds) on any sandbox's total lifetime."""
+
+_FILE_TRANSFER_CHUNK_BYTES = 128 * 1024 * 1024
+"""Stay below the gateway's per-request file limit while moving larger files."""
+
+
+def _copy_slice(source: Path, target: Path, offset: int, size: int) -> None:
+    with source.open("rb") as src, target.open("wb") as dst:
+        src.seek(offset)
+        remaining = size
+        while remaining:
+            chunk = src.read(min(1024 * 1024, remaining))
+            if not chunk:
+                raise EOFError(f"{source} ended before {offset + size} bytes")
+            dst.write(chunk)
+            remaining -= len(chunk)
+
+
+def _append_file(source: Path, target: Path) -> None:
+    with source.open("rb") as src, target.open("ab") as dst:
+        shutil.copyfileobj(src, dst, length=1024 * 1024)
 
 
 class PrimeConfig(NetworkPolicyConfig):
@@ -334,28 +356,132 @@ class PrimeRuntime(Runtime):
             await self.read_to(path, download)
             return await asyncio.to_thread(download.read_bytes)
 
+    async def _remote_file_size(self, path: str) -> int:
+        result = await self.run(
+            ["sh", "-c", f"wc -c < {shlex.quote(path)}"],
+            {},
+        )
+        raw = result.stdout.strip()
+        if result.exit_code or not raw.isdigit():
+            detail = (result.stderr or result.stdout).strip()[-500:]
+            raise SandboxError(f"size {path!r}: {detail}")
+        return int(raw)
+
+    async def _file_command(self, command: str, action: str) -> None:
+        result = await self.run(["sh", "-c", command], {})
+        if result.exit_code:
+            detail = (result.stderr or result.stdout).strip()[-500:]
+            raise SandboxError(f"{action}: {detail}")
+
     async def read_to(self, path: str, local: Path) -> None:
-        # File-to-file via the SDK. NOTE: prime-sandboxes buffers the whole transfer
-        # in memory in transit (no streaming API yet), so this bounds memory to one
-        # transfer at a time rather than eliminating it; the bytes are freed as soon
-        # as the file lands instead of living on the trace.
+        # prime-sandboxes buffers each gateway request in memory and the gateway caps
+        # one file request. Slice large remote files so neither constraint becomes the
+        # artifact limit; each temporary slice is removed before creating the next.
         target = self._abs(path)
+        remote_chunk: str | None = None
         try:
-            await self._client.download_file(self.info.id, target, str(local))
+            size = await self._remote_file_size(target)
+            await asyncio.to_thread(local.parent.mkdir, parents=True, exist_ok=True)
+            if size <= _FILE_TRANSFER_CHUNK_BYTES:
+                await self._client.download_file(self.info.id, target, str(local))
+                return
+
+            remote_chunk = f"/tmp/vf-download-{uuid.uuid4().hex}"
+            await asyncio.to_thread(local.write_bytes, b"")
+            with tempfile.TemporaryDirectory() as directory:
+                chunk = Path(directory) / "chunk"
+                for offset in range(0, size, _FILE_TRANSFER_CHUNK_BYTES):
+                    expected = min(_FILE_TRANSFER_CHUNK_BYTES, size - offset)
+                    block = 1024 * 1024
+                    await self._file_command(
+                        f"dd if={shlex.quote(target)} of={shlex.quote(remote_chunk)} "
+                        f"bs={block} skip={offset // block} "
+                        f"count={math.ceil(expected / block)}",
+                        f"slice {path!r}",
+                    )
+                    await self._client.download_file(
+                        self.info.id, remote_chunk, str(chunk)
+                    )
+                    actual = await asyncio.to_thread(chunk.stat)
+                    if actual.st_size != expected:
+                        raise SandboxError(
+                            f"read {path!r}: chunk at {offset} has {actual.st_size} "
+                            f"bytes, expected {expected}"
+                        )
+                    await asyncio.to_thread(_append_file, chunk, local)
+            actual = await asyncio.to_thread(local.stat)
+            if actual.st_size != size:
+                raise SandboxError(
+                    f"read {path!r}: downloaded {actual.st_size} bytes, expected {size}"
+                )
         except Exception as e:
+            await asyncio.to_thread(local.unlink, missing_ok=True)
+            if isinstance(e, SandboxError):
+                raise
             raise SandboxError(f"read {path!r}: {e}") from e
+        finally:
+            if remote_chunk is not None:
+                with contextlib.suppress(Exception):
+                    await self._client.execute_command(
+                        self.info.id, f"rm -f -- {shlex.quote(remote_chunk)}"
+                    )
 
     async def write_from(self, path: str, local: Path) -> None:
-        # Same in-transit buffering caveat as `read_to`.
         target = self._abs(path)
+        remote_chunk: str | None = None
         try:
             await self._client.execute_command(
                 self.info.id,
                 f"mkdir -p {shlex.quote(str(PurePosixPath(target).parent))}",
             )
-            await self._client.upload_file(self.info.id, target, str(local))
+            size = await asyncio.to_thread(lambda: local.stat().st_size)
+            if size <= _FILE_TRANSFER_CHUNK_BYTES:
+                await self._client.upload_file(self.info.id, target, str(local))
+                return
+
+            remote_chunk = f"/tmp/vf-upload-{uuid.uuid4().hex}"
+            await self._file_command(
+                f": > {shlex.quote(target)}",
+                f"initialize upload {path!r}",
+            )
+            with tempfile.TemporaryDirectory() as directory:
+                chunk = Path(directory) / "chunk"
+                for offset in range(0, size, _FILE_TRANSFER_CHUNK_BYTES):
+                    expected = min(_FILE_TRANSFER_CHUNK_BYTES, size - offset)
+                    await asyncio.to_thread(
+                        _copy_slice,
+                        local,
+                        chunk,
+                        offset,
+                        expected,
+                    )
+                    await self._client.upload_file(
+                        self.info.id, remote_chunk, str(chunk)
+                    )
+                    await self._file_command(
+                        f"cat {shlex.quote(remote_chunk)} >> {shlex.quote(target)} "
+                        f"&& rm -f -- {shlex.quote(remote_chunk)}",
+                        f"append upload chunk to {path!r}",
+                    )
+            actual = await self._remote_file_size(target)
+            if actual != size:
+                raise SandboxError(
+                    f"write {path!r}: uploaded {actual} bytes, expected {size}"
+                )
         except Exception as e:
+            with contextlib.suppress(Exception):
+                await self._client.execute_command(
+                    self.info.id, f"rm -f -- {shlex.quote(target)}"
+                )
+            if isinstance(e, SandboxError):
+                raise
             raise SandboxError(f"write {path!r}: {e}") from e
+        finally:
+            if remote_chunk is not None:
+                with contextlib.suppress(Exception):
+                    await self._client.execute_command(
+                        self.info.id, f"rm -f -- {shlex.quote(remote_chunk)}"
+                    )
 
     async def write(self, path: str, data: bytes) -> None:
         # Upload via the gateway (multipart) — never inline the bytes on the command line

--- a/verifiers/v1/runtimes/subprocess.py
+++ b/verifiers/v1/runtimes/subprocess.py
@@ -162,6 +162,14 @@ class SubprocessRuntime(Runtime):
     async def _read(self, path: str) -> bytes:
         return await asyncio.to_thread((self.workdir / path).read_bytes)
 
+    async def read_to(self, path: str, local: Path) -> None:
+        await asyncio.to_thread(shutil.copyfile, self.workdir / path, local)
+
+    async def write_from(self, path: str, local: Path) -> None:
+        target = self.workdir / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(shutil.copyfile, local, target)
+
     async def write(self, path: str, data: bytes) -> None:
         target = self.workdir / path
         target.parent.mkdir(parents=True, exist_ok=True)

--- a/verifiers/v1/state.py
+++ b/verifiers/v1/state.py
@@ -1,5 +1,7 @@
 """Mutable rollout-level state shared across tool server + host."""
 
+from pathlib import Path
+
 from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import TypeVar
 
@@ -9,7 +11,9 @@ from verifiers.v1.utils.generic import concrete_type
 class State(BaseModel):
     model_config = ConfigDict(ser_json_inf_nan="constants")
 
-    artifacts: dict[str, bytes | None] = Field(default_factory=dict)
+    artifacts: dict[str, Path | None] = Field(default_factory=dict)
+    """Collected artifact archives, spooled on host disk (see `utils.artifacts`),
+    keyed by their source path in the box they came from."""
 
 
 StateT = TypeVar("StateT", bound=State, default=State)

--- a/verifiers/v1/tasksets/harbor/env.py
+++ b/verifiers/v1/tasksets/harbor/env.py
@@ -76,14 +76,15 @@ class HarborEnv(vf.Env[HarborEnvConfig]):
         trace. Infrastructure failures retry per `verifier_retries`; the last one
         fails the episode — a grading box that can't be reached must never read
         as reward 0."""
-        if not isinstance(task, HarborTask) or task.data.verifier is None:
+        if not isinstance(task, HarborTask):
             return
         solution = episode.traces[0]
-        # Grading is this collection's only consumer, so it ends here either way:
-        # scored, failed solve, or out of retries. (The `finally` sits outside
-        # `_grade`'s retry loop, whose attempts re-restore the same archives.)
+        # Separate-verifier grading is this collection's only consumer, so it ends
+        # here either way: scored, shared-mode (graded in-box, no host consumer),
+        # failed solve, or out of retries. (The `finally` sits outside `_grade`'s
+        # retry loop, whose attempts re-restore the same archives.)
         try:
-            if not solution.ok:
+            if task.data.verifier is None or not solution.ok:
                 return
             grader = HarborTask(verifier_box_data(task.data))
             scores = await self._grade(self._verifier_config(task), grader, solution)

--- a/verifiers/v1/tasksets/harbor/env.py
+++ b/verifiers/v1/tasksets/harbor/env.py
@@ -22,7 +22,7 @@ from verifiers.v1.tasksets.harbor.taskset import (
     HarborTask,
     verifier_box_data,
 )
-from verifiers.v1.utils.artifacts import restore
+from verifiers.v1.utils.artifacts import discard, restore
 from verifiers.v1.utils.compile import resolve_runtime_config
 from verifiers.v1.utils.retries import backoff
 
@@ -83,6 +83,7 @@ class HarborEnv(vf.Env[HarborEnvConfig]):
             return
         grader = HarborTask(verifier_box_data(task.data))
         scores = await self._grade(self._verifier_config(task), grader, solution)
+        discard(solution.state.artifacts)  # scored; nothing can grade them again
         items = scores.items() if isinstance(scores, dict) else [("solved", scores)]
         for name, value in items:
             solution.record_reward(name, value)

--- a/verifiers/v1/tasksets/harbor/env.py
+++ b/verifiers/v1/tasksets/harbor/env.py
@@ -79,11 +79,16 @@ class HarborEnv(vf.Env[HarborEnvConfig]):
         if not isinstance(task, HarborTask) or task.data.verifier is None:
             return
         solution = episode.traces[0]
-        if not solution.ok:
-            return
-        grader = HarborTask(verifier_box_data(task.data))
-        scores = await self._grade(self._verifier_config(task), grader, solution)
-        discard(solution.state.artifacts)  # scored; nothing can grade them again
+        # Grading is this collection's only consumer, so it ends here either way:
+        # scored, failed solve, or out of retries. (The `finally` sits outside
+        # `_grade`'s retry loop, whose attempts re-restore the same archives.)
+        try:
+            if not solution.ok:
+                return
+            grader = HarborTask(verifier_box_data(task.data))
+            scores = await self._grade(self._verifier_config(task), grader, solution)
+        finally:
+            discard(solution.state.artifacts)
         items = scores.items() if isinstance(scores, dict) else [("solved", scores)]
         for name, value in items:
             solution.record_reward(name, value)

--- a/verifiers/v1/utils/artifacts.py
+++ b/verifiers/v1/utils/artifacts.py
@@ -22,10 +22,11 @@ ARTIFACTS_DIR = "/logs/artifacts"
 """Implicit artifact directory; tasks that write here need no declaration."""
 
 MAX_ARTIFACT_BYTES = 256 * 1024 * 1024
-"""Ceiling per collection. Archives spool to host disk and stream both ways, so the
-cap guards transfer time and spool space, not host memory. Still sized for a delta,
-not a tree: the grading box boots from the agent's image, so the repo is already
-there and only its output has to travel."""
+"""Ceiling per collection. The cap applies to the completed tar archives, so it
+includes their metadata and padding. Archives spool to host disk and stream or
+chunk both ways, so this guards transfer time and spool space, not host memory. It
+is sized for a delta, not a tree: the grading box boots from the agent's image, so
+the repo is already there and only its output has to travel."""
 
 _spool_root: Path | None = None
 

--- a/verifiers/v1/utils/artifacts.py
+++ b/verifiers/v1/utils/artifacts.py
@@ -103,19 +103,25 @@ async def collect(
 
     collected: dict[str, Path | None] = {}
     budget = MAX_ARTIFACT_BYTES
-    for artifact in entries:
-        source = artifact.source
-        exists = f"test -e {shlex.quote(source)} || test -L {shlex.quote(source)}"
-        if (await runtime.run(["sh", "-c", exists], {})).exit_code != 0:
-            if not artifact.required:
-                collected[source] = None
-                continue
-            raise RuntimeError(
-                f"declared artifact {source!r} does not exist in the runtime"
-            )
-        archive = await _tar_out(runtime, artifact, budget)
-        budget -= archive.stat().st_size
-        collected[source] = archive
+    try:
+        for artifact in entries:
+            source = artifact.source
+            exists = f"test -e {shlex.quote(source)} || test -L {shlex.quote(source)}"
+            if (await runtime.run(["sh", "-c", exists], {})).exit_code != 0:
+                if not artifact.required:
+                    collected[source] = None
+                    continue
+                raise RuntimeError(
+                    f"declared artifact {source!r} does not exist in the runtime"
+                )
+            archive = await _tar_out(runtime, artifact, budget)
+            budget -= archive.stat().st_size
+            collected[source] = archive
+    except BaseException:
+        # A failed collection grades nothing: drop what already spooled rather
+        # than leaving unreachable files until the run's exit sweep.
+        discard(collected)
+        raise
 
     logger.debug("collected artifact roots: %s", list(collected))
     return collected
@@ -170,7 +176,11 @@ async def _tar_out(runtime: Runtime, artifact: Artifact, budget: int) -> Path:
                 "or add `exclude` patterns."
             )
         spooled = _spool_dir() / f"{uuid.uuid4().hex}.tar"
-        await runtime.read_to(path, spooled)
+        try:
+            await runtime.read_to(path, spooled)
+        except BaseException:
+            spooled.unlink(missing_ok=True)  # a partial download grades nothing
+            raise
         return spooled
     finally:
         # Best-effort: the box is about to be destroyed and the name is unique per call.

--- a/verifiers/v1/utils/artifacts.py
+++ b/verifiers/v1/utils/artifacts.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import atexit
 import logging
 import shlex
+import shutil
+import tempfile
 import uuid
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field
@@ -18,9 +21,24 @@ logger = logging.getLogger(__name__)
 ARTIFACTS_DIR = "/logs/artifacts"
 """Implicit artifact directory; tasks that write here need no declaration."""
 
-MAX_ARTIFACT_BYTES = 32 * 1024 * 1024
-"""Ceiling per collection. Sized for a delta, not a tree: the grading box boots from the
-agent's image, so the repo is already there and only its output has to travel."""
+MAX_ARTIFACT_BYTES = 256 * 1024 * 1024
+"""Ceiling per collection. Archives spool to host disk and stream both ways, so the
+cap guards transfer time and spool space, not host memory. Still sized for a delta,
+not a tree: the grading box boots from the agent's image, so the repo is already
+there and only its output has to travel."""
+
+_spool_root: Path | None = None
+
+
+def _spool_dir() -> Path:
+    """A process-wide spool for collected archives, removed at exit. Collections
+    live as long as their trace can still be graded (retries, late finalize), and
+    the run's exit is the one point past which no grading can happen."""
+    global _spool_root
+    if _spool_root is None:
+        _spool_root = Path(tempfile.mkdtemp(prefix="vf-artifacts-"))
+        atexit.register(shutil.rmtree, _spool_root, True)
+    return _spool_root
 
 
 class Artifact(BaseModel):
@@ -34,11 +52,11 @@ class Artifact(BaseModel):
 
 async def collect(
     runtime: Runtime, artifacts: list[Artifact] | None = None
-) -> dict[str, bytes | None]:
-    """Tar the convention dir and every declared path out of `runtime`.
+) -> dict[str, Path | None]:
+    """Tar the convention dir and every declared path out of `runtime` onto host disk.
 
-    Keyed by source path; the values are tar archives. Insertion order is the order
-    they were declared, and a path cannot be collected twice.
+    Keyed by source path; the values are spooled tar archives. Insertion order is the
+    order they were declared, and a path cannot be collected twice.
 
     A declared source that is missing raises: it was declared because grading needs it,
     and grading a partial state scores the rollout wrong rather than failing it. The
@@ -83,7 +101,7 @@ async def collect(
                 )
             entries.append(artifact)
 
-    collected: dict[str, bytes | None] = {}
+    collected: dict[str, Path | None] = {}
     budget = MAX_ARTIFACT_BYTES
     for artifact in entries:
         source = artifact.source
@@ -96,14 +114,14 @@ async def collect(
                 f"declared artifact {source!r} does not exist in the runtime"
             )
         archive = await _tar_out(runtime, artifact, budget)
-        budget -= len(archive)
+        budget -= archive.stat().st_size
         collected[source] = archive
 
     logger.debug("collected artifact roots: %s", list(collected))
     return collected
 
 
-async def restore(runtime: Runtime, collected: dict[str, bytes | None]) -> None:
+async def restore(runtime: Runtime, collected: dict[str, Path | None]) -> None:
     """Extract `collected` in `runtime` at the original absolute paths."""
     if not collected:
         return
@@ -123,7 +141,7 @@ async def restore(runtime: Runtime, collected: dict[str, bytes | None]) -> None:
         if archive is None:
             continue
         path = f"/tmp/vf-artifact-{uuid.uuid4().hex}.tar"
-        await runtime.write(path, archive)
+        await runtime.write_from(path, archive)
         await _run(
             runtime,
             f"tar -xf {shlex.quote(path)} -C / && rm -f {shlex.quote(path)}",
@@ -131,7 +149,7 @@ async def restore(runtime: Runtime, collected: dict[str, bytes | None]) -> None:
         )
 
 
-async def _tar_out(runtime: Runtime, artifact: Artifact, budget: int) -> bytes:
+async def _tar_out(runtime: Runtime, artifact: Artifact, budget: int) -> Path:
     path = f"/tmp/vf-artifact-{uuid.uuid4().hex}.tar"
     excludes = " ".join(f"--exclude={shlex.quote(p)}" for p in artifact.exclude)
     try:
@@ -141,8 +159,8 @@ async def _tar_out(runtime: Runtime, artifact: Artifact, budget: int) -> bytes:
             f"{shlex.quote(artifact.source.lstrip('/'))}",
             f"collect artifact {artifact.source!r}",
         )
-        # Size it in the box: an oversized collection is refused before it reaches host
-        # memory, not after.
+        # Size it in the box: an oversized collection is refused before it is
+        # transferred, not after.
         sized = await runtime.run(["sh", "-c", f"wc -c < {shlex.quote(path)}"], {})
         if (raw := sized.stdout.strip()).isdigit() and int(raw) > budget:
             raise RuntimeError(
@@ -151,13 +169,25 @@ async def _tar_out(runtime: Runtime, artifact: Artifact, budget: int) -> bytes:
                 "agent's image, so only the delta needs to travel — narrow the source "
                 "or add `exclude` patterns."
             )
-        return await runtime.read(path)
+        spooled = _spool_dir() / f"{uuid.uuid4().hex}.tar"
+        await runtime.read_to(path, spooled)
+        return spooled
     finally:
         # Best-effort: the box is about to be destroyed and the name is unique per call.
         try:
             await runtime.run(["rm", "-f", path], {})
         except Exception:
             logger.debug("failed to remove %s", path, exc_info=True)
+
+
+def discard(collected: dict[str, Path | None]) -> None:
+    """Drop a collection's spooled archives once nothing can grade them again.
+    The keys stay — they record what was collected — but the spool must not
+    accumulate every episode's archives until the run's `atexit` sweep."""
+    for source, archive in collected.items():
+        if archive is not None:
+            archive.unlink(missing_ok=True)
+            collected[source] = None
 
 
 async def _run(runtime: Runtime, command: str, action: str) -> None:

--- a/verifiers/v1/utils/retries.py
+++ b/verifiers/v1/utils/retries.py
@@ -28,6 +28,7 @@ from tenacity import (
 )
 
 from verifiers.v1.configs.retries import RetryConfig
+from verifiers.v1.utils.artifacts import discard
 
 if TYPE_CHECKING:
     from verifiers.v1.episode import Episode
@@ -123,6 +124,8 @@ async def run_episode_with_retry(
         history.extend(final.errors)
         for trace in final.traces:
             history.extend(trace.errors)
+            # A whole-episode retry abandons every trace and its artifact spools.
+            discard(trace.state.artifacts)
         delay = backoff(attempt)
         logger.warning(
             "retrying episode %s (retry %d/%d) in %.1fs after error: %s",


### PR DESCRIPTION
Separate-sandbox grading previously held every collected artifact archive as raw bytes on `trace.state.artifacts` for the whole run, pinning host RAM as episodes × archive size. Artifacts now spool to host disk and stream both ways via new `Runtime.read_to`/`write_from` on all four runtimes, with spool files discarded once grading consumes them. `MAX_ARTIFACT_BYTES` rises 32 MiB → 256 MiB: the cap now guards transfer time and disk, not host memory.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Spool collected artifacts to host disk and stream file transfers across all runtimes
> - Changes `State.artifacts` from `dict[str, bytes | None]` to `dict[str, Path | None]` — artifact archives are now written to a host-disk spool directory instead of held in memory, with `atexit` cleanup as a safety net.
> - Adds `read_to`/`write_from` streaming APIs to all runtimes (Docker, Modal, Prime, Subprocess) to transfer files without buffering in memory; `PrimeRuntime` uses chunked transfers to bypass gateway per-request size limits.
> - Increases the artifact size limit from its previous value to 256 MiB in [`verifiers/v1/utils/artifacts.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/2274/files#diff-0d082bad54931be61d7ef55ddce0757034be3013f69ae71cb803cd8416df9138).
> - Adds a `discard(collected)` utility to free spooled files while preserving dict keys; callers in agentic judge, Harbor, and episode retries now call it after grading to avoid accumulating spool files.
> - Behavioral Change: callers that previously read `state.artifacts[key]` as `bytes` must now open the returned `Path`; spooled files persist until explicitly discarded or process exit.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 96a92aa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->