### PR TITLE
fix(v1): use final call input token count

### DIFF
--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -311,7 +311,8 @@ class Branch(BaseModel):
 
     @property
     def num_input_tokens(self) -> int:
-        return self.num_total_tokens - self.num_output_tokens
+        last = self.last_usage
+        return last.input_tokens if last is not None else 0
 
 
 class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):


### PR DESCRIPTION
`num_input_tokens` mixed the final call total with output summed across all calls, which can produce a negative count. Read the final call input directly instead.

Verified with a multi-call cached-usage reproduction and `uv run ruff check verifiers/v1/trace.py`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `num_input_tokens` to use provider-reported input token count
> The `num_input_tokens` property in [trace.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2295/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e) previously derived input tokens as `total_tokens - completion_tokens`, which could be inaccurate. It now reads `input_tokens` directly from `last_usage`, falling back to `0` if unavailable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10d3f20.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small correctness fix to trace token metrics; behavior changes only where the old formula was wrong, with no auth or data-path impact.
> 
> **Overview**
> **Fixes `Branch.num_input_tokens`** so it no longer subtracts aggregated completion tokens from the **last call’s** `total_tokens`, which could yield wrong or **negative** counts on multi-turn rollouts (e.g. with cached prompt usage).
> 
> The property now reads **`input_tokens` from `last_usage`** (same source as `num_total_tokens`), returning `0` when there is no usage. Trace-level `num_input_tokens` and rollout `max_input_tokens` checks inherit the corrected per-branch value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10d3f207b24b798f9b7d31e2c1a3cd489df6c962. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->