### PR TITLE
chore: bump renderers to 0.1.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "uvloop>=0.21.0; sys_platform != 'win32' and sys_platform != 'cygwin' and platform_python_implementation != 'PyPy'",
     "loguru>=0.7.0",
     "tomli-w>=1.0.0",
-    "renderers>=0.1.9.dev9",
+    "renderers>=0.1.9",
     "typing_extensions>=4.12.2",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -4263,7 +4263,7 @@ wheels = [
 
 [[package]]
 name = "renderers"
-version = "0.1.9.dev9"
+version = "0.1.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
@@ -4275,9 +4275,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/55/e7ec6c23404c18b7ee0e38d7f9825f6adfe87334ce9968733e179c4cb4e1/renderers-0.1.9.dev9.tar.gz", hash = "sha256:d46c34f6a94151bf705e4213df197a766b8508e9c5828fac6d733e677f62beaf", size = 349151, upload-time = "2026-07-29T22:54:15.097Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/e4/62fd26ceeb0cdd5b1d11d56a9413014f858670902dfb3d976e9860d04c96/renderers-0.1.9.tar.gz", hash = "sha256:f8516f632b1e0a1bf49d6306606c4ed8815a70671c7409ea804e79203c149999", size = 349102, upload-time = "2026-08-07T00:12:01.042Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/14/996990b4c5669a8979fdc0852c207366dd7d5c61a664274db8f4755328c3/renderers-0.1.9.dev9-py3-none-any.whl", hash = "sha256:f97d31ab83999bcc88bd4471c09f17deb8919b57cc1bba14928155d1e6deef3d", size = 192995, upload-time = "2026-07-29T22:54:13.779Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/19/7d09de9b5b37080f31618d0ebfc14c88f08911a804dae28491021e4c2d21/renderers-0.1.9-py3-none-any.whl", hash = "sha256:e31293c60afd3c632c09e41509f3e6403afecd107caa956a26a7dc9d49554335", size = 192920, upload-time = "2026-08-07T00:11:59.609Z" },
 ]
 
 [[package]]
@@ -5228,6 +5228,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.24.0,<2" },
     { name = "modal", marker = "extra == 'modal'", specifier = ">=1.4.0" },
     { name = "msgpack", specifier = ">=1.1.2" },
+    { name = "nemo-gym", marker = "python_full_version >= '3.12' and extra == 'nemo-gym'", specifier = "==0.4.0" },
     { name = "nest-asyncio", marker = "extra == 'notebook'", specifier = ">=1.6.0" },
     { name = "nltk", marker = "extra == 'ta'", specifier = ">=3.9.2" },
     { name = "numpy", specifier = ">=2.1.0" },
@@ -5241,7 +5242,7 @@ requires-dist = [
     { name = "python-dotenv", marker = "extra == 'browser'", specifier = ">=1.0.0" },
     { name = "pyzmq", specifier = ">=27.1.0" },
     { name = "reasoning-gym", marker = "extra == 'rg'", specifier = ">=0.1.8" },
-    { name = "renderers", specifier = ">=0.1.9.dev9" },
+    { name = "renderers", specifier = ">=0.1.9" },
     { name = "requests" },
     { name = "rich", specifier = ">=11.0.0" },
     { name = "setproctitle", specifier = ">=1.3.0" },
@@ -5252,7 +5253,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.12.2" },
     { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'", specifier = ">=0.21.0" },
 ]
-provides-extras = ["browser", "harbor", "modal", "notebook", "openenv", "rg", "ta"]
+provides-extras = ["browser", "harbor", "modal", "nemo-gym", "notebook", "openenv", "rg", "ta"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Bumps `renderers` to the first stable release since 0.1.8 (`>=0.1.9.dev9` → `>=0.1.9`), dropping the dev-version pin from #2175.

0.1.9 is a patch release: client fixes (vLLM token serving import, malformed sampled-token evidence rejection), GLM tool-name validation, Qwen empty-think-wrapper retention, and a bridge-merge `multi_modal_data` mutation fix. Release notes: https://github.com/PrimeIntellect-ai/renderers/releases/tag/renderers-v0.1.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version pin and lockfile update only; no application logic changes in this PR.
> 
> **Overview**
> Pins the core **`renderers`** dependency from the pre-release floor **`>=0.1.9.dev9`** to the stable release **`>=0.1.9`**, and refreshes **`uv.lock`** so the resolved package is **`renderers` 0.1.9** (new sdist/wheel hashes).
> 
> This is a dependency-only change: consumers pick up the published **0.1.9** renderer stack (client/tooling fixes in that release) without changing verifiers application code in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9555e13b1eebd2eeb1ea7b81633e6c4c79c8f68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `renderers` dependency to stable release 0.1.9
> Updates the `renderers` package constraint in [pyproject.toml](https://github.com/PrimeIntellect-ai/verifiers/pull/2284/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) from `>=0.1.9.dev9` to `>=0.1.9`, switching from a pre-release requirement to the stable release.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a9555e1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->