### PR TITLE
fix(v1): interception server owns and multiplexes model clients

### DIFF
--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -299,8 +299,9 @@ class ElasticRendererPool:
 class TrainClient(Client):
     """Renders prompts to token ids and calls a vLLM `/inference/v1/generate` engine.
 
-    One client per rollout: it owns its engine connection and takes a slot on the shared
-    `ElasticRendererPool` for each turn."""
+    Owned by the interception server and shared by the rollouts it multiplexes: they reuse
+    its engine connection pool, and each turn takes a slot on the shared
+    `ElasticRendererPool`."""
 
     def __init__(self, config: TrainClientConfig) -> None:
         self.config = config

--- a/verifiers/v1/configs/client.py
+++ b/verifiers/v1/configs/client.py
@@ -1,8 +1,9 @@
 """Client configs: describe an OpenAI-compatible endpoint.
 
 A `BaseClientConfig` is an OpenAI-compatible endpoint (base_url + API-key env var
-+ extra headers); `clients.resolve_client` turns one into a live `Client`, and every
-rollout does so for itself. The default Prime endpoint, API key, and team fall back to
++ extra headers); `clients.resolve_client` turns one into a live `Client` — the
+interception server builds one per distinct config and shares it across the rollouts
+it multiplexes. The default Prime endpoint, API key, and team fall back to
 the active Prime CLI config, so direct `uv run eval` calls behave like `prime eval`.
 Both the eval entrypoint (its model client) and in-env LLM calls (e.g. a judge reward)
 build clients from these. `ClientConfig` is the CLI-selectable discriminated union

--- a/verifiers/v1/gepa/runner.py
+++ b/verifiers/v1/gepa/runner.py
@@ -73,7 +73,7 @@ def run_gepa(env: Env, config: GEPAConfig) -> GEPAResult:
             await append_episode(run_dir, episode, write_lock)
 
     try:
-        # The endpoint stays config: each rollout builds and closes its own client.
+        # The endpoint stays config: the interception server builds the live client.
         ctx = ModelContext(
             client=config.client, model=config.model, sampling=config.sampling
         )

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -9,7 +9,9 @@ SSE requests are supported.
 One server multiplexes many rollouts: each rollout registers separate model and state
 capabilities, and the server routes each to the right session. So N rollouts need one
 server (and, behind a remote runtime, one tunnel) per pool member rather than one each —
-see `interception.pool`.
+see `interception.pool`. The server also owns the model clients (one per distinct endpoint
+config, assigned to each session at register and closed with the server), so its rollouts
+share one bounded keepalive connection pool upstream instead of churning per-rollout TCP.
 
 The server is a pure model boundary: one request, one turn — refusal checks (limits,
 `@stop`s), the model call, the graph commit, retry atomicity. A run's user exchange
@@ -34,6 +36,8 @@ from pydantic import ValidationError
 from pydantic_core import PydanticSerializationError, from_json, to_json
 
 from verifiers.v1 import graph
+from verifiers.v1.clients import Client, resolve_client
+from verifiers.v1.configs.client import BaseClientConfig
 from verifiers.v1.dialects import DIALECTS, Dialect
 from verifiers.v1.dialects.base import is_sse_done_event
 from verifiers.v1.errors import (
@@ -130,6 +134,7 @@ class InterceptionServer(Interception):
     ) -> None:
         super().__init__()
         self.sessions: dict[str, RolloutSession] = {}
+        self.clients: dict[str, Client] = {}
         self.state_sessions: dict[str, RolloutSession] = {}
         self.state_routes: dict[str, RolloutSession] = {}
         self.state_service_secrets = frozenset(state_service_secrets)
@@ -147,8 +152,22 @@ class InterceptionServer(Interception):
         """Rollouts currently registered — what the pools balance on."""
         return len(self.sessions)
 
+    def _client(self, config: BaseClientConfig) -> Client:
+        """The server-owned client for `config` — one per distinct endpoint config, shared
+        by every session registered under it, so the rollouts this server multiplexes reuse
+        one bounded keepalive pool instead of each opening (and tearing down) their own
+        connections. Closed with the server."""
+        key = config.model_dump_json()
+        client = self.clients.get(key)
+        if client is None:
+            client = self.clients[key] = resolve_client(config)
+            self.stack.push_async_callback(client.close)
+        return client
+
     def register(self, session: RolloutSession) -> tuple[str, str]:
-        """Register separate capabilities for model inference and private task state."""
+        """Register separate capabilities for model inference and private task state, and
+        assign the session its server-owned model client."""
+        session.client = self._client(session.ctx.client)
         model_secret = secrets.token_urlsafe(16)
         state_secret = secrets.token_urlsafe(16)
         self.sessions[model_secret] = session

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -8,7 +8,7 @@ from collections.abc import Callable
 from contextlib import AsyncExitStack
 from dataclasses import dataclass
 
-from verifiers.v1.clients import ModelContext, resolve_client
+from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.agent import AgentConfig
 from verifiers.v1.errors import (
     HarnessError,
@@ -91,9 +91,8 @@ class Rollout:
         )
         if on_trace is not None:
             on_trace(self.trace)
-        self.client = resolve_client(ctx.client)
         self._session = RolloutSession(
-            ctx, self.client, self.trace, discover_decorated(task, "stop"), limits
+            ctx, self.trace, discover_decorated(task, "stop"), limits
         )
         self._stack = AsyncExitStack()
         self._failed = False
@@ -318,8 +317,8 @@ class Rollout:
         return self.ok and trace.num_turns > turns_before
 
     async def abort(self) -> None:
-        """Free everything this run holds — the entered servers, its client, and an
-        owned runtime — without finalizing or scoring: the escape path when an exception
+        """Free everything this run holds — the entered servers and an owned
+        runtime — without finalizing or scoring: the escape path when an exception
         (a cancellation mid-setup, a lifetime bug raised to the caller) means the
         driver will never reach `close()`. Safe after a partial `close()`."""
         self._closed = True
@@ -328,8 +327,6 @@ class Rollout:
                 await self._harness_session.close()
         with contextlib.suppress(Exception):
             await self._stack.aclose()
-        with contextlib.suppress(Exception):
-            await self.client.close()
         if self.runtime is not None:
             with contextlib.suppress(Exception):
                 await self.harness.cleanup(self.trace, self.runtime)
@@ -424,12 +421,6 @@ class Rollout:
                     logger.warning(
                         "runtime teardown failed (rollout %s)", trace.id, exc_info=True
                     )
-            try:
-                await self.client.close()
-            except Exception:
-                logger.warning(
-                    "client teardown failed (rollout %s)", trace.id, exc_info=True
-                )
         logger.info(
             "rollout done: id=%s task=%s reward=%.3f turns=%d stop=%s",
             trace.id,

--- a/verifiers/v1/session.py
+++ b/verifiers/v1/session.py
@@ -2,8 +2,8 @@
 
 One `RolloutSession` per rollout, registered on an interception server under the rollout's
 secret. The rollout constructs it (model ctx, trace, task `@stop`s, limits) and the server
-drives it: routes each intercepted model call to it, runs `refused()` before each turn,
-and stashes the real failure on `error`. `RolloutLimits` is the framework's per-rollout
+drives it: assigns its model client at register, routes each intercepted model call to it,
+runs `refused()` before each turn, and stashes the real failure on `error`. `RolloutLimits` is the framework's per-rollout
 budget (turns / tokens), checked between turns.
 """
 
@@ -64,10 +64,13 @@ class RolloutLimits:
 @dataclass
 class RolloutSession:
     ctx: ModelContext
-    client: Client
     trace: Trace
     stops: list[Callable[[Trace], Awaitable[bool]]] = field(default_factory=list)
     limits: RolloutLimits = field(default_factory=RolloutLimits)
+    client: Client | None = None
+    """The model client serving this rollout's turns. The interception server assigns it at
+    `register` (one server-owned client per distinct endpoint config), so every rollout it
+    multiplexes shares one keepalive connection pool instead of opening its own."""
     error: "RolloutError | None" = None
     """The latest unresolved model-call failure. The harness only sees it as an HTTP error
     (and may swallow it, or exit non-zero), so the rollout re-raises this original error once the


### PR DESCRIPTION
## Summary

- Move model-client ownership from the rollout to the interception server: `InterceptionServer` keeps one live `Client` per distinct endpoint config (keyed by the config's JSON — configs carry an env-var name, never the key itself), assigns it to each `RolloutSession` at `register`, and closes it with the server via its exit stack.
- `RolloutSession.client` is no longer a constructor argument; the server sets it at registration. `Rollout` no longer builds (`resolve_client`) or closes a client.
- Rollouts multiplexed onto a server (`multiplex`, default 32) now share one keepalive connection pool: since each rollout issues turns sequentially, a server's client never holds more than ~`multiplex` requests in flight — comfortably inside the existing transport limits — so upstream connections are reused warm instead of opened and torn down per rollout.
- Mixed-config sessions on one server (e.g. multi-agent envs with per-role endpoints) fall out of the config-keyed cache. `TrainClient` is safe to share: all per-turn state is local, and the renderer pool has been process-wide since #2218.

## Context

#2218 made each rollout build and close its own httpx client. At ~768 concurrent rollouts that means constant TCP churn against the inference router — the load pattern implicated in the vllm-router wedges (router stops processing mid-stream, engine drains and idles, sessions hashed to it die at the solver timeout). This restores shared, bounded connection reuse while keeping the per-rollout client *configs* introduced there: the sharing rate is naturally the interception server's multiplex rate, with no new knob.

Note on cancellation: previously `Rollout.abort()` closed its own client, killing any in-flight upstream request with it. The shared client stays open; in-flight handlers are cancelled via `session.release()` (which already existed) and their connections return to the pool.

## Verification

- `uv run ruff check` / `ruff format --check` clean; full non-e2e v1 suite: 84 passed.
- Live e2e (prime endpoint): `test_single_turn`, `test_tool`, `test_interaction`, `test_multi_agent_env` legs pass, including the tunneled `harness-in-subprocess-with-tool-in-docker` leg. The modal legs fail identically on unmodified `main` (local modal environment issue, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes upstream connection lifecycle and abort/cancellation behavior on the inference path at high concurrency; mitigated by per-config sharing and existing session.release() for stragglers.
> 
> **Overview**
> Moves **live model `Client` ownership** from each `Rollout` to **`InterceptionServer`**: the server keeps one resolved client per distinct `BaseClientConfig` (keyed by config JSON), assigns it on `RolloutSession` **register**, and closes clients with the server exit stack.
> 
> **Rollouts** no longer call `resolve_client` or `client.close()` in `abort`/`close`; multiplexed sessions on the same server **reuse one upstream keepalive pool** instead of per-rollout TCP churn. `RolloutSession.client` is optional until registration.
> 
> Docs/comments are updated across client config, GEPA runner, `TrainClient`, and session to describe server-owned sharing. **Cancellation** no longer tears down a per-rollout client on `abort`; in-flight work is cancelled via existing `session.release()` while the shared client stays open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30de02706eea45146983f503ce617346786eedac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move model client ownership from `Rollout` to `InterceptionServer` with shared caching
> - `InterceptionServer` now owns model clients, caching them by serialized endpoint config in a `clients` dict and closing them via its async exit stack on teardown.
> - A new `_client` helper on `InterceptionServer` returns a cached `Client` for a given `BaseClientConfig`, creating it via `resolve_client` on first use.
> - `InterceptionServer.register` assigns the server-owned client to the `RolloutSession`, replacing per-rollout client construction.
> - `Rollout` no longer creates or closes a `Client`; `RolloutSession.client` is now optional (`None` until assigned at registration).
> - Behavioral Change: multiplexed rollouts sharing the same endpoint config now reuse a single connection pool and `ElasticRendererPool` slots rather than each maintaining their own.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 30de027.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->