### PR TITLE
feat(compact): one tool call per turn, notes-only carryover

### DIFF
--- a/environments/compact/compact/harness.py
+++ b/environments/compact/compact/harness.py
@@ -3,9 +3,10 @@
 It carries `notes` across compactions and sends a fresh `[system, user]` each one — the
 task on the first turn, then only the carried-over notes — so the prompt is rewritten
 rather than appended, and every compaction is its own branch (the deliberate stress test
-for branch detection). Within a compaction it can use MCP tools (gather, then summarize
-into notes). Its uv script (deps: openai, mcp) is prepared during setup, then launched as
-the harness program.
+for branch detection). Within a compaction it may make at most one MCP tool call, sees
+the result, then must summarize into notes; a disallowed call ends the rollout. Its uv
+script (deps: openai, mcp) is prepared during setup, then launched as the harness
+program.
 """
 
 import json

--- a/environments/compact/compact/harness.py
+++ b/environments/compact/compact/harness.py
@@ -4,9 +4,9 @@ It carries `notes` across compactions and sends a fresh `[system, user]` each on
 task on the first turn, then only the carried-over notes — so the prompt is rewritten
 rather than appended, and every compaction is its own branch (the deliberate stress test
 for branch detection). Within a compaction it may make at most one MCP tool call, sees
-the result, then must summarize into notes; a disallowed call ends the rollout. Its uv
-script (deps: openai, mcp) is prepared during setup, then launched as the harness
-program.
+the result, then must save notes via the harness's `summarize` tool; a disallowed call
+ends the rollout. Its uv script (deps: openai, mcp) is prepared during setup, then
+launched as the harness program.
 """
 
 import json

--- a/environments/compact/compact/harness.py
+++ b/environments/compact/compact/harness.py
@@ -1,12 +1,8 @@
-"""The compacting harness: runs a context-rewrite loop as a uv script.
+"""The compacting harness: a context-rewrite loop run as a uv script.
 
-It carries `notes` across compactions and sends a fresh `[system, user]` each one — the
-task on the first turn, then only the carried-over notes — so the prompt is rewritten
-rather than appended, and every compaction is its own branch (the deliberate stress test
-for branch detection). Within a compaction it may make at most one MCP tool call, sees
-the result, then must save notes via the harness's `summarize` tool; a disallowed call
-ends the rollout. Its uv script (deps: openai, mcp) is prepared during setup, then
-launched as the harness program.
+Each compaction sends a fresh `[system, user]` — the task on the first turn, then only
+the model's saved notes — so every compaction is its own branch. See `program.py` for
+the turn protocol.
 """
 
 import json

--- a/environments/compact/compact/program.py
+++ b/environments/compact/compact/program.py
@@ -6,17 +6,17 @@
 
 Unlike the bash harness (which appends to a growing message list), this sends a FRESH
 `[system, user]` every turn — the task on the first turn, then the model's own
-carried-over `notes` (the task is never shown again, so the notes are the durable memory).
+carried-over notes (the task is never shown again, so the notes are the durable memory).
 Because the prompt is rewritten rather than extended, every turn is its own branch (see
 verifiers.v1.branching). This mirrors context-tools' `context_rewrite=True`.
 
-Tools (the harness sets MCP_CONFIG, a standard `mcpServers` URL map) follow a strict
-one-call-per-turn protocol: the model may make at most ONE tool call, sees its result
-in-context, and must then reply without tools — reasoning plus updated <notes>. Only the
-notes flow into the next turn's prompt; the tool result never does, so anything worth
-keeping must be written into the notes. A disallowed tool call — more than one in a
-reply, or any call after the result — ends the rollout immediately with no answer, so
-the violation itself becomes training signal.
+Notes are saved through a harness-provided `summarize` tool — no tag parsing. Each turn
+the model either calls ONE task tool (MCP, from the harness's MCP_CONFIG), sees its
+result in-context, and must then save updated notes via `summarize`; or it calls
+`summarize` directly. A plain-text reply (no tool call) finishes the run and is printed
+as the answer. A disallowed call — more than one tool in a reply, or a task tool after a
+result — ends the rollout immediately with no answer, so the violation itself becomes
+training signal.
 
 It runs as a uv script (deps: openai, mcp), so the chat + tool plumbing is just the
 SDKs — the harness bootstraps `uv` in the runtime. Model calls go to the interception
@@ -26,21 +26,43 @@ server (OPENAI_BASE_URL/API_KEY); MCP servers are reached over streamable HTTP.
 import asyncio
 import json
 import os
-import re
 import sys
 from contextlib import AsyncExitStack
 
 from openai import AsyncOpenAI
 
 SYSTEM = (
-    "You solve a task across several turns; your NOTES are your only lasting memory. The "
-    "first turn shows the task; after that you see only your notes. Each turn you may "
-    "call at most ONE tool; you will see its result immediately, and must then reply "
-    "WITHOUT calling tools — brief reasoning, then your COMPLETE updated notes in "
-    "<notes>...</notes>. Only the notes carry to the next turn (the tool result does "
-    "not), so copy what you need into them. Any disallowed tool call ends the run. When "
-    "you know the final answer, give it in <answer>...</answer>."
+    "You work in turns, and your context is wiped between turns: the next turn shows "
+    "only this system message plus the notes you last saved with the `summarize` tool. "
+    "The task is shown on the first turn only; tool results and your own replies do NOT "
+    "carry over — your saved notes are your entire memory, so write them complete and "
+    "self-contained. Each turn, either call ONE task tool (you will see its result "
+    "immediately, then you must save updated notes with `summarize`), or call "
+    "`summarize` directly. Calling more than one task tool in a turn ends the run as a "
+    "failure. When the task is complete, reply with plain text instead of calling a "
+    "tool; that ends the run."
 )
+
+SUMMARIZE = {
+    "type": "function",
+    "function": {
+        "name": "summarize",
+        "description": (
+            "Save your complete, self-contained notes — the only thing you will see "
+            "next turn."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "notes": {
+                    "type": "string",
+                    "description": "The full notes to carry into the next turn.",
+                }
+            },
+            "required": ["notes"],
+        },
+    },
+}
 
 # base_url + api_key come from OPENAI_BASE_URL / OPENAI_API_KEY.
 client = AsyncOpenAI()
@@ -51,11 +73,6 @@ async def chat(messages: list[dict], tools: list[dict]):
         model=os.environ["OPENAI_MODEL"], messages=messages, tools=tools or None
     )
     return completion.choices[0].message
-
-
-def extract(tag: str, text: str) -> str | None:
-    match = re.search(rf"<{tag}>(.*?)</{tag}>", text, re.DOTALL)
-    return match.group(1).strip() if match else None
 
 
 async def connect_mcp(stack: AsyncExitStack, config: dict) -> tuple[list[dict], dict]:
@@ -109,6 +126,7 @@ async def main() -> None:
         tools, dispatch = (
             await connect_mcp(stack, config) if config.get("mcpServers") else ([], {})
         )
+        toolset = [*tools, SUMMARIZE]
         while True:  # each turn is a fresh prompt — a new branch
             # The rewrite: the task on the first turn, then only the carried-over notes.
             prompt = f"Task: {task}" if notes is None else f"Notes:\n{notes}"
@@ -116,32 +134,35 @@ async def main() -> None:
                 {"role": "system", "content": SYSTEM},
                 {"role": "user", "content": prompt},
             ]
-            message = await chat(messages, tools)
-            notes = extract("notes", message.content or "") or notes
-            if message.tool_calls:
-                if len(message.tool_calls) > 1:
-                    return  # more than one call in a reply ends the rollout
-                call = message.tool_calls[0]
-                args = json.loads(call.function.arguments or "{}")
-                result = (
-                    await call_mcp(dispatch, call.function.name, args)
-                    if call.function.name in dispatch
-                    else f"error: unknown tool {call.function.name!r}"
-                )
-                messages.append(message)
-                messages.append(
-                    {"role": "tool", "tool_call_id": call.id, "content": result}
-                )
-                # The summary reply: tools stay advertised so a violation is a parsed
-                # tool call we can detect, not junk text in the notes.
-                message = await chat(messages, tools)
-                if message.tool_calls:
-                    return  # a call after the result ends the rollout
-                notes = extract("notes", message.content or "") or notes
-            answer = extract("answer", message.content or "")
-            if answer is not None:
-                print(answer)
+            message = await chat(messages, toolset)
+            if not message.tool_calls:
+                print(message.content or "")  # plain text finishes the run
                 return
+            if len(message.tool_calls) > 1:
+                return  # more than one call in a reply ends the rollout
+            call = message.tool_calls[0]
+            args = json.loads(call.function.arguments or "{}")
+            if call.function.name == "summarize":
+                notes = args.get("notes") or notes
+                continue
+            result = (
+                await call_mcp(dispatch, call.function.name, args)
+                if call.function.name in dispatch
+                else f"error: unknown tool {call.function.name!r}"
+            )
+            messages.append(message)
+            messages.append(
+                {"role": "tool", "tool_call_id": call.id, "content": result}
+            )
+            message = await chat(messages, toolset)
+            if not message.tool_calls:
+                print(message.content or "")  # finishing right after a result is fine
+                return
+            call = message.tool_calls[0]
+            if len(message.tool_calls) > 1 or call.function.name != "summarize":
+                return  # after a tool result, only `summarize` is allowed
+            args = json.loads(call.function.arguments or "{}")
+            notes = args.get("notes") or notes
 
 
 if __name__ == "__main__":

--- a/environments/compact/compact/program.py
+++ b/environments/compact/compact/program.py
@@ -153,13 +153,15 @@ async def main() -> None:
             messages.append(
                 {"role": "tool", "tool_call_id": call.id, "content": result}
             )
-            message = await chat(messages, toolset)
+            # After a tool result, only `summarize` is advertised — saving notes is
+            # the only action left in the turn.
+            message = await chat(messages, [SUMMARIZE])
             if not message.tool_calls:
                 print(message.content or "")  # finishing right after a result is fine
                 return
             call = message.tool_calls[0]
             if len(message.tool_calls) > 1 or call.function.name != "summarize":
-                return  # after a tool result, only `summarize` is allowed
+                return  # a non-`summarize` call after the result ends the rollout
             args = json.loads(call.function.arguments or "{}")
             notes = args.get("notes") or notes
 

--- a/environments/compact/compact/program.py
+++ b/environments/compact/compact/program.py
@@ -39,8 +39,7 @@ SYSTEM = (
     "self-contained. Each turn, either call ONE task tool (you will see its result "
     "immediately, then you must save updated notes with `summarize`), or call "
     "`summarize` directly. Calling more than one task tool in a turn ends the run as a "
-    "failure. When the task is complete, reply with plain text instead of calling a "
-    "tool; that ends the run."
+    "failure."
 )
 
 SUMMARIZE = {

--- a/environments/compact/compact/program.py
+++ b/environments/compact/compact/program.py
@@ -67,9 +67,14 @@ SUMMARIZE = {
 client = AsyncOpenAI()
 
 
-async def chat(messages: list[dict], tools: list[dict]):
+async def chat(
+    messages: list[dict], tools: list[dict], tool_choice: dict | None = None
+):
     completion = await client.chat.completions.create(
-        model=os.environ["OPENAI_MODEL"], messages=messages, tools=tools or None
+        model=os.environ["OPENAI_MODEL"],
+        messages=messages,
+        tools=tools or None,
+        tool_choice=tool_choice or "auto" if tools else None,
     )
     return completion.choices[0].message
 
@@ -153,9 +158,13 @@ async def main() -> None:
             messages.append(
                 {"role": "tool", "tool_call_id": call.id, "content": result}
             )
-            # After a tool result, only `summarize` is advertised — saving notes is
-            # the only action left in the turn.
-            message = await chat(messages, [SUMMARIZE])
+            # After a tool result, `summarize` is forced via tool_choice — saving
+            # notes is the only action left in the turn.
+            message = await chat(
+                messages,
+                [SUMMARIZE],
+                {"type": "function", "function": {"name": "summarize"}},
+            )
             if not message.tool_calls:
                 print(message.content or "")  # finishing right after a result is fine
                 return

--- a/environments/compact/compact/program.py
+++ b/environments/compact/compact/program.py
@@ -2,25 +2,14 @@
 # requires-python = ">=3.10"
 # dependencies = ["openai", "mcp>=1.24.0,<2"]
 # ///
-"""The compacting harness's program: a context-REWRITE loop (so every turn branches).
+"""The compacting harness's program: a context-rewrite loop (every turn branches).
 
-Unlike the bash harness (which appends to a growing message list), this sends a FRESH
-`[system, user]` every turn — the task on the first turn, then the model's own
-carried-over notes (the task is never shown again, so the notes are the durable memory).
-Because the prompt is rewritten rather than extended, every turn is its own branch (see
-verifiers.v1.branching). This mirrors context-tools' `context_rewrite=True`.
-
-Notes are saved through a harness-provided `summarize` tool — no tag parsing. Each turn
-the model either calls ONE task tool (MCP, from the harness's MCP_CONFIG), sees its
-result in-context, and must then save updated notes via `summarize`; or it calls
-`summarize` directly. A plain-text reply (no tool call) finishes the run and is printed
-as the answer. A disallowed call — more than one tool in a reply, or a task tool after a
-result — ends the rollout immediately with no answer, so the violation itself becomes
-training signal.
-
-It runs as a uv script (deps: openai, mcp), so the chat + tool plumbing is just the
-SDKs — the harness bootstraps `uv` in the runtime. Model calls go to the interception
-server (OPENAI_BASE_URL/API_KEY); MCP servers are reached over streamable HTTP.
+Each turn sends a fresh `[system, user]` — the task on the first turn, then only the
+notes the model saved via the `summarize` tool. Per turn: at most one task tool call,
+its result shown in-context, then a forced `summarize`; a plain-text reply finishes the
+run and is printed as the answer; a disallowed call ends the rollout with no answer
+(training signal). Model calls go to the interception server (OPENAI_BASE_URL/API_KEY);
+MCP servers are reached over streamable HTTP.
 """
 
 import asyncio

--- a/environments/compact/compact/program.py
+++ b/environments/compact/compact/program.py
@@ -37,8 +37,9 @@ SYSTEM = (
     "The task is shown on the first turn only; tool results and your own replies do NOT "
     "carry over — your saved notes are your entire memory, so write them complete and "
     "self-contained. Each turn, either call ONE task tool (you will see its result "
-    "immediately, then you must save updated notes with `summarize`), or call "
-    "`summarize` directly. Calling more than one task tool in a turn ends the run as a "
+    "immediately, then you must save updated notes with `summarize`), call `summarize` "
+    "directly, or reply with plain text and no tool call to finish the run and deliver "
+    "your final answer. Calling more than one task tool in a turn ends the run as a "
     "failure."
 )
 

--- a/environments/compact/compact/program.py
+++ b/environments/compact/compact/program.py
@@ -10,11 +10,13 @@ carried-over `notes` (the task is never shown again, so the notes are the durabl
 Because the prompt is rewritten rather than extended, every turn is its own branch (see
 verifiers.v1.branching). This mirrors context-tools' `context_rewrite=True`.
 
-To make progress with tools (the harness sets MCP_CONFIG, a standard `mcpServers` URL
-map), the rewrite also carries the LAST tool call's output into the next turn's prompt —
-kept for exactly one turn, so the model can actually read a result and act on it before
-it's gone. Anything it needs longer it copies into <notes>; the raw output is dropped on
-the next rewrite. So tools work, and the trajectory still branches every turn.
+Tools (the harness sets MCP_CONFIG, a standard `mcpServers` URL map) follow a strict
+one-call-per-turn protocol: the model may make at most ONE tool call, sees its result
+in-context, and must then reply without tools — reasoning plus updated <notes>. Only the
+notes flow into the next turn's prompt; the tool result never does, so anything worth
+keeping must be written into the notes. A disallowed tool call — more than one in a
+reply, or any call after the result — ends the rollout immediately with no answer, so
+the violation itself becomes training signal.
 
 It runs as a uv script (deps: openai, mcp), so the chat + tool plumbing is just the
 SDKs — the harness bootstraps `uv` in the runtime. Model calls go to the interception
@@ -32,11 +34,12 @@ from openai import AsyncOpenAI
 
 SYSTEM = (
     "You solve a task across several turns; your NOTES are your only lasting memory. The "
-    "first turn shows the task; after that you see only your notes — plus, the turn right "
-    "after you call a tool, that tool's output (shown ONCE, so copy what you need into your "
-    "notes before it's gone). Each turn, reply with brief reasoning, then your COMPLETE "
-    "updated notes in <notes>...</notes>, and either call a tool to gather more or give the "
-    "final answer in <answer>...</answer>."
+    "first turn shows the task; after that you see only your notes. Each turn you may "
+    "call at most ONE tool; you will see its result immediately, and must then reply "
+    "WITHOUT calling tools — brief reasoning, then your COMPLETE updated notes in "
+    "<notes>...</notes>. Only the notes carry to the next turn (the tool result does "
+    "not), so copy what you need into them. Any disallowed tool call ends the run. When "
+    "you know the final answer, give it in <answer>...</answer>."
 )
 
 # base_url + api_key come from OPENAI_BASE_URL / OPENAI_API_KEY.
@@ -102,40 +105,43 @@ async def main() -> None:
     task = sys.argv[1]
     config = json.loads(os.environ.get("MCP_CONFIG", "{}"))
     notes: str | None = None  # the durable memory carried across turns
-    tool_output: str | None = None  # the last tool result, kept for exactly one turn
     async with AsyncExitStack() as stack:
         tools, dispatch = (
             await connect_mcp(stack, config) if config.get("mcpServers") else ([], {})
         )
         while True:  # each turn is a fresh prompt — a new branch
-            # The rewrite: the task on the first turn, then only the carried-over notes;
-            # plus the last tool output, kept one turn so the model can actually use it.
-            parts = [f"Task: {task}" if notes is None else f"Notes:\n{notes}"]
-            if tool_output is not None:
-                parts.append(f"Latest tool output:\n{tool_output}")
+            # The rewrite: the task on the first turn, then only the carried-over notes.
+            prompt = f"Task: {task}" if notes is None else f"Notes:\n{notes}"
             messages = [
                 {"role": "system", "content": SYSTEM},
-                {"role": "user", "content": "\n\n".join(parts)},
+                {"role": "user", "content": prompt},
             ]
             message = await chat(messages, tools)
             notes = extract("notes", message.content or "") or notes
+            if message.tool_calls:
+                if len(message.tool_calls) > 1:
+                    return  # more than one call in a reply ends the rollout
+                call = message.tool_calls[0]
+                args = json.loads(call.function.arguments or "{}")
+                result = (
+                    await call_mcp(dispatch, call.function.name, args)
+                    if call.function.name in dispatch
+                    else f"error: unknown tool {call.function.name!r}"
+                )
+                messages.append(message)
+                messages.append(
+                    {"role": "tool", "tool_call_id": call.id, "content": result}
+                )
+                # The summary reply: tools stay advertised so a violation is a parsed
+                # tool call we can detect, not junk text in the notes.
+                message = await chat(messages, tools)
+                if message.tool_calls:
+                    return  # a call after the result ends the rollout
+                notes = extract("notes", message.content or "") or notes
             answer = extract("answer", message.content or "")
             if answer is not None:
                 print(answer)
                 return
-            # Carry only the latest tool output to the next turn (dropped after that).
-            tool_output = None
-            if message.tool_calls:
-                results = []
-                for call in message.tool_calls:
-                    args = json.loads(call.function.arguments or "{}")
-                    result = (
-                        await call_mcp(dispatch, call.function.name, args)
-                        if call.function.name in dispatch
-                        else f"error: unknown tool {call.function.name!r}"
-                    )
-                    results.append(f"{call.function.name}:\n{result}")
-                tool_output = "\n\n".join(results)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- The compact harness's program now enforces a strict one-tool-call-per-turn protocol within each compaction: the model may make at most **one** task tool call, sees its result in-context, and must then save its updated notes.
- Notes are saved through a harness-provided **`summarize` tool** (no tag parsing): each turn the model either calls one task tool → sees the result → calls `summarize`, or calls `summarize` directly. Only the saved notes flow into the next turn's fresh `[system, user]` prompt — tool results never carry over.
- After a task-tool result, **`summarize` is forced via `tool_choice`** — advertising alone is not enough (models with agentic priors emit task-tool calls anyway, and server-side parsers extract any tool-call-shaped output); constraining decoding is. Smoke test: GLM-5.2 on wikispeedia-v1 goes 0/8 → 6/8 with proper note cycles.
- The run finishes when the model replies with **plain text** (no tool call); that reply is printed as the answer. No `<answer>`/`<notes>` tags anywhere.
- A disallowed call still ends the rollout harness-side with no answer — more than one tool call in a reply, or a hallucinated non-`summarize` call after a result — so residual violations become training signal.
- System prompt rewritten to spell the mechanism out explicitly: context is wiped between turns, the task appears only on the first turn, saved notes are the entire memory.

## Breaking

- `compact` protocol change: tool results are no longer injected into the next compaction's user prompt (`Latest tool output:` is gone) — they appear as an in-context tool round instead; `<notes>`/`<answer>` tag parsing is removed in favor of the `summarize` tool and plain-text finish; rollouts now terminate on disallowed tool calls. Existing configs keep working — the change is behavioral only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavioral protocol change for compact rollouts: existing trajectories that relied on tag parsing or multi-tool turns will behave differently; harness integration is unchanged but training/eval outcomes may shift.
> 
> **Overview**
> The compact harness **program** (`program.py`) changes how rollouts run: memory is no longer `<notes>`/`<answer>` tags or “latest tool output” in the next user prompt.
> 
> **Per-turn protocol:** The first model reply in a turn may use **one** task tool call, call **`summarize`** directly, or reply with **plain text** (printed as the final answer). After a task tool, the result stays **in-context** for a second model call where only **`summarize`** is offered and **`tool_choice` forces** it—so notes are saved via the tool, not tags.
> 
> **Carryover:** Only notes from **`summarize`** appear on the next turn’s fresh `[system, user]` prompt; tool results and prior replies do not.
> 
> **Termination:** Disallowed behavior (multiple tool calls in one reply, or a non-`summarize` call after a task result) ends the rollout **without** printing an answer (training signal). `harness.py` docstrings point readers to `program.py` for the protocol.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14c837432662a3893add8ed384564873968a27df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce one task tool call per turn with `summarize`-only notes carryover in compact harness
> - Replaces `<notes>`/`<answer>` tag parsing with a new `summarize` function tool that the model must call to persist notes between turns.
> - Enforces a strict per-turn protocol in [program.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2313/files#diff-67f3207e6853521a388c3d2c0c34f663db4476c8bdab10acadf0d8b59288fd49): at most one task tool call per turn; after a task tool result, the model is forced to call `summarize`; a plain-text reply (no tool calls) ends the rollout and is printed as the answer.
> - Multiple tool calls in a single reply, or an unexpected tool call after a task result, terminate the rollout with no output.
> - Tool results and assistant replies no longer carry over into the next turn's prompt — only the saved notes do.
> - Behavioral Change: prior rollouts that relied on tag-based memory or multi-tool-call turns will now fail silently (no answer emitted).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 781673c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->