### PR TITLE
Make Chat Completions sampling overrides authoritative

### DIFF
--- a/tests/v1/test_dialects.py
+++ b/tests/v1/test_dialects.py
@@ -1,0 +1,40 @@
+from verifiers.v1.dialects.chat import ChatDialect
+from verifiers.v1.types import SamplingConfig
+
+
+def test_chat_sampling_overrides_are_authoritative():
+    body = {
+        "model": "harness-model",
+        "messages": [{"role": "user", "content": "hello"}],
+        "stream": True,
+        "temperature": 0.2,
+        "top_p": 0.8,
+        "top_k": 20,
+        "max_tokens": 16_384,
+        "max_completion_tokens": 8_192,
+        "reasoning_effort": "low",
+        "stop": ["done"],
+        "tool_choice": "auto",
+    }
+
+    result = ChatDialect().apply_overrides(
+        body,
+        "eval-model",
+        SamplingConfig(temperature=1.0, top_p=1.0, reasoning_effort="max"),
+    )
+
+    assert result == {
+        "model": "eval-model",
+        "messages": [{"role": "user", "content": "hello"}],
+        "stream": True,
+        "temperature": 1.0,
+        "top_p": 1.0,
+        "reasoning_effort": "max",
+    }
+    assert body["max_tokens"] == 16_384
+
+    limited = ChatDialect().apply_overrides(
+        body, "eval-model", SamplingConfig(max_tokens=4_096)
+    )
+    assert limited["max_tokens"] == 4_096
+    assert "max_completion_tokens" not in limited

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -352,6 +352,8 @@ class ChatDialect(Dialect[dict, ChatCompletion]):
         return ChatStreamParser()
 
     def apply_overrides(self, body: dict, model: str, sampling: SamplingConfig) -> dict:
-        # Preserve the program's native fields, overlaying only what the eval owns: the model and
-        # the sampling knobs it set (later keys win, so the eval's override the program's).
-        return {**body, "model": model, **sampling.model_dump(exclude_none=True)}
+        return {
+            **{k: v for k, v in body.items() if k not in self.sampling_fields},
+            "model": model,
+            **sampling.model_dump(exclude_none=True),
+        }


### PR DESCRIPTION
## Overview

Make eval sampling configuration authoritative for intercepted Chat Completions requests.

## Details

Chat Completions now removes harness-provided sampling fields before applying the eval's non-null sampling settings, matching the dialect contract already used by the Responses path. Native request data such as messages, tools, and streaming configuration remains intact, while the eval continues to own the model.

This prevents implicit harness defaults such as Pi's 16K output limit from surviving when an evaluation intentionally leaves `max_tokens` unset, while still forwarding an explicit eval limit when one is configured.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes forwarded Chat Completions request shaping for intercepted eval traffic; wrong stripping could drop required fields or alter token limits, but scope is limited to `apply_overrides` with test coverage.
> 
> **Overview**
> **Chat Completions** `apply_overrides` now matches the dialect contract used on the Responses path: harness-provided sampling keys are **removed** before the eval’s `model` and non-null `SamplingConfig` fields are applied.
> 
> Previously, merging the full request body with eval sampling let implicit harness defaults (e.g. Pi’s 16K `max_tokens`, `stop`, `tool_choice`) persist when the eval omitted those knobs. Non-sampling payload (`messages`, `stream`, tools, etc.) is unchanged; the original request dict is not mutated.
> 
> A regression test in `test_dialects.py` covers partial eval overrides and explicit `max_tokens`, including dropping `max_completion_tokens` when the eval sets a limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f37b0bfdb31204fb0cfa3ff98dc180042818100d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `ChatDialect.apply_overrides` strip original sampling fields before merging
> Previously, `apply_overrides` merged `SamplingConfig` on top of the request body, leaving any sampling fields not present in `SamplingConfig` (e.g. `max_completion_tokens`) in the result. Now, all known sampling fields are stripped from the original body before merging, so only fields explicitly set in `SamplingConfig` appear in the returned dict.
>
> - [chat.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2307/files#diff-5d2fcbf59a03489b63b0626038a853eee89543b591074597161ee29aab901280): filters out all sampling-related keys from `body` before merging with the model and `SamplingConfig` dump.
> - [test_dialects.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2307/files#diff-c56f2b682d430fdcc55174c9e38af706ab8105e48f2a997f682c191f9462a668): adds `test_chat_sampling_overrides_are_authoritative` to verify that non-sampling fields are preserved and unspecified sampling fields are omitted.
> - Behavioral Change: callers that relied on sampling fields from the original request body passing through `apply_overrides` unchanged will now have those fields removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f37b0bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->