### PR TITLE
feat: config-plugged functions (stops, metrics, rewards)

### DIFF
--- a/docs/v1/tasksets.md
+++ b/docs/v1/tasksets.md
@@ -231,6 +231,23 @@ class JudgeTraceTaskset(vf.Taskset[JudgedTask, SetConfig]):
 
 To override the judge model, set `env.taskset.task.judge.model` in your config (it is a string).
 
+## Plugging hooks via config
+
+Stop conditions, metrics, and rewards can also be plugged into any task from config, without touching the taskset's code. Each entry names a function by import path (`pkg.module.function`, `pkg.module:function`, or `path/to/file.py:function`); functions may be sync or async and declare what they need by parameter name (`task`, `trace`, `runtime` — stops receive the trace only):
+
+```toml
+[env.taskset.task.stops]
+single_turn = { fn = "my_hooks.py:two_turns" }
+
+[env.taskset.task.metrics]
+reply_length = { fn = "my_hooks.py:reply_length" }
+
+[env.taskset.task.rewards]
+exact_match = { fn = "my_hooks.py:exact_match", weight = 0.5 }
+```
+
+Plugged hooks merge with the task's decorated `@vf.stop` / `@vf.metric` / `@vf.reward` methods; a plugged hook replaces a decorated one with the same name, so an existing signal can be swapped out (like `single_turn` above). Rewards take a `weight`, and every entry takes a `priority` (higher runs first).
+
 ## Beyond one agent
 
 One episode doesn't have to be one agent run: agents, the control flow between agents, and cross-agent rewards are the environment's job — see [The Env](env.md).

--- a/docs/v1/tasksets.md
+++ b/docs/v1/tasksets.md
@@ -233,7 +233,7 @@ To override the judge model, set `env.taskset.task.judge.model` in your config (
 
 ## Plugging hooks via config
 
-Stop conditions, metrics, and rewards can also be plugged into any task from config, without touching the taskset's code. Each entry names a function by import path (`pkg.module.function`, `pkg.module:function`, or `path/to/file.py:function`); functions may be sync or async and declare what they need by parameter name (`task`, `trace`, `runtime` — stops receive the trace only):
+Stop conditions, metrics, and rewards can also be plugged into any task from config, without touching the taskset's code. Each entry names an async function by import path (`pkg.module.function`, `pkg.module:function`, or `path/to/file.py:function`); like decorated hooks, functions declare what they need by parameter name (`task`, `trace`, `runtime` — stops receive the trace only):
 
 ```toml
 [env.taskset.task.stops]

--- a/docs/v1/tasksets.md
+++ b/docs/v1/tasksets.md
@@ -240,7 +240,7 @@ Stop conditions, metrics, and rewards can also be plugged into any task from con
 single_turn = { fn = "my_hooks.py:two_turns" }
 
 [env.taskset.task.metrics]
-reply_length = { fn = "my_hooks.py:reply_length" }
+reply_length = { fn = "my_hooks.py:reply_length", priority = 10 }
 
 [env.taskset.task.rewards]
 exact_match = { fn = "my_hooks.py:exact_match", weight = 0.5 }

--- a/tests/v1/test_scoring.py
+++ b/tests/v1/test_scoring.py
@@ -2,7 +2,7 @@ import verifiers.v1 as vf
 from verifiers.v1.graph import MessageNode
 from verifiers.v1.types import AssistantMessage, UserMessage
 
-HOOKS_PY = """
+PLUGGED_FNS_PY = """
 def reply_length(trace) -> float:
     return float(len(trace.last_reply or ""))
 
@@ -34,15 +34,15 @@ class HookTask(vf.Task[HookData]):
         return 0.5
 
 
-async def test_config_plugged_hooks_merge_and_override(tmp_path) -> None:
-    hooks = tmp_path / "hooks.py"
-    hooks.write_text(HOOKS_PY)
+async def test_config_plugged_fns_merge_and_override(tmp_path) -> None:
+    fns = tmp_path / "fns.py"
+    fns.write_text(PLUGGED_FNS_PY)
     config = vf.TaskConfig(
-        stops={"single_turn": vf.HookConfig(fn=f"{hooks}:two_turns")},
-        metrics={"reply_length": vf.HookConfig(fn=f"{hooks}:reply_length")},
+        stops={"single_turn": vf.DecoratedFunctionConfig(fn=f"{fns}:two_turns")},
+        metrics={"reply_length": vf.DecoratedFunctionConfig(fn=f"{fns}:reply_length")},
         rewards={
-            "exact_match": vf.RewardConfig(fn=f"{hooks}:exact_match", weight=0.5),
-            "lcs": vf.RewardConfig(fn=f"{hooks}:marker", weight=2.0),
+            "exact_match": vf.RewardFunctionConfig(fn=f"{fns}:exact_match", weight=0.5),
+            "lcs": vf.RewardFunctionConfig(fn=f"{fns}:marker", weight=2.0),
         },
     )
     task = HookTask(HookData(idx=0, prompt="abc", answer="cba"), config)

--- a/tests/v1/test_scoring.py
+++ b/tests/v1/test_scoring.py
@@ -3,7 +3,7 @@ from verifiers.v1.graph import MessageNode
 from verifiers.v1.types import AssistantMessage, UserMessage
 
 PLUGGED_FNS_PY = """
-def reply_length(trace) -> float:
+async def reply_length(trace) -> float:
     return float(len(trace.last_reply or ""))
 
 
@@ -11,11 +11,11 @@ async def exact_match(task, trace) -> float:
     return float(task.answer in (trace.last_reply or ""))
 
 
-def marker(trace) -> float:
+async def marker(trace) -> float:
     return 0.125
 
 
-def two_turns(trace) -> bool:
+async def two_turns(trace) -> bool:
     return trace.num_turns >= 2
 """
 

--- a/tests/v1/test_scoring.py
+++ b/tests/v1/test_scoring.py
@@ -1,4 +1,74 @@
 import verifiers.v1 as vf
+from verifiers.v1.graph import MessageNode
+from verifiers.v1.types import AssistantMessage, UserMessage
+
+HOOKS_PY = """
+def reply_length(trace) -> float:
+    return float(len(trace.last_reply or ""))
+
+
+async def exact_match(task, trace) -> float:
+    return float(task.answer in (trace.last_reply or ""))
+
+
+def marker(trace) -> float:
+    return 0.125
+
+
+def two_turns(trace) -> bool:
+    return trace.num_turns >= 2
+"""
+
+
+class HookData(vf.TaskData):
+    answer: str = ""
+
+
+class HookTask(vf.Task[HookData]):
+    @vf.stop
+    async def single_turn(self, trace: vf.Trace) -> bool:
+        return trace.num_turns >= 1
+
+    @vf.reward
+    async def lcs(self, trace: vf.Trace) -> float:
+        return 0.5
+
+
+async def test_config_plugged_hooks_merge_and_override(tmp_path) -> None:
+    hooks = tmp_path / "hooks.py"
+    hooks.write_text(HOOKS_PY)
+    config = vf.TaskConfig(
+        stops={"single_turn": vf.HookConfig(fn=f"{hooks}:two_turns")},
+        metrics={"reply_length": vf.HookConfig(fn=f"{hooks}:reply_length")},
+        rewards={
+            "exact_match": vf.RewardConfig(fn=f"{hooks}:exact_match", weight=0.5),
+            "lcs": vf.RewardConfig(fn=f"{hooks}:marker", weight=2.0),
+        },
+    )
+    task = HookTask(HookData(idx=0, prompt="abc", answer="cba"), config)
+    trace = vf.Trace(
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
+        task=vf.TraceTask(type="HookTask", data=task.data),
+        nodes=[
+            MessageNode(parent=None, message=UserMessage(content="abc"), sampled=False),
+            MessageNode(
+                parent=0, message=AssistantMessage(content="cba"), sampled=True
+            ),
+        ],
+    )
+
+    # the plugged `single_turn` replaces the decorated one: no stop after one turn
+    (stop,) = task.hooks("stop")
+    assert stop.__name__ == "single_turn"
+    assert not await stop(trace)
+
+    await task.score(trace)
+    # `lcs` scored by the plugged marker (config wins the name clash), config weight
+    assert trace.rewards["lcs"].score == 0.125
+    assert trace.rewards["lcs"].weight == 2.0
+    assert trace.rewards["exact_match"].score == 1.0
+    assert trace.rewards["exact_match"].weight == 0.5
+    assert trace.metrics["reply_length"] == 3.0
 
 
 def test_compare_stdout_results_accepts_token_equal_text() -> None:

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -26,7 +26,12 @@ from verifiers.v1.configs.serve import (
     StaticPoolConfig,
     pool_serve_kwargs,
 )
-from verifiers.v1.configs.task import HookConfig, RewardConfig, TaskConfig
+from verifiers.v1.configs.task import (
+    DecoratedFunctionConfig,
+    FunctionConfig,
+    RewardFunctionConfig,
+    TaskConfig,
+)
 from verifiers.v1.configs.taskset import TasksetConfig
 from verifiers.v1.env import Env
 from verifiers.v1.envs.single_agent import SingleAgentEnv, SingleAgentEnvConfig
@@ -240,8 +245,9 @@ __all__ = [  # noqa: RUF022 - grouped by public API area
     "Taskset",
     "TaskConfig",
     "TasksetConfig",
-    "HookConfig",
-    "RewardConfig",
+    "FunctionConfig",
+    "DecoratedFunctionConfig",
+    "RewardFunctionConfig",
     "BaseConfig",
     "Harness",
     "HarnessSession",

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -26,7 +26,7 @@ from verifiers.v1.configs.serve import (
     StaticPoolConfig,
     pool_serve_kwargs,
 )
-from verifiers.v1.configs.task import TaskConfig
+from verifiers.v1.configs.task import HookConfig, RewardConfig, TaskConfig
 from verifiers.v1.configs.taskset import TasksetConfig
 from verifiers.v1.env import Env
 from verifiers.v1.envs.single_agent import SingleAgentEnv, SingleAgentEnvConfig
@@ -240,6 +240,8 @@ __all__ = [  # noqa: RUF022 - grouped by public API area
     "Taskset",
     "TaskConfig",
     "TasksetConfig",
+    "HookConfig",
+    "RewardConfig",
     "BaseConfig",
     "Harness",
     "HarnessSession",

--- a/verifiers/v1/configs/task.py
+++ b/verifiers/v1/configs/task.py
@@ -2,10 +2,26 @@
 
 from __future__ import annotations
 
-from pydantic import Field, model_validator
+from pydantic import Field, FiniteFloat, model_validator
 from pydantic_config import BaseConfig
 
 from verifiers.v1.configs.judge import Judges, check_judges, resolve_judges
+
+
+class HookConfig(BaseConfig):
+    """A hook function plugged into a task by import path."""
+
+    fn: str
+    """Import path to the hook function: `pkg.module.function`, `pkg.module:function`,
+    or `path/to/file.py:function`."""
+    priority: int = 0
+    """Execution order among the task's hooks — higher runs first, ties break by name."""
+
+
+class RewardConfig(HookConfig):
+    """A reward hook plugged into a task by import path."""
+
+    weight: FiniteFloat = 1.0
 
 
 class TaskConfig(BaseConfig):
@@ -18,6 +34,17 @@ class TaskConfig(BaseConfig):
 
     judges: Judges = Field(default_factory=list)
     """Judge plugins run after task rewards, set through `--env.taskset.task.judges`."""
+
+    stops: dict[str, HookConfig] = Field(default_factory=dict)
+    """Stop conditions `(trace) -> bool` plugged by name, merged with the task's
+    `@vf.stop` methods (a plugged hook replaces a decorated one with the same name),
+    set through `--env.taskset.task.stops`."""
+    metrics: dict[str, HookConfig] = Field(default_factory=dict)
+    """Metrics `(task, trace, runtime) -> float` plugged by name, merged with the
+    task's `@vf.metric` methods, set through `--env.taskset.task.metrics`."""
+    rewards: dict[str, RewardConfig] = Field(default_factory=dict)
+    """Weighted rewards `(task, trace, runtime) -> float` plugged by name, merged with
+    the task's `@vf.reward` methods, set through `--env.taskset.task.rewards`."""
 
     @model_validator(mode="before")
     @classmethod

--- a/verifiers/v1/configs/task.py
+++ b/verifiers/v1/configs/task.py
@@ -8,18 +8,23 @@ from pydantic_config import BaseConfig
 from verifiers.v1.configs.judge import Judges, check_judges, resolve_judges
 
 
-class HookConfig(BaseConfig):
-    """A hook function plugged into a task by import path."""
+class FunctionConfig(BaseConfig):
+    """A function plugged in by import path."""
 
     fn: str
-    """Import path to the hook function: `pkg.module.function`, `pkg.module:function`,
+    """Import path to the function: `pkg.module.function`, `pkg.module:function`,
     or `path/to/file.py:function`."""
+
+
+class DecoratedFunctionConfig(FunctionConfig):
+    """A plugged function standing in for a decorated task method."""
+
     priority: int = 0
-    """Execution order among the task's hooks — higher runs first, ties break by name."""
+    """Execution order, like the decorator's — higher runs first, ties break by name."""
 
 
-class RewardConfig(HookConfig):
-    """A reward hook plugged into a task by import path."""
+class RewardFunctionConfig(DecoratedFunctionConfig):
+    """A plugged function standing in for a `@vf.reward` task method."""
 
     weight: FiniteFloat = 1.0
 
@@ -35,14 +40,14 @@ class TaskConfig(BaseConfig):
     judges: Judges = Field(default_factory=list)
     """Judge plugins run after task rewards, set through `--env.taskset.task.judges`."""
 
-    stops: dict[str, HookConfig] = Field(default_factory=dict)
+    stops: dict[str, DecoratedFunctionConfig] = Field(default_factory=dict)
     """Stop conditions `(trace) -> bool` plugged by name, merged with the task's
-    `@vf.stop` methods (a plugged hook replaces a decorated one with the same name),
-    set through `--env.taskset.task.stops`."""
-    metrics: dict[str, HookConfig] = Field(default_factory=dict)
+    `@vf.stop` methods (a plugged function replaces a decorated one with the same
+    name), set through `--env.taskset.task.stops`."""
+    metrics: dict[str, DecoratedFunctionConfig] = Field(default_factory=dict)
     """Metrics `(task, trace, runtime) -> float` plugged by name, merged with the
     task's `@vf.metric` methods, set through `--env.taskset.task.metrics`."""
-    rewards: dict[str, RewardConfig] = Field(default_factory=dict)
+    rewards: dict[str, RewardFunctionConfig] = Field(default_factory=dict)
     """Weighted rewards `(task, trace, runtime) -> float` plugged by name, merged with
     the task's `@vf.reward` methods, set through `--env.taskset.task.rewards`."""
 

--- a/verifiers/v1/configs/task.py
+++ b/verifiers/v1/configs/task.py
@@ -43,13 +43,13 @@ class TaskConfig(BaseConfig):
     stops: dict[str, DecoratedFunctionConfig] = Field(default_factory=dict)
     """Stop conditions `(trace) -> bool` plugged by name, merged with the task's
     `@vf.stop` methods (a plugged function replaces a decorated one with the same
-    name), set through `--env.taskset.task.stops`."""
+    name)."""
     metrics: dict[str, DecoratedFunctionConfig] = Field(default_factory=dict)
     """Metrics `(task, trace, runtime) -> float` plugged by name, merged with the
-    task's `@vf.metric` methods, set through `--env.taskset.task.metrics`."""
+    task's `@vf.metric` methods."""
     rewards: dict[str, RewardFunctionConfig] = Field(default_factory=dict)
     """Weighted rewards `(task, trace, runtime) -> float` plugged by name, merged with
-    the task's `@vf.reward` methods, set through `--env.taskset.task.rewards`."""
+    the task's `@vf.reward` methods."""
 
     @model_validator(mode="before")
     @classmethod

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -30,7 +30,7 @@ from verifiers.v1.state import state_cls
 from verifiers.v1.task import Task
 from verifiers.v1.trace import AgentInfo, Trace, TraceTask
 from verifiers.v1.types import Messages
-from verifiers.v1.utils.decorators import discover_decorated, invoke
+from verifiers.v1.utils.decorators import invoke
 
 logger = logging.getLogger(__name__)
 
@@ -91,9 +91,7 @@ class Rollout:
         )
         if on_trace is not None:
             on_trace(self.trace)
-        self._session = RolloutSession(
-            ctx, self.trace, discover_decorated(task, "stop"), limits
-        )
+        self._session = RolloutSession(ctx, self.trace, task.hooks("stop"), limits)
         self._stack = AsyncExitStack()
         self._failed = False
         self._failure: Exception | None = None

--- a/verifiers/v1/task.py
+++ b/verifiers/v1/task.py
@@ -12,8 +12,8 @@ from __future__ import annotations
 import copy
 import inspect
 import logging
-from collections.abc import Mapping
-from typing import TYPE_CHECKING, ClassVar, Generic, Self
+from collections.abc import Callable, Mapping
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, Self
 
 from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import TypeVar
@@ -164,8 +164,8 @@ class Task(Generic[DataT, StateT, ConfigT]):
             available["runtime"] = runtime
 
         async with boundary(TaskError, f"task {type(self).__name__} scoring"):
-            metrics = discover_decorated(self, "metric")
-            rewards = discover_decorated(self, "reward")
+            metrics = self.hooks("metric")
+            rewards = self.hooks("reward")
             if runtime is None:
                 skipped = [
                     fn.__name__ for fn in (*metrics, *rewards) if requires_runtime(fn)
@@ -230,6 +230,23 @@ class Task(Generic[DataT, StateT, ConfigT]):
         from verifiers.v1.utils.loaders import load_judge
 
         return [load_judge(config) for config in self.config.judges]
+
+    def hooks(self, attr: str) -> list[Callable[..., Any]]:
+        """The task's `@vf.<attr>` methods merged with the config-plugged entries — a
+        plugged hook replaces a decorated one with the same name — sorted by
+        descending priority then name."""
+        from verifiers.v1.utils.loaders import load_hook
+
+        plugged = {
+            "stop": self.config.stops,
+            "metric": self.config.metrics,
+            "reward": self.config.rewards,
+        }[attr]
+        merged = {fn.__name__: fn for fn in discover_decorated(self, attr)}
+        merged |= {name: load_hook(name, spec, attr) for name, spec in plugged.items()}
+        fns = list(merged.values())
+        fns.sort(key=lambda fn: (-getattr(fn, f"{attr}_priority", 0), fn.__name__))
+        return fns
 
     @classmethod
     def toolsets(cls, config: ConfigT) -> list[Toolset]:

--- a/verifiers/v1/task.py
+++ b/verifiers/v1/task.py
@@ -232,10 +232,10 @@ class Task(Generic[DataT, StateT, ConfigT]):
         return [load_judge(config) for config in self.config.judges]
 
     def hooks(self, attr: str) -> list[Callable[..., Any]]:
-        """The task's `@vf.<attr>` methods merged with the config-plugged entries — a
-        plugged hook replaces a decorated one with the same name — sorted by
+        """The task's `@vf.<attr>` methods merged with the config-plugged functions —
+        a plugged function replaces a decorated method with the same name — sorted by
         descending priority then name."""
-        from verifiers.v1.utils.loaders import load_hook
+        from verifiers.v1.utils.loaders import load_plugged_fn
 
         plugged = {
             "stop": self.config.stops,
@@ -243,7 +243,9 @@ class Task(Generic[DataT, StateT, ConfigT]):
             "reward": self.config.rewards,
         }[attr]
         merged = {fn.__name__: fn for fn in discover_decorated(self, attr)}
-        merged |= {name: load_hook(name, spec, attr) for name, spec in plugged.items()}
+        merged |= {
+            name: load_plugged_fn(name, spec, attr) for name, spec in plugged.items()
+        }
         fns = list(merged.values())
         fns.sort(key=lambda fn: (-getattr(fn, f"{attr}_priority", 0), fn.__name__))
         return fns

--- a/verifiers/v1/utils/loaders.py
+++ b/verifiers/v1/utils/loaders.py
@@ -1,11 +1,15 @@
-"""Resolve taskset, harness, judge, and environment plugins."""
+"""Resolve taskset, harness, judge, hook, and environment plugins."""
 
 import contextvars
+import functools
 import importlib
 import importlib.util
+import inspect
 import pkgutil
 from collections.abc import Callable
+from pathlib import Path
 from types import ModuleType
+from typing import Any
 
 from pydantic import ValidationError
 from pydantic_config import BaseConfig
@@ -13,6 +17,7 @@ from pydantic_config import BaseConfig
 from verifiers.v1.configs.env import EnvConfig
 from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.configs.judge import JudgeConfig
+from verifiers.v1.configs.task import HookConfig, RewardConfig
 from verifiers.v1.configs.taskset import TasksetConfig
 from verifiers.v1.env import Env
 from verifiers.v1.envs.single_agent import SingleAgentEnv
@@ -203,6 +208,58 @@ def load_harness(config: HarnessConfig) -> Harness:
 
 def load_judge(config: JudgeConfig) -> Judge:
     return judge_class(config.id)(config)
+
+
+@functools.cache
+def _file_module(path: str) -> ModuleType:
+    """Import a standalone `.py` file, cached by path so repeated hook loads share
+    one module object."""
+    resolved = Path(path).resolve()
+    spec = importlib.util.spec_from_file_location(resolved.stem, resolved)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot import hook module from {path!r}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def hook_fn(path: str) -> Callable[..., Any]:
+    """Resolve a hook import path: `pkg.module.function`, `pkg.module:function`, or
+    `path/to/file.py:function`."""
+    module_path, _, attr = path.rpartition(":")
+    if not module_path:
+        module_path, _, attr = path.rpartition(".")
+    if not module_path or not attr:
+        raise ValueError(
+            f"hook fn {path!r} must be `pkg.module.function`, `pkg.module:function`, "
+            "or `path/to/file.py:function`"
+        )
+    if module_path.endswith(".py"):
+        module = _file_module(module_path)
+    else:
+        module = importlib.import_module(module_path)
+    fn = getattr(module, attr, None)
+    if not callable(fn):
+        raise TypeError(f"hook fn {path!r} is not a function (got {fn!r})")
+    return fn
+
+
+def load_hook(name: str, config: HookConfig, attr: str) -> Callable[..., Any]:
+    """Build a task hook from a config entry: the imported function (sync or async)
+    wrapped under the plugged `name`, tagged like its `@vf.<attr>` equivalent."""
+    fn = hook_fn(config.fn)
+
+    @functools.wraps(fn)
+    async def hook(*args: Any, **kwargs: Any) -> Any:
+        result = fn(*args, **kwargs)
+        return await result if inspect.isawaitable(result) else result
+
+    hook.__name__ = name
+    setattr(hook, attr, True)
+    setattr(hook, f"{attr}_priority", config.priority)
+    if isinstance(config, RewardConfig):
+        hook._vf_weight = config.weight
+    return hook
 
 
 def taskset_config_type(taskset_id: str) -> type[TasksetConfig]:

--- a/verifiers/v1/utils/loaders.py
+++ b/verifiers/v1/utils/loaders.py
@@ -17,7 +17,7 @@ from pydantic_config import BaseConfig
 from verifiers.v1.configs.env import EnvConfig
 from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.configs.judge import JudgeConfig
-from verifiers.v1.configs.task import HookConfig, RewardConfig
+from verifiers.v1.configs.task import DecoratedFunctionConfig, RewardFunctionConfig
 from verifiers.v1.configs.taskset import TasksetConfig
 from verifiers.v1.env import Env
 from verifiers.v1.envs.single_agent import SingleAgentEnv
@@ -212,26 +212,26 @@ def load_judge(config: JudgeConfig) -> Judge:
 
 @functools.cache
 def _file_module(path: str) -> ModuleType:
-    """Import a standalone `.py` file, cached by path so repeated hook loads share
-    one module object."""
+    """Import a standalone `.py` file, cached by path so repeated plugged-fn loads
+    share one module object."""
     resolved = Path(path).resolve()
     spec = importlib.util.spec_from_file_location(resolved.stem, resolved)
     if spec is None or spec.loader is None:
-        raise ImportError(f"cannot import hook module from {path!r}")
+        raise ImportError(f"cannot import module from {path!r}")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
 
 
-def hook_fn(path: str) -> Callable[..., Any]:
-    """Resolve a hook import path: `pkg.module.function`, `pkg.module:function`, or
-    `path/to/file.py:function`."""
+def plugged_fn(path: str) -> Callable[..., Any]:
+    """Resolve a plugged function's import path: `pkg.module.function`,
+    `pkg.module:function`, or `path/to/file.py:function`."""
     module_path, _, attr = path.rpartition(":")
     if not module_path:
         module_path, _, attr = path.rpartition(".")
     if not module_path or not attr:
         raise ValueError(
-            f"hook fn {path!r} must be `pkg.module.function`, `pkg.module:function`, "
+            f"fn {path!r} must be `pkg.module.function`, `pkg.module:function`, "
             "or `path/to/file.py:function`"
         )
     if module_path.endswith(".py"):
@@ -240,26 +240,28 @@ def hook_fn(path: str) -> Callable[..., Any]:
         module = importlib.import_module(module_path)
     fn = getattr(module, attr, None)
     if not callable(fn):
-        raise TypeError(f"hook fn {path!r} is not a function (got {fn!r})")
+        raise TypeError(f"fn {path!r} is not a function (got {fn!r})")
     return fn
 
 
-def load_hook(name: str, config: HookConfig, attr: str) -> Callable[..., Any]:
+def load_plugged_fn(
+    name: str, config: DecoratedFunctionConfig, attr: str
+) -> Callable[..., Any]:
     """Build a task hook from a config entry: the imported function (sync or async)
     wrapped under the plugged `name`, tagged like its `@vf.<attr>` equivalent."""
-    fn = hook_fn(config.fn)
+    fn = plugged_fn(config.fn)
 
     @functools.wraps(fn)
-    async def hook(*args: Any, **kwargs: Any) -> Any:
+    async def plugged(*args: Any, **kwargs: Any) -> Any:
         result = fn(*args, **kwargs)
         return await result if inspect.isawaitable(result) else result
 
-    hook.__name__ = name
-    setattr(hook, attr, True)
-    setattr(hook, f"{attr}_priority", config.priority)
-    if isinstance(config, RewardConfig):
-        hook._vf_weight = config.weight
-    return hook
+    plugged.__name__ = name
+    setattr(plugged, attr, True)
+    setattr(plugged, f"{attr}_priority", config.priority)
+    if isinstance(config, RewardFunctionConfig):
+        plugged._vf_weight = config.weight
+    return plugged
 
 
 def taskset_config_type(taskset_id: str) -> type[TasksetConfig]:

--- a/verifiers/v1/utils/loaders.py
+++ b/verifiers/v1/utils/loaders.py
@@ -210,7 +210,7 @@ def load_judge(config: JudgeConfig) -> Judge:
 
 
 @functools.cache
-def _file_module(path: str) -> ModuleType:
+def file_module(path: str) -> ModuleType:
     """Import a standalone `.py` file, cached by path so repeated plugged-fn loads
     share one module object."""
     resolved = Path(path).resolve()
@@ -234,7 +234,7 @@ def plugged_fn(path: str) -> Callable[..., Any]:
             "or `path/to/file.py:function`"
         )
     if module_path.endswith(".py"):
-        module = _file_module(module_path)
+        module = file_module(module_path)
     else:
         module = importlib.import_module(module_path)
     fn = getattr(module, attr, None)

--- a/verifiers/v1/utils/loaders.py
+++ b/verifiers/v1/utils/loaders.py
@@ -4,7 +4,6 @@ import contextvars
 import functools
 import importlib
 import importlib.util
-import inspect
 import pkgutil
 from collections.abc import Callable
 from pathlib import Path
@@ -247,14 +246,13 @@ def plugged_fn(path: str) -> Callable[..., Any]:
 def load_plugged_fn(
     name: str, config: DecoratedFunctionConfig, attr: str
 ) -> Callable[..., Any]:
-    """Build a task hook from a config entry: the imported function (sync or async)
-    wrapped under the plugged `name`, tagged like its `@vf.<attr>` equivalent."""
+    """Build a task hook from a config entry: the imported async function wrapped
+    under the plugged `name`, tagged like its `@vf.<attr>` equivalent."""
     fn = plugged_fn(config.fn)
 
     @functools.wraps(fn)
-    async def plugged(*args: Any, **kwargs: Any) -> Any:
-        result = fn(*args, **kwargs)
-        return await result if inspect.isawaitable(result) else result
+    def plugged(*args: Any, **kwargs: Any) -> Any:
+        return fn(*args, **kwargs)
 
     plugged.__name__ = name
     setattr(plugged, attr, True)


### PR DESCRIPTION
## Summary

- Task hooks (`stop`, `metric`, `reward`) can now be plugged into any task from config, without touching the taskset's code:

  ```toml
  [env.taskset.task.stops]
  single_turn = { fn = "my_hooks.py:two_turns" }

  [env.taskset.task.metrics]
  reply_length = { fn = "my_hooks.py:reply_length" }

  [env.taskset.task.rewards]
  exact_match = { fn = "my_hooks.py:exact_match", weight = 0.5 }
  lcs = { fn = "my_hooks.py:marker", weight = 2.0 }
  ```

- New config hierarchy on `TaskConfig` under `stops` / `metrics` / `rewards`, keyed by the hook name (the reward/metric key, the stop condition name): `FunctionConfig` (`fn`) → `DecoratedFunctionConfig` (`+ priority`) → `RewardFunctionConfig` (`+ weight`).
- `fn` accepts `pkg.module.function`, `pkg.module:function`, or `path/to/file.py:function`, resolved by `plugged_fn` / `load_plugged_fn` in `utils/loaders.py`. Plugged functions have the same contract as decorated hooks: async, declaring what they need by parameter name (`task`, `trace`, `runtime` — stops receive the trace only).
- Plugged functions merge with the task's `@vf.stop` / `@vf.metric` / `@vf.reward` methods through the new `Task.hooks(attr)`; a plugged function replaces a decorated method with the same name, so an existing signal can be swapped out or re-weighted from config.

## Verification

E2E on `reverse-text-v1` with `deepseek/deepseek-v4-flash` (3 tasks, bash harness), plugging the config above: `exact_match` scored 1.0 on a solved task, `reply_length` recorded 72.0, the plugged `lcs` override replaced the decorated LCS reward on every trace (a constant marker value at weight 2.0 instead of the decorated weight-1.0 LCS), and the plugged `single_turn` replacement let rollouts run 2 turns (traces show `stop_condition: single_turn` firing at 2 turns, where the decorated hook stops at 1).

Offline coverage in `tests/v1/test_scoring.py`: merge + name-clash override across all three hook kinds via `Task.score` / `Task.hooks` with no network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how stops and rewards are resolved at runtime and loads arbitrary Python by path from config, which affects rollout termination and scoring semantics when hooks are overridden.
> 
> **Overview**
> **Tasks can now register stop conditions, metrics, and rewards from config** without subclass changes, using the same async hook contracts as `@vf.stop` / `@vf.metric` / `@vf.reward`.
> 
> `TaskConfig` gains `stops`, `metrics`, and `rewards` maps (`fn` import path, optional `priority`, reward `weight`). `Task.hooks()` merges decorated methods with config-loaded functions; **a config entry with the same name replaces the decorated hook**. Rollout stop evaluation and `Task.score` now call `hooks()` instead of `discover_decorated` only. Resolution lives in `plugged_fn` / `load_plugged_fn` (module or `path/to/file.py:function`).
> 
> Docs cover TOML examples; `test_config_plugged_fns_merge_and_override` exercises override and scoring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5929d2db499ae850dc9129133a24456a446b80e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add config-plugged stop conditions, metrics, and rewards to tasks
> - Adds `stops`, `metrics`, and `rewards` fields to `TaskConfig` ([task.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2309/files#diff-4b77e01abe3b2434ab451dca298b978a8000a120271e9d67df307e9a6581d3f6)), each accepting a dict of import-path references (`FunctionConfig`, `DecoratedFunctionConfig`, `RewardFunctionConfig`).
> - Introduces `Task.hooks()` ([task.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2309/files#diff-a1b4a5d6915beae41831864087ea497ed41f0b67b9091ad1ee614834cbfd9399)) to merge config-plugged and decorator-based hooks, with config entries overriding decorated ones by name and all hooks sorted by priority then name.
> - Adds `load_plugged_fn` in [loaders.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2309/files#diff-8a5157fb871a453f35b062da0a08d18436b69017a5fee4885f283e7697c8fb18) to resolve functions by `pkg.module.fn`, `pkg.module:fn`, or `path/to/file.py:fn` format, wrapping them with the metadata expected of decorated hooks.
> - Updates `Rollout.__init__` and `Task.score` to use `Task.hooks()` instead of `discover_decorated`, so plugged functions participate in stop, metric, and reward evaluation.
> - Behavioral Change: hook execution order and active hook sets now depend on both config and decorators; config entries with the same name as a decorated hook silently replace it.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #2309 opened
>
> - Added `priority` field to metric configuration example [f5929d2]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5ac1b99.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->