### PR TITLE
Restore NeMo Gym MCP tool names

### DIFF
--- a/verifiers/v1/tasksets/nemo_gym/response.py
+++ b/verifiers/v1/tasksets/nemo_gym/response.py
@@ -1,6 +1,7 @@
 """Convert Verifiers traces to NeMo Gym Responses objects."""
 
 import json
+from collections.abc import Collection
 from typing import Any
 
 from verifiers.v1.trace import Trace
@@ -10,6 +11,7 @@ from verifiers.v1.types import AssistantMessage, ToolMessage
 def trace_to_nemo_response(
     trace: Trace,
     responses_create_params: dict[str, Any],
+    tool_names: Collection[str],
 ) -> dict[str, Any]:
     """Convert the one completed V1 branch into a Gym Responses object."""
 
@@ -81,6 +83,17 @@ def trace_to_nemo_response(
                     "output": content,
                 }
             )
+
+    known_names = sorted(tool_names, key=len, reverse=True)
+    for index, item in enumerate(output):
+        name = item.get("name")
+        if item.get("type") != "function_call" or not isinstance(name, str):
+            continue
+        if name.startswith("mcp__"):
+            for tool_name in known_names:
+                if name.endswith(f"__{tool_name}"):
+                    output[index] = item | {"name": tool_name}
+                    break
 
     return {
         "id": f"resp_{trace.id}",

--- a/verifiers/v1/tasksets/nemo_gym/response.py
+++ b/verifiers/v1/tasksets/nemo_gym/response.py
@@ -89,6 +89,8 @@ def trace_to_nemo_response(
         name = item.get("name")
         if item.get("type") != "function_call" or not isinstance(name, str):
             continue
+        if name in tool_names:
+            continue
         if name.startswith("mcp__"):
             for tool_name in known_names:
                 if name.endswith(f"__{tool_name}"):

--- a/verifiers/v1/tasksets/nemo_gym/taskset.py
+++ b/verifiers/v1/tasksets/nemo_gym/taskset.py
@@ -60,6 +60,7 @@ class NeMoGymTask(Task[NeMoGymData, NeMoGymState, NeMoGymTaskConfig]):
         state.direct_tools = {
             tool["name"]: tool for tool in tools if tool.get("type") == "function"
         }
+        state.tool_names = list(state.direct_tools)
 
         response = await state.post("seed_session", self.data.row)
         response.raise_for_status()
@@ -74,7 +75,8 @@ class NeMoGymTask(Task[NeMoGymData, NeMoGymState, NeMoGymTaskConfig]):
         params = self.data.row["responses_create_params"]
         response = await state.post(
             "verify",
-            self.data.row | {"response": trace_to_nemo_response(trace, params)},
+            self.data.row
+            | {"response": trace_to_nemo_response(trace, params, state.tool_names)},
         )
         response.raise_for_status()
         result = response.json()

--- a/verifiers/v1/tasksets/nemo_gym/toolset.py
+++ b/verifiers/v1/tasksets/nemo_gym/toolset.py
@@ -28,6 +28,7 @@ class NeMoGymState(State):
     mcp_url: str | None = None
     mcp_headers: dict[str, str] = Field(default_factory=dict)
     direct_tools: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    tool_names: list[str] = Field(default_factory=list)
 
     async def post(self, path: str, body: dict[str, Any]) -> httpx.Response:
         """POST to Gym while carrying this rollout's cookie session forward."""
@@ -74,15 +75,18 @@ class NeMoGymToolset(Toolset[SharedToolsetConfig, NeMoGymState]):
     async def list_tools(self) -> list[Tool]:
         if self.state.mcp_url is not None:
             async with self.state.mcp_session() as session:
-                return (await session.list_tools()).tools
-        return [
-            Tool(
-                name=spec["name"],
-                description=spec.get("description") or None,
-                inputSchema=spec.get("parameters") or {},
-            )
-            for spec in self.state.direct_tools.values()
-        ]
+                tools = (await session.list_tools()).tools
+        else:
+            tools = [
+                Tool(
+                    name=spec["name"],
+                    description=spec.get("description") or None,
+                    inputSchema=spec.get("parameters") or {},
+                )
+                for spec in self.state.direct_tools.values()
+            ]
+        self.state.tool_names = [tool.name for tool in tools]
+        return tools
 
     async def call_tool(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
         if self.state.mcp_url is not None:


### PR DESCRIPTION
## Overview

Preserve the raw NeMo Gym tool names advertised to harnesses and restore them before sending completed traces to the resource server.

## Details

- Record exact direct and MCP-discovered names in rollout state.
- Restore Codex-qualified function-call names in synthesized and provider-native response items.
- Match known names by longest suffix so names containing double underscores remain unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the verify payload shape for NeMo Gym scoring; incorrect normalization could skew rewards, but scope is limited to the NeMo Gym taskset integration.
> 
> **Overview**
> NeMo Gym verification was receiving **function_call** names in harness-qualified form (e.g. `mcp__…__{tool}`) while the resource server expects the **canonical tool names** advertised at rollout time.
> 
> Rollout state now tracks **`tool_names`** from direct function tools at seed and refreshes them whenever tools are listed (MCP or direct). **`trace_to_nemo_response`** takes that set and rewrites non-matching `function_call` entries whose names start with `mcp__` back to a known name via **longest-suffix** matching (`__{tool_name}`), including items copied from provider-native output.
> 
> **Breaking:** `trace_to_nemo_response` now requires a `tool_names` argument; the NeMo Gym reward hook passes `state.tool_names`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 849e0ad236cfe3a194fae4aea6f8bb7a99ec2d23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore original tool names from MCP-prefixed function call names in NeMo Gym responses
> - Adds a `tool_names` parameter to `trace_to_nemo_response` in [response.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2289/files#diff-3596621a20116154128ec5ebaa2355b0ef68430a54b538400f5945a725a5db6b); when a function call name matches the pattern `mcp__...__<tool_name>` and `<tool_name>` is a known tool, the name is replaced with the canonical tool name.
> - Tracks available tool names in `NeMoGymState` (new `tool_names` field) and populates it in both `NeMoGymToolset.list_tools` and `NeMoGymTask.setup`.
> - Passes `state.tool_names` through to `trace_to_nemo_response` in the reward function so normalization applies at verify time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 849e0ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->