### PR TITLE
fix(v1): hand ACP agents the sandbox env, not the runner's uv-script env

### DIFF
--- a/verifiers/v1/acp/runner.py
+++ b/verifiers/v1/acp/runner.py
@@ -209,6 +209,35 @@ async def prompt(
     return client.visible_reply
 
 
+
+def _agent_process_env() -> dict[str, str]:
+    """Env for the agent process — never this client's own uv-script env.
+
+    ``Runtime.prepare_uv_script`` execs this module with the script's ephemeral
+    uv environment's ``bin/`` prepended to PATH and VIRTUAL_ENV pointing at it
+    (uv run parity). That is right for this leaf process: it needs the pinned
+    ``agent-client-protocol`` dependency, which base-task images do not carry.
+    It is wrong for the agent process it spawns: the agent performs task work
+    and must see the sandbox image's toolchain (e.g. the image python3 with
+    pip or pytest). A child that inherits the client's env sees the bare uv
+    interpreter instead — no pip, no pytest — so any task-side
+    `python3 -c 'import pytest'` gate fails and provisioning fallbacks error
+    with "No module named pip".
+
+    Strip the uv-injected vars and pass everything else (image env plus the
+    harness's configured vars) through unchanged.
+    """
+    env = os.environ.copy()
+    venv = env.pop("VIRTUAL_ENV", None)
+    if venv and env.get("PATH"):
+        bin_dir = os.path.join(venv, "bin")
+        env["PATH"] = os.pathsep.join(
+            part for part in env["PATH"].split(os.pathsep) if part != bin_dir
+        )
+    env.pop("UV_RUN_RECURSION_DEPTH", None)
+    return env
+
+
 async def run_once(config: dict) -> str:
     client = VerifiersACPClient()
     command = config["command"]
@@ -216,7 +245,7 @@ async def run_once(config: dict) -> str:
         client,
         command[0],
         *command[1:],
-        env=os.environ.copy(),
+        env=_agent_process_env(),
         transport_kwargs={"stderr": None},
     ) as agent_process:
         connection = agent_process[0]
@@ -294,7 +323,7 @@ class LiveACPSession:
                     self.client,
                     command[0],
                     *command[1:],
-                    env=os.environ.copy(),
+                    env=_agent_process_env(),
                     transport_kwargs={"stderr": None},
                 )
             )


### PR DESCRIPTION
## Problem

The ACP runner needs a private uv environment for `agent-client-protocol`, but it passed that environment to the agent process too. Task-side `python3` then resolved to the runner’s bare interpreter, which has no pip or pytest.

## Change

At the agent spawn boundary:

- remove the runner’s `VIRTUAL_ENV`;
- remove that environment’s `bin/` entry from `PATH`;
- remove `UV_RUN_RECURSION_DEPTH`;
- preserve the sandbox environment and harness-provided variables.

The ACP runner keeps its private environment; only the spawned agent gets the sandbox toolchain.

## Verification

On a live Prime sandbox, the old path selected the pip-less uv interpreter and a pytest-gated task scored 0. After the change, `python3` resolved to the image interpreter, the task installed pytest, ran, and scored 1. Agent startup and harness variables were unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process env for all ACP agent subprocesses across harnesses; behavior is intentional but affects every task-facing shell/python invocation from agents.
> 
> **Overview**
> ACP harnesses spawn agents with the runner's full environment, so task subprocesses inherited the **uv-script** `python3` (no pip/pytest) instead of the sandbox image toolchain.
> 
> **Fix:** `_agent_process_env()` strips `VIRTUAL_ENV`, removes the script env's `bin/` from `PATH`, and drops `UV_RUN_RECURSION_DEPTH`, while keeping image and harness env vars. Both `spawn_agent_process` call sites (`run_once` and `LiveACPSession.start`) use it instead of `os.environ.copy()`.
> 
> The ACP client process still runs under `prepare_uv_script` for its pinned `agent-client-protocol` dependency; only the spawned agent's env boundary changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7e1ca910f7376e52ba4e1f502e5b28a9cd1dcf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ACP agent processes to inherit sandbox env instead of runner's uv-script env
> When spawning ACP agent processes, the runner was passing `os.environ.copy()` directly, which included uv-injected variables (`VIRTUAL_ENV`, `UV_RUN_RECURSION_DEPTH`) and the uv virtualenv bin directory in `PATH`.
>
> - Adds `_agent_process_env()` helper in [runner.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2277/files#diff-d5f52739b5575f4d9a3006836e988d6527ccfd28d82a299aa1554eb0878b95ca) that strips `VIRTUAL_ENV`, removes the uv virtualenv bin dir from `PATH`, and drops `UV_RUN_RECURSION_DEPTH` before passing the environment to the agent process.
> - Updates both `run_once` and `LiveACPSession.start` to use this helper instead of the raw `os.environ.copy()`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b7e1ca9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
