### PR TITLE
fix(v1): absorb out-of-enum finish labels instead of crashing trace commit

### DIFF
--- a/tests/v1/test_dialects.py
+++ b/tests/v1/test_dialects.py
@@ -1,0 +1,106 @@
+"""Dialect wire parsing of finish labels: providers emit labels outside the SDKs' closed
+enums; widened wire fields plus the existing unknown -> None coercion absorb them."""
+
+import logging
+from collections.abc import Iterator
+
+import pytest
+
+from verifiers.v1.dialects.anthropic import AnthropicDialect
+from verifiers.v1.dialects.chat import ChatDialect, ChatStreamParser
+
+CHAT_HEAD = (
+    b'data: {"id":"chatcmpl-x","object":"chat.completion.chunk","created":1,'
+    b'"model":"test-model","choices":[{"index":0,'
+    b'"delta":{"role":"assistant","content":"Hello"}}]}\n\n'
+)
+CHAT_TERMINAL_ERROR = (
+    b'data: {"id":"chatcmpl-x","object":"chat.completion.chunk","created":1,'
+    b'"model":"test-model","choices":[{"index":0,"delta":{},"finish_reason":"error"}],'
+    b'"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}}\n\n'
+)
+
+
+@pytest.fixture
+def chat_warnings() -> Iterator[list[logging.LogRecord]]:
+    """Capture records from the chat dialect's own logger. A handler directly on that
+    logger: v1's logging setup turns off library propagation, so root-attached capture
+    (caplog) would miss these once any other test has configured logging."""
+    logger = logging.getLogger("verifiers.v1.dialects.chat")
+    records: list[logging.LogRecord] = []
+    handler = logging.Handler()
+    handler.emit = records.append
+    logger.addHandler(handler)
+    try:
+        yield records
+    finally:
+        logger.removeHandler(handler)
+
+
+def test_chat_dialect_absorbs_out_of_enum_finish_reason(
+    chat_warnings: list[logging.LogRecord],
+):
+    """A stream ending with a provider-specific finish label still finishes: the
+    assembled response parses, the unknown label records as None, and the weirdness
+    is warned about."""
+    parser = ChatStreamParser()
+    parser.feed(CHAT_HEAD)
+    parser.feed(CHAT_TERMINAL_ERROR)
+    response = parser.finish()
+
+    assert response.finish_reason is None
+    assert response.message.content == "Hello"
+    assert any("'error'" in r.getMessage() for r in chat_warnings)
+
+    # The non-streamed path validates against the same response model.
+    dialect = ChatDialect()
+    completion = dialect.validate_response(
+        {
+            "id": "chatcmpl-x",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "test-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "Hello"},
+                    "finish_reason": "error",
+                }
+            ],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+        }
+    )
+    assert dialect.parse_response(completion).finish_reason is None
+
+
+def test_anthropic_dialect_absorbs_out_of_enum_stop_reason():
+    """The Anthropic SDK closes `stop_reason` to a `Literal` too; the same validation
+    boundary must not reject a gateway-specific label."""
+    dialect = AnthropicDialect()
+    message = dialect.validate_response(
+        {
+            "id": "msg_x",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-test",
+            "content": [{"type": "text", "text": "Hello"}],
+            "stop_reason": "error",
+            "stop_sequence": None,
+            "usage": {"input_tokens": 3, "output_tokens": 2},
+        }
+    )
+    response = dialect.parse_response(message)
+    assert response.finish_reason is None
+    assert response.message.content == "Hello"
+
+
+def test_stream_parser_keeps_enum_finish_reasons() -> None:
+    """Known labels round-trip unchanged: the widening doesn't alter valid values."""
+    parser = ChatStreamParser()
+    parser.feed(
+        b'data: {"id": "cmpl-2", "object": "chat.completion.chunk", "created": 1,'
+        b' "model": "m", "choices": [{"index": 0, "delta": {"content": "done"},'
+        b' "finish_reason": "stop"}]}\n\n'
+    )
+
+    assert parser.finish().finish_reason == "stop"

--- a/tests/v1/test_interception.py
+++ b/tests/v1/test_interception.py
@@ -1,0 +1,103 @@
+"""Interception-server tests: a provider stream with an out-of-enum finish label.
+
+Regression for the trace-commit loss: the SDK's closed `finish_reason` Literal used to
+make `ChatStreamParser.finish()` raise AFTER the stream had been relayed — the client
+got HTTP 200 and the full stream, but the turn never committed (node=None, no usage,
+an errored ModelCall). The dialect now absorbs the label, so the turn must commit.
+"""
+
+import httpx
+from aiohttp import web
+
+import verifiers.v1 as vf
+from verifiers.v1.clients import resolve_client
+from verifiers.v1.clients.client import ModelContext
+from verifiers.v1.configs.client import EvalClientConfig
+from verifiers.v1.interception.server import InterceptionServer
+from verifiers.v1.session import RolloutSession
+
+UP_CHUNKS = [
+    (
+        b'data: {"id":"chatcmpl-x","object":"chat.completion.chunk","created":1,'
+        b'"model":"test-model","choices":[{"index":0,'
+        b'"delta":{"role":"assistant","content":"Hello"}}]}\n\n'
+    ),
+    (
+        b'data: {"id":"chatcmpl-x","object":"chat.completion.chunk","created":1,'
+        b'"model":"test-model","choices":[{"index":0,"delta":{},"finish_reason":"error"}],'
+        b'"usage":{"prompt_tokens":3,"completion_tokens":1,"total_tokens":4}}\n\n'
+    ),
+    b"data: [DONE]\n\n",
+]
+
+
+async def test_stream_with_out_of_enum_finish_reason_commits_turn():
+    """A fake upstream streams a terminal chunk with `finish_reason: "error"`: the
+    client still receives the full stream AND the turn commits to the trace."""
+
+    async def upstream(request: web.Request) -> web.StreamResponse:
+        resp = web.StreamResponse(
+            status=200, headers={"Content-Type": "text/event-stream"}
+        )
+        await resp.prepare(request)
+        for chunk in UP_CHUNKS:
+            await resp.write(chunk)
+        await resp.write_eof()
+        return resp
+
+    up_app = web.Application()
+    up_app.router.add_post("/chat/completions", upstream)
+    up_runner = web.AppRunner(up_app)
+    await up_runner.setup()
+    up_site = web.TCPSite(up_runner, "127.0.0.1", 0)
+    await up_site.start()
+    up_port = up_site._server.sockets[0].getsockname()[1]
+
+    client_cfg = EvalClientConfig(
+        base_url=f"http://127.0.0.1:{up_port}", api_key_var="NO_SUCH_KEY_VAR"
+    )
+    session = RolloutSession(
+        ctx=ModelContext(model="test-model", client=client_cfg),
+        client=resolve_client(client_cfg),
+        trace=vf.Trace(
+            agent=vf.AgentInfo(config=vf.AgentConfig()),
+            task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="hi")),
+        ),
+    )
+    try:
+        async with (
+            InterceptionServer(requires_tunnel=False) as server,
+            server.acquire(session) as (base_url, model_secret, _state_secret),
+        ):
+            received = b""
+            async with (
+                httpx.AsyncClient(timeout=30) as http,
+                http.stream(
+                    "POST",
+                    f"{base_url}/v1/chat/completions",
+                    headers={"Authorization": f"Bearer {model_secret}"},
+                    json={
+                        "model": "test-model",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "stream": True,
+                    },
+                ) as reply,
+            ):
+                assert reply.status_code == 200
+                async for chunk in reply.aiter_bytes():
+                    received += chunk
+
+            # The client received the full stream, including the terminal event.
+            assert b'"finish_reason":"error"' in received
+            assert received.rstrip().endswith(b"data: [DONE]")
+
+            # ... and the turn committed to the trace despite the out-of-enum label.
+            assert session.trace.num_turns == 1
+            assert len(session.trace.calls) == 1
+            call = session.trace.calls[0]
+            assert call.error is None
+            assert call.node is not None
+            assert call.finish_reason is None  # unknown label -> None
+            assert call.usage is not None
+    finally:
+        await up_runner.cleanup()

--- a/verifiers/v1/dialects/anthropic.py
+++ b/verifiers/v1/dialects/anthropic.py
@@ -7,6 +7,7 @@ trace. `count_tokens` is relayed as native JSON (an `aux_route`), never recorded
 """
 
 import json
+import logging
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 
@@ -41,6 +42,17 @@ STOP_REASONS = {
     "stop_sequence": "stop",
 }
 THINKING = ("thinking", "redacted_thinking")
+# Known labels beyond what vf records: `pause_turn` and `refusal` are members of the
+# SDK's closed enum; `model_context_window_exceeded` is a real Anthropic-API label the
+# pinned SDK's enum predates, kept here so a legitimate server label doesn't warn.
+# Anything outside this set is provider weirdness worth a warning.
+KNOWN_STOP_REASONS = set(STOP_REASONS) | {
+    "pause_turn",
+    "refusal",
+    "model_context_window_exceeded",
+}
+
+logger = logging.getLogger(__name__)
 
 
 def parse_content(content) -> str | list[ContentPart]:
@@ -142,7 +154,13 @@ def response_from_wire(message: AnthropicMessage) -> Response:
                     arguments=json.dumps(block.get("input") or {}),
                 )
             )
-    finish: FinishReason = STOP_REASONS.get(data.get("stop_reason") or "")
+    stop_reason = data.get("stop_reason")
+    finish: FinishReason = STOP_REASONS.get(stop_reason or "")
+    if stop_reason is not None and stop_reason not in KNOWN_STOP_REASONS:
+        logger.warning(
+            "provider returned out-of-enum stop_reason %r; recording it as none",
+            stop_reason,
+        )
     provider_usage = message.usage
     output_details = data.get("usage", {}).get("output_tokens_details")
     # Anthropic reports three disjoint input buckets. Cache writes are uncached work;
@@ -253,7 +271,13 @@ class ModdedUsage(AnthropicUsage):
 
 
 class ModdedAnthropicMessage(AnthropicMessage):
+    """Same leniency as `ModdedChatCompletion`: the SDK closes `stop_reason` to a fixed
+    `Literal`, but Anthropic-compatible gateways can emit their own labels, which would make
+    `model_validate` reject the whole turn. Widen to a plain string — downstream
+    `STOP_REASONS.get(...)` already maps unknown labels to None."""
+
     usage: ModdedUsage  # type: ignore[assignment]
+    stop_reason: str | None = None
 
 
 class AnthropicDialect(Dialect[dict, AnthropicMessage]):

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -6,6 +6,7 @@ and responses (`parse_response`). Reasoning extraction mirrors the v0 chat clien
 read them in the same precedence (`reasoning` / `reasoning_content` / `reasoning_details`).
 """
 
+import logging
 import time
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -13,6 +14,7 @@ from dataclasses import field as dataclass_field
 from typing import Any
 
 from openai.types.chat import ChatCompletion
+from openai.types.chat.chat_completion import Choice
 
 from verifiers.v1.dialects.base import Dialect, StreamParser, parse_sse_event
 from verifiers.v1.types import (
@@ -32,17 +34,34 @@ from verifiers.v1.types import (
     content_to_parts,
 )
 
+logger = logging.getLogger(__name__)
+
+
+class ModdedChoice(Choice):
+    """The OpenAI SDK closes `finish_reason` to a fixed `Literal`, but providers emit finish
+    labels outside it (gateways report e.g. `error`), which makes `model_validate` reject an
+    otherwise valid completion. Widen the field to a plain string: downstream,
+    `response_from_wire` already coerces labels outside `FINISH_REASONS` to None, so parsing
+    stays lenient about the label instead of dropping the turn."""
+
+    finish_reason: str | None = None
+
 
 class ModdedChatCompletion(ChatCompletion):
     """The OpenAI SDK closes `service_tier` to a fixed `Literal`, but providers return tiers
     outside it (e.g. Prime's `provisioned`), which makes `model_validate` reject an otherwise
     valid completion. Widen the field to a plain string — we don't consume it — so parsing stays
-    lenient about the label instead of dropping it."""
+    lenient about the label instead of dropping it. Same for `choices[].finish_reason`."""
 
     service_tier: str | None = None
+    choices: list[ModdedChoice]
 
 
 FINISH_REASONS = frozenset({"stop", "length", "tool_calls"})
+# The SDK's closed enum beyond what vf records (`content_filter`, `function_call`): known
+# labels we don't report on, only coerced to None. Anything outside this set is provider
+# weirdness worth a warning.
+KNOWN_FINISH_REASONS = FINISH_REASONS | {"content_filter", "function_call"}
 
 # Providers name the model's reasoning differently; read them in the v0 client's precedence.
 # `reasoning` (vLLM / Together / OpenRouter), `reasoning_content` (DeepSeek / Qwen / SGLang /
@@ -186,6 +205,14 @@ def response_from_wire(completion: ChatCompletion) -> Response:
     finish: FinishReason = (
         choice.finish_reason if choice.finish_reason in FINISH_REASONS else None
     )
+    if (
+        choice.finish_reason is not None
+        and choice.finish_reason not in KNOWN_FINISH_REASONS
+    ):
+        logger.warning(
+            "provider returned out-of-enum finish_reason %r; recording it as none",
+            choice.finish_reason,
+        )
     usage = Usage.from_openai(completion.usage)
     return Response(
         id=completion.id,


### PR DESCRIPTION
## Problem

Some providers return finish labels outside the enums pinned by the OpenAI and Anthropic SDKs. We observed `finish_reason: "error"`. Validation then rejects the response: streamed calls lose the trace commit, while non-streamed calls fail with a 502.

## Change

- Accept arbitrary wire-level finish labels in the chat and Anthropic dialects.
- Keep the existing internal mapping: known labels are preserved; unknown labels become `None`.
- Warn once when a provider returns an unknown label.

Unknown labels are not coerced to `stop`, because that would record a failed generation as a clean completion.

## Verification

- Regression coverage for streamed chat, non-streamed chat, and Anthropic responses.
- Interception test confirms an `error` terminal chunk still commits the turn and usage.
- `pytest tests/v1 -m "not e2e"`: 73 passed.
- Ruff and ty: clean/no new diagnostics.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Absorb out-of-enum finish labels in chat and Anthropic dialects instead of crashing trace commit
> - Unknown `finish_reason` (OpenAI) and `stop_reason` (Anthropic) values are now coerced to `None` in the parsed `Response` instead of causing a validation error that crashes the trace commit.
> - Both [chat.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2280/files#diff-5d2fcbf59a03489b63b0626038a853eee89543b591074597161ee29aab901280) and [anthropic.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2280/files#diff-abc86b3ad07c2d6ab09cd923f50271c4f6c4cb928a9bb82c12f6e97aac17b04d) introduce a `KNOWN_*` set of expected values; anything outside that set logs a warning via the module logger.
> - `ModdedChoice` and `ModdedAnthropicMessage` widen the SDK's closed `Literal` fields to `str | None` so Pydantic validation passes before the coercion step.
> - Behavioral Change: provider-specific labels like `content_filter`, `function_call`, `pause_turn`, and `refusal` now produce `finish_reason=None` in traces rather than a hard error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8c88c3a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
