### PR TITLE
feat(v1): preserve inbound ACP metadata in the trace

### DIFF
--- a/tests/v1/fixtures/prime_agent_autonomous_gate_v1.py
+++ b/tests/v1/fixtures/prime_agent_autonomous_gate_v1.py
@@ -4,7 +4,11 @@ from prime_agent_meta_guards import autonomous_continued, gate_attempted
 
 import verifiers.v1 as vf
 
-TASK = "Create a file named gate.txt containing ok, then reply with exactly DONE."
+# The gate must FAIL at least once, or autonomous never continues: a gate that
+# passes immediately emits continuationsUsed 0 and no gateAttempt at all
+# (verified against real gpt-5.6-luna), so this fixture would score 0 forever.
+# The agent creates the file the gate demands only on a later pass.
+TASK = "Reply with exactly DONE. Do not create any files unless a gate tells you to."
 
 
 class PrimeAgentAutonomousGateTask(vf.Task):

--- a/tests/v1/fixtures/prime_agent_autonomous_gate_v1.py
+++ b/tests/v1/fixtures/prime_agent_autonomous_gate_v1.py
@@ -19,3 +19,21 @@ class PrimeAgentAutonomousGateEnv(vf.SingleAgentEnv):
     async def run(self, task, agents):
         async with agents.agent.interaction(task) as interaction:
             await interaction.turn(TASK)
+
+
+class PrimeAgentAutonomousGateTaskset(
+    vf.Taskset[PrimeAgentAutonomousGateTask, vf.TasksetConfig]
+):
+    def load(self) -> list[PrimeAgentAutonomousGateTask]:
+        return [
+            PrimeAgentAutonomousGateTask(
+                vf.TaskData(
+                    idx=0,
+                    prompt=None,
+                    system_prompt="Follow instructions exactly; create files when asked.",
+                )
+            )
+        ]
+
+
+__all__ = ["PrimeAgentAutonomousGateEnv", "PrimeAgentAutonomousGateTaskset"]

--- a/tests/v1/fixtures/prime_agent_autonomous_gate_v1.py
+++ b/tests/v1/fixtures/prime_agent_autonomous_gate_v1.py
@@ -1,0 +1,21 @@
+"""Prime Agent autonomous gates observed through preserved ACP `_meta`."""
+
+from prime_agent_meta_guards import autonomous_continued, gate_attempted
+
+import verifiers.v1 as vf
+
+TASK = "Create a file named gate.txt containing ok, then reply with exactly DONE."
+
+
+class PrimeAgentAutonomousGateTask(vf.Task):
+    @vf.reward(weight=1.0)
+    async def autonomous_gate(self, trace: vf.Trace) -> float:
+        # A gate configured but never run scores zero: that is the silent-inert
+        # failure this fixture exists to catch.
+        return float(autonomous_continued(trace) and gate_attempted(trace))
+
+
+class PrimeAgentAutonomousGateEnv(vf.SingleAgentEnv):
+    async def run(self, task, agents):
+        async with agents.agent.interaction(task) as interaction:
+            await interaction.turn(TASK)

--- a/tests/v1/fixtures/prime_agent_failing_gate_v1.py
+++ b/tests/v1/fixtures/prime_agent_failing_gate_v1.py
@@ -1,0 +1,37 @@
+"""Prime Agent gate failure metadata fixture."""
+
+from prime_agent_meta_guards import gate_failure_reported
+
+import verifiers.v1 as vf
+
+
+class PrimeAgentFailingGateTask(vf.Task):
+    @vf.reward(weight=1.0)
+    async def failing_gate_is_loud(self, trace: vf.Trace) -> float:
+        return float(gate_failure_reported(trace))
+
+
+class PrimeAgentFailingGateEnv(vf.SingleAgentEnv):
+    async def run(self, task, agents):
+        async with agents.agent.interaction(task) as interaction:
+            await interaction.turn(
+                "Create a file named gate.txt containing ok, then reply with exactly DONE."
+            )
+
+
+class PrimeAgentFailingGateTaskset(
+    vf.Taskset[PrimeAgentFailingGateTask, vf.TasksetConfig]
+):
+    def load(self) -> list[PrimeAgentFailingGateTask]:
+        return [
+            PrimeAgentFailingGateTask(
+                vf.TaskData(
+                    idx=0,
+                    prompt=None,
+                    system_prompt="Follow instructions exactly when handling gates.",
+                )
+            )
+        ]
+
+
+__all__ = ["PrimeAgentFailingGateEnv", "PrimeAgentFailingGateTaskset"]

--- a/tests/v1/fixtures/prime_agent_harness_state_v1.py
+++ b/tests/v1/fixtures/prime_agent_harness_state_v1.py
@@ -1,6 +1,6 @@
 """Prime Agent goal and continual-harness state over preserved ACP `_meta`."""
 
-from prime_agent_meta_guards import goal_progressed, refinement_applied
+from prime_agent_meta_guards import MissingAcpMeta, goal_progressed, refinement_applied
 
 import verifiers.v1 as vf
 
@@ -10,15 +10,52 @@ TASK = (
 )
 
 
+def _any_metadata(trace) -> bool:
+    """Whether the ACP envelope arrived at all, regardless of which keys it held."""
+    recorded = (trace.info or {}).get("acp_meta") or {}
+    return bool(recorded)
+
+
 class PrimeAgentHarnessStateTask(vf.Task):
     @vf.reward(weight=1.0)
     async def harness_state(self, trace: vf.Trace) -> float:
-        # Either surface proves continual-harness observability; requiring both
-        # would couple this fixture to whether the task also set a goal.
-        return float(refinement_applied(trace) or goal_progressed(trace))
+        # Either surface proves continual-harness observability, so a missing
+        # `refinement` envelope must fall through to `goal` rather than raising:
+        # the guards raise on absent metadata, which would make this `or` dead.
+        # Only raise when NEITHER surface is present, since that means the harness
+        # preserved nothing and the run cannot be scored either way.
+        seen = []
+        for guard in (refinement_applied, goal_progressed):
+            try:
+                seen.append(guard(trace))
+            except MissingAcpMeta:
+                seen.append(False)
+        if not any(seen) and not _any_metadata(trace):
+            raise MissingAcpMeta(
+                "neither refinement nor goal metadata was preserved for this rollout"
+            )
+        return float(any(seen))
 
 
 class PrimeAgentHarnessStateEnv(vf.SingleAgentEnv):
     async def run(self, task, agents):
         async with agents.agent.interaction(task) as interaction:
             await interaction.turn(TASK)
+
+
+class PrimeAgentHarnessStateTaskset(
+    vf.Taskset[PrimeAgentHarnessStateTask, vf.TasksetConfig]
+):
+    def load(self) -> list[PrimeAgentHarnessStateTask]:
+        return [
+            PrimeAgentHarnessStateTask(
+                vf.TaskData(
+                    idx=0,
+                    prompt=None,
+                    system_prompt="Use /refine when asked to record a durable preference.",
+                )
+            )
+        ]
+
+
+__all__ = ["PrimeAgentHarnessStateEnv", "PrimeAgentHarnessStateTaskset"]

--- a/tests/v1/fixtures/prime_agent_harness_state_v1.py
+++ b/tests/v1/fixtures/prime_agent_harness_state_v1.py
@@ -1,0 +1,24 @@
+"""Prime Agent goal and continual-harness state over preserved ACP `_meta`."""
+
+from prime_agent_meta_guards import goal_progressed, refinement_applied
+
+import verifiers.v1 as vf
+
+TASK = (
+    "Run /refine to record that this environment prefers concise answers, then "
+    "reply with exactly DONE."
+)
+
+
+class PrimeAgentHarnessStateTask(vf.Task):
+    @vf.reward(weight=1.0)
+    async def harness_state(self, trace: vf.Trace) -> float:
+        # Either surface proves continual-harness observability; requiring both
+        # would couple this fixture to whether the task also set a goal.
+        return float(refinement_applied(trace) or goal_progressed(trace))
+
+
+class PrimeAgentHarnessStateEnv(vf.SingleAgentEnv):
+    async def run(self, task, agents):
+        async with agents.agent.interaction(task) as interaction:
+            await interaction.turn(TASK)

--- a/tests/v1/fixtures/prime_agent_meta_guards.py
+++ b/tests/v1/fixtures/prime_agent_meta_guards.py
@@ -1,0 +1,153 @@
+"""Reward guards over preserved ACP `_meta`, shared by the Prime Agent fixtures.
+
+Every guard reads `trace.info["acp_meta"][NAMESPACE]`, the ordered event history
+recorded by `verifiers/v1/acp`. Ordering matters: a subagent's `running -> done`
+transition only exists in the sequence, so a guard that inspected the last event
+alone could not tell a finished child from one that never started.
+
+These deliberately raise `MissingAcpMeta` when the metadata a fixture depends on
+is absent. Returning 0.0 would report "the agent failed" for what is actually a
+broken harness or an agent build that never emitted the field.
+"""
+
+NAMESPACE = "ai.primeintellect.prime-agent"
+
+
+class MissingAcpMeta(RuntimeError):
+    """Required Prime Agent metadata never arrived, so the run cannot be scored."""
+
+
+def events(trace) -> list[dict]:
+    recorded = (trace.info or {}).get("acp_meta")
+    if not recorded or NAMESPACE not in recorded:
+        raise MissingAcpMeta(
+            f"no {NAMESPACE!r} metadata in trace.info['acp_meta']; the harness did "
+            "not preserve inbound ACP _meta, or this agent build does not emit it"
+        )
+    return [event for event in recorded[NAMESPACE] if isinstance(event, dict)]
+
+
+def field_history(trace, key: str) -> list[dict]:
+    """Every value this metadata key took, in arrival order."""
+    history = [
+        event[key] for event in events(trace) if isinstance(event.get(key), dict)
+    ]
+    if not history:
+        raise MissingAcpMeta(f"{NAMESPACE}.{key} never appeared in the ACP metadata")
+    return history
+
+
+def subagent_history(trace) -> list[list[dict]]:
+    """Each `subagents` roster snapshot, in arrival order."""
+    seen = events(trace)
+    if not seen:
+        raise MissingAcpMeta(f"{NAMESPACE} metadata history is empty; nothing to score")
+    snapshots = [
+        event["subagents"] for event in seen if isinstance(event.get("subagents"), list)
+    ]
+    if not snapshots:
+        raise MissingAcpMeta(
+            f"{NAMESPACE}.subagents never appeared in the ACP metadata"
+        )
+    return snapshots
+
+
+def observed_child_statuses(trace) -> dict[str, list[str]]:
+    """Status sequence per child id, so a lifecycle transition is checkable."""
+    statuses: dict[str, list[str]] = {}
+    for snapshot in subagent_history(trace):
+        for child in snapshot:
+            if not isinstance(child, dict):
+                continue
+            child_id = child.get("id")
+            status = child.get("status")
+            if not isinstance(child_id, str) or not isinstance(status, str):
+                continue
+            seen = statuses.setdefault(child_id, [])
+            if not seen or seen[-1] != status:
+                seen.append(status)
+    if not statuses:
+        raise MissingAcpMeta("no identifiable subagents appeared in the ACP metadata")
+    return statuses
+
+
+def spawned_and_finished(trace) -> bool:
+    """A child ran and reached a terminal state before scoring.
+
+    Interception cannot establish this: `ModelCall` carries no parent or agent
+    field, so a child's model calls are indistinguishable from its parent's. The
+    `subagents` roster is the only place this is observable.
+    """
+    statuses = observed_child_statuses(trace)
+    terminal = {"completed", "done", "error", "cancelled"}
+    return any(
+        any(status not in terminal for status in seen) and seen[-1] in terminal
+        for seen in statuses.values()
+    )
+
+
+def child_tokens_attributed(trace) -> bool:
+    """Some child reported nonzero token usage."""
+    return any(
+        isinstance(child, dict)
+        and isinstance(child.get("tokenCount"), int)
+        and child["tokenCount"] > 0
+        for snapshot in subagent_history(trace)
+        for child in snapshot
+    )
+
+
+def quiescent_at_end(trace) -> bool:
+    """The final quiescence snapshot shows no outstanding work.
+
+    Scoring a turn that is still working races the agent, so a fixture that cares
+    about completeness must assert this rather than trusting `end_turn`.
+    """
+    final = field_history(trace, "quiescence")[-1]
+    return final.get("outstandingSubagents") == 0 and (
+        final.get("remainingAutonomousContinuations") in (0, None)
+        or isinstance(final.get("remainingAutonomousContinuations"), int)
+    )
+
+
+def no_outstanding_subagents(trace) -> bool:
+    return field_history(trace, "quiescence")[-1].get("outstandingSubagents") == 0
+
+
+def autonomous_continued(trace) -> bool:
+    """Autonomous mode actually engaged, rather than being silently inert."""
+    history = field_history(trace, "autonomous")
+    return any(
+        event.get("enabled")
+        and isinstance(event.get("continuationsUsed"), int)
+        and event["continuationsUsed"] > 0
+        for event in history
+    )
+
+
+def gate_attempted(trace) -> bool:
+    history = field_history(trace, "autonomous")
+    return any(
+        isinstance(event.get("gateAttempt"), int) and event["gateAttempt"] >= 1
+        for event in history
+    )
+
+
+def gate_failure_reported(trace) -> bool:
+    """A failing gate surfaced its failure instead of passing silently."""
+    return any(event.get("gateFailure") for event in field_history(trace, "autonomous"))
+
+
+def goal_progressed(trace) -> bool:
+    statuses = [event.get("status") for event in field_history(trace, "goal")]
+    return any(isinstance(status, str) and status for status in statuses)
+
+
+def refinement_applied(trace) -> bool:
+    """Continual-harness state changed, with the applied edits enumerated."""
+    return any(
+        event.get("status") == "complete"
+        and isinstance(event.get("changes"), list)
+        and event["changes"]
+        for event in field_history(trace, "refinement")
+    )

--- a/tests/v1/fixtures/prime_agent_negatives_v1.py
+++ b/tests/v1/fixtures/prime_agent_negatives_v1.py
@@ -13,7 +13,6 @@ fixture whose agent genuinely failed, and that ambiguity is what hides bugs.
 from prime_agent_meta_guards import (
     MissingAcpMeta,
     field_history,
-    gate_failure_reported,
     observed_child_statuses,
 )
 
@@ -59,20 +58,6 @@ class PrimeAgentKilledChildEnv(vf.SingleAgentEnv):
             )
 
 
-class PrimeAgentFailingGateTask(vf.Task):
-    @vf.reward(weight=1.0)
-    async def failing_gate_is_loud(self, trace: vf.Trace) -> float:
-        return float(gate_failure_reported(trace))
-
-
-class PrimeAgentFailingGateEnv(vf.SingleAgentEnv):
-    async def run(self, task, agents):
-        async with agents.agent.interaction(task) as interaction:
-            await interaction.turn(
-                "Create a file named gate.txt containing ok, then reply with exactly DONE."
-            )
-
-
 class PrimeAgentKilledChildTaskset(
     vf.Taskset[PrimeAgentKilledChildTask, vf.TasksetConfig]
 ):
@@ -90,8 +75,6 @@ class PrimeAgentKilledChildTaskset(
 
 __all__ = [
     "MissingAcpMeta",
-    "PrimeAgentFailingGateEnv",
-    "PrimeAgentFailingGateTask",
     "PrimeAgentKilledChildEnv",
     "PrimeAgentKilledChildTask",
     "PrimeAgentKilledChildTaskset",

--- a/tests/v1/fixtures/prime_agent_negatives_v1.py
+++ b/tests/v1/fixtures/prime_agent_negatives_v1.py
@@ -1,0 +1,84 @@
+"""Prime Agent failures that must be loud.
+
+Every bug this integration hit scored *wrongly* rather than erroring: a starved
+follow-up, an ACP turn that reported a clean `end_turn` after failing, an agent
+inheriting the runner's uv interpreter. Each looked like a weak model instead of
+broken infrastructure.
+
+So these guards convert "the evidence is missing" into an exception. A fixture
+that silently returns 0.0 when metadata is absent is indistinguishable from a
+fixture whose agent genuinely failed, and that ambiguity is what hides bugs.
+"""
+
+from prime_agent_meta_guards import (
+    MissingAcpMeta,
+    field_history,
+    gate_failure_reported,
+    observed_child_statuses,
+)
+
+import verifiers.v1 as vf
+
+
+def child_error_reported(trace) -> bool:
+    """A killed child surfaced a terminal error rather than vanishing."""
+    return any(
+        seen[-1] in {"error", "cancelled"}
+        for seen in observed_child_statuses(trace).values()
+    )
+
+
+def quiescence_blocked_scoring(trace) -> bool:
+    """Quiescence reported outstanding work at some point.
+
+    This is the signal a consumer needs in order to refuse to score early; if it
+    never appears, a harness cannot tell a finished turn from a busy one.
+    """
+    return any(
+        isinstance(event.get("outstandingSubagents"), int)
+        and event["outstandingSubagents"] > 0
+        for event in field_history(trace, "quiescence")
+    )
+
+
+class PrimeAgentKilledChildTask(vf.Task):
+    @vf.reward(weight=1.0)
+    async def killed_child_is_loud(self, trace: vf.Trace) -> float:
+        # Absent metadata raises out of the reward rather than scoring 0.0, so a
+        # harness regression fails the run instead of blaming the model.
+        return float(child_error_reported(trace))
+
+
+class PrimeAgentKilledChildEnv(vf.SingleAgentEnv):
+    async def run(self, task, agents):
+        async with agents.agent.interaction(task) as interaction:
+            await interaction.turn(
+                "Use IPython to spawn a subagent with rlm() that sleeps for a long "
+                "time. Then delete it with rlm.delete_subagent() before it finishes "
+                "and reply with exactly DONE."
+            )
+
+
+class PrimeAgentFailingGateTask(vf.Task):
+    @vf.reward(weight=1.0)
+    async def failing_gate_is_loud(self, trace: vf.Trace) -> float:
+        return float(gate_failure_reported(trace))
+
+
+class PrimeAgentFailingGateEnv(vf.SingleAgentEnv):
+    async def run(self, task, agents):
+        async with agents.agent.interaction(task) as interaction:
+            await interaction.turn(
+                "Create a file named gate.txt containing ok, then reply with exactly DONE."
+            )
+
+
+__all__ = [
+    "MissingAcpMeta",
+    "PrimeAgentFailingGateEnv",
+    "PrimeAgentFailingGateTask",
+    "PrimeAgentKilledChildEnv",
+    "PrimeAgentKilledChildTask",
+    "child_error_reported",
+    "quiescence_blocked_scoring",
+]

--- a/tests/v1/fixtures/prime_agent_negatives_v1.py
+++ b/tests/v1/fixtures/prime_agent_negatives_v1.py
@@ -73,12 +73,28 @@ class PrimeAgentFailingGateEnv(vf.SingleAgentEnv):
             )
 
 
+class PrimeAgentKilledChildTaskset(
+    vf.Taskset[PrimeAgentKilledChildTask, vf.TasksetConfig]
+):
+    def load(self) -> list[PrimeAgentKilledChildTask]:
+        return [
+            PrimeAgentKilledChildTask(
+                vf.TaskData(
+                    idx=0,
+                    prompt=None,
+                    system_prompt="Follow instructions exactly when managing subagents.",
+                )
+            )
+        ]
+
+
 __all__ = [
     "MissingAcpMeta",
     "PrimeAgentFailingGateEnv",
     "PrimeAgentFailingGateTask",
     "PrimeAgentKilledChildEnv",
     "PrimeAgentKilledChildTask",
+    "PrimeAgentKilledChildTaskset",
     "child_error_reported",
     "quiescence_blocked_scoring",
 ]

--- a/tests/v1/fixtures/prime_agent_subagents_v1.py
+++ b/tests/v1/fixtures/prime_agent_subagents_v1.py
@@ -1,0 +1,33 @@
+"""Prime Agent subagent lifecycle and token accounting over preserved ACP `_meta`."""
+
+from prime_agent_meta_guards import (
+    child_tokens_attributed,
+    no_outstanding_subagents,
+    spawned_and_finished,
+)
+
+import verifiers.v1 as vf
+
+TASK = (
+    "Use IPython to spawn one subagent with rlm(). Ask it to reply to you, wait "
+    "for its message, then reply with exactly DONE."
+)
+
+
+class PrimeAgentSubagentTask(vf.Task):
+    @vf.reward(weight=1.0)
+    async def subagent_lifecycle(self, trace: vf.Trace) -> float:
+        # Each clause is independently necessary: a child that never finished, or
+        # finished with no usage, or was still outstanding at scoring time, all
+        # mean the rollout was scored against incomplete work.
+        return float(
+            spawned_and_finished(trace)
+            and child_tokens_attributed(trace)
+            and no_outstanding_subagents(trace)
+        )
+
+
+class PrimeAgentSubagentEnv(vf.SingleAgentEnv):
+    async def run(self, task, agents):
+        async with agents.agent.interaction(task) as interaction:
+            await interaction.turn(TASK)

--- a/tests/v1/fixtures/prime_agent_subagents_v1.py
+++ b/tests/v1/fixtures/prime_agent_subagents_v1.py
@@ -31,3 +31,19 @@ class PrimeAgentSubagentEnv(vf.SingleAgentEnv):
     async def run(self, task, agents):
         async with agents.agent.interaction(task) as interaction:
             await interaction.turn(TASK)
+
+
+class PrimeAgentSubagentTaskset(vf.Taskset[PrimeAgentSubagentTask, vf.TasksetConfig]):
+    def load(self) -> list[PrimeAgentSubagentTask]:
+        return [
+            PrimeAgentSubagentTask(
+                vf.TaskData(
+                    idx=0,
+                    prompt=None,
+                    system_prompt="Spawn exactly one subagent when asked and wait for its reply before answering.",
+                )
+            )
+        ]
+
+
+__all__ = ["PrimeAgentSubagentEnv", "PrimeAgentSubagentTaskset"]

--- a/tests/v1/test_acp.py
+++ b/tests/v1/test_acp.py
@@ -1,6 +1,5 @@
 """ACP metadata accumulation preserves ordered, namespaced extension events."""
 
-import asyncio
 import importlib.util
 import sys
 import types
@@ -93,37 +92,6 @@ def test_acp_run_forwards_trace_to_the_recording_path() -> None:
     )
 
 
-def test_acp_runner_preserves_late_turn_metadata_and_drops_failed_turn_metadata() -> (
-    None
-):
-    """Guard the standalone runner's metadata ownership across live turns."""
-    runner = (Path(__file__).parents[2] / "verifiers/v1/acp/runner.py").read_text()
-    reset_start = runner.index("    def reset(self) -> None:")
-    reset_end = runner.index("    async def session_update", reset_start)
-    assert "turn_acp_meta = {}" not in runner[reset_start:reset_end]
-    prompt_end = runner.index(
-        "\n\nasync def run_once", runner.index("async def prompt(")
-    )
-    prompt_source = runner[runner.index("async def prompt(") : prompt_end]
-    assert "LATE_UPDATE_GRACE_SECONDS" in prompt_source
-    assert "wait_for" in prompt_source
-    assert "await wait_for_late_metadata(client)" in prompt_source
-    helper_start = runner.index("async def wait_for_late_metadata")
-    helper_end = runner.index("\n\ndef content_blocks", helper_start)
-    helper_source = runner[helper_start:helper_end]
-    metadata_wait = "client.output_changed.wait_for(lambda: bool(client.turn_acp_meta))"
-    assert metadata_wait in helper_source
-    # A turn which already has its SessionInfoUpdate must return immediately,
-    # rather than waiting out the late-update grace period on every prompt.
-    assert "if client.turn_acp_meta:" in helper_source
-    assert "return" in helper_source
-    error_start = runner.index("            except Exception as error:")
-    error_end = runner.index("            write_packet", error_start)
-    error_source = runner[error_start:error_end]
-    assert 'response["meta"]' not in error_source
-    assert "session.client.turn_acp_meta = {}" in error_source
-
-
 def load_runner_without_acp_dependency(monkeypatch: pytest.MonkeyPatch):
     """Load the standalone script with only the ACP names this unit path needs."""
     acp = types.ModuleType("acp")
@@ -159,51 +127,23 @@ def load_runner_without_acp_dependency(monkeypatch: pytest.MonkeyPatch):
     return module
 
 
-@pytest.mark.asyncio
-async def test_acp_runner_skips_metadata_grace_when_turn_already_has_metadata(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Metadata received before prompt completion must not add a fixed delay."""
-    runner = load_runner_without_acp_dependency(monkeypatch)
+def test_wait_for_late_metadata_waits_for_quiet_not_first_event():
+    """Stopping at the FIRST metadata event drops the trailing terminal update.
 
-    class NoWaitCondition:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *args):
-            return None
-
-        async def wait_for(self, predicate):
-            raise AssertionError("a metadata-bearing turn must not wait")
-
-    class Client:
-        def __init__(self) -> None:
-            self.visible_reply = "DONE"
-            self.tool_calls = {}
-            self.turn_acp_meta = {"ai.primeintellect.prime-agent": [{"goal": {}}]}
-            self.output_changed = NoWaitCondition()
-
-        def reset(self) -> None:
-            # Production reset clears reply/tool state but intentionally preserves
-            # metadata until the stream response serializes this turn.
-            pass
-
-    class Connection:
-        async def prompt(self, **kwargs):
-            return types.SimpleNamespace(stop_reason="end_turn")
-
-    reply = await asyncio.wait_for(
-        runner.prompt(
-            Client(),
-            Connection(),
-            types.SimpleNamespace(
-                prompt_capabilities=types.SimpleNamespace(image=False)
-            ),
-            "session",
-            {"messages": [{"role": "user", "content": "hi"}], "system_prompt": ""},
-            is_new=True,
-        ),
-        timeout=0.1,
-    )
-
-    assert reply == "DONE"
+    ACP can dispatch several SessionInfoUpdates around the response, and the
+    bucket is cleared once the response is built, so an event arriving after the
+    first is lost or attributed to the next turn. runner.py executes under its own
+    standalone ACP dependencies and cannot be imported here, so this asserts the
+    settle contract at the source level.
+    """
+    source = Path("verifiers/v1/acp/runner.py").read_text()
+    helper = source[source.index("async def wait_for_late_metadata") :]
+    helper = helper[: helper.index("\ndef ")]
+    # Loops until the event COUNT stops changing, rather than returning on the
+    # first truthy bucket.
+    assert "_meta_event_count(client) != seen" in helper
+    assert "LATE_METADATA_SETTLE_SECONDS" in helper
+    # Still bounded by the overall grace period.
+    assert "LATE_UPDATE_GRACE_SECONDS" in helper
+    # The old early-return on any existing metadata must be gone.
+    assert "if client.turn_acp_meta:\n        return" not in helper

--- a/tests/v1/test_acp.py
+++ b/tests/v1/test_acp.py
@@ -1,6 +1,12 @@
 """ACP metadata accumulation preserves ordered, namespaced extension events."""
 
+import asyncio
+import importlib.util
+import sys
+import types
 from pathlib import Path
+
+import pytest
 
 from verifiers.v1.acp import _record_acp_meta
 
@@ -101,12 +107,103 @@ def test_acp_runner_preserves_late_turn_metadata_and_drops_failed_turn_metadata(
     prompt_source = runner[runner.index("async def prompt(") : prompt_end]
     assert "LATE_UPDATE_GRACE_SECONDS" in prompt_source
     assert "wait_for" in prompt_source
-    assert (
-        "client.output_changed.wait_for(lambda: bool(client.turn_acp_meta))"
-        in prompt_source
-    )
+    assert "await wait_for_late_metadata(client)" in prompt_source
+    helper_start = runner.index("async def wait_for_late_metadata")
+    helper_end = runner.index("\n\ndef content_blocks", helper_start)
+    helper_source = runner[helper_start:helper_end]
+    metadata_wait = "client.output_changed.wait_for(lambda: bool(client.turn_acp_meta))"
+    assert metadata_wait in helper_source
+    # A turn which already has its SessionInfoUpdate must return immediately,
+    # rather than waiting out the late-update grace period on every prompt.
+    assert "if client.turn_acp_meta:" in helper_source
+    assert "return" in helper_source
     error_start = runner.index("            except Exception as error:")
     error_end = runner.index("            write_packet", error_start)
     error_source = runner[error_start:error_end]
     assert 'response["meta"]' not in error_source
     assert "session.client.turn_acp_meta = {}" in error_source
+
+
+def load_runner_without_acp_dependency(monkeypatch: pytest.MonkeyPatch):
+    """Load the standalone script with only the ACP names this unit path needs."""
+    acp = types.ModuleType("acp")
+    acp.PROTOCOL_VERSION = "0.11"
+    acp.Client = object
+    acp.RequestError = RuntimeError
+    acp.image_block = lambda data, media_type: (data, media_type)
+    acp.spawn_agent_process = None
+    acp.text_block = lambda text: text
+    schema = types.ModuleType("acp.schema")
+    for name in (
+        "AgentMessageChunk",
+        "AllowedOutcome",
+        "ClientCapabilities",
+        "DeniedOutcome",
+        "HttpMcpServer",
+        "PermissionOption",
+        "RequestPermissionResponse",
+        "SessionInfoUpdate",
+        "TextContentBlock",
+        "ToolCall",
+        "ToolCallUpdate",
+    ):
+        setattr(schema, name, type(name, (), {}))
+    monkeypatch.setitem(sys.modules, "acp", acp)
+    monkeypatch.setitem(sys.modules, "acp.schema", schema)
+    spec = importlib.util.spec_from_file_location(
+        "test_acp_runner", Path(__file__).parents[2] / "verifiers/v1/acp/runner.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.asyncio
+async def test_acp_runner_skips_metadata_grace_when_turn_already_has_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Metadata received before prompt completion must not add a fixed delay."""
+    runner = load_runner_without_acp_dependency(monkeypatch)
+
+    class NoWaitCondition:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def wait_for(self, predicate):
+            raise AssertionError("a metadata-bearing turn must not wait")
+
+    class Client:
+        def __init__(self) -> None:
+            self.visible_reply = "DONE"
+            self.tool_calls = {}
+            self.turn_acp_meta = {"ai.primeintellect.prime-agent": [{"goal": {}}]}
+            self.output_changed = NoWaitCondition()
+
+        def reset(self) -> None:
+            # Production reset clears reply/tool state but intentionally preserves
+            # metadata until the stream response serializes this turn.
+            pass
+
+    class Connection:
+        async def prompt(self, **kwargs):
+            return types.SimpleNamespace(stop_reason="end_turn")
+
+    reply = await asyncio.wait_for(
+        runner.prompt(
+            Client(),
+            Connection(),
+            types.SimpleNamespace(
+                prompt_capabilities=types.SimpleNamespace(image=False)
+            ),
+            "session",
+            {"messages": [{"role": "user", "content": "hi"}], "system_prompt": ""},
+            is_new=True,
+        ),
+        timeout=0.1,
+    )
+
+    assert reply == "DONE"

--- a/tests/v1/test_acp.py
+++ b/tests/v1/test_acp.py
@@ -1,5 +1,6 @@
 """ACP metadata accumulation preserves ordered, namespaced extension events."""
 
+import asyncio
 import importlib.util
 import sys
 import types
@@ -127,23 +128,66 @@ def load_runner_without_acp_dependency(monkeypatch: pytest.MonkeyPatch):
     return module
 
 
-def test_wait_for_late_metadata_waits_for_quiet_not_first_event():
-    """Stopping at the FIRST metadata event drops the trailing terminal update.
+class _MetaClient:
+    def __init__(self, initial=None):
+        self.turn_acp_meta = dict(initial or {})
+        self.output_changed = asyncio.Condition()
 
-    ACP can dispatch several SessionInfoUpdates around the response, and the
-    bucket is cleared once the response is built, so an event arriving after the
-    first is lost or attributed to the next turn. runner.py executes under its own
-    standalone ACP dependencies and cannot be imported here, so this asserts the
-    settle contract at the source level.
+    async def emit(self, event):
+        async with self.output_changed:
+            self.turn_acp_meta.setdefault("ns", []).append(event)
+            self.output_changed.notify_all()
+
+
+@pytest.mark.asyncio
+async def test_late_metadata_keeps_full_grace_before_the_first_event(monkeypatch):
+    """A first event arriving after the settle interval must not be dropped.
+
+    Waiting only for the stream to go quiet collapses the grace window down to
+    the settle interval while nothing has arrived yet.
     """
-    source = Path("verifiers/v1/acp/runner.py").read_text()
-    helper = source[source.index("async def wait_for_late_metadata") :]
-    helper = helper[: helper.index("\ndef ")]
-    # Loops until the event COUNT stops changing, rather than returning on the
-    # first truthy bucket.
-    assert "_meta_event_count(client) != seen" in helper
-    assert "LATE_METADATA_SETTLE_SECONDS" in helper
-    # Still bounded by the overall grace period.
-    assert "LATE_UPDATE_GRACE_SECONDS" in helper
-    # The old early-return on any existing metadata must be gone.
-    assert "if client.turn_acp_meta:\n        return" not in helper
+    runner = load_runner_without_acp_dependency(monkeypatch)
+    client = _MetaClient()
+
+    async def emit_late():
+        await asyncio.sleep(0.3)  # after settle, well inside the grace window
+        await client.emit({"late": True})
+
+    task = asyncio.create_task(emit_late())
+    await runner.wait_for_late_metadata(client)
+    # Snapshot at RETURN time: awaiting the producer first would let a dropped
+    # event land afterwards and make the assertion vacuous.
+    collected = len(client.turn_acp_meta.get("ns", []))
+    await task
+    assert collected == 1
+
+
+@pytest.mark.asyncio
+async def test_late_metadata_collects_a_trailing_update(monkeypatch):
+    """The bucket is cleared once the response is built, so stragglers are lost."""
+    runner = load_runner_without_acp_dependency(monkeypatch)
+    client = _MetaClient()
+
+    async def emit_two():
+        await asyncio.sleep(0.01)
+        await client.emit({"first": True})
+        await asyncio.sleep(0.01)
+        await client.emit({"trailing": True})
+
+    task = asyncio.create_task(emit_two())
+    await runner.wait_for_late_metadata(client)
+    collected = len(client.turn_acp_meta.get("ns", []))
+    await task
+    assert collected == 2
+
+
+@pytest.mark.asyncio
+async def test_late_metadata_does_not_delay_a_turn_that_already_has_metadata(
+    monkeypatch,
+):
+    """Otherwise every prompt pays a fixed delay it does not need."""
+    runner = load_runner_without_acp_dependency(monkeypatch)
+    started = asyncio.get_event_loop().time()
+    await runner.wait_for_late_metadata(_MetaClient({"ns": [{"done": True}]}))
+    elapsed = asyncio.get_event_loop().time() - started
+    assert elapsed < runner.LATE_UPDATE_GRACE_SECONDS / 2, elapsed

--- a/tests/v1/test_acp.py
+++ b/tests/v1/test_acp.py
@@ -1,0 +1,65 @@
+"""ACP metadata accumulation preserves ordered, namespaced extension events."""
+
+from verifiers.v1.acp import _record_acp_meta
+
+
+def test_acp_meta_accumulates_history_without_flattening() -> None:
+    trace = type("TraceStub", (), {"info": {}})()
+    namespace = "ai.primeintellect.prime-agent"
+    _record_acp_meta(
+        trace,
+        {
+            namespace: [
+                {"autonomous": {"continuationsUsed": 0}},
+                {
+                    "quiescence": {
+                        "outstandingSubagents": 1,
+                        "remainingAutonomousContinuations": 2,
+                    }
+                },
+            ],
+            "other.namespace": [{"value": 1}],
+        },
+    )
+    _record_acp_meta(
+        trace,
+        {
+            namespace: [
+                {
+                    "quiescence": {
+                        "outstandingSubagents": 0,
+                        "remainingAutonomousContinuations": 0,
+                    }
+                }
+            ]
+        },
+    )
+
+    assert trace.info["acp_meta"][namespace] == [
+        {"autonomous": {"continuationsUsed": 0}},
+        {
+            "quiescence": {
+                "outstandingSubagents": 1,
+                "remainingAutonomousContinuations": 2,
+            }
+        },
+        {
+            "quiescence": {
+                "outstandingSubagents": 0,
+                "remainingAutonomousContinuations": 0,
+            }
+        },
+    ]
+    assert trace.info["acp_meta"]["other.namespace"] == [{"value": 1}]
+    assert trace.info["acp_meta"][namespace][-1]["quiescence"] == {
+        "outstandingSubagents": 0,
+        "remainingAutonomousContinuations": 0,
+    }
+
+
+def test_acp_meta_without_events_is_additive() -> None:
+    trace = type("TraceStub", (), {"info": {"existing": "value"}})()
+
+    _record_acp_meta(trace, {})
+
+    assert trace.info == {"existing": "value"}

--- a/tests/v1/test_acp.py
+++ b/tests/v1/test_acp.py
@@ -63,3 +63,23 @@ def test_acp_meta_without_events_is_additive() -> None:
     _record_acp_meta(trace, {})
 
     assert trace.info == {"existing": "value"}
+
+
+def test_acp_run_forwards_trace_to_the_recording_path() -> None:
+    """`ACP.run` must hand `trace` to `_run`, or every caller's opt-in is a no-op.
+
+    This was a silent hole: `run()` accepted `trace` and dropped it, so the
+    one-shot path recorded nothing while appearing wired up. A signature-level
+    check is enough and stays honest without a live runtime.
+    """
+    import inspect
+
+    from verifiers.v1.acp import ACP
+
+    assert "trace" in inspect.signature(ACP.run).parameters
+    assert "trace" in inspect.signature(ACP._run).parameters
+    source = inspect.getsource(ACP.run)
+    # The forwarding argument itself, not merely the parameter.
+    assert "trace=trace" in source, (
+        "ACP.run accepts trace but never forwards it to _run"
+    )

--- a/tests/v1/test_acp.py
+++ b/tests/v1/test_acp.py
@@ -191,3 +191,46 @@ async def test_late_metadata_does_not_delay_a_turn_that_already_has_metadata(
     await runner.wait_for_late_metadata(_MetaClient({"ns": [{"done": True}]}))
     elapsed = asyncio.get_event_loop().time() - started
     assert elapsed < runner.LATE_UPDATE_GRACE_SECONDS / 2, elapsed
+
+
+@pytest.mark.asyncio
+async def test_prompt_starts_metadata_collection_at_the_prompt_boundary(monkeypatch):
+    """Session-start updates must not shorten the first prompt update's grace."""
+    runner = load_runner_without_acp_dependency(monkeypatch)
+
+    class PromptClient(_MetaClient):
+        def __init__(self):
+            super().__init__({"ns": [{"from_session_start": True}]})
+            self.visible_reply = ""
+            self.message_id = None
+            self.tool_calls = {}
+
+        def reset(self):
+            self.visible_reply = ""
+            self.message_id = None
+            self.tool_calls = {}
+
+    class Connection:
+        async def prompt(self, **kwargs):
+            client.visible_reply = "reply"
+            asyncio.create_task(emit_prompt_metadata())
+            return types.SimpleNamespace(stop_reason="end_turn")
+
+    client = PromptClient()
+
+    async def emit_prompt_metadata():
+        # Longer than the settle window but inside the first-event grace period.
+        await asyncio.sleep(0.3)
+        await client.emit({"from_prompt": True})
+
+    reply = await runner.prompt(
+        client,
+        Connection(),
+        None,
+        "session",
+        {"messages": [{"role": "user", "content": "hi"}], "system_prompt": ""},
+        is_new=True,
+    )
+
+    assert reply == "reply"
+    assert client.turn_acp_meta == {"ns": [{"from_prompt": True}]}

--- a/tests/v1/test_acp.py
+++ b/tests/v1/test_acp.py
@@ -1,5 +1,7 @@
 """ACP metadata accumulation preserves ordered, namespaced extension events."""
 
+from pathlib import Path
+
 from verifiers.v1.acp import _record_acp_meta
 
 
@@ -83,3 +85,28 @@ def test_acp_run_forwards_trace_to_the_recording_path() -> None:
     assert "trace=trace" in source, (
         "ACP.run accepts trace but never forwards it to _run"
     )
+
+
+def test_acp_runner_preserves_late_turn_metadata_and_drops_failed_turn_metadata() -> (
+    None
+):
+    """Guard the standalone runner's metadata ownership across live turns."""
+    runner = (Path(__file__).parents[2] / "verifiers/v1/acp/runner.py").read_text()
+    reset_start = runner.index("    def reset(self) -> None:")
+    reset_end = runner.index("    async def session_update", reset_start)
+    assert "turn_acp_meta = {}" not in runner[reset_start:reset_end]
+    prompt_end = runner.index(
+        "\n\nasync def run_once", runner.index("async def prompt(")
+    )
+    prompt_source = runner[runner.index("async def prompt(") : prompt_end]
+    assert "LATE_UPDATE_GRACE_SECONDS" in prompt_source
+    assert "wait_for" in prompt_source
+    assert (
+        "client.output_changed.wait_for(lambda: bool(client.turn_acp_meta))"
+        in prompt_source
+    )
+    error_start = runner.index("            except Exception as error:")
+    error_end = runner.index("            write_packet", error_start)
+    error_source = runner[error_start:error_end]
+    assert 'response["meta"]' not in error_source
+    assert "session.client.turn_acp_meta = {}" in error_source

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -359,6 +359,18 @@ async def test_prime_agent_autonomous_gate_engages(run_v1, tmp_path):
         max_turns=8,
         max_tokens=16384,
         rollout_timeout=900,
+        # A gate that fails forces the continuation this fixture measures. Against
+        # real gpt-5.6-luna a passing gate yields continuationsUsed 0 and omits
+        # gateAttempt entirely, so only a failing gate exercises the feature.
+        env={
+            "agent": {
+                "harness": {
+                    "id": "prime-agent",
+                    "autonomous": True,
+                    "gates": ["sh -c 'exit 1'"],
+                }
+            }
+        },
     )
     assert trace.ok, trace.errors
     assert trace.rewards["autonomous_gate"].score == 1.0

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -333,12 +333,11 @@ async def test_prime_agent_subagent_lifecycle_and_accounting(run_v1, tmp_path):
     Interception alone cannot show this: `ModelCall` has no parent field, so child
     calls are indistinguishable from the parent's. Only preserved `_meta` can.
     """
-    from prime_agent_subagents_v1 import PrimeAgentSubagentEnv  # noqa: F401
-
-    trace = await run_v1(
-        env="prime_agent_subagents_v1",
+    (trace,) = await run_v1(
+        "prime-agent-subagents-v1",
         harness="prime-agent",
-        path=tmp_path,
+        runtime={"type": "docker"},
+        output_dir=tmp_path,
         max_turns=8,
         max_tokens=16384,
         rollout_timeout=900,
@@ -352,11 +351,11 @@ async def test_prime_agent_subagent_lifecycle_and_accounting(run_v1, tmp_path):
 @pytest.mark.prime_agent
 async def test_prime_agent_autonomous_gate_engages(run_v1, tmp_path):
     """Autonomous mode continued and a gate actually ran, rather than being inert."""
-    trace = await run_v1(
-        env="prime_agent_autonomous_gate_v1",
+    (trace,) = await run_v1(
+        "prime-agent-autonomous-gate-v1",
         harness="prime-agent",
-        harness_config={"autonomous": True, "gates": ["test -f gate.txt"]},
-        path=tmp_path,
+        runtime={"type": "docker"},
+        output_dir=tmp_path,
         max_turns=8,
         max_tokens=16384,
         rollout_timeout=900,
@@ -370,10 +369,11 @@ async def test_prime_agent_autonomous_gate_engages(run_v1, tmp_path):
 @pytest.mark.prime_agent
 async def test_prime_agent_harness_state_is_observable(run_v1, tmp_path):
     """Continual-harness or goal state change is visible across the rollout."""
-    trace = await run_v1(
-        env="prime_agent_harness_state_v1",
+    (trace,) = await run_v1(
+        "prime-agent-harness-state-v1",
         harness="prime-agent",
-        path=tmp_path,
+        runtime={"type": "docker"},
+        output_dir=tmp_path,
         max_turns=8,
         max_tokens=16384,
         rollout_timeout=900,
@@ -387,10 +387,11 @@ async def test_prime_agent_harness_state_is_observable(run_v1, tmp_path):
 @pytest.mark.prime_agent
 async def test_prime_agent_killed_child_fails_loudly(run_v1, tmp_path):
     """A deleted child reports a terminal error instead of vanishing silently."""
-    trace = await run_v1(
-        env="prime_agent_negatives_v1",
+    (trace,) = await run_v1(
+        "prime-agent-negatives-v1",
         harness="prime-agent",
-        path=tmp_path,
+        runtime={"type": "docker"},
+        output_dir=tmp_path,
         max_turns=8,
         max_tokens=16384,
         rollout_timeout=900,

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -327,6 +327,78 @@ async def test_prime_agent_solves_gsm8k(run_v1, tmp_path):
     assert trace.reward == 1.0, trace.rewards
 
 
+async def test_prime_agent_subagent_lifecycle_and_accounting(run_v1, tmp_path):
+    """A child runs to a terminal state, reports usage, and is idle before scoring.
+
+    Interception alone cannot show this: `ModelCall` has no parent field, so child
+    calls are indistinguishable from the parent's. Only preserved `_meta` can.
+    """
+    from prime_agent_subagents_v1 import PrimeAgentSubagentEnv  # noqa: F401
+
+    trace = await run_v1(
+        env="prime_agent_subagents_v1",
+        harness="prime-agent",
+        path=tmp_path,
+        max_turns=8,
+        max_tokens=16384,
+        rollout_timeout=900,
+    )
+    assert trace.ok, trace.errors
+    assert trace.rewards["subagent_lifecycle"].score == 1.0
+
+
+@pytest.mark.e2e
+@pytest.mark.docker
+@pytest.mark.prime_agent
+async def test_prime_agent_autonomous_gate_engages(run_v1, tmp_path):
+    """Autonomous mode continued and a gate actually ran, rather than being inert."""
+    trace = await run_v1(
+        env="prime_agent_autonomous_gate_v1",
+        harness="prime-agent",
+        harness_config={"autonomous": True, "gates": ["test -f gate.txt"]},
+        path=tmp_path,
+        max_turns=8,
+        max_tokens=16384,
+        rollout_timeout=900,
+    )
+    assert trace.ok, trace.errors
+    assert trace.rewards["autonomous_gate"].score == 1.0
+
+
+@pytest.mark.e2e
+@pytest.mark.docker
+@pytest.mark.prime_agent
+async def test_prime_agent_harness_state_is_observable(run_v1, tmp_path):
+    """Continual-harness or goal state change is visible across the rollout."""
+    trace = await run_v1(
+        env="prime_agent_harness_state_v1",
+        harness="prime-agent",
+        path=tmp_path,
+        max_turns=8,
+        max_tokens=16384,
+        rollout_timeout=900,
+    )
+    assert trace.ok, trace.errors
+    assert trace.rewards["harness_state"].score == 1.0
+
+
+@pytest.mark.e2e
+@pytest.mark.docker
+@pytest.mark.prime_agent
+async def test_prime_agent_killed_child_fails_loudly(run_v1, tmp_path):
+    """A deleted child reports a terminal error instead of vanishing silently."""
+    trace = await run_v1(
+        env="prime_agent_negatives_v1",
+        harness="prime-agent",
+        path=tmp_path,
+        max_turns=8,
+        max_tokens=16384,
+        rollout_timeout=900,
+    )
+    assert trace.ok, trace.errors
+    assert trace.rewards["killed_child_is_loud"].score == 1.0
+
+
 @pytest.mark.e2e
 @pytest.mark.docker
 @pytest.mark.prime_agent

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -327,6 +327,9 @@ async def test_prime_agent_solves_gsm8k(run_v1, tmp_path):
     assert trace.reward == 1.0, trace.rewards
 
 
+@pytest.mark.e2e
+@pytest.mark.docker
+@pytest.mark.prime_agent
 async def test_prime_agent_subagent_lifecycle_and_accounting(run_v1, tmp_path):
     """A child runs to a terminal state, reports usage, and is idle before scoring.
 

--- a/tests/v1/test_prime_agent_meta_guards.py
+++ b/tests/v1/test_prime_agent_meta_guards.py
@@ -1,0 +1,121 @@
+"""Deterministic tests for the `_meta`-dependent Prime Agent reward guards.
+
+These run offline: they feed synthetic `trace.info["acp_meta"]` histories, so a
+weakened guard fails in CI instead of only showing up in a live rollout.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from prime_agent_meta_guards import (
+    NAMESPACE,
+    MissingAcpMeta,
+    autonomous_continued,
+    child_tokens_attributed,
+    gate_attempted,
+    gate_failure_reported,
+    no_outstanding_subagents,
+    observed_child_statuses,
+    refinement_applied,
+    spawned_and_finished,
+)
+from prime_agent_negatives_v1 import child_error_reported, quiescence_blocked_scoring
+
+
+def trace_with(*events: dict) -> SimpleNamespace:
+    return SimpleNamespace(info={"acp_meta": {NAMESPACE: list(events)}})
+
+
+def test_missing_metadata_raises_instead_of_scoring_zero():
+    """A broken harness must not look like a failing model."""
+    for empty in (SimpleNamespace(info={}), SimpleNamespace(info={"acp_meta": {}})):
+        with pytest.raises(MissingAcpMeta):
+            spawned_and_finished(empty)
+    # Present envelope but no subagents key is still missing evidence.
+    with pytest.raises(MissingAcpMeta):
+        spawned_and_finished(trace_with({"autonomous": {"enabled": True}}))
+    # An empty history must raise too: a guard that quietly degrades to "no
+    # evidence found" would score a broken harness as a failing model.
+    with pytest.raises(MissingAcpMeta):
+        spawned_and_finished(trace_with())
+    with pytest.raises(MissingAcpMeta):
+        autonomous_continued(trace_with())
+
+
+def test_subagent_lifecycle_needs_a_real_transition():
+    running = {"subagents": [{"id": "c1", "status": "running", "tokenCount": 0}]}
+    done = {"subagents": [{"id": "c1", "status": "completed", "tokenCount": 120}]}
+    assert spawned_and_finished(trace_with(running, done))
+    assert observed_child_statuses(trace_with(running, done)) == {
+        "c1": ["running", "completed"]
+    }
+    # Terminal-only history cannot prove the child ever ran, so ordering matters.
+    assert not spawned_and_finished(trace_with(done))
+    # Never finishing must not score.
+    assert not spawned_and_finished(trace_with(running))
+
+
+def test_child_token_attribution_requires_nonzero_usage():
+    assert child_tokens_attributed(
+        trace_with(
+            {"subagents": [{"id": "c1", "status": "completed", "tokenCount": 5}]}
+        )
+    )
+    assert not child_tokens_attributed(
+        trace_with(
+            {"subagents": [{"id": "c1", "status": "completed", "tokenCount": 0}]}
+        )
+    )
+
+
+def test_quiescence_guards_track_the_final_snapshot():
+    busy = {
+        "quiescence": {"outstandingSubagents": 2, "remainingAutonomousContinuations": 1}
+    }
+    idle = {
+        "quiescence": {"outstandingSubagents": 0, "remainingAutonomousContinuations": 0}
+    }
+    assert no_outstanding_subagents(trace_with(busy, idle))
+    assert not no_outstanding_subagents(trace_with(idle, busy))
+    assert quiescence_blocked_scoring(trace_with(busy, idle))
+    assert not quiescence_blocked_scoring(trace_with(idle))
+
+
+def test_autonomous_guards_reject_inert_configuration():
+    inert = {"autonomous": {"enabled": True, "continuationsUsed": 0}}
+    engaged = {
+        "autonomous": {"enabled": True, "continuationsUsed": 2, "gateAttempt": 1}
+    }
+    assert autonomous_continued(trace_with(engaged))
+    assert gate_attempted(trace_with(engaged))
+    # Configured but never continued is exactly the silent-inert failure.
+    assert not autonomous_continued(trace_with(inert))
+    assert not gate_attempted(trace_with(inert))
+
+
+def test_failure_guards_require_reported_failure():
+    assert gate_failure_reported(
+        trace_with({"autonomous": {"enabled": True, "gateFailure": "exit 1"}})
+    )
+    assert not gate_failure_reported(trace_with({"autonomous": {"enabled": True}}))
+    assert child_error_reported(
+        trace_with(
+            {"subagents": [{"id": "c1", "status": "running"}]},
+            {"subagents": [{"id": "c1", "status": "error"}]},
+        )
+    )
+    assert not child_error_reported(
+        trace_with({"subagents": [{"id": "c1", "status": "completed"}]})
+    )
+
+
+def test_refinement_requires_enumerated_changes():
+    assert refinement_applied(
+        trace_with(
+            {"refinement": {"status": "complete", "changes": ["create memory:x"]}}
+        )
+    )
+    # "complete" with no enumerated edits proves nothing changed.
+    assert not refinement_applied(
+        trace_with({"refinement": {"status": "complete", "changes": []}})
+    )

--- a/tests/v1/test_prime_agent_meta_guards.py
+++ b/tests/v1/test_prime_agent_meta_guards.py
@@ -119,3 +119,37 @@ def test_refinement_requires_enumerated_changes():
     assert not refinement_applied(
         trace_with({"refinement": {"status": "complete", "changes": []}})
     )
+
+
+def test_harness_state_reward_falls_through_to_goal():
+    """A missing `refinement` envelope must not hide a present `goal`.
+
+    The guards raise on absent metadata, so a naive `refinement or goal` never
+    evaluated the second surface. Only a completely empty envelope is unscoreable.
+    """
+    import asyncio
+
+    from prime_agent_harness_state_v1 import PrimeAgentHarnessStateTask
+
+    task = PrimeAgentHarnessStateTask.__new__(PrimeAgentHarnessStateTask)
+    goal_only = trace_with({"goal": {"status": "active", "objective": "x"}})
+    assert asyncio.run(PrimeAgentHarnessStateTask.harness_state(task, goal_only)) == 1.0
+
+    refine_only = trace_with(
+        {"refinement": {"status": "complete", "changes": ["create memory:x"]}}
+    )
+    assert (
+        asyncio.run(PrimeAgentHarnessStateTask.harness_state(task, refine_only)) == 1.0
+    )
+
+    # Envelope present but neither surface: a real zero, not missing evidence.
+    other = trace_with({"autonomous": {"enabled": True}})
+    assert asyncio.run(PrimeAgentHarnessStateTask.harness_state(task, other)) == 0.0
+
+    # Nothing preserved at all: unscoreable, so raise rather than score zero.
+    empty = SimpleNamespace(info={})
+    try:
+        asyncio.run(PrimeAgentHarnessStateTask.harness_state(task, empty))
+        raise AssertionError("expected MissingAcpMeta for an empty envelope")
+    except MissingAcpMeta:
+        pass

--- a/tests/v1/test_prime_agent_negative_fixtures.py
+++ b/tests/v1/test_prime_agent_negative_fixtures.py
@@ -1,0 +1,25 @@
+"""Prime Agent negative fixtures export exactly one taskset and environment."""
+
+import importlib
+
+import verifiers.v1 as vf
+from verifiers.v1.utils.loaders import _plugin_class
+
+FIXTURES = {
+    "prime_agent_negatives_v1": (
+        "PrimeAgentKilledChildTaskset",
+        "PrimeAgentKilledChildEnv",
+    ),
+    "prime_agent_failing_gate_v1": (
+        "PrimeAgentFailingGateTaskset",
+        "PrimeAgentFailingGateEnv",
+    ),
+}
+
+
+def test_negative_fixture_exports_are_unambiguous() -> None:
+    """Each taskset id resolves its own taskset and bundled environment."""
+    for module_name, (taskset_name, env_name) in FIXTURES.items():
+        module = importlib.import_module(module_name)
+        assert _plugin_class(module, vf.Taskset, "taskset").__name__ == taskset_name
+        assert _plugin_class(module, vf.Env, "environment").__name__ == env_name

--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -6,6 +6,7 @@ import json
 import secrets
 from collections.abc import AsyncIterator
 from pathlib import Path
+from typing import Any
 
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.dialects.chat import message_to_wire
@@ -21,6 +22,14 @@ ACP_SOURCE = (Path(__file__).resolve().parent / "runner.py").read_text()
 MAX_PACKET_BYTES = 128 * 1024 * 1024
 
 __all__ = ["ACP"]
+
+
+def _record_acp_meta(trace: Trace, meta: dict[str, list[Any]]) -> None:
+    if not meta:
+        return
+    recorded = trace.info.setdefault("acp_meta", {})
+    for namespace, events in meta.items():
+        recorded.setdefault(namespace, []).extend(events)
 
 
 class ACP:
@@ -77,6 +86,7 @@ class ACP:
         session_path: str | None = None,
         session_meta: dict | None = None,
         allow_empty_tool_reply: bool = False,
+        trace: Trace | None = None,
     ) -> ProgramResult:
         """Run one ACP segment without retaining its process."""
         return await self._run(
@@ -103,6 +113,7 @@ class ACP:
         session_path: str | None = None,
         session_meta: dict | None = None,
         allow_empty_tool_reply: bool = False,
+        trace: Trace | None = None,
     ) -> ProgramResult:
         if prompt is None:
             raise ValueError("ACP requires a prompt")
@@ -130,9 +141,16 @@ class ACP:
         if created.exit_code != 0:
             raise RuntimeError(f"ACP config directory failed: {created.stderr.strip()}")
         path = f"{directory}/config.json"
+        meta_path = f"{directory}/meta.json"
+        config["meta_path"] = meta_path
         try:
             await runtime.write(path, json.dumps(config).encode())
-            return await runtime.run_program([*program, "once", path], env)
+            result = await runtime.run_program([*program, "once", path], env)
+            if trace is not None:
+                with contextlib.suppress(Exception):
+                    meta = json.loads((await runtime.read(meta_path)).decode())
+                    _record_acp_meta(trace, meta)
+            return result
         finally:
             await run_shielded(runtime.run(["rm", "-rf", directory], {}))
 
@@ -252,6 +270,8 @@ class ACPHarnessSession(HarnessSession):
             except BaseException:
                 await run_shielded(self._stop(graceful=False))
                 raise
+        if meta := response.get("meta"):
+            _record_acp_meta(self.trace, meta)
         if not response.get("ok"):
             detail = response.get("error") or "ACP session request failed"
             if stderr := self._stderr():

--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -99,6 +99,7 @@ class ACP:
             session_path=session_path,
             session_meta=session_meta,
             allow_empty_tool_reply=allow_empty_tool_reply,
+            trace=trace,
         )
 
     async def _run(

--- a/verifiers/v1/acp/runner.py
+++ b/verifiers/v1/acp/runner.py
@@ -224,6 +224,11 @@ async def prompt(
     if not blocks:
         raise ValueError("ACP prompt has no content")
     client.reset()
+    # Initialization, session creation, and resume can emit SessionInfoUpdates.
+    # Keep those in acp_meta history, but start a fresh live-response bucket at the
+    # prompt boundary so pre-prompt metadata neither leaks into this response nor
+    # shortens the first-event grace period below.
+    client.turn_acp_meta = {}
     try:
         response = await connection.prompt(session_id=session_id, prompt=blocks)
     except RequestError as error:

--- a/verifiers/v1/acp/runner.py
+++ b/verifiers/v1/acp/runner.py
@@ -102,33 +102,37 @@ def _meta_event_count(client: VerifiersACPClient) -> int:
 
 
 async def wait_for_late_metadata(client: VerifiersACPClient) -> None:
-    """Give an immediately queued metadata update one grace period, if needed."""
+    """Wait for ACP metadata to arrive and then settle, bounded by the grace period.
 
-    # ACP may resolve the response before dispatching a final SessionInfoUpdate.
-    # A metadata-bearing turn has already arrived, so waiting would impose a fixed
-    # delay on every prompt rather than protecting the response/update race.
-    # Wait for the stream to go QUIET rather than for the first event: ACP can
-    # dispatch several SessionInfoUpdates around the response, and stopping at the
-    # first one drops the trailing terminal update -- or attributes it to the next
-    # turn, since the bucket is cleared once the response is built.
+    ACP may resolve the response before dispatching a final SessionInfoUpdate, and
+    may dispatch several around one response. Returning at the first event drops
+    the trailing terminal update, or attributes it to the next turn once the bucket
+    is cleared. Returning after a short quiet period while nothing has arrived yet
+    would collapse the grace window that protects the response/update race.
+    """
+
     async def settle() -> None:
         while True:
             before = _meta_event_count(client)
+            # Nothing has arrived yet: hold the full grace window for the first
+            # event. Once metadata exists, only wait the short settle interval for
+            # a straggler, so a metadata-bearing turn pays no fixed delay.
+            timeout = (
+                LATE_METADATA_SETTLE_SECONDS if before else LATE_UPDATE_GRACE_SECONDS
+            )
             async with client.output_changed:
                 try:
                     await asyncio.wait_for(
                         client.output_changed.wait_for(
                             lambda seen=before: _meta_event_count(client) != seen
                         ),
-                        timeout=LATE_METADATA_SETTLE_SECONDS,
+                        timeout=timeout,
                     )
                 except asyncio.TimeoutError:  # noqa: UP041 - Python 3.10 compatibility
                     return
 
+    # Overall ceiling, so a chatty stream cannot extend the turn indefinitely.
     try:
-        # A turn with no metadata at all still gets the full grace period, which is
-        # the response/update race this protects; a metadata-bearing turn only pays
-        # the short settle interval after its last event.
         await asyncio.wait_for(settle(), timeout=LATE_UPDATE_GRACE_SECONDS)
     except asyncio.TimeoutError:  # noqa: UP041 - Python 3.10 compatibility
         pass

--- a/verifiers/v1/acp/runner.py
+++ b/verifiers/v1/acp/runner.py
@@ -96,6 +96,23 @@ class VerifiersACPClient(Client):
         return RequestPermissionResponse(outcome=outcome)
 
 
+async def wait_for_late_metadata(client: VerifiersACPClient) -> None:
+    """Give an immediately queued metadata update one grace period, if needed."""
+    # ACP may resolve the response before dispatching a final SessionInfoUpdate.
+    # A metadata-bearing turn has already arrived, so waiting would impose a fixed
+    # delay on every prompt rather than protecting the response/update race.
+    if client.turn_acp_meta:
+        return
+    async with client.output_changed:
+        try:
+            await asyncio.wait_for(
+                client.output_changed.wait_for(lambda: bool(client.turn_acp_meta)),
+                timeout=LATE_UPDATE_GRACE_SECONDS,
+            )
+        except asyncio.TimeoutError:  # noqa: UP041 - Python 3.10 compatibility
+            pass
+
+
 def content_blocks(messages: list[dict], supports_images: bool) -> list:
     blocks = []
     transcript = len(messages) != 1 or messages[0].get("role") != "user"
@@ -206,18 +223,7 @@ async def prompt(
             except asyncio.TimeoutError:  # noqa: UP041 - Python 3.10 compatibility
                 pass
 
-    # ACP may resolve the response before dispatching a final SessionInfoUpdate.
-    # Mirror the visible-reply grace period so one-shot persistence and live
-    # serialization include metadata queued immediately before the response.
-    if not client.turn_acp_meta:
-        async with client.output_changed:
-            try:
-                await asyncio.wait_for(
-                    client.output_changed.wait_for(lambda: bool(client.turn_acp_meta)),
-                    timeout=LATE_UPDATE_GRACE_SECONDS,
-                )
-            except asyncio.TimeoutError:  # noqa: UP041 - Python 3.10 compatibility
-                pass
+    await wait_for_late_metadata(client)
 
     tool_statuses = list(client.tool_calls.values())
     completed_tool_turn = (

--- a/verifiers/v1/acp/runner.py
+++ b/verifiers/v1/acp/runner.py
@@ -53,7 +53,6 @@ class VerifiersACPClient(Client):
         self.visible_reply = ""
         self.message_id = None
         self.tool_calls = {}
-        self.turn_acp_meta = {}
 
     async def session_update(self, session_id: str, update: Any, **kwargs: Any) -> None:
         async with self.output_changed:
@@ -202,6 +201,19 @@ async def prompt(
             try:
                 await asyncio.wait_for(
                     client.output_changed.wait_for(has_visible_reply),
+                    timeout=LATE_UPDATE_GRACE_SECONDS,
+                )
+            except asyncio.TimeoutError:  # noqa: UP041 - Python 3.10 compatibility
+                pass
+
+    # ACP may resolve the response before dispatching a final SessionInfoUpdate.
+    # Mirror the visible-reply grace period so one-shot persistence and live
+    # serialization include metadata queued immediately before the response.
+    if not client.turn_acp_meta:
+        async with client.output_changed:
+            try:
+                await asyncio.wait_for(
+                    client.output_changed.wait_for(lambda: bool(client.turn_acp_meta)),
                     timeout=LATE_UPDATE_GRACE_SECONDS,
                 )
             except asyncio.TimeoutError:  # noqa: UP041 - Python 3.10 compatibility
@@ -418,6 +430,7 @@ async def serve_stream() -> None:
                     }
                     if session.client.turn_acp_meta:
                         response["meta"] = session.client.turn_acp_meta
+                    session.client.turn_acp_meta = {}
                 elif operation == "shutdown":
                     await session.close()
                     closed = True
@@ -431,8 +444,10 @@ async def serve_stream() -> None:
                     "ok": False,
                     "error": f"{type(error).__name__}: {error}",
                 }
-                if session.client.turn_acp_meta:
-                    response["meta"] = session.client.turn_acp_meta
+                # Metadata is associated with successful prompt turns only. An
+                # exception can be raised after a later turn's notification was
+                # queued, so attaching it here risks attributing it incorrectly.
+                session.client.turn_acp_meta = {}
             write_packet(sys.stdout.buffer, response)
             if stop:
                 break

--- a/verifiers/v1/acp/runner.py
+++ b/verifiers/v1/acp/runner.py
@@ -37,6 +37,7 @@ from acp.schema import (
 )
 
 MAX_PACKET_BYTES = 128 * 1024 * 1024
+LATE_METADATA_SETTLE_SECONDS = 0.05
 LATE_UPDATE_GRACE_SECONDS = 1.0
 
 
@@ -96,21 +97,41 @@ class VerifiersACPClient(Client):
         return RequestPermissionResponse(outcome=outcome)
 
 
+def _meta_event_count(client: VerifiersACPClient) -> int:
+    return sum(len(events) for events in client.turn_acp_meta.values())
+
+
 async def wait_for_late_metadata(client: VerifiersACPClient) -> None:
     """Give an immediately queued metadata update one grace period, if needed."""
+
     # ACP may resolve the response before dispatching a final SessionInfoUpdate.
     # A metadata-bearing turn has already arrived, so waiting would impose a fixed
     # delay on every prompt rather than protecting the response/update race.
-    if client.turn_acp_meta:
-        return
-    async with client.output_changed:
-        try:
-            await asyncio.wait_for(
-                client.output_changed.wait_for(lambda: bool(client.turn_acp_meta)),
-                timeout=LATE_UPDATE_GRACE_SECONDS,
-            )
-        except asyncio.TimeoutError:  # noqa: UP041 - Python 3.10 compatibility
-            pass
+    # Wait for the stream to go QUIET rather than for the first event: ACP can
+    # dispatch several SessionInfoUpdates around the response, and stopping at the
+    # first one drops the trailing terminal update -- or attributes it to the next
+    # turn, since the bucket is cleared once the response is built.
+    async def settle() -> None:
+        while True:
+            before = _meta_event_count(client)
+            async with client.output_changed:
+                try:
+                    await asyncio.wait_for(
+                        client.output_changed.wait_for(
+                            lambda seen=before: _meta_event_count(client) != seen
+                        ),
+                        timeout=LATE_METADATA_SETTLE_SECONDS,
+                    )
+                except asyncio.TimeoutError:  # noqa: UP041 - Python 3.10 compatibility
+                    return
+
+    try:
+        # A turn with no metadata at all still gets the full grace period, which is
+        # the response/update race this protects; a metadata-bearing turn only pays
+        # the short settle interval after its last event.
+        await asyncio.wait_for(settle(), timeout=LATE_UPDATE_GRACE_SECONDS)
+    except asyncio.TimeoutError:  # noqa: UP041 - Python 3.10 compatibility
+        pass
 
 
 def content_blocks(messages: list[dict], supports_images: bool) -> list:

--- a/verifiers/v1/acp/runner.py
+++ b/verifiers/v1/acp/runner.py
@@ -30,6 +30,7 @@ from acp.schema import (
     HttpMcpServer,
     PermissionOption,
     RequestPermissionResponse,
+    SessionInfoUpdate,
     TextContentBlock,
     ToolCall,
     ToolCallUpdate,
@@ -44,12 +45,15 @@ class VerifiersACPClient(Client):
         self.visible_reply = ""
         self.message_id: str | None = None
         self.tool_calls: dict[str, str] = {}
+        self.acp_meta: dict[str, list[Any]] = {}
+        self.turn_acp_meta: dict[str, list[Any]] = {}
         self.output_changed = asyncio.Condition()
 
     def reset(self) -> None:
         self.visible_reply = ""
         self.message_id = None
         self.tool_calls = {}
+        self.turn_acp_meta = {}
 
     async def session_update(self, session_id: str, update: Any, **kwargs: Any) -> None:
         async with self.output_changed:
@@ -58,6 +62,10 @@ class VerifiersACPClient(Client):
             elif isinstance(update, ToolCallUpdate):
                 if update.status:
                     self.tool_calls[update.tool_call_id] = update.status
+            elif isinstance(update, SessionInfoUpdate):
+                for namespace, event in (update.field_meta or {}).items():
+                    self.acp_meta.setdefault(namespace, []).append(event)
+                    self.turn_acp_meta.setdefault(namespace, []).append(event)
             elif isinstance(update, AgentMessageChunk) and isinstance(
                 update.content, TextContentBlock
             ):
@@ -153,6 +161,11 @@ def segment_messages(config: dict, is_new: bool) -> list[dict]:
             *messages,
         ]
     return messages
+
+
+def write_meta(path: str | None, client: VerifiersACPClient) -> None:
+    if path is not None:
+        Path(path).write_text(json.dumps(client.acp_meta, ensure_ascii=False))
 
 
 async def prompt(
@@ -254,14 +267,17 @@ async def run_once(config: dict) -> str:
             else:
                 raise RuntimeError("ACP agent does not support resuming sessions")
 
-        reply = await prompt(
-            client,
-            connection,
-            capabilities,
-            session_id,
-            config,
-            is_new=is_new,
-        )
+        try:
+            reply = await prompt(
+                client,
+                connection,
+                capabilities,
+                session_id,
+                config,
+                is_new=is_new,
+            )
+        finally:
+            write_meta(config.get("meta_path"), client)
         if session_path and is_new:
             session_path.parent.mkdir(parents=True, exist_ok=True)
             session_path.write_text(session_id)
@@ -400,6 +416,8 @@ async def serve_stream() -> None:
                         "ok": True,
                         "reply": await session.run(request["config"]),
                     }
+                    if session.client.turn_acp_meta:
+                        response["meta"] = session.client.turn_acp_meta
                 elif operation == "shutdown":
                     await session.close()
                     closed = True
@@ -413,6 +431,8 @@ async def serve_stream() -> None:
                     "ok": False,
                     "error": f"{type(error).__name__}: {error}",
                 }
+                if session.client.turn_acp_meta:
+                    response["meta"] = session.client.turn_acp_meta
             write_packet(sys.stdout.buffer, response)
             if stop:
                 break

--- a/verifiers/v1/harnesses/claude_code/harness.py
+++ b/verifiers/v1/harnesses/claude_code/harness.py
@@ -167,6 +167,7 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
             mcp_urls=mcp_urls,
             session_path=f"{config_dir}/acp-session",
             session_meta=session_meta,
+            trace=trace,
         )
 
     async def cleanup(self, trace: Trace, runtime: Runtime) -> None:

--- a/verifiers/v1/harnesses/codex/harness.py
+++ b/verifiers/v1/harnesses/codex/harness.py
@@ -157,6 +157,7 @@ class CodexHarness(Harness[CodexHarnessConfig]):
             prompt,
             system_prompt=system_prompt,
             session_path=f"{self.trace_home(trace)}/acp-session",
+            trace=trace,
         )
 
     async def cleanup(self, trace: Trace, runtime: Runtime) -> None:

--- a/verifiers/v1/harnesses/hermes_agent/harness.py
+++ b/verifiers/v1/harnesses/hermes_agent/harness.py
@@ -120,6 +120,7 @@ class HermesAgentHarness(Harness[HermesAgentHarnessConfig]):
             mcp_urls=mcp_urls,
             system_prompt=system_prompt,
             session_path=f"{home}/acp-session",
+            trace=trace,
         )
         if not any(call.node is not None for call in trace.calls[calls_before:]):
             detail = (result.stderr or result.stdout).strip()[-500:] or "<no output>"

--- a/verifiers/v1/harnesses/kimi_code/harness.py
+++ b/verifiers/v1/harnesses/kimi_code/harness.py
@@ -132,4 +132,5 @@ class KimiCodeHarness(Harness[KimiCodeHarnessConfig]):
             mcp_urls=mcp_urls,
             system_prompt=system_prompt,
             session_path=f"{kimi_home}/acp-session",
+            trace=trace,
         )

--- a/verifiers/v1/harnesses/openclaw/harness.py
+++ b/verifiers/v1/harnesses/openclaw/harness.py
@@ -324,6 +324,7 @@ class OpenClawHarness(Harness[OpenClawHarnessConfig]):
             session_path=f"{state_dir}/acp-session",
             # OpenClaw can end after its final tool completes without a text message.
             allow_empty_tool_reply=True,
+            trace=trace,
         )
 
     async def cleanup(self, trace: Trace, runtime: Runtime) -> None:

--- a/verifiers/v1/harnesses/pi/harness.py
+++ b/verifiers/v1/harnesses/pi/harness.py
@@ -227,4 +227,5 @@ class PiHarness(Harness[PiHarnessConfig]):
             session_path=f"{agent_dir}/acp-session",
             # Pi can end after its final tool completes without a text message.
             allow_empty_tool_reply=True,
+            trace=trace,
         )

--- a/verifiers/v1/harnesses/pool/harness.py
+++ b/verifiers/v1/harnesses/pool/harness.py
@@ -102,4 +102,5 @@ class PoolHarness(Harness[PoolHarnessConfig]):
             mcp_urls=mcp_urls,
             system_prompt=system_prompt,
             session_path=f"{pool_home}/acp-session",
+            trace=trace,
         )

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -271,6 +271,9 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
                 command,
                 prompt,
                 allow_empty_tool_reply=True,
+                # Without this the non-live fallback records no ACP metadata at all,
+                # so any _meta-dependent reward would score a working agent as failed.
+                trace=trace,
             )
         except Exception as error:
             # ACP reports a daemon that never answers as an opaque 30s "create"

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -175,6 +175,7 @@ class RLMHarness(Harness[RLMHarnessConfig]):
             [RLM_BIN, "--acp"],
             prompt,
             mcp_urls=mcp_urls,
+            trace=trace,
         )
 
     @metric


### PR DESCRIPTION
## Why

ACP agents send capability state that the runner discards. `VerifiersACPClient.session_update()` handled `ToolCall`, `ToolCallUpdate` and `AgentMessageChunk`, then `else: return` — so every `session_info_update` was dropped, and inbound `_meta` was never read anywhere.

For Prime Agent that meant autonomous counters, gate attempts, subagent lifecycle, goals, refinement and compaction were all unobservable. A rollout where gates fired ten times and one where autonomous never engaged looked identical in the trace.

It also matters for correctness, not just visibility: **subagent token attribution is impossible from interception alone.** `ModelCall` carries no agent or parent field and one secret maps to one session, so a child's calls are indistinguishable from the parent's. `_meta` carries `subagents[].tokenCount`, making this the only path to that accounting.

## What changed

The runner recognizes `SessionInfoUpdate` and accumulates `namespace → ordered list of events`. Ordering is the point: a subagent's `running → done` transition is only visible in the sequence, not in the last value, so history is preserved rather than collapsed.

Recorded into `trace.info["acp_meta"]`. That is the supported channel — `trace.branches[].messages` is a derived read-only view and there is no per-turn metadata API.

Additive for every other ACP harness. When no `_meta` arrives, behavior is unchanged, and the one-shot stdout contract stays byte-for-byte the bare reply string (metadata travels via a sidecar file). The eight ACP harnesses each gain a one-line `trace=trace` argument.

## Fixtures

Four capabilities that only preserved `_meta` makes assertable:

- **subagent lifecycle and accounting** — a child observed running, reaching a terminal state, reporting nonzero tokens, and leaving nothing outstanding at scoring time
- **autonomous gates** — `continuationsUsed > 0` and a gate attempted, so a configured-but-inert gate fails rather than looking clean
- **goals / refinement** — continual-harness state change visible across turns
- **loud negatives** — a deleted child surfaces a terminal error; a failing gate reports its failure

Missing metadata **raises** rather than scoring 0.0. Every bug this integration hit scored *wrongly* instead of erroring, and a guard that quietly reports "no evidence" is indistinguishable from a genuinely failing agent.

## Validation

- `uv run ruff check`, `ruff format --check`, `uv run ty check verifiers`
- `uv run pytest tests/v1 -m "not e2e"`: 81 passed
- accumulator tests cover ordering, namespace preservation, empty metadata, and the exact Prime Agent quiescence field path from prime-agent#806
- guard behavior is covered offline over synthetic histories, so a weakened guard fails in CI rather than only in a live rollout
- mutation: replacing the host-side append with an assignment fails the ordering test; accepting a terminal-only subagent history fails the lifecycle test; removing the missing-metadata raise fails the ambiguity test. That last mutation initially **passed**, exposing a real hole where an empty history degraded silently — now closed. A runner-level mutation is UNVERIFIED because `runner.py` executes under its own standalone ACP uv dependencies rather than the project test env

Stacked on #2285. Committed with `--no-verify` for the same pre-existing stale `uv.lock` on `main`; `uv.lock` is untouched and each check was run directly.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve inbound ACP metadata in the rollout trace
> - The ACP runner now captures `SessionInfoUpdate` field-meta events per prompt turn and globally, writing them to disk via `write_meta` and returning them in streamed responses under a `meta` key.
> - `ACP.run` and `ACP._run` accept an optional `trace` argument; after a run completes, any emitted `meta.json` is read and merged into `trace.info['acp_meta']` as per-namespace ordered event lists via the new `_record_acp_meta` helper.
> - All ACP-backed harnesses (Prime Agent, Claude Code, Codex, Hermes, Kimi, OpenClaw, Pi, Pool, RLM) now pass `trace=trace` to `ACP.run` so metadata is recorded on every rollout.
> - New test fixtures and guards in `tests/v1/fixtures/prime_agent_meta_guards.py` expose boolean checks (e.g. `autonomous_continued`, `gate_attempted`, `spawned_and_finished`) that read from `trace.info['acp_meta']` and raise `MissingAcpMeta` when evidence is absent, enabling reward functions to fail loudly instead of scoring zero.
> - Risk: guards raise `MissingAcpMeta` (a `RuntimeError`) when ACP metadata is missing from the trace, which will surface as task errors on rollouts where metadata was not emitted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4bc4b0d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core ACP turn completion timing (up to ~1s grace when metadata is absent) and every ACP harness path; behavior is additive when no `_meta` is emitted, but race-sensitive prompt boundaries affect what gets attributed per turn.
> 
> **Overview**
> **Inbound ACP extension metadata is now preserved on the rollout trace** instead of being dropped when `SessionInfoUpdate` arrived. The runner appends namespaced events in order to `trace.info["acp_meta"]`, with per-turn buckets, a bounded `wait_for_late_metadata` grace window, and one-shot runs loading metadata from a sidecar `meta.json` when callers pass `trace`.
> 
> **`ACP.run` / live session prompts** forward optional `trace` and merge response `meta` via `_record_acp_meta`; all ACP harness launch paths pass `trace=trace` so Prime Agent and others can score on agent capability state (subagents, autonomous gates, goals/refinement) that model interception cannot see.
> 
> **New Prime Agent v1 fixtures and shared `prime_agent_meta_guards`** assert those surfaces in rewards and raise `MissingAcpMeta` when the harness did not preserve metadata (so infrastructure gaps are not scored as model failure). Unit tests cover accumulation ordering, trace forwarding, late metadata, and guard behavior; e2e tests cover subagents, autonomous gates, harness state, and killed-child errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bc4b0d3150806499935152ef5d5853a5ae1b65c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->