### PR TITLE
fix: fail agentic-judge episodes on the solver's own error

### DIFF
--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -309,8 +309,6 @@ class AgenticJudgeEnv(vf.Env[AgenticJudgeEnvConfig]):
 
     async def finalize(self, task: vf.Task, episode: vf.Episode) -> None:
         by_agent = {t.agent.name: t for t in episode.traces}
-        if "judge" not in by_agent:
-            return
         solution, verdict = by_agent["solver"], by_agent["judge"]
         verdicts = RubricVerdicts.model_validate(verdict.info.get("verdict")).verdicts
         criteria = self.config.task.criteria()
@@ -332,6 +330,10 @@ class SharedAgenticJudgeEnv(AgenticJudgeEnv):
     async def run(self, task: vf.Task, agents: vf.Agents) -> None:
         async with agents.solver.provision(task) as box:
             solution = await agents.solver.run(task, runtime=box)
+            if not solution.ok:
+                raise RuntimeError(
+                    "the solver's rollout failed, so the judge never ran"
+                )
             judge_task = JudgeTask.from_trace(solution, self.config.task)
             await agents.judge.run(judge_task, runtime=box)
 
@@ -342,7 +344,7 @@ class IsolatedAgenticJudgeEnv(AgenticJudgeEnv):
     async def run(self, task: vf.Task, agents: vf.Agents) -> None:
         solution = await agents.solver.run(task)
         if not solution.ok:
-            return
+            raise RuntimeError("the solver's rollout failed, so the judge never ran")
         await agents.judge.run(
             JudgeTask.from_trace(solution, self.config.task, share_runtime=False)
         )


### PR DESCRIPTION
## Summary
- Both agentic-judge `run()` paths now raise `RuntimeError("the solver's rollout failed, so the judge never ran")` when the solver's trace ends not-ok, so the episode fails descriptively at the run boundary and the judge never runs.
- `finalize()` drops its judge-missing early return: with the guard in place, a judge trace is guaranteed whenever `finalize()` runs.
- Episode retry/resume semantics are unchanged — `episode_should_retry` already keys off errors on failed traces, and the episode ended not-ok on a failed solve before this change too.

## Verification
Before: a solver failure is data on its trace, not an exception, so it slipped past judging in both envs. Shared judging still sent the judge into the box — if the judge then wrote no verdict, `finalize()` raised an opaque `ValidationError` from `RubricVerdicts.model_validate(None)`, blaming the judge/finalize for the solver's failure. Isolated judging skipped the judge silently, leaving a not-ok episode with no episode-level error saying why.

After: the episode error reads `EnvError: <Env>.run(): RuntimeError: the solver's rollout failed, so the judge never ran` (the solver's own error stays on its trace).

`uv run ruff check` and `uv run pytest tests/v1/test_judges.py` (34 passed) run clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes episode error behavior for failed solver rollouts in agentic-judge envs; callers that relied on silent skips or judge runs after solver failure will see exceptions instead.
> 
> **Overview**
> When the **solver** rollout fails (`solution.ok` is false), both **shared** and **isolated** agentic-judge `run()` paths now **raise `RuntimeError`** with a clear message that the judge never ran, instead of continuing into judging (shared) or **returning silently** (isolated).
> 
> `finalize()` no longer **bails out** when there is no judge trace; it always expects solver and judge traces, which matches the new guarantee that judging is not attempted after a failed solve.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c76e604710f82f166d89f683f664d240078ddce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fail agentic-judge episodes with a RuntimeError on solver rollout failure
> - In [`SharedAgenticJudgeEnv.run`](https://github.com/PrimeIntellect-ai/verifiers/pull/2276/files#diff-6c0b86ec43e4d94e2bde0d8ed0ac8ff6c3a422e074161c486bb7aa45c9ae1c81) and [`IsolatedAgenticJudgeEnv.run`](https://github.com/PrimeIntellect-ai/verifiers/pull/2276/files#diff-6c0b86ec43e4d94e2bde0d8ed0ac8ff6c3a422e074161c486bb7aa45c9ae1c81), a silent return on solver failure is replaced with a `RuntimeError`, ensuring the episode is marked as failed rather than silently skipped.
> - In `AgenticJudgeEnv.finalize`, the early-return guard for a missing `judge` trace is removed; the method now always attempts to access and score judge metrics, raising a `KeyError` if the judge trace is absent.
> - Behavioral Change: Episodes where the solver fails previously produced no error signal; they now propagate a `RuntimeError`, which may affect callers that did not previously need to handle exceptions from `run`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c76e60.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->