### PR TITLE
fix: account for discarded reasoning in input tokens

### DIFF
--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -98,3 +98,48 @@ def test_wire_trace_round_trip():
 
     # the env-server wire form (a plain model_dump) loads too
     assert vf.WireTrace.model_validate(tr.model_dump()).num_branches == 2
+
+
+def test_input_tokens_only_retain_replayable_reasoning_state():
+    calls = [
+        vf.ModelCall(
+            usage=vf.Usage(
+                prompt_tokens=909,
+                completion_tokens=67,
+                cached_input_tokens=0,
+                reasoning_tokens=11,
+            )
+        ),
+        vf.ModelCall(
+            usage=vf.Usage(
+                prompt_tokens=995,
+                completion_tokens=11,
+                cached_input_tokens=0,
+                reasoning_tokens=0,
+            )
+        ),
+    ]
+    discarded = vf.Branch(
+        index=0,
+        nodes=[
+            MessageNode(
+                message=AssistantMessage(
+                    content="answer", reasoning_content="discarded reasoning"
+                ),
+                sampled=True,
+            ),
+            MessageNode(
+                parent=0,
+                message=AssistantMessage(content="done"),
+                sampled=True,
+            ),
+        ],
+        calls=calls,
+    )
+    carried = discarded.model_copy(deep=True)
+    message = carried.nodes[0].message
+    assert isinstance(message, AssistantMessage)
+    message.provider_state = [{"type": "reasoning.encrypted", "data": "state"}]
+
+    assert discarded.num_input_tokens == 909 + 30
+    assert carried.num_input_tokens == 909 + 19

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import time
 import traceback
 import uuid
-from collections.abc import Callable, Iterable, Iterator, Mapping
+from collections.abc import Callable, Iterator, Mapping
 from typing import TYPE_CHECKING, Annotated, Any, Generic, Literal
 
 import numpy as np
@@ -171,20 +171,6 @@ class ModelCall(BaseModel):
     """The failure that ended this call, coupled to the exchange that caused it."""
 
 
-def min_new_input_tokens(calls: Iterable[ModelCall]) -> Iterator[tuple[ModelCall, int]]:
-    """Per-call lower bound on newly fed-in tokens: each call's prompt beyond the
-    previous call's final sequence, clamped at zero. Exact while the history is
-    append-only; tokens the engine drops between calls (stripped reasoning, truncated
-    history) register as an undercount of that call's new input rather than going
-    negative."""
-    prev_total = 0
-    for call in calls:
-        if call.usage is None:
-            continue
-        yield call, max(0, call.usage.input_tokens - prev_total)
-        prev_total = call.usage.total_tokens
-
-
 class Branch(BaseModel):
     """A root-to-leaf graph path; each branch becomes one training sample."""
 
@@ -313,6 +299,31 @@ class Branch(BaseModel):
             (c.usage for c in reversed(self.calls) if c.usage is not None), None
         )
 
+    def input_token_increments(self) -> Iterator[tuple[ModelCall, int]]:
+        """New input beyond the prior response state represented in the next request.
+
+        Textual reasoning may be omitted by the next request's chat template. Only
+        provider state explicitly designed for reasoning replay is therefore retained;
+        otherwise reported reasoning is excluded from the previous sequence before
+        taking the clamped prompt delta.
+        """
+        prev_retained_tokens = 0
+        sampled_nodes = (node for node in self.nodes if node.sampled)
+        for call, node in zip(self.calls, sampled_nodes, strict=True):
+            if call.usage is None:
+                continue
+            yield call, max(0, call.usage.input_tokens - prev_retained_tokens)
+            message = node.message
+            reasoning_retained = isinstance(message, AssistantMessage) and any(
+                str(state.get("type", "")).startswith("reasoning")
+                or state.get("type") in ("thinking", "redacted_thinking")
+                for state in message.provider_state or []
+            )
+            dropped_reasoning = (
+                0 if reasoning_retained else call.usage.reasoning_tokens or 0
+            )
+            prev_retained_tokens = call.usage.total_tokens - dropped_reasoning
+
     @property
     def num_total_tokens(self) -> int:
         last = self.last_usage
@@ -327,7 +338,7 @@ class Branch(BaseModel):
     def num_input_tokens(self) -> int:
         """Fed-in tokens (system + user + tool), counted once; a lower bound whenever
         the engine drops tokens between calls."""
-        return sum(increment for _, increment in min_new_input_tokens(self.calls))
+        return sum(increment for _, increment in self.input_token_increments())
 
 
 class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
@@ -395,7 +406,7 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
         for branch in self.branches:
             # A call's predecessors are fixed by the graph, so its increment is the
             # same in every branch containing it; keep the first occurrence.
-            for call, increment in min_new_input_tokens(branch.calls):
+            for call, increment in branch.input_token_increments():
                 if id(call) not in seen:
                     seen.add(id(call))
                     total += increment


### PR DESCRIPTION
## Overview

Account for reasoning that a chat template discards while preserving provider state explicitly designed for replay.

## Details

Branch input accounting pairs calls with their sampled assistant nodes. Reported reasoning tokens are excluded from the previous sequence when the response only carries textual `reasoning_content`, because ordinary chat templates may omit it on the next request. Opaque provider continuation state—such as encrypted OpenAI reasoning, reasoning detail items, or Anthropic thinking blocks—keeps the full prior sequence because that state is replayable.

The existing zero clamp remains for unrelated context drops. Regression coverage uses identical two-turn usage for both cases: textual Nemotron-style reasoning contributes to newly introduced input after it is discarded, while encrypted reasoning state remains part of the carried context.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes metrics used for training/billing-style rollout reporting; totals drop for multi-turn traces where reasoning is stripped between calls, with retention keyed only on provider_state rather than textual reasoning fields.
> 
> **Overview**
> **Input token accounting** no longer treats provider-reported reasoning as part of the sequence carried into the next turn when that reasoning will not be replayed.
> 
> The standalone `min_new_input_tokens` helper is removed in favor of **`Branch.input_token_increments()`**, which zips each `ModelCall` with its sampled assistant node. After each increment, the retained sequence length uses `total_tokens` minus that call’s `reasoning_tokens` unless the node has replayable **`provider_state`** (types starting with `reasoning`, or `thinking` / `redacted_thinking`). **`Branch.num_input_tokens`** and **`Trace.num_input_tokens`** now sum those increments (trace-level dedup of shared calls is unchanged).
> 
> A regression test compares identical two-turn usage: without encrypted reasoning state, the second-turn delta is larger; with `reasoning.encrypted` state on the first assistant message, reasoning stays in the retained prefix and reported input is lower.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33e1e3a26427a93ec2fd6782370d39b008bb433b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix input token counts to exclude non-replayable reasoning tokens in `Branch` and `Trace`
> - Replaces the standalone `min_new_input_tokens` function with a new `Branch.input_token_increments()` method in [trace.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2300/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e) that accounts for reasoning state retention when computing per-call token deltas.
> - For each call, the method checks whether the preceding `AssistantMessage`'s `provider_state` indicates replayable reasoning (type starting with `'reasoning'`, or exactly `'thinking'`/`'redacted_thinking'`); non-retained reasoning tokens are subtracted from the previous total before computing the next delta.
> - `Branch.num_input_tokens` and `Trace.num_input_tokens` both now use `input_token_increments()`, so reported input token counts can change for traces that include reasoning-heavy sequences.
> - Behavioral Change: total input token counts reported by `Branch` and `Trace` may decrease for branches where prior calls produced non-replayable reasoning tokens.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 33e1e3a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->