### PR TITLE
Report when the gold check had nothing to check against

### DIFF
--- a/verifiers/v1/cli/validate.py
+++ b/verifiers/v1/cli/validate.py
@@ -154,6 +154,22 @@ def load_results(
     return rows, owed
 
 
+def gold_implemented(task: Task) -> bool:
+    """Whether the taskset actually wrote a gold check.
+
+    `Task.validate` returns `True` unconditionally, so a task that does not override it
+    passes the gold check for every item without anything having been checked."""
+    return type(task).validate is not Task.validate
+
+
+def _gold_row(row: ResultRow) -> ResultRow | None:
+    """The gold row inside a result row, whichever mode produced it."""
+    if row.get("mode") == "gold":
+        return row
+    gold = row.get("gold")
+    return gold if isinstance(gold, dict) else None
+
+
 def summarize(rows: Sequence[ResultRow], total: int, mode: str) -> dict[str, Any]:
     counts = Counter(row.get("reason") for row in rows)
     missing = max(0, total - len(rows))
@@ -169,6 +185,12 @@ def summarize(rows: Sequence[ResultRow], total: int, mode: str) -> dict[str, Any
         "outcomes": outcomes,
         "valid_rate": round(outcomes["valid"] / total, 6) if total else None,
     }
+    if mode in ("gold", "all"):
+        golds = [gold for gold in map(_gold_row, rows) if gold is not None]
+        # Gold rows that were reported valid without a gold check to be valid against.
+        summary["gold_unchecked"] = sum(
+            1 for gold in golds if gold.get("checked") is False
+        )
     if mode == "all":
         checks: dict[str, dict[str, int]] = {}
         for check in ("gold", "setup"):
@@ -271,7 +293,9 @@ async def _run_gold(task: Task, config: ValidateConfig) -> ResultRow:
             logger.warning(
                 "runtime teardown failed (task %s)", task.data.idx, exc_info=True
             )
-    return _row(task, "gold", valid, exc, start)
+    # A task that never overrode `validate` is valid against nothing; say so on the row
+    # rather than letting the base class's unconditional `True` read as a passing check.
+    return {**_row(task, "gold", valid, exc, start), "checked": gold_implemented(task)}
 
 
 async def _run_setup(task: Task, config: ValidateConfig) -> ResultRow:
@@ -406,6 +430,15 @@ async def run_validate(config: ValidateConfig) -> list[dict]:
         checks,
     )
     logger.info("results: %s", out)
+    if mode in ("gold", "all"):
+        unchecked = sorted({type(t).__name__ for t in tasks if not gold_implemented(t)})
+        if unchecked:
+            logger.warning(
+                "no gold check: %s does not override Task.validate, which returns True "
+                "unconditionally - the gold check will pass every task without checking "
+                "anything (see gold_unchecked in the summary)",
+                ", ".join(unchecked),
+            )
 
     sem = asyncio.Semaphore(config.max_concurrent) if config.max_concurrent else None
     states = [TaskProgress(idx=t.data.idx, name=t.data.name) for t in tasks]


### PR DESCRIPTION
## The problem

`Task.validate` returns `True` unconditionally, so a taskset that does not override it
passes the gold check for **every** item without anything having been checked.

Of the five in-tree tasksets defining a `Task` subclass, only `lean` overrides `validate`.
`harbor`, `openenv`, `textarena` and `nemo_gym` inherit the base implementation. For those,
`validate --only-gold` reports `valid_rate: 1.0` — which reads as a passing check, but
measures nothing. The failure is silent and flattering: absence of a check is reported as
agreement.

## The change

34 lines in `verifiers/v1/cli/validate.py`:

- `gold_implemented(task)` — whether the taskset actually wrote a gold check
  (`type(task).validate is not Task.validate`, so inheriting from an overriding class
  still counts).
- `_run_gold` marks each row `checked: true|false`.
- `summarize` reports `gold_unchecked` in `gold` and `all` modes (`_gold_row` reads the
  nested gold row in `all` mode).
- `run_validate` warns once, naming the classes that don't override `validate`.

Validation behaviour is unchanged. This only separates "checked and valid" from
"never checked".

## A stronger alternative, if you'd prefer it

Add an `unchecked` value to `reason` so it fails loudly rather than being reported in the
summary. I kept this additive because that would touch `FINAL_REASONS`, `_is_final` and
resume semantics — happy to switch if you'd rather have the louder version.

## Verification

Per AGENTS.md ("to check your own work, write a temporary script instead of committing new
tests") I used a temporary script, not a committed test. It checks:

- the predicate on synthetic cases: inherits `Task.validate`, overrides it, and inherits a
  class that overrides it;
- all five in-tree taskset classes, imported live — 4 unchecked, `lean` checked;
- `summarize` in `gold`, `all` and `setup` modes, including a row with no `checked` field;
- a negative control — the old always-true predicate — which fires, so the checks aren't
  passing vacuously.

All pass. `uv run ruff check` and `uv run ruff format --check` are clean.

One caveat I'd rather state than hide: I could not run `uv run pytest tests/` on this
machine. `verifiers/v1/runtimes/limiters.py` imports `fcntl`, which is Unix-only, so the
package doesn't import on Windows. I stashed the change, collected, un-stashed, and
collected again — the failure set is byte-identical (38 both ways, same 6 collection
errors), so nothing here is caused by this change. Still worth a CI run on Linux.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Report unchecked gold validations when a task does not override `Task.validate`
> - Adds a `gold_unchecked` count to the summary in `gold` and `all` modes, tracking results that passed without a real gold check being implemented.
> - Each result row from `_run_gold` now includes a `checked` boolean derived from whether the task's class overrides `Task.validate`.
> - Before validation runs, `run_validate` logs a warning listing any task classes whose gold checks will always pass due to missing `validate` overrides.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a74e93.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->