### PR TITLE
Update Pi ACP terminal turns

### DIFF
--- a/verifiers/v1/harnesses/pi/harness.py
+++ b/verifiers/v1/harnesses/pi/harness.py
@@ -23,8 +23,8 @@ PI_DIR = "/var/tmp/vf-pi"
 PACKAGES_DIR = f"{PI_DIR}/mcp"
 PI_BIN = f"{PACKAGES_DIR}/node_modules/.bin/pi"
 SKILLS_DIR = ".agents/skills"
-MCP_VERSION = "2.11.0"
-ACP_VERSION = "0.0.31"
+MCP_VERSION = "2.20.1"
+ACP_VERSION = "0.0.33"
 MCP_ADAPTER = f"{PACKAGES_DIR}/node_modules/pi-mcp-adapter/index.ts"
 ACP_BIN = f"{PACKAGES_DIR}/node_modules/.bin/pi-acp"
 ACP_COMMAND = [
@@ -86,7 +86,7 @@ PI_ACP = ACP()
 
 
 class PiHarnessConfig(HarnessConfig):
-    version: str = "0.80.10"
+    version: str = "0.84.0"
     """Pi release to install, pinned for reproducibility."""
 
 
@@ -223,4 +223,6 @@ class PiHarness(Harness[PiHarnessConfig]):
             ACP_COMMAND,
             prompt,
             session_path=f"{agent_dir}/acp-session",
+            # Pi can end after its final tool completes without a text message.
+            allow_empty_tool_reply=True,
         )


### PR DESCRIPTION
## Overview

- Refresh Pi, pi-acp, and pi-mcp-adapter to their current pinned releases.
- Accept a tool-only ACP turn when Pi returns end_turn after every observed tool reaches a terminal state.
- Preserve strict errors for refusals, silent no-tool turns, and non-terminal tool execution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version pin updates and opting into an existing ACP runner flag already used elsewhere; no new auth or data-path logic in this diff.
> 
> **Overview**
> **Dependency pins** for the Pi harness move to Pi **0.84.0** (from 0.80.10), **pi-mcp-adapter 2.20.1** (from 2.11.0), and **pi-acp 0.0.33** (from 0.0.31).
> 
> **ACP launch behavior** now passes `allow_empty_tool_reply=True` into `PI_ACP.run`, matching the OpenClaw harness. That lets a turn finish when Pi returns `end_turn` after observed tools reach a terminal state, even if there is no visible assistant text—instead of failing with “no visible reply.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7c093e3a2dba9d2221a92700a63e83f11323bb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update Pi ACP terminal turns to allow empty tool replies
> - Adds `allow_empty_tool_reply=True` to the `PI_ACP.run` invocation in [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2292/files#diff-d9ee2431b7427a96633e83be4179a971f5a199c76bb0f603d70bb44147476ace), permitting completion when a final tool produces no text reply.
> - Bumps `ACP_VERSION` from `0.0.31` to `0.0.33` and `MCP_VERSION` from `2.11.0` to `2.20.1`.
> - Updates the default Pi release in `PiHarnessConfig` from `0.80.10` to `0.84.0`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a7c093e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->