### PR TITLE
Update pinned V1 harness releases

### DIFF
--- a/verifiers/v1/harnesses/claude_code/harness.py
+++ b/verifiers/v1/harnesses/claude_code/harness.py
@@ -2,6 +2,8 @@
 
 import shlex
 
+from pydantic import Field
+
 from verifiers.v1.acp import ACP
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
@@ -13,7 +15,8 @@ from verifiers.v1.trace import Trace
 
 CLAUDE_ACP_DIR = "/var/tmp/vf-claude-agent-acp"
 PACKAGES_DIR = f"{CLAUDE_ACP_DIR}/packages"
-ACP_VERSION = "0.63.0"
+ACP_VERSION = "0.65.0"
+CLAUDE_BIN = f"{PACKAGES_DIR}/node_modules/.bin/claude"
 ACP_BIN = f"{PACKAGES_DIR}/node_modules/.bin/claude-agent-acp"
 ACP_COMMAND = [f"{NODE_BIN_DIR}/node", ACP_BIN]
 CLAUDE_CONFIG_ROOT = ".vf-claude"
@@ -21,21 +24,25 @@ SKILLS_DIR = ".claude/skills"
 ACP_INSTALL = r"""
 set -e
 export PATH="/var/tmp/vf-node/bin:$PATH"
-if [ "$(cat /var/tmp/vf-claude-agent-acp/.version 2>/dev/null)" = "$VF_CLAUDE_ACP_VERSION" ] \
+versions="$VF_CLAUDE_CODE_VERSION:$VF_CLAUDE_ACP_VERSION"
+if [ "$(cat /var/tmp/vf-claude-agent-acp/.versions 2>/dev/null)" = "$versions" ] \
+    && [ -x /var/tmp/vf-claude-agent-acp/packages/node_modules/.bin/claude ] \
     && [ -x /var/tmp/vf-claude-agent-acp/packages/node_modules/.bin/claude-agent-acp ]; then
     exit 0
 fi
-npm install --prefix /var/tmp/vf-claude-agent-acp/packages --ignore-scripts --no-audit --no-fund \
+npm install --prefix /var/tmp/vf-claude-agent-acp/packages --no-audit --no-fund \
     --omit=dev \
+    "@anthropic-ai/claude-code@$VF_CLAUDE_CODE_VERSION" \
     "@agentclientprotocol/claude-agent-acp@$VF_CLAUDE_ACP_VERSION" >/dev/null
-printf %s "$VF_CLAUDE_ACP_VERSION" > /var/tmp/vf-claude-agent-acp/.version
+printf %s "$versions" > /var/tmp/vf-claude-agent-acp/.versions
 """
 
 CLAUDE_ACP = ACP()
 
 
 class ClaudeCodeHarnessConfig(HarnessConfig):
-    pass
+    version: str = Field(default="2.1.223", pattern=r"^[A-Za-z0-9._+-]+$")
+    """Claude Code release to install, pinned for reproducibility."""
 
 
 class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
@@ -56,6 +63,7 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
             ["sh", "-c", acp_guarded],
             {
                 **self.config.resolved_env,
+                "VF_CLAUDE_CODE_VERSION": self.config.version,
                 "VF_CLAUDE_ACP_VERSION": ACP_VERSION,
             },
         )
@@ -92,6 +100,7 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
             "ANTHROPIC_BASE_URL": endpoint.removesuffix("/v1"),
             "ANTHROPIC_API_KEY": secret,
             "ANTHROPIC_MODEL": ctx.model,
+            "CLAUDE_CODE_EXECUTABLE": CLAUDE_BIN,
             "CLAUDE_CONFIG_DIR": config_dir,
             "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
             "DISABLE_AUTOUPDATER": "1",
@@ -138,6 +147,7 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
             "ANTHROPIC_BASE_URL": endpoint.removesuffix("/v1"),
             "ANTHROPIC_API_KEY": secret,
             "ANTHROPIC_MODEL": ctx.model,
+            "CLAUDE_CODE_EXECUTABLE": CLAUDE_BIN,
             "CLAUDE_CONFIG_DIR": config_dir,
             "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
             "DISABLE_AUTOUPDATER": "1",

--- a/verifiers/v1/harnesses/claude_code/harness.py
+++ b/verifiers/v1/harnesses/claude_code/harness.py
@@ -13,28 +13,20 @@ from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
 
-CLAUDE_ACP_DIR = "/var/tmp/vf-claude-agent-acp"
+CLAUDE_ACP_DIR = "/var/tmp/vf-claude-agent-acp-{version}-{acp_version}"
 PACKAGES_DIR = f"{CLAUDE_ACP_DIR}/packages"
 ACP_VERSION = "0.65.0"
 CLAUDE_BIN = f"{PACKAGES_DIR}/node_modules/.bin/claude"
 ACP_BIN = f"{PACKAGES_DIR}/node_modules/.bin/claude-agent-acp"
-ACP_COMMAND = [f"{NODE_BIN_DIR}/node", ACP_BIN]
 CLAUDE_CONFIG_ROOT = ".vf-claude"
 SKILLS_DIR = ".claude/skills"
 ACP_INSTALL = r"""
 set -e
 export PATH="/var/tmp/vf-node/bin:$PATH"
-versions="$VF_CLAUDE_CODE_VERSION:$VF_CLAUDE_ACP_VERSION"
-if [ "$(cat /var/tmp/vf-claude-agent-acp/.versions 2>/dev/null)" = "$versions" ] \
-    && [ -x /var/tmp/vf-claude-agent-acp/packages/node_modules/.bin/claude ] \
-    && [ -x /var/tmp/vf-claude-agent-acp/packages/node_modules/.bin/claude-agent-acp ]; then
-    exit 0
-fi
-npm install --prefix /var/tmp/vf-claude-agent-acp/packages --no-audit --no-fund \
+npm install --prefix {packages} --no-audit --no-fund \
     --omit=dev \
     "@anthropic-ai/claude-code@$VF_CLAUDE_CODE_VERSION" \
     "@agentclientprotocol/claude-agent-acp@$VF_CLAUDE_ACP_VERSION" >/dev/null
-printf %s "$versions" > /var/tmp/vf-claude-agent-acp/.versions
 """
 
 CLAUDE_ACP = ACP()
@@ -54,10 +46,17 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
     async def setup(self, runtime: Runtime) -> None:
         await self.install_skills(runtime, SKILLS_DIR)
         await ensure_node(runtime)
+        versions = {"version": self.config.version, "acp_version": ACP_VERSION}
+        directory = CLAUDE_ACP_DIR.format(**versions)
+        packages = PACKAGES_DIR.format(**versions)
+        claude_bin = CLAUDE_BIN.format(**versions)
+        acp_bin = ACP_BIN.format(**versions)
+        script = ACP_INSTALL.replace("{packages}", packages)
+        ensure = shlex.quote(f"[ -x {claude_bin} ] && [ -x {acp_bin} ] || ({script})")
         acp_guarded = (
-            f"mkdir -p {CLAUDE_ACP_DIR} && "
-            f'"$(command -v flock || command -v lockf)" {CLAUDE_ACP_DIR}/install.lock '
-            f"sh -c {shlex.quote(ACP_INSTALL)}"
+            f"mkdir -p {directory} && "
+            f'"$(command -v flock || command -v lockf)" {directory}/install.lock '
+            f"sh -c {ensure}"
         )
         acp_result = await runtime.run(
             ["sh", "-c", acp_guarded],
@@ -88,6 +87,7 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
             )
         system_prompt, prompt = self.resolve_prompt(data)
         config_dir = self.config_dir(trace)
+        versions = {"version": self.config.version, "acp_version": ACP_VERSION}
         options: dict[str, object] = {
             "strictMcpConfig": True,
             "disallowedTools": self.config.disabled_tools or [],
@@ -100,7 +100,7 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
             "ANTHROPIC_BASE_URL": endpoint.removesuffix("/v1"),
             "ANTHROPIC_API_KEY": secret,
             "ANTHROPIC_MODEL": ctx.model,
-            "CLAUDE_CODE_EXECUTABLE": CLAUDE_BIN,
+            "CLAUDE_CODE_EXECUTABLE": CLAUDE_BIN.format(**versions),
             "CLAUDE_CONFIG_DIR": config_dir,
             "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
             "DISABLE_AUTOUPDATER": "1",
@@ -116,7 +116,7 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
             mcp_urls,
             data,
             env=env,
-            command=ACP_COMMAND,
+            command=[f"{NODE_BIN_DIR}/node", ACP_BIN.format(**versions)],
             prompt=prompt or "",
             session_meta=session_meta,
         )
@@ -133,6 +133,7 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(data)
         config_dir = self.config_dir(trace)
+        versions = {"version": self.config.version, "acp_version": ACP_VERSION}
 
         options: dict[str, object] = {
             "strictMcpConfig": True,
@@ -147,7 +148,7 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
             "ANTHROPIC_BASE_URL": endpoint.removesuffix("/v1"),
             "ANTHROPIC_API_KEY": secret,
             "ANTHROPIC_MODEL": ctx.model,
-            "CLAUDE_CODE_EXECUTABLE": CLAUDE_BIN,
+            "CLAUDE_CODE_EXECUTABLE": CLAUDE_BIN.format(**versions),
             "CLAUDE_CONFIG_DIR": config_dir,
             "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
             "DISABLE_AUTOUPDATER": "1",
@@ -156,7 +157,7 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
         return await CLAUDE_ACP.run(
             runtime,
             env,
-            ACP_COMMAND,
+            [f"{NODE_BIN_DIR}/node", ACP_BIN.format(**versions)],
             prompt or "",
             mcp_urls=mcp_urls,
             session_path=f"{config_dir}/acp-session",

--- a/verifiers/v1/harnesses/claude_code/harness.py
+++ b/verifiers/v1/harnesses/claude_code/harness.py
@@ -23,10 +23,12 @@ SKILLS_DIR = ".claude/skills"
 ACP_INSTALL = r"""
 set -e
 export PATH="/var/tmp/vf-node/bin:$PATH"
+rm -f {ready}
 npm install --prefix {packages} --no-audit --no-fund \
     --omit=dev \
     "@anthropic-ai/claude-code@$VF_CLAUDE_CODE_VERSION" \
     "@agentclientprotocol/claude-agent-acp@$VF_CLAUDE_ACP_VERSION" >/dev/null
+touch {ready}
 """
 
 CLAUDE_ACP = ACP()
@@ -51,8 +53,11 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
         packages = PACKAGES_DIR.format(**versions)
         claude_bin = CLAUDE_BIN.format(**versions)
         acp_bin = ACP_BIN.format(**versions)
-        script = ACP_INSTALL.replace("{packages}", packages)
-        ensure = shlex.quote(f"[ -x {claude_bin} ] && [ -x {acp_bin} ] || ({script})")
+        ready = f"{directory}/.ready"
+        script = ACP_INSTALL.replace("{packages}", packages).replace("{ready}", ready)
+        ensure = shlex.quote(
+            f"[ -f {ready} ] && [ -x {claude_bin} ] && [ -x {acp_bin} ] || ({script})"
+        )
         acp_guarded = (
             f"mkdir -p {directory} && "
             f'"$(command -v flock || command -v lockf)" {directory}/install.lock '

--- a/verifiers/v1/harnesses/codex/harness.py
+++ b/verifiers/v1/harnesses/codex/harness.py
@@ -23,8 +23,8 @@ KEY_VAR = "CODEX_INTERCEPT_KEY"
 
 CODEX_DIR = "/var/tmp/vf-codex"
 PACKAGES_DIR = f"{CODEX_DIR}/acp"
-CODEX_VERSION = "0.145.0"
-ACP_VERSION = "1.1.7"
+CODEX_VERSION = "0.146.1"
+ACP_VERSION = "1.1.10"
 ACP_BIN = f"{PACKAGES_DIR}/node_modules/.bin/codex-acp"
 ACP_COMMAND = [f"{NODE_BIN_DIR}/node", ACP_BIN]
 SKILLS_DIR = ".agents/skills"

--- a/verifiers/v1/harnesses/codex/harness.py
+++ b/verifiers/v1/harnesses/codex/harness.py
@@ -7,6 +7,8 @@ import re
 import shlex
 from collections import Counter
 
+from pydantic import Field
+
 from verifiers.v1.acp import ACP
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
@@ -21,33 +23,27 @@ logger = logging.getLogger(__name__)
 PROVIDER = "intercept"
 KEY_VAR = "CODEX_INTERCEPT_KEY"
 
-CODEX_DIR = "/var/tmp/vf-codex"
+CODEX_DIR = "/var/tmp/vf-codex-{version}-{acp_version}"
 PACKAGES_DIR = f"{CODEX_DIR}/acp"
-CODEX_VERSION = "0.146.1"
 ACP_VERSION = "1.1.10"
+CODEX_BIN = f"{PACKAGES_DIR}/node_modules/.bin/codex"
 ACP_BIN = f"{PACKAGES_DIR}/node_modules/.bin/codex-acp"
-ACP_COMMAND = [f"{NODE_BIN_DIR}/node", ACP_BIN]
 SKILLS_DIR = ".agents/skills"
 INSTALL = r"""
 set -e
 export PATH="/var/tmp/vf-node/bin:$PATH"
-versions="$VF_CODEX_VERSION:$VF_CODEX_ACP_VERSION"
-if [ "$(cat /var/tmp/vf-codex/.versions 2>/dev/null)" = "$versions" ] \
-    && [ -x /var/tmp/vf-codex/acp/node_modules/.bin/codex ] \
-    && [ -x /var/tmp/vf-codex/acp/node_modules/.bin/codex-acp ]; then
-    exit 0
-fi
-npm install --prefix /var/tmp/vf-codex/acp --ignore-scripts --no-audit --no-fund \
+npm install --prefix {packages} --ignore-scripts --no-audit --no-fund \
     --omit=dev \
     "@agentclientprotocol/codex-acp@$VF_CODEX_ACP_VERSION" \
     "@openai/codex@$VF_CODEX_VERSION" >/dev/null
-printf %s "$versions" > /var/tmp/vf-codex/.versions
 """
 
 CODEX_ACP = ACP()
 
 
 class CodexHarnessConfig(HarnessConfig):
+    version: str = Field(default="0.146.1", pattern=r"^[A-Za-z0-9._+-]+$")
+    """Codex release to install, pinned for reproducibility."""
     multi_agent: bool = False
     """Enable Codex's native multi-agent v2 tools."""
 
@@ -63,19 +59,26 @@ class CodexHarness(Harness[CodexHarnessConfig]):
         await ensure_node(runtime)
         logger.info(
             "codex: ensuring Codex %s and codex-acp %s are installed",
-            CODEX_VERSION,
+            self.config.version,
             ACP_VERSION,
         )
+        versions = {"version": self.config.version, "acp_version": ACP_VERSION}
+        directory = CODEX_DIR.format(**versions)
+        packages = PACKAGES_DIR.format(**versions)
+        codex_bin = CODEX_BIN.format(**versions)
+        acp_bin = ACP_BIN.format(**versions)
+        script = INSTALL.replace("{packages}", packages)
+        ensure = shlex.quote(f"[ -x {codex_bin} ] && [ -x {acp_bin} ] || ({script})")
         guarded = (
-            f"mkdir -p {CODEX_DIR} && "
-            f'"$(command -v flock || command -v lockf)" {CODEX_DIR}/install.lock '
-            f"sh -c {shlex.quote(INSTALL)}"
+            f"mkdir -p {directory} && "
+            f'"$(command -v flock || command -v lockf)" {directory}/install.lock '
+            f"sh -c {ensure}"
         )
         install = await runtime.run(
             ["sh", "-c", guarded],
             {
                 **self.config.resolved_env,
-                "VF_CODEX_VERSION": CODEX_VERSION,
+                "VF_CODEX_VERSION": self.config.version,
                 "VF_CODEX_ACP_VERSION": ACP_VERSION,
             },
         )
@@ -112,7 +115,10 @@ class CodexHarness(Harness[CodexHarnessConfig]):
             {},
             data,
             env=env,
-            command=ACP_COMMAND,
+            command=[
+                f"{NODE_BIN_DIR}/node",
+                ACP_BIN.format(version=self.config.version, acp_version=ACP_VERSION),
+            ],
             prompt=prompt,
             system_prompt=system_prompt,
         )
@@ -139,7 +145,10 @@ class CodexHarness(Harness[CodexHarnessConfig]):
         return await CODEX_ACP.run(
             runtime,
             env,
-            ACP_COMMAND,
+            [
+                f"{NODE_BIN_DIR}/node",
+                ACP_BIN.format(version=self.config.version, acp_version=ACP_VERSION),
+            ],
             prompt,
             system_prompt=system_prompt,
             session_path=f"{self.trace_home(trace)}/acp-session",

--- a/verifiers/v1/harnesses/codex/harness.py
+++ b/verifiers/v1/harnesses/codex/harness.py
@@ -32,10 +32,12 @@ SKILLS_DIR = ".agents/skills"
 INSTALL = r"""
 set -e
 export PATH="/var/tmp/vf-node/bin:$PATH"
+rm -f {ready}
 npm install --prefix {packages} --ignore-scripts --no-audit --no-fund \
     --omit=dev \
     "@agentclientprotocol/codex-acp@$VF_CODEX_ACP_VERSION" \
     "@openai/codex@$VF_CODEX_VERSION" >/dev/null
+touch {ready}
 """
 
 CODEX_ACP = ACP()
@@ -67,8 +69,11 @@ class CodexHarness(Harness[CodexHarnessConfig]):
         packages = PACKAGES_DIR.format(**versions)
         codex_bin = CODEX_BIN.format(**versions)
         acp_bin = ACP_BIN.format(**versions)
-        script = INSTALL.replace("{packages}", packages)
-        ensure = shlex.quote(f"[ -x {codex_bin} ] && [ -x {acp_bin} ] || ({script})")
+        ready = f"{directory}/.ready"
+        script = INSTALL.replace("{packages}", packages).replace("{ready}", ready)
+        ensure = shlex.quote(
+            f"[ -f {ready} ] && [ -x {codex_bin} ] && [ -x {acp_bin} ] || ({script})"
+        )
         guarded = (
             f"mkdir -p {directory} && "
             f'"$(command -v flock || command -v lockf)" {directory}/install.lock '

--- a/verifiers/v1/harnesses/kimi_code/harness.py
+++ b/verifiers/v1/harnesses/kimi_code/harness.py
@@ -43,7 +43,7 @@ KIMI_ACP = ACP()
 
 
 class KimiCodeHarnessConfig(HarnessConfig):
-    version: str = "0.29.0"
+    version: str = "0.34.0"
     """Kimi Code release to install, pinned for reproducibility."""
 
 

--- a/verifiers/v1/harnesses/kimi_code/harness.py
+++ b/verifiers/v1/harnesses/kimi_code/harness.py
@@ -4,6 +4,8 @@ import json
 import logging
 import shlex
 
+from pydantic import Field
+
 from verifiers.v1.acp import ACP
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
@@ -43,7 +45,7 @@ KIMI_ACP = ACP()
 
 
 class KimiCodeHarnessConfig(HarnessConfig):
-    version: str = "0.34.0"
+    version: str = Field(default="0.34.0", pattern=r"^[A-Za-z0-9._+-]+$")
     """Kimi Code release to install, pinned for reproducibility."""
 
 

--- a/verifiers/v1/harnesses/mini_swe_agent/harness.py
+++ b/verifiers/v1/harnesses/mini_swe_agent/harness.py
@@ -11,7 +11,7 @@ PROGRAM_SOURCE = (Path(__file__).resolve().parent / "program.py").read_text()
 
 
 class MiniSWEAgentHarnessConfig(HarnessConfig):
-    version: str = "2.4.5"
+    version: str = "2.4.6"
     """mini-swe-agent release to install, pinned for reproducibility."""
 
 

--- a/verifiers/v1/harnesses/mini_swe_agent/harness.py
+++ b/verifiers/v1/harnesses/mini_swe_agent/harness.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+from pydantic import Field
+
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.harness import Harness
@@ -11,7 +13,7 @@ PROGRAM_SOURCE = (Path(__file__).resolve().parent / "program.py").read_text()
 
 
 class MiniSWEAgentHarnessConfig(HarnessConfig):
-    version: str = "2.4.6"
+    version: str = Field(default="2.4.6", pattern=r"^[A-Za-z0-9._+-]+$")
     """mini-swe-agent release to install, pinned for reproducibility."""
 
 

--- a/verifiers/v1/harnesses/pi/harness.py
+++ b/verifiers/v1/harnesses/pi/harness.py
@@ -4,6 +4,8 @@ import json
 import logging
 import shlex
 
+from pydantic import Field
+
 from verifiers.v1.acp import ACP
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
@@ -86,7 +88,7 @@ PI_ACP = ACP()
 
 
 class PiHarnessConfig(HarnessConfig):
-    version: str = "0.84.0"
+    version: str = Field(default="0.84.0", pattern=r"^[A-Za-z0-9._+-]+$")
     """Pi release to install, pinned for reproducibility."""
 
 

--- a/verifiers/v1/harnesses/pool/harness.py
+++ b/verifiers/v1/harnesses/pool/harness.py
@@ -31,7 +31,7 @@ POOL_ACP = ACP()
 
 
 class PoolHarnessConfig(HarnessConfig):
-    version: str = Field(default="1.0.11", pattern=r"^[A-Za-z0-9._+-]+$")
+    version: str = Field(default="1.0.15", pattern=r"^[A-Za-z0-9._+-]+$")
     """Pool release to install, pinned for reproducibility."""
 
 

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -30,7 +30,7 @@ RLM_ACP = ACP()
 
 
 class RLMHarnessConfig(HarnessConfig):
-    version: str = "main"
+    version: str = Field(default="main", min_length=1)
     """Git ref (branch, tag, or commit) of rlm-harness to install."""
     max_depth: int = 0
     """Recursion depth rlm may spawn sub-harnesses to (RLM_MAX_DEPTH)."""

--- a/verifiers/v1/harnesses/terminus_2/harness.py
+++ b/verifiers/v1/harnesses/terminus_2/harness.py
@@ -1,6 +1,8 @@
 import logging
 from pathlib import Path
 
+from pydantic import Field
+
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.harness import Harness
@@ -13,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class Terminus2HarnessConfig(HarnessConfig):
-    version: str = "0.20.0"
+    version: str = Field(default="0.20.0", pattern=r"^[A-Za-z0-9._+-]+$")
     """Harbor release to install, pinned for reproducibility."""
 
 


### PR DESCRIPTION
## Overview

- Refresh the pinned Claude Code, Codex, Kimi Code, mini-swe-agent, and Pool releases.
- Install Claude Code alongside its ACP adapter and select that executable explicitly.
- Expose the Claude Code release as typed harness configuration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect runtime npm installs and which agent binaries run in sandboxes; mis-pinned versions or install failures would break harness setup, but scope is limited to harness infrastructure rather than auth or data paths.
> 
> **Overview**
> **Refreshes pinned agent releases** across V1 harnesses (Claude Code, Codex, Kimi Code, mini-swe-agent, Pool, and related ACP adapters) and adds **Pydantic `Field` validation** on `version` strings where they were plain defaults.
> 
> **Claude Code and Codex** now install into **per tool+ACP version directories** under `/var/tmp`, with setup gated on a `.ready` marker plus both the CLI and ACP binaries (replacing single global paths and `.version`/`.versions` files). Claude Code’s npm install **adds `@anthropic-ai/claude-code`** and runtime env sets **`CLAUDE_CODE_EXECUTABLE`** to the pinned binary; Codex’s version moves from a module constant into **`CodexHarnessConfig.version`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12b9a7cc005b9dbf69b7abb26c6affe874a21aef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update pinned release versions and add versioned install paths for V1 harnesses
> - Bumps default versions for Claude Code (2.1.223), Codex (0.146.1), Kimi Code (0.34.0), mini-swe-agent (2.4.6), and Pool (1.0.15).
> - Refactors Claude Code and Codex harnesses to install binaries into versioned directories keyed by both the agent version and ACP version, preventing conflicts when multiple versions coexist.
> - Adds a `version` field (via pydantic `Field`) to harness configs to allow selecting a specific release; adds pattern validation to constrain accepted values.
> - Passes `VF_CLAUDE_CODE_VERSION` / `VF_CODEX_VERSION` into the subprocess environment and exposes `CLAUDE_CODE_EXECUTABLE` for session and launch commands.
> - Behavioral Change: install skip logic now checks for both the agent and ACP executables in the versioned directory; previously installed (unversioned) directories will not be reused.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 12b9a7c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->