### PR TITLE
fix: clamp per-call input token accounting so it never goes negative

### DIFF
--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -171,11 +171,12 @@ class ModelCall(BaseModel):
     """The failure that ended this call, coupled to the exchange that caused it."""
 
 
-def _new_input_tokens(calls: Iterable[ModelCall]) -> Iterator[tuple[ModelCall, int]]:
-    """Per-call newly fed-in tokens: each call's prompt beyond the previous call's
-    final sequence, clamped at zero. Exact while the history is append-only; tokens
-    the engine drops between calls (stripped reasoning, truncated history) register
-    as an undercount of that call's new input rather than going negative."""
+def min_new_input_tokens(calls: Iterable[ModelCall]) -> Iterator[tuple[ModelCall, int]]:
+    """Per-call lower bound on newly fed-in tokens: each call's prompt beyond the
+    previous call's final sequence, clamped at zero. Exact while the history is
+    append-only; tokens the engine drops between calls (stripped reasoning, truncated
+    history) register as an undercount of that call's new input rather than going
+    negative."""
     prev_total = 0
     for call in calls:
         if call.usage is None:
@@ -326,7 +327,7 @@ class Branch(BaseModel):
     def num_input_tokens(self) -> int:
         """Fed-in tokens (system + user + tool), counted once; a lower bound whenever
         the engine drops tokens between calls."""
-        return sum(increment for _, increment in _new_input_tokens(self.calls))
+        return sum(increment for _, increment in min_new_input_tokens(self.calls))
 
 
 class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
@@ -394,7 +395,7 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
         for branch in self.branches:
             # A call's predecessors are fixed by the graph, so its increment is the
             # same in every branch containing it; keep the first occurrence.
-            for call, increment in _new_input_tokens(branch.calls):
+            for call, increment in min_new_input_tokens(branch.calls):
                 if id(call) not in seen:
                     seen.add(id(call))
                     total += increment

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import time
 import traceback
 import uuid
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from typing import TYPE_CHECKING, Annotated, Any, Generic, Literal
 
 import numpy as np
@@ -171,6 +171,19 @@ class ModelCall(BaseModel):
     """The failure that ended this call, coupled to the exchange that caused it."""
 
 
+def _new_input_tokens(calls: Iterable[ModelCall]) -> Iterator[tuple[ModelCall, int]]:
+    """Per-call newly fed-in tokens: each call's prompt beyond the previous call's
+    final sequence, clamped at zero. Exact while the history is append-only; tokens
+    the engine drops between calls (stripped reasoning, truncated history) register
+    as an undercount of that call's new input rather than going negative."""
+    prev_total = 0
+    for call in calls:
+        if call.usage is None:
+            continue
+        yield call, max(0, call.usage.input_tokens - prev_total)
+        prev_total = call.usage.total_tokens
+
+
 class Branch(BaseModel):
     """A root-to-leaf graph path; each branch becomes one training sample."""
 
@@ -311,7 +324,9 @@ class Branch(BaseModel):
 
     @property
     def num_input_tokens(self) -> int:
-        return self.num_total_tokens - self.num_output_tokens
+        """Fed-in tokens (system + user + tool), counted once; a lower bound whenever
+        the engine drops tokens between calls."""
+        return sum(increment for _, increment in _new_input_tokens(self.calls))
 
 
 class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
@@ -372,8 +387,18 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
 
     @property
     def num_input_tokens(self) -> int:
-        """Fed-in tokens (system + user + tool), counted once, summed across branches."""
-        return sum(branch.num_input_tokens for branch in self.branches)
+        """Fed-in tokens (system + user + tool), counted once across all branches —
+        calls on shared branch prefixes contribute once, not once per branch."""
+        seen: set[int] = set()
+        total = 0
+        for branch in self.branches:
+            # A call's predecessors are fixed by the graph, so its increment is the
+            # same in every branch containing it; keep the first occurrence.
+            for call, increment in _new_input_tokens(branch.calls):
+                if id(call) not in seen:
+                    seen.add(id(call))
+                    total += increment
+        return total
 
     @property
     def num_output_tokens(self) -> int:


### PR DESCRIPTION
## Summary

- `Branch.num_input_tokens` was derived as `last_total − Σ completions`, which assumes every completion is carried verbatim into the next prompt. Inference engines break that invariant silently — reasoning models (e.g. Nemotron) count reasoning in `completion_tokens` but don't feed it back, and harnesses truncate history — making `Σ completions` exceed the final sequence length and the derived input go negative.
- Replaced with per-call telescoping, clamped at zero: `new_input_i = max(0, input_tokens_i − total_tokens_{i−1})`, summed over the branch (`min_new_input_tokens` in `verifiers/v1/trace.py` — named as a lower bound, since that's the contract). Uses `Usage.input_tokens`/`total_tokens` so cache reads are counted.
- `Trace.num_input_tokens` now sums increments over unique calls instead of summing per-branch: calls on shared branch prefixes previously counted once per branch, double-counting the shared prompt. A call's predecessors are fixed by the graph, so its increment is branch-invariant and first-occurrence dedup is exact.
- `num_output_tokens` and `num_total_tokens` are unchanged.

This also un-breaks `StopConfig.max_input_tokens` (`session.py`), which compares against `num_input_tokens` and can never trigger while the value is negative.

## Verification

On a Nemotron eval file with 5 traces that all reported negative input tokens:

| trace | task | before | after | output |
|---|---|---:|---:|---:|
| e023d463 | chillerwatch-sigma-detector | -99 | 2,614 | 7,346 |
| e88b8f0d | probe-grid-hamiltonian | -5,007 | 1,918 | 23,179 |
| b20a2283 | tapvm-fare-replay | -20,035 | 5,055 | 73,766 |
| c16a2004 | orchardview-plugin-manifest | -50,076 | 5,649 | 107,071 |
| 6f29e04d | aircheck-session-lifetime | -99,981 | 14,827 | 149,224 |

Branches where the append-only invariant holds produce the same value as before (e.g. per-branch inputs `1115 → 1115`, `4528 → 4528` on the healthy branches of these traces).

`uv run ruff check`, `uv run pytest tests/` (all pass; PRIME_API_KEY-gated tests skipped). `ty` diagnostics on `trace.py` are pre-existing and unrelated.

## Known inaccuracies

The exact once-counted input is **not identifiable** from usage numbers once the engine drops tokens: from counts alone, "k previous-completion tokens were dropped" and "k fewer new input tokens were fed" look identical. The clamp resolves that ambiguity in one direction, with these consequences:

- **Lower bound, not exact, under drops.** When a call's dropped tokens exceed that turn's new input (stripped reasoning, truncated history), the surplus is silently absorbed by the clamp — the turn's new input is undercounted, possibly to 0. The error no longer propagates across the branch (the old formula let one bad call poison the whole branch negative), but it isn't recovered either.
- **Retokenization drift.** Even fully-kept assistant text can retokenize slightly differently inside the next prompt, so healthy branches can be off by a handful of tokens per turn in either direction (clamped at zero per call).
- **Cross-call drops are invisible when masked by large new input.** If a turn both drops old tokens and feeds a large tool result, the drop deflates that turn's measured new input without ever hitting the clamp — undetectable by construction.

For billing-style accounting none of this matters: `trace.usage.prompt_tokens` (context re-counted per call, as providers charge) is unaffected and remains the number to use for cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `num_input_tokens` to never return negative values in `Branch` and `Trace`
> - Introduces `min_new_input_tokens`, a generator in [trace.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2297/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e) that yields per-call non-negative input token increments by computing `max(0, call.usage.input_tokens - prev_total)` and skipping calls with missing usage.
> - `Branch.num_input_tokens` now sums these per-call increments instead of computing `last_usage.total_tokens - completion_tokens`, which could go negative when tokens are dropped between calls.
> - `Trace.num_input_tokens` deduplicates calls shared across branch prefixes by tracking seen call identities before summing increments, avoiding double-counting.
> - Behavioral Change: both properties now represent a lower bound on input tokens rather than an exact count when tokens are dropped between calls.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f65a751. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->