### PR TITLE
feat: make ServeConfig.address optional with no default

### DIFF
--- a/verifiers/v1/configs/serve.py
+++ b/verifiers/v1/configs/serve.py
@@ -43,8 +43,10 @@ class ServeConfig(BaseConfig):
     pool: PoolConfig = Field(default_factory=ElasticPoolConfig)
     """Worker-pool sizing. `elastic` (default) starts at one worker and scales up on
     demand; `static` pre-spawns a fixed `num_workers`."""
-    address: str = "tcp://127.0.0.1:5000"
-    """ZMQ address the ROUTER binds (and clients connect to)."""
+    address: str | None = None
+    """ZMQ address the ROUTER binds (and clients connect to). None leaves the choice
+    to whoever hosts the env — `serve_env` falls back to its default loopback bind, a
+    launcher may derive one per server."""
     max_concurrent: int | None = Field(None, ge=1)
     """Episodes in flight per worker (None = take the run's own bound, e.g. an eval's
     `--max-concurrent`). Pin it to hold a worker below what the run asks for; how many

--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -272,7 +272,7 @@ def serve_env(
     *,
     max_workers: int | None,
     legacy: bool = False,
-    address: str = "tcp://127.0.0.1:5000",
+    address: str | None = None,
     address_queue=None,
     death_pipe=None,
     log_setup: Callable[[], None] | None = None,
@@ -284,7 +284,7 @@ def serve_env(
     else an `EnvServerPool` broker over up to `max_workers` worker processes (`None` =
     unbounded). The frontend speaks the same protocol either way, so the client is
     identical. Reports the bound address on `address_queue` (for a spawner that passed an
-    OS-assigned `:0`).
+    OS-assigned `:0`). `address` None binds the default loopback `tcp://127.0.0.1:5000`.
 
     `elastic` (default True) starts the pool at one worker and scales up to `max_workers`
     as load grows; `multiplex` is the per-worker capacity for the scale-up trigger (spawn
@@ -307,6 +307,7 @@ def serve_env(
     _arm_teardown(death_pipe)
     if log_setup is not None:
         log_setup()
+    address = address or "tcp://127.0.0.1:5000"
     try:
         if max_workers is None or max_workers > 1:
             if (


### PR DESCRIPTION
## Summary
- `ServeConfig.address` is now `str | None = None`: the config no longer bakes in a bind address, leaving the choice to whoever hosts the env.
- `serve_env` accepts `address=None` and falls back to its previous default loopback bind (`tcp://127.0.0.1:5000`), so standalone serving behaves exactly as before.
- Nothing inside verifiers reads `ServeConfig.address` (the eval runner binds an OS-assigned `tcp://127.0.0.1:0`), so this only affects downstream consumers of the config.

Companion to PrimeIntellect-ai/prime-rl#3218, which consumes `vf.ServeConfig` as-is per source: an unset `address` means the prime-rl launcher serves the source at a derived loopback address, a set one marks the server externally managed (e.g. its own k8s pod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `ServeConfig.address` optional with `None` as default
> Changes `ServeConfig.address` from a required `str` defaulting to `"tcp://127.0.0.1:5000"` to `Optional[str]` defaulting to `None`. When `None`, `serve_env` coerces the value to `"tcp://127.0.0.1:5000"` internally, keeping runtime behavior unchanged while allowing callers to omit the address and defer bind selection to the host.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4aba2da.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small API/config default change with explicit runtime fallback; no auth or data-path changes.
> 
> **Overview**
> **`ServeConfig.address` no longer defaults to a bind URL** — it is `str | None` with default `None`, so the `[serve]` block does not imply where the ZMQ ROUTER listens; hosts (eval runner, external launchers) decide or derive an address.
> 
> **`serve_env` accepts `address=None`** and normalizes to `tcp://127.0.0.1:5000` at entry, so direct/standalone serving keeps the same loopback bind as before. Docstrings describe that split: unset config defers to the host; unset `serve_env` arg still gets the historical default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aba2da7c27907ba46ea2181ceec9ea2a2d2694f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->