### PR TITLE
Use native model catalogs in agent harnesses

### DIFF
--- a/verifiers/v1/harnesses/openclaw/harness.py
+++ b/verifiers/v1/harnesses/openclaw/harness.py
@@ -117,8 +117,7 @@ class OpenClawHarness(Harness[OpenClawHarnessConfig]):
         data: TaskData,
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(data)
-        # Opt-in via sampling: OpenClaw redacts persisted encrypted reasoning, so resumed sessions 400 replaying it.
-        reasoning = ctx.sampling.reasoning_effort not in (None, "none")
+        provider, _ = ctx.model.split("/", 1)
         directory = OPENCLAW_DIR.format(version=self.config.version)
         state_dir = f".vf-openclaw/{trace.id}"
         config_path = f"{state_dir}/openclaw.json"
@@ -130,7 +129,7 @@ class OpenClawHarness(Harness[OpenClawHarnessConfig]):
                     "workspace": ".",
                     "skipBootstrap": True,
                     "sandbox": {"mode": "off"},
-                    "model": {"primary": f"intercept/{ctx.model}"},
+                    "model": {"primary": ctx.model},
                 }
             },
             "tools": {
@@ -140,21 +139,10 @@ class OpenClawHarness(Harness[OpenClawHarnessConfig]):
                 "deny": self.config.disabled_tools or [],
             },
             "models": {
-                "mode": "replace",
                 "providers": {
-                    "intercept": {
+                    provider: {
                         "baseUrl": endpoint,
                         "apiKey": "${OPENCLAW_INTERCEPT_KEY}",
-                        "api": "openai-responses",
-                        "authHeader": True,
-                        "models": [
-                            {
-                                "id": ctx.model,
-                                "name": ctx.model,
-                                "reasoning": reasoning,
-                                "input": ["text", "image"],
-                            }
-                        ],
                     }
                 },
             },

--- a/verifiers/v1/harnesses/pi/harness.py
+++ b/verifiers/v1/harnesses/pi/harness.py
@@ -17,7 +17,6 @@ from verifiers.v1.trace import Trace
 
 logger = logging.getLogger(__name__)
 
-PROVIDER = "intercept"
 KEY_VAR = "PI_INTERCEPT_KEY"
 HOME_VAR = "VF_PI_ORIGINAL_HOME"
 
@@ -143,23 +142,12 @@ class PiHarness(Harness[PiHarnessConfig]):
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(data)
         agent_dir = f".vf-pi-agent-{trace.id}"
-        reasoning = ctx.sampling.reasoning_effort not in (
-            None,
-            "none",
-        ) or ctx.model.rsplit("/", 1)[-1].startswith(("gpt-5", "o1", "o3", "o4"))
+        provider, model = ctx.model.split("/", 1)
         models = {
             "providers": {
-                PROVIDER: {
+                provider: {
                     "baseUrl": endpoint,
-                    "api": "openai-completions",
                     "apiKey": f"${KEY_VAR}",
-                    "models": [
-                        {
-                            "id": ctx.model,
-                            "reasoning": reasoning,
-                            "input": ["text", "image"],
-                        }
-                    ],
                 }
             }
         }
@@ -202,9 +190,9 @@ class PiHarness(Harness[PiHarnessConfig]):
             PI_BIN,
             "--no-approve",
             "--provider",
-            PROVIDER,
+            provider,
             "--model",
-            ctx.model,
+            model,
             *mcp_args,
             *skill_args,
         ]


### PR DESCRIPTION
## Overview

Use the native model catalogs provided by Pi and OpenClaw while routing requests through Verifiers interception.

## Details

- Configure the selected native provider with the interception base URL and rollout secret instead of registering a synthetic `intercept` model.
- Pass Pi the provider and model portions of the provider-qualified model ID.
- Let OpenClaw select the provider-qualified model directly and retain its default catalog merge behavior.
- Leave API type, reasoning support, input modalities, and other model capabilities owned by each harness's catalog.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Routing and model identity now depend on each harness’s native catalog merge behavior; misaligned provider IDs or catalog gaps could change API surface or reasoning behavior versus the old synthetic intercept definitions.
> 
> **Overview**
> **Pi** and **OpenClaw** harnesses no longer register a synthetic **`intercept`** provider with inline model definitions (API flavor, reasoning flags, input modalities). They parse **`provider/model`** from `ctx.model`, configure that **native provider** with the rollout interception **base URL** and secret, and let each agent’s built-in catalog supply capabilities.
> 
> For **OpenClaw**, the agent default **`primary`** model is the full provider-qualified ID (not `intercept/...`), and the **`models`** block drops **`mode: replace`** and the custom **`openai-responses`** / per-model **`models`** list—only provider endpoint credentials are injected. Reasoning is no longer derived from **`ctx.sampling.reasoning_effort`** in the harness.
> 
> For **Pi**, **`models.json`** mirrors the same pattern (provider key + endpoint only), and the CLI gets **`--provider`** / **`--model`** from the split ID instead of a fixed intercept provider and full model string. Harness-side reasoning heuristics (sampling effort and GPT/o-series name checks) are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 571c9314a1e70bd89c6eca269f53b12b068c70fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use native model catalogs in OpenClaw and Pi agent harnesses
> - Both [openclaw/harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2308/files#diff-d7278b9055ef0f18d323c2ac3010b475bc2122a03e99b44977384fab44c24362) and [pi/harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2308/files#diff-d9ee2431b7427a96633e83be4179a971f5a199c76bb0f603d70bb44147476ace) now derive `provider` and `model` by splitting `ctx.model`, replacing hardcoded provider keys and prefixed model references.
> - The generated `models.json` for each harness is simplified to only `baseUrl` and `apiKey`; the embedded models list, reasoning flag, and explicit API/authHeader fields are removed.
> - The Pi CLI invocation now passes `--provider` and `--model` as the split components of `ctx.model` instead of a prefixed string.
> - Behavioral Change: harnesses no longer inject a reasoning flag or a models list into provider config, relying on the native catalog instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 571c931.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->