### PR TITLE
feat(v1): add runtime workspace snapshots with Docker and Modal backends

### DIFF
--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -183,6 +183,15 @@ class Runtime(ABC):
         """Whether `open_process()` is implemented for this runtime instance."""
         return type(self).open_process is not Runtime.open_process
 
+    @property
+    def supports_snapshots(self) -> bool:
+        """Whether this runtime can capture and restore workspace snapshots."""
+        return (
+            type(self).snapshot is not Runtime.snapshot
+            and type(self).restore is not Runtime.restore
+            and type(self).delete_snapshot is not Runtime.delete_snapshot
+        )
+
     def __init__(self, name: str | None = None) -> None:
         self.name = name or f"vf-{uuid.uuid4().hex[:12]}"
         self._uv_interpreters: dict[str, str] = {}
@@ -262,6 +271,23 @@ class Runtime(ABC):
         raise NotImplementedError(
             f"{type(self).__name__} does not support run_background"
         )
+
+    async def snapshot(self) -> str:
+        """Capture the configured workspace and return an opaque reference.
+
+        The reference must outlive this runtime instance so a later compatible runtime
+        can restore it. Providers define the reference's durability and storage. Callers
+        own returned snapshots and should release them with `delete_snapshot`.
+        """
+        raise NotImplementedError(f"{type(self).__name__} does not support snapshots")
+
+    async def restore(self, ref: str) -> None:
+        """Replace the configured workspace with the contents of `ref`."""
+        raise NotImplementedError(f"{type(self).__name__} does not support snapshots")
+
+    async def delete_snapshot(self, ref: str) -> None:
+        """Release a snapshot previously returned by this runtime type."""
+        raise NotImplementedError(f"{type(self).__name__} does not support snapshots")
 
     async def prepare_uv_script(
         self,

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -286,7 +286,11 @@ class Runtime(ABC):
         raise NotImplementedError(f"{type(self).__name__} does not support snapshots")
 
     async def delete_snapshot(self, ref: str) -> None:
-        """Release a snapshot previously returned by this runtime type."""
+        """Release a snapshot previously returned by this runtime type.
+
+        This must not require a live runtime: callers may delete through a stopped or
+        unstarted compatible instance after the runtime that captured `ref` is gone.
+        """
         raise NotImplementedError(f"{type(self).__name__} does not support snapshots")
 
     async def prepare_uv_script(

--- a/verifiers/v1/runtimes/docker/__init__.py
+++ b/verifiers/v1/runtimes/docker/__init__.py
@@ -162,6 +162,8 @@ async def _archive_workspace(container: str, workdir: str, path: Path) -> None:
         proc = await asyncio.create_subprocess_exec(
             "docker",
             "exec",
+            "--user",
+            "0",
             "--workdir",
             "/",
             container,
@@ -194,6 +196,8 @@ async def _extract_workspace(container: str, workdir: str, path: Path) -> None:
             "docker",
             "exec",
             "-i",
+            "--user",
+            "0",
             "--workdir",
             "/",
             container,
@@ -631,22 +635,85 @@ class DockerRuntime(Runtime):
         if not path.is_file():
             raise SandboxError(f"Docker workspace snapshot is unavailable: {ref}")
         workdir = self._snapshot_workdir()
-        clear = await docker(
+        nonce = uuid.uuid4().hex
+        staging = f"{workdir}.vf-restore-{nonce}"
+        backup = f"{workdir}.vf-backup-{nonce}"
+        prepare = await docker(
             "exec",
+            "--user",
+            "0",
             "--workdir",
-            workdir,
+            "/",
             self._container,
-            "sh",
-            "-c",
-            "find . -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +",
+            "mkdir",
+            "--",
+            staging,
         )
-        if clear.exit_code != 0:
+        if prepare.exit_code != 0:
             raise SandboxError(
-                f"docker workspace restore failed to clear {workdir}: "
-                f"{(clear.stderr or clear.stdout).strip()}"
+                "docker workspace restore failed to create staging directory: "
+                f"{(prepare.stderr or prepare.stdout).strip()}"
             )
-        await _extract_workspace(self._container, workdir, path)
+        try:
+            await _extract_workspace(self._container, staging, path)
+        except BaseException:
+            await run_shielded(self._remove_restore_staging(staging))
+            raise
+
+        swap = await run_shielded(
+            docker(
+                "exec",
+                "--user",
+                "0",
+                "--workdir",
+                "/",
+                self._container,
+                "sh",
+                "-c",
+                (
+                    "work=$1 staging=$2 backup=$3; "
+                    'if ! mv -- "$work" "$backup"; then '
+                    'echo "failed to preserve existing workspace" >&2; exit 1; fi; '
+                    'mv -- "$staging" "$work"; rc=$?; '
+                    'if [ "$rc" -eq 0 ]; then rm -rf -- "$backup" || true; exit 0; fi; '
+                    'if mv -- "$backup" "$work"; then '
+                    'echo "failed to install snapshot; original workspace restored" >&2; '
+                    'else echo "failed to install snapshot; original workspace retained at $backup" >&2; fi; '
+                    'exit "$rc"'
+                ),
+                "vf-restore",
+                workdir,
+                staging,
+                backup,
+            )
+        )
+        if swap.exit_code != 0:
+            await self._remove_restore_staging(staging)
+            raise SandboxError(
+                f"docker workspace restore failed to swap {workdir}: "
+                f"{(swap.stderr or swap.stdout).strip()}"
+            )
         logger.info("docker: restored workspace %s <- %s", self._container, ref)
+
+    async def _remove_restore_staging(self, staging: str) -> None:
+        cleanup = await docker(
+            "exec",
+            "--user",
+            "0",
+            "--workdir",
+            "/",
+            self._container,
+            "rm",
+            "-rf",
+            "--",
+            staging,
+        )
+        if cleanup.exit_code != 0:
+            logger.warning(
+                "docker: failed to remove restore staging %s: %s",
+                staging,
+                (cleanup.stderr or cleanup.stdout).strip(),
+            )
 
     async def delete_snapshot(self, ref: str) -> None:
         """Delete a process-local Docker workspace snapshot, idempotently."""

--- a/verifiers/v1/runtimes/docker/__init__.py
+++ b/verifiers/v1/runtimes/docker/__init__.py
@@ -4,6 +4,7 @@ import array
 import asyncio
 import contextlib
 import logging
+import posixpath
 import shlex
 import socket
 import subprocess
@@ -11,7 +12,7 @@ import sys
 import tempfile
 import uuid
 from collections.abc import AsyncIterator
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import Literal
 from urllib.parse import urlsplit
 
@@ -28,6 +29,9 @@ from verifiers.v1.runtimes.docker.egress import HOST_ALIAS, EgressProxy, Network
 from verifiers.v1.utils.aio import run_shielded
 
 logger = logging.getLogger(__name__)
+
+_SNAPSHOT_PREFIX = "docker-workspace:v1:"
+_snapshot_store: tempfile.TemporaryDirectory[str] | None = None
 
 
 class DockerConfig(NetworkPolicyConfig):
@@ -125,6 +129,94 @@ async def docker(*args: str) -> ProgramResult:
         stdout=stdout.decode(errors="replace"),
         stderr=stderr.decode(errors="replace"),
     )
+
+
+def _snapshot_id(ref: str) -> str:
+    if not ref.startswith(_SNAPSHOT_PREFIX):
+        raise SandboxError(f"invalid Docker workspace snapshot reference: {ref!r}")
+    raw = ref.removeprefix(_SNAPSHOT_PREFIX)
+    try:
+        snapshot_id = uuid.UUID(raw)
+    except ValueError as e:
+        raise SandboxError(
+            f"invalid Docker workspace snapshot reference: {ref!r}"
+        ) from e
+    if snapshot_id.hex != raw:
+        raise SandboxError(f"invalid Docker workspace snapshot reference: {ref!r}")
+    return snapshot_id.hex
+
+
+def _snapshot_path(ref: str, *, create: bool = False) -> Path:
+    snapshot_id = _snapshot_id(ref)
+
+    global _snapshot_store
+    if _snapshot_store is None:
+        if not create:
+            raise SandboxError(f"Docker workspace snapshot is unavailable: {ref}")
+        _snapshot_store = tempfile.TemporaryDirectory(prefix="vf-docker-snapshots-")
+    return Path(_snapshot_store.name) / f"{snapshot_id}.tar"
+
+
+async def _archive_workspace(container: str, workdir: str, path: Path) -> None:
+    with path.open("wb") as archive:
+        proc = await asyncio.create_subprocess_exec(
+            "docker",
+            "exec",
+            "--workdir",
+            "/",
+            container,
+            "tar",
+            "-C",
+            workdir,
+            "-cf",
+            "-",
+            ".",
+            stdout=archive,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            _, stderr = await proc.communicate()
+        except BaseException:
+            if proc.returncode is None:
+                with contextlib.suppress(ProcessLookupError):
+                    proc.kill()
+            await run_shielded(proc.communicate())
+            raise
+    if proc.returncode != 0:
+        raise SandboxError(
+            f"docker workspace snapshot failed: {stderr.decode(errors='replace').strip()}"
+        )
+
+
+async def _extract_workspace(container: str, workdir: str, path: Path) -> None:
+    with path.open("rb") as archive:
+        proc = await asyncio.create_subprocess_exec(
+            "docker",
+            "exec",
+            "-i",
+            "--workdir",
+            "/",
+            container,
+            "tar",
+            "-C",
+            workdir,
+            "-xf",
+            "-",
+            stdin=archive,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await proc.communicate()
+        except BaseException:
+            if proc.returncode is None:
+                with contextlib.suppress(ProcessLookupError):
+                    proc.kill()
+            await run_shielded(proc.communicate())
+            raise
+    if proc.returncode != 0:
+        detail = (stderr or stdout).decode(errors="replace").strip()
+        raise SandboxError(f"docker workspace restore failed: {detail}")
 
 
 async def _abort_process_startup(
@@ -501,6 +593,66 @@ class DockerRuntime(Runtime):
         )  # detached → lives in the container until it's removed in stop()
         if run.exit_code != 0:
             raise SandboxError(f"docker exec -d failed: {run.stderr.strip()}")
+
+    def _snapshot_workdir(self) -> str:
+        workdir = posixpath.normpath(self.config.workdir)
+        if not workdir.startswith("/") or not workdir.lstrip("/"):
+            raise SandboxError(
+                "Docker workspace snapshots require an absolute, non-root workdir"
+            )
+        return workdir
+
+    async def snapshot(self) -> str:
+        """Stream the complete workspace into process-local host storage."""
+        if self._container is None or self._stopped:
+            raise SandboxError("cannot snapshot a Docker container that is not running")
+        snapshot_id = uuid.uuid4().hex
+        ref = f"{_SNAPSHOT_PREFIX}{snapshot_id}"
+        path = _snapshot_path(ref, create=True)
+        pending = path.with_suffix(".tmp")
+        try:
+            await _archive_workspace(
+                self._container,
+                self._snapshot_workdir(),
+                pending,
+            )
+            pending.replace(path)
+        except BaseException:
+            pending.unlink(missing_ok=True)
+            raise
+        logger.info("docker: snapshotted workspace %s -> %s", self._container, ref)
+        return ref
+
+    async def restore(self, ref: str) -> None:
+        """Replace the workspace with a compatible Docker snapshot."""
+        if self._container is None or self._stopped:
+            raise SandboxError("cannot restore a Docker container that is not running")
+        path = _snapshot_path(ref)
+        if not path.is_file():
+            raise SandboxError(f"Docker workspace snapshot is unavailable: {ref}")
+        workdir = self._snapshot_workdir()
+        clear = await docker(
+            "exec",
+            "--workdir",
+            workdir,
+            self._container,
+            "sh",
+            "-c",
+            "find . -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +",
+        )
+        if clear.exit_code != 0:
+            raise SandboxError(
+                f"docker workspace restore failed to clear {workdir}: "
+                f"{(clear.stderr or clear.stdout).strip()}"
+            )
+        await _extract_workspace(self._container, workdir, path)
+        logger.info("docker: restored workspace %s <- %s", self._container, ref)
+
+    async def delete_snapshot(self, ref: str) -> None:
+        """Delete a process-local Docker workspace snapshot, idempotently."""
+        snapshot_id = _snapshot_id(ref)
+        if _snapshot_store is not None:
+            (Path(_snapshot_store.name) / f"{snapshot_id}.tar").unlink(missing_ok=True)
 
     async def _read(self, path: str) -> bytes:
         proc = await asyncio.create_subprocess_exec(

--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -10,6 +10,7 @@ program in the sandbox reaching a host service) is the shared host-side `Tunnel`
 import asyncio
 import contextlib
 import logging
+import posixpath
 import shlex
 import uuid
 from collections.abc import AsyncIterator
@@ -33,6 +34,17 @@ logger = logging.getLogger(__name__)
 
 # Shared Modal app every rollout's sandbox attaches to (created on first lookup).
 _APP_NAME = "verifiers-v1"
+_SNAPSHOT_PREFIX = "modal-workspace:v1:"
+
+
+def _snapshot_image_id(ref: str) -> str:
+    """Validate a Modal workspace snapshot reference and return its Image ID."""
+    if not ref.startswith(_SNAPSHOT_PREFIX):
+        raise SandboxError(f"invalid Modal workspace snapshot reference: {ref!r}")
+    image_id = ref.removeprefix(_SNAPSHOT_PREFIX)
+    if not image_id.startswith("im-") or not image_id.removeprefix("im-"):
+        raise SandboxError(f"invalid Modal workspace snapshot reference: {ref!r}")
+    return image_id
 
 
 class ModalConfig(BaseConfig):
@@ -256,6 +268,61 @@ class ModalRuntime(Runtime):
             raise SandboxError(
                 f"modal background launch failed: {result.stderr.strip()}"
             )
+
+    def _snapshot_workdir(self) -> str:
+        workdir = posixpath.normpath(self.config.workdir)
+        if not workdir.startswith("/") or not workdir.lstrip("/"):
+            raise SandboxError(
+                "Modal workspace snapshots require an absolute, non-root workdir"
+            )
+        return workdir
+
+    async def snapshot(self) -> str:
+        """Capture the workspace as a provider-hosted Modal directory snapshot."""
+        if self._sandbox is None or self.stopped:
+            raise SandboxError("cannot snapshot a Modal sandbox that is not running")
+        try:
+            image = await self._sandbox.snapshot_directory.aio(self._snapshot_workdir())
+        except Exception as e:
+            raise SandboxError(f"Modal workspace snapshot failed: {e}") from e
+        ref = f"{_SNAPSHOT_PREFIX}{image.object_id}"
+        logger.info("modal: snapshotted workspace %s -> %s", self.info.id, ref)
+        return ref
+
+    async def restore(self, ref: str) -> None:
+        """Replace the workspace with a provider-hosted Modal snapshot."""
+        if self._sandbox is None or self.stopped:
+            raise SandboxError("cannot restore a Modal sandbox that is not running")
+        image_id = _snapshot_image_id(ref)
+        try:
+            import modal
+
+            image = modal.Image.from_id(image_id)
+            await self._sandbox.mount_image.aio(self._snapshot_workdir(), image)
+        except ModuleNotFoundError as e:
+            raise ModuleNotFoundError(
+                "ModalRuntime requires the Modal SDK; install `verifiers[modal]`."
+            ) from e
+        except Exception as e:
+            raise SandboxError(f"Modal workspace restore failed for {ref}: {e}") from e
+        logger.info("modal: restored workspace %s <- %s", self.info.id, ref)
+
+    async def delete_snapshot(self, ref: str) -> None:
+        """Delete a provider-hosted Modal snapshot, idempotently."""
+        image_id = _snapshot_image_id(ref)
+        try:
+            import modal
+            import modal.experimental
+
+            await modal.experimental.image_delete.aio(image_id)
+        except ModuleNotFoundError as e:
+            raise ModuleNotFoundError(
+                "ModalRuntime requires the Modal SDK; install `verifiers[modal]`."
+            ) from e
+        except modal.exception.NotFoundError:
+            return
+        except Exception as e:
+            raise SandboxError(f"Modal workspace snapshot deletion failed: {e}") from e
 
     def _abs(self, path: str) -> str:
         # Modal's filesystem API only accepts absolute remote paths; resolve a relative


### PR DESCRIPTION
## Summary

- add a v1 runtime capability gate plus `snapshot()`, `restore(ref)`, and `delete_snapshot(ref)`
- define snapshots as exact captures of the configured workspace, with opaque provider-owned references that outlive the source runtime
- implement Docker snapshots by streaming tar archives directly between the container and process-local host storage, without buffering the workspace in Python memory
- make Docker restore failure-atomic by extracting into a sibling staging directory, preserving the current workspace, swapping only after successful extraction, and rolling back failed swaps
- implement Modal snapshots with provider-hosted directory Images mounted at the configured workdir
- require snapshot deletion to work through a compatible stopped or unstarted runtime

## Why

Evaluators need a provider-native way to transfer or branch complete workspace state. Artifact collection can approximate this, but it imposes transfer limits and makes each environment reimplement workspace lifecycle semantics. A runtime-level contract gives sandbox providers a place to map native snapshot handles while keeping callers provider-agnostic.

The same primitive supports replay curricula: a sampler can retain a completed trajectory's transcript plus snapshot reference, later branch from any retained item, append another user turn, and capture the successor state.

## Docker semantics

Docker snapshot references survive the source container and can be restored by another Docker runtime in the same Verifiers process. The archive is host-backed and process-local; callers own snapshots and release them explicitly with `delete_snapshot`.

## Modal semantics

Modal uses Directory Snapshots, matching this PR's workspace-only contract. `snapshot()` captures the configured workdir with `Sandbox.snapshot_directory()` and returns an opaque `modal-workspace:v1:im-...` reference. `restore(ref)` rehydrates the Image and mounts it over the workdir in a running Sandbox. `delete_snapshot(ref)` uses Modal's image deletion API and is idempotent when the Image has already expired or been deleted.

The snapshot is provider-hosted, so it can cross Verifiers processes and outlive the source Sandbox. Modal currently retains Directory Snapshots for 30 days by default. Directory Snapshots are a Modal beta feature.

## Continuation integration

This PR intentionally owns the runtime storage primitive, not replay-buffer policy. The clean follow-up for [prime-rl #3261](https://github.com/PrimeIntellect-ai/prime-rl/pull/3261) is a first-class dispatch envelope containing:

- the unchanged base task and stable task key
- a transcript prefix plus the next user turn
- an optional snapshot reference to restore
- whether to capture a successor snapshot
- parent trace/branch identity for lineage

Keeping continuation state outside `TaskData` avoids changing task identity whenever a new branch is sampled. The curriculum sampler should own snapshot references in its checkpointed buffer and call `delete_snapshot` on eviction. The env worker should restore immediately before the continuation, capture before runtime teardown, and return the successor reference with the finalized trace.

## Scope

These are workspace snapshots, not full container or memory snapshots. They do not capture files outside the configured workdir, the image layer, running processes, memory, or network state. ProgramBench can use them for solver-to-evaluator workspace handoff; exact process continuation would require a separate full-runtime clone primitive.

## Validation

- `uv run pytest tests/`: 913 passed, 73 credential-gated tests skipped
- Ruff check and format: passed
- `uv run --locked --python 3.13 ty check verifiers`: passed
- `uv run pre-commit run --all-files`: passed
- temporary cross-runtime Docker transport probe: exact restore, stale-file removal, dotfiles, symlinks, executable modes, deletion, extraction/swap failure rollback, and root-workdir refusal
- temporary mocked Modal lifecycle probe: capture, restore, cross-provider ref rejection, and deletion after runtime stop
- Modal 1.4.0 minimum-version compatibility checked for the async Directory Snapshot, mount, and image deletion APIs

Live Docker-daemon and Modal-account round trips remain for CI or reviewer validation.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add runtime workspace snapshot and restore support for Docker and Modal backends
> - Adds `snapshot`, `restore`, and `delete_snapshot` async methods to the base `Runtime` class in [base.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2281/files#diff-0811c040a163eb5a3212208f1e3a6c6388d7690fcc4780c081cc7754036232b9), with a `supports_snapshots` property that detects whether a subclass implements all three.
> - `DockerRuntime` implements snapshots by archiving/extracting the container workdir via `docker exec tar`, storing archives in a process-local `TemporaryDirectory`. Restore uses a staging-and-swap approach with backup and rollback on failure.
> - `ModalRuntime` delegates to Modal's `sandbox.snapshot_directory` and `sandbox.mount_image` APIs, storing snapshot references as `modal-workspace:v1:<image_id>` strings. Deletion uses `modal.experimental.image_delete` and ignores `NotFoundError`.
> - Both backends validate that the workdir is an absolute, non-root path before any snapshot operation, raising `SandboxError` otherwise.
> - Risk: Docker snapshot store is process-local and ephemeral — snapshots are lost if the process restarts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a1ef01f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Restore mutates live sandbox filesystems (Docker swap logic is complex but rollback-aware); Docker snapshots are process-local and Modal refs depend on beta provider APIs and retention.
> 
> **Overview**
> Adds a **v1 runtime workspace snapshot contract**: `supports_snapshots`, plus `snapshot()`, `restore(ref)`, and `delete_snapshot(ref)` on the base `Runtime`, with opaque refs that outlive the capturing instance and deletion allowed on a stopped/unstarted compatible runtime.
> 
> **Docker** streams the configured workdir to process-local `docker-workspace:v1:` tar files via `docker exec` tar (no full-workspace Python buffering). **Restore** is failure-atomic: extract to a staging dir, backup/swap the live workdir, and roll back on failed swaps; root workdirs are rejected.
> 
> **Modal** uses directory snapshots (`snapshot_directory` / `mount_image`) and returns `modal-workspace:v1:im-...` refs; `delete_snapshot` calls Modal’s experimental image delete API (idempotent on missing images).
> 
> Scope is **workspace-only** (configured workdir)—not processes, memory, or image layers. No rollout/curriculum wiring in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1ef01f901298dd53492b983f5ee0ce6c0a89dcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->