### PR TITLE
Restore native model catalogs with relay compatibility

### DIFF
--- a/verifiers/v1/clients/eval.py
+++ b/verifiers/v1/clients/eval.py
@@ -37,6 +37,9 @@ _BLOCKED_REQUEST_HEADERS = frozenset(
         "te",
         "trailer",
         "upgrade",
+        # Some harness SDKs send provider-specific affinity fields. The eval replaces them with
+        # the rollout-wide X-Session-ID below so routing stays stable across harness dialects.
+        "session_id",
         # The eval owns the model and sampling settings, so it changes those JSON fields before
         # sending upstream. Hashes and signatures calculated from the intercepted body are stale.
         "content-digest",

--- a/verifiers/v1/dialects/responses.py
+++ b/verifiers/v1/dialects/responses.py
@@ -329,6 +329,20 @@ class ResponsesDialect(Dialect[dict, OpenAIResponse]):
             and ("/" not in model or model.startswith("openai/"))
         )
         overrides: dict = {"model": model}
+        # OpenClaw masks dotted encrypted_content with an ellipsis when persisting sessions.
+        # The masked ciphertext is invalid, but Responses permits omitting it for stateless replay.
+        if isinstance(input_items := body.get("input"), list):
+            clean_input = [
+                {k: v for k, v in item.items() if k != "encrypted_content"}
+                if isinstance(item, dict)
+                and item.get("type") == "reasoning"
+                and isinstance(item.get("encrypted_content"), str)
+                and "…" in item["encrypted_content"]
+                else item
+                for item in input_items
+            ]
+            if clean_input != input_items:
+                overrides["input"] = clean_input
         if reasoning_model:
             # Preserve opaque reasoning state so it can be replayed on the next turn.
             include = list(body.get("include") or [])

--- a/verifiers/v1/harnesses/openclaw/harness.py
+++ b/verifiers/v1/harnesses/openclaw/harness.py
@@ -117,8 +117,7 @@ class OpenClawHarness(Harness[OpenClawHarnessConfig]):
         data: TaskData,
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(data)
-        # Opt-in via sampling: OpenClaw redacts persisted encrypted reasoning, so resumed sessions 400 replaying it.
-        reasoning = ctx.sampling.reasoning_effort not in (None, "none")
+        provider, _ = ctx.model.split("/", 1)
         directory = OPENCLAW_DIR.format(version=self.config.version)
         state_dir = f".vf-openclaw/{trace.id}"
         config_path = f"{state_dir}/openclaw.json"
@@ -130,7 +129,7 @@ class OpenClawHarness(Harness[OpenClawHarnessConfig]):
                     "workspace": ".",
                     "skipBootstrap": True,
                     "sandbox": {"mode": "off"},
-                    "model": {"primary": f"intercept/{ctx.model}"},
+                    "model": {"primary": ctx.model},
                 }
             },
             "tools": {
@@ -140,21 +139,10 @@ class OpenClawHarness(Harness[OpenClawHarnessConfig]):
                 "deny": self.config.disabled_tools or [],
             },
             "models": {
-                "mode": "replace",
                 "providers": {
-                    "intercept": {
+                    provider: {
                         "baseUrl": endpoint,
                         "apiKey": "${OPENCLAW_INTERCEPT_KEY}",
-                        "api": "openai-responses",
-                        "authHeader": True,
-                        "models": [
-                            {
-                                "id": ctx.model,
-                                "name": ctx.model,
-                                "reasoning": reasoning,
-                                "input": ["text", "image"],
-                            }
-                        ],
                     }
                 },
             },

--- a/verifiers/v1/harnesses/pi/harness.py
+++ b/verifiers/v1/harnesses/pi/harness.py
@@ -17,7 +17,6 @@ from verifiers.v1.trace import Trace
 
 logger = logging.getLogger(__name__)
 
-PROVIDER = "intercept"
 KEY_VAR = "PI_INTERCEPT_KEY"
 HOME_VAR = "VF_PI_ORIGINAL_HOME"
 
@@ -143,23 +142,12 @@ class PiHarness(Harness[PiHarnessConfig]):
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(data)
         agent_dir = f".vf-pi-agent-{trace.id}"
-        reasoning = ctx.sampling.reasoning_effort not in (
-            None,
-            "none",
-        ) or ctx.model.rsplit("/", 1)[-1].startswith(("gpt-5", "o1", "o3", "o4"))
+        provider, model = ctx.model.split("/", 1)
         models = {
             "providers": {
-                PROVIDER: {
+                provider: {
                     "baseUrl": endpoint,
-                    "api": "openai-completions",
                     "apiKey": f"${KEY_VAR}",
-                    "models": [
-                        {
-                            "id": ctx.model,
-                            "reasoning": reasoning,
-                            "input": ["text", "image"],
-                        }
-                    ],
                 }
             }
         }
@@ -202,9 +190,9 @@ class PiHarness(Harness[PiHarnessConfig]):
             PI_BIN,
             "--no-approve",
             "--provider",
-            PROVIDER,
+            provider,
             "--model",
-            ctx.model,
+            model,
             *mcp_args,
             *skill_args,
         ]


### PR DESCRIPTION
## Overview

Restore Pi and OpenClaw's native model catalogs while directing their native providers to the eval endpoint with only `baseUrl` and API-key configuration.

## Details

- Keep native provider model metadata, API dialect selection, reasoning capabilities, and catalog behavior instead of replacing the catalogs with a synthetic `intercept` provider.
- Normalize Pi's provider-specific `session_id` header into the relay-owned rollout session routing header.
- Preserve OpenClaw reasoning replay while omitting only encrypted reasoning content that OpenClaw has already masked during transcript persistence; the remaining Responses reasoning item is valid stateless replay.

## Root cause

The endpoint accepts the native Chat and Responses dialects. The failures came from request metadata around those native calls: Pi added a conflicting affinity header, while OpenClaw persisted an irreversible redaction of dotted encrypted reasoning state and replayed the masked value after restart.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eval relay header handling and Responses body overrides plus harness model configuration; scope is bounded to Pi/OpenClaw interoperability but affects upstream request shaping on every intercepted call.
> 
> **Overview**
> Pi and OpenClaw no longer use a synthetic **`intercept`** provider that replaced each harness’s native model catalog. They now register only **`baseUrl`** and API key against the real **`provider`** from **`ctx.model`**, so dialect choice, reasoning metadata, and catalog behavior stay native while traffic still goes to the eval relay.
> 
> The eval strips harness **`session_id`** headers before upstream calls and applies rollout **`X-Session-ID`**, avoiding Pi’s provider-specific affinity conflicting with relay routing.
> 
> For OpenClaw session resume, the Responses dialect drops **`encrypted_content`** on reasoning **`input`** items when OpenClaw has masked the value with an ellipsis (invalid ciphertext), while still requesting **`reasoning.encrypted_content`** on reasoning models for valid replay state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89821b355fd2da89c3bfcb41d67253f6fc82d9f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore native model catalogs with relay compatibility in OpenClaw and Pi harnesses
> - Updates [OpenClaw](https://github.com/PrimeIntellect-ai/verifiers/pull/2315/files#diff-d7278b9055ef0f18d323c2ac3010b475bc2122a03e99b44977384fab44c24362) and [Pi](https://github.com/PrimeIntellect-ai/verifiers/pull/2315/files#diff-d9ee2431b7427a96633e83be4179a971f5a199c76bb0f603d70bb44147476ace) harnesses to derive `provider` and `model` by splitting `ctx.model` on `/`, replacing the previous `intercept` provider routing approach.
> - Provider config now contains only `baseUrl` and `apiKey`; removes `api`, `authHeader`, `models`, and `models.mode='replace'` fields, restoring native model catalog behavior.
> - Strips masked reasoning `encrypted_content` fields (those containing `…`) from `input` items in [responses.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2315/files#diff-73f89a1b25536fd7a806555e765120f5189cb934eff813f4c7900838efa56b5a) before forwarding upstream.
> - Adds `session_id` to blocked request headers in [eval.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2315/files#diff-8a1cc6d0e01dde461a22ef26597ccf8f011f4c12328b1c7297cae7acebc78df8) so routing uses the rollout-wide `X-Session-ID` instead.
> - Behavioral Change: Pi CLI now receives `--provider` and `--model` as separate arguments rather than a combined model string with a fixed provider.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 89821b3. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->