### PR TITLE
Fix plain HTTP CONNECT for Docker framework routes

### DIFF
--- a/verifiers/v1/runtimes/docker/egress.py
+++ b/verifiers/v1/runtimes/docker/egress.py
@@ -59,7 +59,11 @@ class NetworkPolicy:
             connect
             and port != 443
             and not any(
-                rule == "*" or _rule_matches(rule, scheme, host, port)
+                rule == "*"
+                or (
+                    urlsplit(rule.lower()).scheme == scheme
+                    and _rule_matches(rule, scheme, host, port)
+                )
                 for rule in [*self.routes, *self.allow]
             )
         ):

--- a/verifiers/v1/runtimes/docker/egress.py
+++ b/verifiers/v1/runtimes/docker/egress.py
@@ -59,11 +59,7 @@ class NetworkPolicy:
             connect
             and port != 443
             and not any(
-                rule == "*"
-                or (
-                    urlsplit(rule.lower()).scheme == "https"
-                    and _rule_matches(rule, scheme, host, port)
-                )
+                rule == "*" or _rule_matches(rule, scheme, host, port)
                 for rule in [*self.routes, *self.allow]
             )
         ):
@@ -186,8 +182,19 @@ class EgressProxy:
             connect = method == "CONNECT"
             if connect:
                 parsed = urlsplit(f"//{target}")
-                scheme = "https"
                 host, port = parsed.hostname or "", parsed.port or 443
+                # Some HTTP clients tunnel plain HTTP through CONNECT. Only an
+                # explicit framework route can identify that otherwise-ambiguous
+                # tunnel without broadening user-configured egress.
+                scheme = (
+                    "http"
+                    if any(
+                        urlsplit(route.lower()).scheme == "http"
+                        and _rule_matches(route, "http", host, port)
+                        for route in self.policy.routes
+                    )
+                    else "https"
+                )
             else:
                 parsed = urlsplit(target)
                 scheme = parsed.scheme.lower()
@@ -241,17 +248,18 @@ class EgressProxy:
                 response_started = True
                 writer.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
                 await _drain(writer)
-                client_hello, server_name = await _read_client_hello(reader)
-                if server_name is None:
-                    with contextlib.suppress(ValueError):
-                        ip_address(host)
-                        server_name = host
-                if server_name is None or not self.policy.permits(
-                    "https", server_name, port, connect=True
-                ):
-                    return
-                upstream_writer.write(client_hello)
-                await _drain(upstream_writer)
+                if scheme == "https":
+                    client_hello, server_name = await _read_client_hello(reader)
+                    if server_name is None:
+                        with contextlib.suppress(ValueError):
+                            ip_address(host)
+                            server_name = host
+                    if server_name is None or not self.policy.permits(
+                        "https", server_name, port, connect=True
+                    ):
+                        return
+                    upstream_writer.write(client_hello)
+                    await _drain(upstream_writer)
                 await _relay(reader, writer, upstream_reader, upstream_writer)
             else:
                 path = urlunsplit(("", "", parsed.path or "/", parsed.query, ""))


### PR DESCRIPTION
## Summary

- recognize plain-HTTP `CONNECT` tunnels when they exactly match a declared framework route
- relay those tunnels without requiring a TLS ClientHello
- preserve HTTPS SNI validation and deny undeclared nonstandard tunnels

## Why

Restricted Docker runtimes expose interception at a plain-HTTP `vf.host.internal` route and force execution traffic through the Verifiers egress proxy. Some HTTP clients, including the Undici version bundled by Kimi Code 0.29.0, use `CONNECT` even for plain HTTP. The proxy previously treated every `CONNECT` as HTTPS, so the request failed before reaching interception and surfaced later as an empty ACP turn.

## Validation

- `uv run --frozen ruff check verifiers/v1/runtimes/docker/egress.py`
- `uv run --frozen ruff format --check verifiers/v1/runtimes/docker/egress.py`
- `uv run --frozen pytest -q tests/v1 -m 'not e2e'`
- focused proxy probe: declared HTTP framework tunnel returns 200 and relays a request; the same tunnel without the route returns 403
- live restricted-Docker Kimi probe reached `/v1/chat/completions` and completed repeated streamed turns instead of failing with `ACP agent produced no visible reply`

The pre-commit and pre-push wrappers could not start their tools because current `main` reports that `uv.lock` needs an update under their `uv run --locked` commands. The equivalent Ruff and pytest commands above passed directly with the checked-in lock frozen; this PR does not modify dependency metadata.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes network egress policy and CONNECT handling in restricted Docker runtimes; scope is limited to explicit framework HTTP routes but misclassification could affect tunnel security.
> 
> **Overview**
> Fixes the Docker egress proxy so clients that use **`CONNECT` for plain HTTP** (e.g. Undici in Kimi Code) can reach declared framework routes such as `vf.host.internal` interception instead of failing before the tunnel is established.
> 
> **`NetworkPolicy.permits`** now matches non-443 **`CONNECT`** tunnels against allow/route rules using the **caller’s scheme** (`http` or `https`), not only `https`.
> 
> On **`CONNECT`**, the proxy **infers scheme**: if a **`policy.routes`** entry is explicitly **`http`** and matches host/port, the tunnel is treated as HTTP; otherwise it stays HTTPS. **TLS ClientHello / SNI checks run only for HTTPS tunnels**; HTTP tunnels get `200 Connection Established` and byte relay with no TLS parsing.
> 
> Undeclared nonstandard tunnels remain denied; HTTPS **`CONNECT`** behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49d8ac37a098547349e7740c36bc90b1ad8860e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix plain HTTP CONNECT handling in Docker framework egress routes
> - `EgressProxy._handle` in [egress.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2298/files#diff-09ea94564846221a7800c3777052fe00328e68c1c119ee5cede79246889f2e96) no longer hardcodes the scheme as `https` for CONNECT requests; it checks framework routes to determine if the target matches an HTTP route, and skips TLS/SNI inspection for those tunnels.
> - `NetworkPolicy.permits` fixes the scheme comparison in the non-443 CONNECT guard to use the request's actual scheme instead of a fixed `'https'`, so HTTP CONNECT rules can match correctly.
> - Behavioral Change: HTTPS CONNECT behavior is unchanged, but plain HTTP CONNECT tunnels now bypass ClientHello parsing and SNI-based policy checks entirely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49d8ac3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->