### PR TITLE
Fix concurrent sdist build deduplication

### DIFF
--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -44,6 +44,7 @@ _SDIST_BUILD_TIMEOUT_SECONDS = 300
 @dataclass
 class _SdistBuildState:
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    build: asyncio.Task[tuple[str, bytes]] | None = None
     users: int = 0
 
 
@@ -143,7 +144,9 @@ async def _cached_sdist(src: Path) -> tuple[str, bytes]:
         async with state.lock:
             # Coordinate before entering the default executor so concurrent
             # same-source waiters do not occupy executor threads.
-            build = asyncio.create_task(asyncio.to_thread(_build_sdist, src))
+            if state.build is None:
+                state.build = asyncio.create_task(asyncio.to_thread(_build_sdist, src))
+            build = state.build
             try:
                 return await asyncio.shield(build)
             except asyncio.CancelledError:


### PR DESCRIPTION
## Overview

Ensure concurrent sandbox installs share one source-distribution build per source and event loop.

## Details

- Retain the in-flight build task in the existing per-source coordination state.
- Reuse that task for all waiters while preserving cancellation handling and state cleanup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small concurrency fix in MCP launch caching; behavior is strictly deduplication with existing shield/cancel semantics preserved.
> 
> **Overview**
> Concurrent sandbox installs that hit `_cached_sdist` for the same source on one event loop could each spawn a separate `uv build` after taking the coordination lock, instead of waiting on a single in-flight build.
> 
> **`_SdistBuildState`** now keeps an optional `build` task. The first waiter under the lock creates `asyncio.to_thread(_build_sdist, …)` once; later waiters reuse that same task and `await asyncio.shield(build)` on it. Cancellation behavior is unchanged (still drain the task before releasing the lock).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8dce550e2e4977be49f987ea8c199903c964715. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix concurrent sdist build deduplication in `_cached_sdist`
> Previously, concurrent callers to `_cached_sdist` in [launch.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2288/files#diff-989d87123d40d48511f9e1df74594d2e30776e9a99c11eca49d9cc20bf9e2230) could each start a separate `to_thread` build task for the same source. The fix stores the build task on `_SdistBuildState` so subsequent callers reuse the single in-progress or completed task rather than spawning redundant builds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e8dce55.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->