### PR TITLE
fix(v1): isolate Prime process transports

### DIFF
--- a/tests/v1/test_prime_process_transport.py
+++ b/tests/v1/test_prime_process_transport.py
@@ -1,0 +1,210 @@
+from types import SimpleNamespace
+from typing import ClassVar
+
+import pytest
+
+from verifiers.v1.errors import SandboxError
+from verifiers.v1.runtimes.prime import PrimeConfig, PrimeProcess, PrimeRuntime
+
+
+class _FakeTransport:
+    instances: ClassVar[list["_FakeTransport"]] = []
+
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = kwargs
+        self.closed = False
+        self.instances.append(self)
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class _FakeHTTPClient:
+    def __init__(self, transport=None) -> None:
+        self.transport = transport
+
+
+class _FakeConnectClient:
+    unary_transports: ClassVar[list[object]] = []
+
+    def __init__(self, base_url: str, *, http_client=None) -> None:
+        self.base_url = base_url
+        self.http_client = http_client
+
+    def execute_server_stream(self, *, request, method, headers, timeout_ms):
+        del request, method, headers, timeout_ms
+        return SimpleNamespace(kind="stream")
+
+    async def execute_unary(self, *, request, method, headers, timeout_ms):
+        del request, method, headers, timeout_ms
+        self.unary_transports.append(self.http_client.transport)
+
+    async def close(self) -> None:
+        pass
+
+
+async def _empty_stream():
+    return
+    yield b""
+
+
+class _FakeSDKProcess:
+    fail_create = False
+
+    def __init__(self, write_stdin) -> None:
+        self.stdout = _empty_stream()
+        self.stderr = _empty_stream()
+        self._write_stdin = write_stdin
+        self.closed = False
+
+    @classmethod
+    async def _create(cls, stream_client, stream, write_stdin, send_signal):
+        del stream, send_signal
+        assert stream_client.http_client is not None
+        if cls.fail_create:
+            raise RuntimeError("process stream refused")
+        return cls(write_stdin)
+
+    async def write_stdin(self, data: bytes) -> None:
+        await self._write_stdin(4242, data)
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def _runtime(monkeypatch) -> PrimeRuntime:
+    import connectrpc.client
+    import prime_sandboxes.process
+    import pyqwest
+
+    monkeypatch.setattr(pyqwest, "HTTPTransport", _FakeTransport)
+    monkeypatch.setattr(pyqwest, "Client", _FakeHTTPClient)
+    monkeypatch.setattr(connectrpc.client, "ConnectClient", _FakeConnectClient)
+    monkeypatch.setattr(prime_sandboxes.process, "AsyncSandboxProcess", _FakeSDKProcess)
+    _FakeConnectClient.unary_transports = []
+    _FakeSDKProcess.fail_create = False
+    _FakeTransport.instances = []
+
+    class AuthCache:
+        async def get_or_refresh(self, sandbox_id: str) -> dict:
+            assert sandbox_id == "sandbox"
+            return {
+                "gateway_url": "https://gateway.test/",
+                "user_ns": "ns",
+                "job_id": "job",
+                "token": "token",
+            }
+
+    class Client:
+        _auth_cache = AuthCache()
+
+        async def _should_retry_401(self, sandbox_id: str, reauthed: bool) -> bool:
+            del sandbox_id, reauthed
+            return False
+
+    runtime = PrimeRuntime(PrimeConfig(vm=True), name="test")
+    runtime._client = Client()
+    runtime.info.id = "sandbox"
+    return runtime
+
+
+@pytest.mark.asyncio
+async def test_prime_live_processes_get_one_transport_each(monkeypatch) -> None:
+    runtime = _runtime(monkeypatch)
+
+    first = await runtime.open_process(["cat"], {})
+    second = await runtime.open_process(["cat"], {})
+
+    assert isinstance(first, PrimeProcess) and isinstance(second, PrimeProcess)
+    assert first._transport is not second._transport
+    assert first._transport.kwargs == {"tls_include_system_certs": True}
+
+    await first.write(b"ping")
+    await second.write(b"pong")
+    assert _FakeConnectClient.unary_transports == [first._transport, second._transport]
+
+    await first.aclose()
+    assert first._process.closed
+    assert first._transport.closed
+    assert not second._transport.closed
+
+
+@pytest.mark.asyncio
+async def test_prime_open_process_closes_transport_on_failure(monkeypatch) -> None:
+    runtime = _runtime(monkeypatch)
+    _FakeSDKProcess.fail_create = True
+
+    with pytest.raises(SandboxError, match="process stream refused"):
+        await runtime.open_process(["cat"], {})
+
+    assert [transport.closed for transport in _FakeTransport.instances] == [True]
+
+
+@pytest.mark.asyncio
+async def test_prime_process_aclose_releases_transport_when_close_fails() -> None:
+    class SDKProcess:
+        stdout = _empty_stream()
+        stderr = _empty_stream()
+
+        async def aclose(self) -> None:
+            raise RuntimeError("stream already dead")
+
+    transport = _FakeTransport()
+    process = PrimeProcess(SDKProcess(), transport)
+
+    with pytest.raises(RuntimeError, match="stream already dead"):
+        await process.aclose()
+
+    assert transport.closed
+
+
+@pytest.mark.asyncio
+async def test_acp_stop_always_closes_runtime_process() -> None:
+    from verifiers.v1.acp import ACPHarnessSession
+    from verifiers.v1.task import TaskData
+    from verifiers.v1.trace import Trace
+
+    class Process:
+        stdout = _empty_stream()
+        stderr = _empty_stream()
+
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def write(self, data: bytes) -> None:
+            del data
+
+        async def wait(self) -> int:
+            return 0
+
+        async def terminate(self) -> None:
+            pass
+
+        async def kill(self) -> None:
+            pass
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+    session = ACPHarnessSession(
+        SimpleNamespace(config=SimpleNamespace(id="rlm")),
+        SimpleNamespace(),
+        Trace.model_construct(id="trace"),
+        SimpleNamespace(),
+        "http://intercept",
+        "secret",
+        {},
+        TaskData(prompt="hello"),
+        env={},
+        command=["rlm"],
+        prompt="hello",
+        system_prompt=None,
+        session_meta=None,
+    )
+    process = Process()
+    session._process = process
+
+    await session._stop(graceful=False)
+
+    assert process.closed
+    assert session._process is None

--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -316,6 +316,13 @@ class ACPHarnessSession(HarnessSession):
                     stderr_task.cancel()
                 with contextlib.suppress(BaseException):
                     await stderr_task
+            # A process abandoned without its exit event still holds its remote
+            # stream open (on Prime, one gateway HTTP/2 stream slot plus its
+            # dedicated connection) until the sandbox dies. Always release it.
+            closer = getattr(process, "aclose", None)
+            if closer is not None:
+                with contextlib.suppress(BaseException):
+                    await closer()
         if failure is not None:
             detail = str(failure)
             if stderr := self._stderr():

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -77,6 +77,13 @@ class RuntimeProcess(ABC):
     async def kill(self) -> None:
         pass
 
+    async def aclose(self) -> None:
+        """Release transport resources pinned by this process handle.
+
+        Runtimes whose processes hold remote streams or dedicated connections
+        override this. Local processes have nothing to release."""
+        return
+
 
 def parse_gpu(gpu: str | None) -> tuple[str | None, int]:
     """A Modal-style GPU spec -> (type, count) for providers that want them split:

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -103,8 +103,9 @@ class PrimeRuntimeInfo(PrimeConfig, BaseRuntimeInfo):
 
 
 class PrimeProcess(RuntimeProcess):
-    def __init__(self, process) -> None:
+    def __init__(self, process, transport=None) -> None:
         self._process = process
+        self._transport = transport
         self.stdout: AsyncIterator[bytes] = process.stdout
         self.stderr: AsyncIterator[bytes] = process.stderr
 
@@ -119,6 +120,18 @@ class PrimeProcess(RuntimeProcess):
 
     async def kill(self) -> None:
         await self._process.kill()
+
+    async def aclose(self) -> None:
+        # The SDK handle owns the command-session stream and its pump task; the
+        # transport owns this process's dedicated connection. Both must go even
+        # when the remote exit event never arrived — an abandoned stream pins a
+        # gateway HTTP/2 stream slot until the sandbox is deleted.
+        try:
+            await self._process.aclose()
+        finally:
+            if self._transport is not None:
+                with contextlib.suppress(Exception):
+                    await self._transport.aclose()
 
 
 class PrimeRuntime(Runtime):
@@ -278,15 +291,122 @@ class PrimeRuntime(Runtime):
                 "set runtime.prime.vm=true"
             )
         try:
-            process = await self._client.open_process(
-                self.info.id,
-                shlex.join(argv),
-                working_dir=self.config.workdir,
-                env=env,
+            process, transport = await self._open_process_on_own_transport(
+                shlex.join(argv), env
             )
         except Exception as e:
             raise SandboxError(f"prime live process failed to start: {e}") from e
-        return PrimeProcess(process)
+        return PrimeProcess(process, transport)
+
+    async def _open_process_on_own_transport(self, command: str, env: dict[str, str]):
+        """Start a live process whose RPCs ride one dedicated HTTP connection.
+
+        The SDK routes every command-session RPC over pyqwest's shared default
+        transport, and the gateway caps one HTTP/2 connection at 100 concurrent
+        streams. Each live process pins one stream for its whole life, so
+        accumulated sessions starve stdin/signal RPCs into their 30s deadline
+        ("deadline_exceeded") and queue new process streams for minutes under
+        the 24h stream timeout. One transport per process keeps a process
+        competing only with itself. Rebuilds the SDK's open_process wiring from
+        prime-sandboxes internals (pinned >=0.2.35); drop this once the SDK
+        isolates its own command-session transports."""
+        from connectrpc.client import ConnectClient
+        from connectrpc.code import Code
+        from connectrpc.errors import ConnectError
+        from prime_sandboxes.core import APIError
+        from prime_sandboxes.process import AsyncSandboxProcess
+        from prime_sandboxes.rpc_command_session import (
+            COMMAND_SESSION_SEND_INPUT_RPC_METHOD,
+            COMMAND_SESSION_SEND_SIGNAL_RPC_METHOD,
+            COMMAND_SESSION_START_RPC_METHOD,
+            build_command_session_send_input_request,
+            build_command_session_send_signal_request,
+            build_command_session_start_request,
+        )
+        from prime_sandboxes.sandbox import (
+            _LIVE_PROCESS_TIMEOUT_MS,
+            _PROCESS_INPUT_TIMEOUT_MS,
+            _PROCESS_SIGNAL_TIMEOUT_MS,
+        )
+        from pyqwest import Client as HTTPClient
+        from pyqwest import HTTPTransport
+
+        client = self._client
+        sandbox_id = self.info.id
+        transport = HTTPTransport()
+        http_client = HTTPClient(transport=transport)
+
+        async def authed_target() -> tuple[str, dict[str, str]]:
+            auth = await client._auth_cache.get_or_refresh(sandbox_id)
+            gateway_url = auth["gateway_url"].rstrip("/")
+            return (
+                f"{gateway_url}/{auth['user_ns']}/{auth['job_id']}",
+                {"Authorization": f"Bearer {auth['token']}"},
+            )
+
+        async def control_rpc(request, method, timeout_ms: int, operation: str) -> None:
+            # Mirrors AsyncSandboxClient._execute_process_control_rpc, including
+            # its error strings, but sends over this process's own transport.
+            reauthed = False
+            while True:
+                base_url, headers = await authed_target()
+                rpc_client = ConnectClient(base_url, http_client=http_client)
+                try:
+                    await rpc_client.execute_unary(
+                        request=request,
+                        method=method,
+                        headers=headers,
+                        timeout_ms=timeout_ms,
+                    )
+                    return
+                except ConnectError as error:
+                    if (
+                        error.code == Code.UNAUTHENTICATED
+                        and await client._should_retry_401(sandbox_id, reauthed)
+                    ):
+                        reauthed = True
+                        continue
+                    raise APIError(
+                        f"process {operation} RPC failed ({error.code.value}): {error.message}"
+                    ) from error
+                finally:
+                    await rpc_client.close()
+
+        async def write_stdin(pid: int, data: bytes) -> None:
+            await control_rpc(
+                build_command_session_send_input_request(pid, data),
+                COMMAND_SESSION_SEND_INPUT_RPC_METHOD,
+                _PROCESS_INPUT_TIMEOUT_MS,
+                "stdin",
+            )
+
+        async def send_signal(pid: int, signal: Literal["terminate", "kill"]) -> None:
+            await control_rpc(
+                build_command_session_send_signal_request(pid, signal),
+                COMMAND_SESSION_SEND_SIGNAL_RPC_METHOD,
+                _PROCESS_SIGNAL_TIMEOUT_MS,
+                "signal",
+            )
+
+        try:
+            base_url, headers = await authed_target()
+            stream_client = ConnectClient(base_url, http_client=http_client)
+            stream = stream_client.execute_server_stream(
+                request=build_command_session_start_request(
+                    command, self.config.workdir, env, stdin=True
+                ),
+                method=COMMAND_SESSION_START_RPC_METHOD,
+                headers=headers,
+                timeout_ms=_LIVE_PROCESS_TIMEOUT_MS,
+            )
+            process = await AsyncSandboxProcess._create(
+                stream_client, stream, write_stdin, send_signal
+            )
+        except BaseException:
+            with contextlib.suppress(Exception):
+                await transport.aclose()
+            raise
+        return process, transport
 
     async def expose(self, port: int) -> str | None:
         # Publish a server hosted IN the sandbox via the SDK's native port exposure → a public

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -333,7 +333,12 @@ class PrimeRuntime(Runtime):
 
         client = self._client
         sandbox_id = self.info.id
-        transport = HTTPTransport()
+        try:
+            # pyqwest >= 0.7 leaves system CA trust off for bare transports; a
+            # bare HTTPTransport() there fails TLS with "UnknownIssuer".
+            transport = HTTPTransport(tls_include_system_certs=True)
+        except TypeError:  # pyqwest 0.6.x trusts system CAs by default
+            transport = HTTPTransport()
         http_client = HTTPClient(transport=transport)
 
         async def authed_target() -> tuple[str, dict[str, str]]:


### PR DESCRIPTION
## Summary

Prime live processes currently share pyqwest's default HTTP/2 transport. Each persistent ACP process pins one stream, so the gateway's 100-stream connection limit blocks new process streams and stdin or signal RPCs.

This gives each Prime live process its own transport, sends that process's control RPCs over the same transport, and always releases the SDK handle and transport during ACP teardown. The TLS setup supports pyqwest 0.6 and 0.7.

## Verification

- Reproduced on `prime-sandboxes==0.2.35`: 100 open processes caused stdin to fail after its 30-second deadline, and process 101 could not open.
- Integrated Verifiers canary: 105/105 processes opened, 105/105 accepted stdin, all 105 closed in 0.15 seconds.
- Prime RLM smoke: 20 persistent designer turns completed and closed cleanly with no process-stream errors.
- `pytest -q tests/v1 -m "not e2e"`: passed.
- Focused Ruff checks passed.

This PR targets the ACP metadata branch used by Hillclimb. It does not include the separate ACP application-keepalive experiment because Prime's command-session service already emits transport keepalives every 90 seconds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reimplements prime-sandboxes command-session wiring against SDK internals; behavior is critical for multi-session Prime ACP but covered by focused unit tests and described canary validation.
> 
> **Overview**
> **Fixes Prime live-process starvation** when many persistent ACP sessions share one gateway connection (100 HTTP/2 stream cap). Instead of the SDK’s shared pyqwest transport, each `open_process` now builds a **dedicated `HTTPTransport`** (with TLS compatible for pyqwest 0.6/0.7) and routes that process’s command-session stream plus stdin/signal RPCs over it.
> 
> `PrimeProcess` keeps the transport and **`aclose()`** closes the SDK handle and transport even if the remote exit never arrives. **`RuntimeProcess.aclose()`** is a no-op default; **ACP `_stop`** always invokes `aclose()` after terminate/kill/wait so abandoned sessions don’t pin gateway slots until sandbox delete.
> 
> Adds **`tests/v1/test_prime_process_transport.py`** for per-process transports, transport cleanup on open failure, transport release when SDK close fails, and ACP stop calling `aclose`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82f7fbbdc39b5877edf2ac632cff135d9a711775. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Isolate HTTP transport per process in Prime runtime
> - Each `PrimeProcess` now gets a dedicated `pyqwest` HTTP transport and `ConnectClient`, created in a new `_open_process_on_own_transport` helper in [prime.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2302/files#diff-d22d61279ff7587a2b14c72ab1a0fc9d3f805a735338a70f8efc7fe19aaa8502).
> - `PrimeProcess.aclose()` closes both the underlying SDK process and its transport, suppressing errors on the transport close.
> - `RuntimeProcess` in [base.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2302/files#diff-0811c040a163eb5a3212208f1e3a6c6388d7690fcc4780c081cc7754036232b9) gains a default no-op `aclose()` so callers can invoke it uniformly.
> - `ACPHarnessSession._stop` in [acp/__init__.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2302/files#diff-4a98e09e3584605f8da12349ce8fa454922c607127e29c836edfae5094b41ccf) now always calls `process.aclose()` in a finally block, ensuring transport cleanup even if termination or wait paths fail.
> - Risk: auth handling and retry logic (401) is re-implemented inline in the new helper; divergence from the SDK's auth path is possible if the SDK changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 82f7fbb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->