### PR TITLE
fix: harden the verifiers.legacy alias finder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,19 +178,19 @@ prime-pydantic-config = false
 renderers = false
 
 [project.scripts]
-vf-eval = "verifiers.scripts.eval:main"
+vf-eval = "verifiers.legacy.scripts.eval:main"
 eval = "verifiers.v1.cli.eval.main:main"
 validate = "verifiers.v1.cli.validate:main"
 debug = "verifiers.v1.cli.debug:main"
 replay = "verifiers.v1.cli.replay:main"
 init = "verifiers.v1.cli.init:main"
 gepa = "verifiers.v1.cli.gepa:main"
-vf-gepa = "verifiers.scripts.gepa:main"
-vf-init = "verifiers.scripts.init:main"
-vf-install = "verifiers.scripts.install:main"
-vf-setup = "verifiers.scripts.setup:main"
-vf-build = "verifiers.scripts.build:main"
-vf-tui = "verifiers.scripts.tui:main"
+vf-gepa = "verifiers.legacy.scripts.gepa:main"
+vf-init = "verifiers.legacy.scripts.init:main"
+vf-install = "verifiers.legacy.scripts.install:main"
+vf-setup = "verifiers.legacy.scripts.setup:main"
+vf-build = "verifiers.legacy.scripts.build:main"
+vf-tui = "verifiers.legacy.scripts.tui:main"
 
 # hatchling configuration
 [tool.hatch.version]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,13 +178,13 @@ prime-pydantic-config = false
 renderers = false
 
 [project.scripts]
-vf-eval = "verifiers.legacy.scripts.eval:main"
 eval = "verifiers.v1.cli.eval.main:main"
 validate = "verifiers.v1.cli.validate:main"
 debug = "verifiers.v1.cli.debug:main"
 replay = "verifiers.v1.cli.replay:main"
 init = "verifiers.v1.cli.init:main"
 gepa = "verifiers.v1.cli.gepa:main"
+vf-eval = "verifiers.legacy.scripts.eval:main"
 vf-gepa = "verifiers.legacy.scripts.gepa:main"
 vf-init = "verifiers.legacy.scripts.init:main"
 vf-install = "verifiers.legacy.scripts.install:main"

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -50,8 +50,9 @@ class TestImports:
 
     def test_lazy_imports_work(self):
         """Test that lazy imports work correctly."""
-        # Dynamically detect lazy imports by checking verifiers module
-        lazy_imports = getattr(verifiers, "_LAZY_IMPORTS", {})
+        # The lazy table lives on the legacy package; the root forwards its names.
+        lazy_imports = verifiers.legacy._LAZY_IMPORTS
+        assert lazy_imports, "legacy lazy-import table is empty"
 
         for name in lazy_imports.keys():
             assert name in verifiers.__all__, f"Lazy import {name} not in __all__"

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,13 +1,15 @@
 """The verifiers package root.
 
 The v1 stack lives in `verifiers.v1`; the classic (v0) stack lives in
-`verifiers.legacy`. The v0 modules keep answering at their pre-move paths —
-`verifiers.envs`, `verifiers.types`, `import verifiers as vf`, ... — through the
-alias finder below, so importing this package root stays side-effect free (the
-v0 surface only loads when something touches it).
+`verifiers.legacy`. The v0 modules also answer at their historical top-level
+paths — `verifiers.envs`, `verifiers.types`, `import verifiers as vf`, ... —
+through the alias finder below, so importing this package root stays
+side-effect free (the v0 surface only loads when something touches it).
 """
 
+import pkgutil
 import sys
+from functools import cache
 from importlib import import_module
 from importlib.abc import Loader, MetaPathFinder
 from importlib.machinery import ModuleSpec
@@ -21,23 +23,17 @@ try:
 except PackageNotFoundError:  # source tree without install metadata
     __version__ = "0.0.0+unknown"
 
-# The v0 modules that moved under `verifiers.legacy` and stay importable at
-# their old top-level paths.
-LEGACY_MODULES = frozenset(
-    {
-        "clients",
-        "decorators",
-        "envs",
-        "errors",
-        "gepa",
-        "parsers",
-        "rubrics",
-        "scripts",
-        "serve",
-        "types",
-        "utils",
-    }
-)
+
+@cache
+def _legacy_modules() -> frozenset:
+    """Top-level modules of `verifiers.legacy`, addressable at `verifiers.<name>`.
+    Read off the package directory, without executing its `__init__`."""
+    spec = find_spec("verifiers.legacy")
+    if spec is None or spec.submodule_search_locations is None:
+        return frozenset()
+    return frozenset(
+        module.name for module in pkgutil.iter_modules(spec.submodule_search_locations)
+    )
 
 
 class LegacyAliasFinder(MetaPathFinder, Loader):
@@ -45,27 +41,36 @@ class LegacyAliasFinder(MetaPathFinder, Loader):
 
     The loaded module is the legacy module object itself (one instance, aliased
     in `sys.modules` under both names), so `verifiers.types.State is
-    verifiers.legacy.types.State` and pre-move imports — including the absolute
-    ones inside the moved code — keep working. Installed at the *front* of
-    `sys.meta_path` so the path finder never re-executes an aliased package's
-    children under the old name.
+    verifiers.legacy.types.State`. Installed at the *front* of `sys.meta_path`
+    so the path finder never re-executes an aliased package's children under
+    the old name.
     """
 
     _prefix = "verifiers."
     _legacy_prefix = "verifiers.legacy."
 
+    def _legacy_name(self, fullname: str) -> str:
+        return self._legacy_prefix + fullname.removeprefix(self._prefix)
+
     def find_spec(self, fullname, path=None, target=None):
-        if not fullname.startswith(self._prefix) or fullname.startswith(
-            self._legacy_prefix
-        ):
+        if not fullname.startswith(self._prefix):
             return None
-        tail = fullname.removeprefix(self._prefix)
-        if tail.split(".", 1)[0] not in LEGACY_MODULES:
+        top = fullname.removeprefix(self._prefix).split(".", 1)[0]
+        # `legacy` first: probing the membership set resolves `verifiers.legacy`
+        # through this very finder, so it must pass through before the lookup.
+        if top in ("legacy", "v1", "cli") or top not in _legacy_modules():
             return None
+        legacy_name = self._legacy_name(fullname)
         try:
-            legacy_spec = find_spec(self._legacy_prefix + tail)
-        except ModuleNotFoundError:
-            legacy_spec = None
+            legacy_spec = find_spec(legacy_name)
+        except ModuleNotFoundError as e:
+            # A miss on the probed module itself just means the alias has no
+            # target; anything else (a missing dependency raised while the
+            # legacy package initializes) is a real failure and must surface.
+            if e.name and legacy_name.startswith(e.name):
+                legacy_spec = None
+            else:
+                raise
         if legacy_spec is None:  # unknown submodule: fail like any missing import
             return None
         spec = ModuleSpec(
@@ -74,15 +79,45 @@ class LegacyAliasFinder(MetaPathFinder, Loader):
             origin=legacy_spec.origin,
             is_package=legacy_spec.submodule_search_locations is not None,
         )
+        if legacy_spec.submodule_search_locations is not None:
+            # The real search path (not a copy), so package walkers —
+            # pkgutil.iter_modules over the alias spec, child imports through
+            # the parent's __path__ — see the legacy tree.
+            spec.submodule_search_locations = legacy_spec.submodule_search_locations
         return spec
 
     def create_module(self, spec):
-        # The already-initialized legacy module keeps its own __name__/__spec__
-        # (`module_from_spec` only fills attributes that are missing).
-        return import_module(self._legacy_prefix + spec.name.removeprefix(self._prefix))
+        module = import_module(self._legacy_name(spec.name))
+        # module_from_spec is about to stamp the alias spec onto this shared
+        # module object; stash its real identity for exec_module to restore.
+        spec.loader_state = (
+            module.__dict__.get("__spec__"),
+            module.__dict__.get("__loader__"),
+        )
+        return module
 
     def exec_module(self, module):
-        pass  # imported (or in progress) under its legacy name already
+        # Restore the legacy module's own __spec__/__loader__ so reload,
+        # find_spec on the module, and importlib.resources keep seeing its
+        # real identity — the alias exists only in sys.modules.
+        alias_spec = module.__dict__.get("__spec__")
+        state = getattr(alias_spec, "loader_state", None)
+        if state:
+            real_spec, real_loader = state
+            if real_spec is not None:
+                module.__spec__ = real_spec
+                module.__loader__ = real_loader or real_spec.loader
+                if real_spec.submodule_search_locations is not None:
+                    module.__path__ = real_spec.submodule_search_locations
+
+    # runpy (`python -m verifiers.<v0 module>`) executes through the loader.
+    def get_code(self, fullname):
+        legacy_name = self._legacy_name(fullname)
+        return find_spec(legacy_name).loader.get_code(legacy_name)
+
+    def get_source(self, fullname):
+        legacy_name = self._legacy_name(fullname)
+        return find_spec(legacy_name).loader.get_source(legacy_name)
 
 
 if not any(isinstance(finder, LegacyAliasFinder) for finder in sys.meta_path):
@@ -97,6 +132,11 @@ def __getattr__(name: str):
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
     legacy = import_module("verifiers.legacy")
     return getattr(legacy, name)
+
+
+def __dir__():
+    legacy = import_module("verifiers.legacy")
+    return sorted(set(globals()) | set(legacy.__all__) | _legacy_modules())
 
 
 if TYPE_CHECKING:  # static view of the forwarded surface

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -11,7 +11,7 @@ import pkgutil
 import sys
 from functools import cache
 from importlib import import_module
-from importlib.abc import Loader, MetaPathFinder
+from importlib.abc import InspectLoader, Loader, MetaPathFinder
 from importlib.machinery import ModuleSpec
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _version
@@ -110,14 +110,23 @@ class LegacyAliasFinder(MetaPathFinder, Loader):
                 if real_spec.submodule_search_locations is not None:
                     module.__path__ = real_spec.submodule_search_locations
 
+    def _inspect_loader(self, fullname: str) -> tuple[str, InspectLoader]:
+        legacy_name = self._legacy_name(fullname)
+        spec = find_spec(legacy_name)
+        if spec is None or not isinstance(spec.loader, InspectLoader):
+            raise ImportError(
+                f"no loadable source behind alias {fullname!r}", name=fullname
+            )
+        return legacy_name, spec.loader
+
     # runpy (`python -m verifiers.<v0 module>`) executes through the loader.
     def get_code(self, fullname):
-        legacy_name = self._legacy_name(fullname)
-        return find_spec(legacy_name).loader.get_code(legacy_name)
+        legacy_name, loader = self._inspect_loader(fullname)
+        return loader.get_code(legacy_name)
 
     def get_source(self, fullname):
-        legacy_name = self._legacy_name(fullname)
-        return find_spec(legacy_name).loader.get_source(legacy_name)
+        legacy_name, loader = self._inspect_loader(fullname)
+        return loader.get_source(legacy_name)
 
 
 if not any(isinstance(finder, LegacyAliasFinder) for finder in sys.meta_path):

--- a/verifiers/legacy/__init__.py
+++ b/verifiers/legacy/__init__.py
@@ -150,7 +150,7 @@ def __getattr__(name: str):
         module, attr = _LAZY_IMPORTS[name].split(":")
         return getattr(importlib.import_module(module), attr)
     except KeyError:
-        raise AttributeError(f"module 'verifiers' has no attribute '{name}'")
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
     except ModuleNotFoundError as e:
         if name == "RendererClient":
             raise

--- a/verifiers/legacy/utils/process_utils.py
+++ b/verifiers/legacy/utils/process_utils.py
@@ -83,16 +83,3 @@ def terminate_processes(
         t.start()
     for t in threads:
         t.join()
-
-
-def use_threading_tqdm_lock() -> None:
-    """Pin tqdm to a threading lock so it never lazily creates an `mp.RLock` a killed worker would
-    leak (a `resource_tracker` semaphore warning). No-op if tqdm isn't installed."""
-    try:
-        import threading
-
-        import tqdm
-
-        tqdm.tqdm.set_lock(threading.RLock())
-    except Exception:
-        pass


### PR DESCRIPTION
## Summary

Hardens the `verifiers.legacy` alias finder from #2303. Every item below was found by an adversarial post-merge review and reproduced by execution before fixing:

- **runpy**: the loader now implements `get_code`/`get_source` (delegating to the legacy loader), so `python -m verifiers.scripts.eval` works again — it died with `AttributeError: 'LegacyAliasFinder' object has no attribute 'get_code'`.
- **Package walking**: the alias spec carries the legacy package's real `submodule_search_locations`; `pkgutil.iter_modules(find_spec("verifiers.envs").submodule_search_locations)` listed nothing.
- **Module identity**: `module_from_spec` stamps the alias spec onto the shared legacy module object; `exec_module` now restores its own `__spec__`/`__loader__`/`__path__`. Before, an old-path import made `importlib.reload` a silent no-op and degraded `importlib.resources.files("verifiers.legacy.envs")` to an empty `SpecPath` — under both names.
- **Truthful errors**: `find_spec` re-raises `ModuleNotFoundError` unless the probed module itself is the missing one. A missing legacy dependency (e.g. `stagehand`) previously surfaced as a phantom `No module named 'verifiers.envs'`.
- **No hand-kept module list**: the aliased-name set derives from the legacy package directory (`pkgutil.iter_modules`), so a module added to `verifiers/legacy/` gets its old-path alias automatically.
- **Introspection**: `__dir__` exposes the forwarded API (tab-completion showed only loader plumbing); `verifiers.legacy.__getattr__`'s `AttributeError` names `verifiers.legacy` instead of `verifiers`.
- **Test de-vacuation**: `test_lazy_imports_work` read `verifiers._LAZY_IMPORTS` through the underscore-guarded `__getattr__`, fell back to `{}`, and asserted nothing; it now reads the table from `verifiers.legacy` and refuses an empty one.
- Cleanups: `use_threading_tqdm_lock` deleted (its only caller left with the bridge), and the `vf-*` console entry points state `verifiers.legacy.scripts.*` directly instead of relying on the alias.

Known, accepted: pickles minted by ≥ this version reference `verifiers.legacy.*` class paths and cannot unpickle on pre-move verifiers (old→new works via the alias).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden `LegacyAliasFinder` in `verifiers/__init__.py` to dynamically discover legacy modules
> - Replaces the hardcoded `LEGACY_MODULES` constant with a cached `_legacy_modules()` function that enumerates `verifiers.legacy`'s package directory at runtime via `pkgutil.iter_modules`.
> - Fixes `LegacyAliasFinder` to preserve the legacy module's `__spec__`, `__loader__`, and `__path__` on aliased modules, and propagates `submodule_search_locations` so package walkers and child imports work correctly.
> - Adds `get_code`/`get_source` delegation to the legacy loader, enabling `python -m verifiers.<legacy-module>` execution through the alias.
> - Improves error handling: a direct miss on the probed legacy target returns `None` (no alias), while real initialization errors from the legacy package are re-raised.
> - Redirects `vf-*` console entry points from `verifiers.scripts.*` to `verifiers.legacy.scripts.*` in [pyproject.toml](https://github.com/PrimeIntellect-ai/verifiers/pull/2311/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c855cf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core import machinery (`sys.meta_path`) used by all legacy `verifiers.*` aliases; mistakes could break backward-compatible imports or `python -m` execution, though scope is limited to compatibility plumbing rather than runtime eval logic.
> 
> **Overview**
> **Hardens `LegacyAliasFinder`** so historical `verifiers.<module>` imports behave like real legacy modules instead of broken aliases.
> 
> The aliased set is **discovered from `verifiers/legacy/`** via `pkgutil.iter_modules` (replacing a hand-maintained list). Alias specs now carry the legacy package **`submodule_search_locations`**, and after load **`exec_module` restores** the legacy module’s `__spec__`, `__loader__`, and `__path__` so `reload`, `importlib.resources`, and package walkers work. The loader **delegates `get_code`/`get_source`** so `python -m verifiers.<legacy>` works again. **`find_spec`** only swallows `ModuleNotFoundError` when the missing name is the probed legacy module; other init failures propagate. **`__dir__`** includes the forwarded legacy API for tab completion.
> 
> **`test_lazy_imports_work`** reads `_LAZY_IMPORTS` from `verifiers.legacy` and fails if empty (instead of vacuously passing via `{}`). **`vf-*` console scripts** in `pyproject.toml` target `verifiers.legacy.scripts.*` directly. **`use_threading_tqdm_lock`** is removed from `process_utils`. **`verifiers.legacy.__getattr__`** reports the correct module name in `AttributeError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c855cf2cb74bbe52f1e2e6fc760340918ce0fa9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->