### PR TITLE
fix: revert native model catalogs in agent harnesses

### DIFF
--- a/verifiers/v1/harnesses/openclaw/harness.py
+++ b/verifiers/v1/harnesses/openclaw/harness.py
@@ -117,7 +117,8 @@ class OpenClawHarness(Harness[OpenClawHarnessConfig]):
         data: TaskData,
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(data)
-        provider, _ = ctx.model.split("/", 1)
+        # Opt-in via sampling: OpenClaw redacts persisted encrypted reasoning, so resumed sessions 400 replaying it.
+        reasoning = ctx.sampling.reasoning_effort not in (None, "none")
         directory = OPENCLAW_DIR.format(version=self.config.version)
         state_dir = f".vf-openclaw/{trace.id}"
         config_path = f"{state_dir}/openclaw.json"
@@ -129,7 +130,7 @@ class OpenClawHarness(Harness[OpenClawHarnessConfig]):
                     "workspace": ".",
                     "skipBootstrap": True,
                     "sandbox": {"mode": "off"},
-                    "model": {"primary": ctx.model},
+                    "model": {"primary": f"intercept/{ctx.model}"},
                 }
             },
             "tools": {
@@ -139,10 +140,21 @@ class OpenClawHarness(Harness[OpenClawHarnessConfig]):
                 "deny": self.config.disabled_tools or [],
             },
             "models": {
+                "mode": "replace",
                 "providers": {
-                    provider: {
+                    "intercept": {
                         "baseUrl": endpoint,
                         "apiKey": "${OPENCLAW_INTERCEPT_KEY}",
+                        "api": "openai-responses",
+                        "authHeader": True,
+                        "models": [
+                            {
+                                "id": ctx.model,
+                                "name": ctx.model,
+                                "reasoning": reasoning,
+                                "input": ["text", "image"],
+                            }
+                        ],
                     }
                 },
             },

--- a/verifiers/v1/harnesses/pi/harness.py
+++ b/verifiers/v1/harnesses/pi/harness.py
@@ -17,6 +17,7 @@ from verifiers.v1.trace import Trace
 
 logger = logging.getLogger(__name__)
 
+PROVIDER = "intercept"
 KEY_VAR = "PI_INTERCEPT_KEY"
 HOME_VAR = "VF_PI_ORIGINAL_HOME"
 
@@ -142,12 +143,23 @@ class PiHarness(Harness[PiHarnessConfig]):
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(data)
         agent_dir = f".vf-pi-agent-{trace.id}"
-        provider, model = ctx.model.split("/", 1)
+        reasoning = ctx.sampling.reasoning_effort not in (
+            None,
+            "none",
+        ) or ctx.model.rsplit("/", 1)[-1].startswith(("gpt-5", "o1", "o3", "o4"))
         models = {
             "providers": {
-                provider: {
+                PROVIDER: {
                     "baseUrl": endpoint,
+                    "api": "openai-completions",
                     "apiKey": f"${KEY_VAR}",
+                    "models": [
+                        {
+                            "id": ctx.model,
+                            "reasoning": reasoning,
+                            "input": ["text", "image"],
+                        }
+                    ],
                 }
             }
         }
@@ -190,9 +202,9 @@ class PiHarness(Harness[PiHarnessConfig]):
             PI_BIN,
             "--no-approve",
             "--provider",
-            provider,
+            PROVIDER,
             "--model",
-            model,
+            ctx.model,
             *mcp_args,
             *skill_args,
         ]


### PR DESCRIPTION
## Summary
- Reverts [#2308](https://github.com/PrimeIntellect-ai/verifiers/pull/2308) (merge commit b911b728f) via `git revert`.
- Restores the synthetic `intercept` provider in the Pi and OpenClaw harnesses: inline model definitions (API flavor, reasoning flag, input modalities) in the generated `models.json` instead of relying on each harness's native catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revert native model catalogs to static intercept provider in OpenClaw and Pi harnesses
> - [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2314/files#diff-d7278b9055ef0f18d323c2ac3010b475bc2122a03e99b44977384fab44c24362): Replaces dynamic provider extraction from `ctx.model` with a static `intercept` provider using the OpenAI responses API, sets the primary model to `intercept/{ctx.model}`, and adds `mode: replace` to override existing model config.
> - [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2314/files#diff-d9ee2431b7427a96633e83be4179a971f5a199c76bb0f603d70bb44147476ace): Similarly switches Pi to a static `intercept` provider using the OpenAI completions API; derives a `reasoning` flag from `sampling.reasoning_effort` or model name prefix instead of splitting `ctx.model` for provider/model parts.
> - Both harnesses now pass a full model manifest (id, reasoning flag, multimodal input types) rather than relying on the agent's native catalog.
> - Behavioral Change: Pi CLI invocation changes from provider/model values derived by splitting the model string to `--provider intercept --model {ctx.model}`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 57c487d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how both harnesses declare and invoke models for all intercepted rollouts; misconfigured API flavor or reasoning flags could break agent runs or resume behavior.
> 
> **Overview**
> **Reverts the native model-catalog approach** in the OpenClaw and Pi agent harnesses and brings back the static **`intercept`** provider that points at the eval interception endpoint.
> 
> For **OpenClaw**, the primary model is **`intercept/{ctx.model}`** with **`models.mode: replace`**, an **`openai-responses`** intercept provider (auth header, full model entry with id/reasoning/multimodal input), and **`reasoning`** driven only by **`ctx.sampling.reasoning_effort`** (to avoid resumed sessions failing when OpenClaw redacts persisted encrypted reasoning).
> 
> For **Pi**, the CLI uses **`--provider intercept --model {full ctx.model}`** instead of splitting the model string; generated **`models.json`** uses the same intercept pattern with **`openai-completions`**, and **`reasoning`** is on when sampling requests it or the model name looks like a reasoning family (**`gpt-5`**, **`o1`**, **`o3`**, **`o4`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57c487dd0b142ef4503779e86acb7fc4de8de65e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->