### PR TITLE
Connect ACP harness tool interception

### DIFF
--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -95,6 +95,9 @@ class Harness(ABC, Generic[ConfigT]):
     async def setup(self, runtime: Runtime) -> None:
         """Provision this harness in `runtime` before its execution timeout starts."""
 
+    async def setup_tool_interception(self, runtime: Runtime) -> None:
+        """Provision optional native hooks before execution-time egress is restricted."""
+
     async def install_skills(self, runtime: Runtime, dest: str) -> None:
         """Upload each `config.skills` folder into `runtime` at `dest/<folder name>` —
         the program's fixed skill discovery location, which a supporting harness's

--- a/verifiers/v1/harnesses/claude_code/harness.py
+++ b/verifiers/v1/harnesses/claude_code/harness.py
@@ -9,6 +9,7 @@ from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.harness import Harness, HarnessSession
 from verifiers.v1.harnesses.node import NODE_BIN_DIR, ensure_node
+from verifiers.v1.interception.tool import configure_tool_hook, prepare_tool_hook
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
@@ -44,6 +45,7 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
     SUPPORTS_MCP = True
     SUPPORTS_RESUME = True
     SUPPORTS_SKILLS = True
+    SUPPORTS_TOOL_INTERCEPTION = True
 
     async def setup(self, runtime: Runtime) -> None:
         await self.install_skills(runtime, SKILLS_DIR)
@@ -76,6 +78,9 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
             raise RuntimeError(f"Claude Agent ACP install failed: {detail}")
         await CLAUDE_ACP.setup(self, runtime)
 
+    async def setup_tool_interception(self, runtime: Runtime) -> None:
+        await prepare_tool_hook(runtime)
+
     async def session(
         self,
         ctx: ModelContext,
@@ -85,13 +90,20 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
         secret: str,
         mcp_urls: dict[str, str],
         data: TaskData,
+        tool_interception_url: str | None = None,
     ) -> HarnessSession:
         if not runtime.supports_live_processes:
             return await super().session(
-                ctx, trace, runtime, endpoint, secret, mcp_urls, data
+                ctx,
+                trace,
+                runtime,
+                endpoint,
+                secret,
+                mcp_urls,
+                data,
+                tool_interception_url,
             )
         system_prompt, prompt = self.resolve_prompt(data)
-        config_dir = self.config_dir(trace)
         versions = {"version": self.config.version, "acp_version": ACP_VERSION}
         options: dict[str, object] = {
             "strictMcpConfig": True,
@@ -100,17 +112,9 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
         session_meta: dict[str, object] = {"claudeCode": {"options": options}}
         if system_prompt:
             session_meta["systemPrompt"] = {"append": system_prompt}
-        env = {
-            **self.config.resolved_env,
-            "ANTHROPIC_BASE_URL": endpoint.removesuffix("/v1"),
-            "ANTHROPIC_API_KEY": secret,
-            "ANTHROPIC_MODEL": ctx.model,
-            "CLAUDE_CODE_EXECUTABLE": CLAUDE_BIN.format(**versions),
-            "CLAUDE_CONFIG_DIR": config_dir,
-            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
-            "DISABLE_AUTOUPDATER": "1",
-            "IS_SANDBOX": "1",
-        }
+        env = await self.build_env(
+            ctx, trace, runtime, endpoint, secret, tool_interception_url
+        )
         return CLAUDE_ACP.session(
             self,
             ctx,
@@ -135,6 +139,7 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
         secret: str,
         mcp_urls: dict[str, str],
         data: TaskData,
+        tool_interception_url: str | None = None,
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(data)
         config_dir = self.config_dir(trace)
@@ -147,18 +152,9 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
         session_meta: dict[str, object] = {"claudeCode": {"options": options}}
         if system_prompt:
             session_meta["systemPrompt"] = {"append": system_prompt}
-        env = {
-            **self.config.resolved_env,
-            # Claude appends /v1/messages; give it the interception root, not the model endpoint.
-            "ANTHROPIC_BASE_URL": endpoint.removesuffix("/v1"),
-            "ANTHROPIC_API_KEY": secret,
-            "ANTHROPIC_MODEL": ctx.model,
-            "CLAUDE_CODE_EXECUTABLE": CLAUDE_BIN.format(**versions),
-            "CLAUDE_CONFIG_DIR": config_dir,
-            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
-            "DISABLE_AUTOUPDATER": "1",
-            "IS_SANDBOX": "1",
-        }
+        env = await self.build_env(
+            ctx, trace, runtime, endpoint, secret, tool_interception_url
+        )
         return await CLAUDE_ACP.run(
             runtime,
             env,
@@ -168,6 +164,44 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
             session_path=f"{config_dir}/acp-session",
             session_meta=session_meta,
         )
+
+    async def build_env(
+        self,
+        ctx: ModelContext,
+        trace: Trace,
+        runtime: Runtime,
+        endpoint: str,
+        secret: str,
+        tool_interception_url: str | None,
+    ) -> dict[str, str]:
+        config_dir = self.config_dir(trace)
+        env = {
+            **self.config.resolved_env,
+            # Claude appends /v1/messages; give it the interception root, not the model endpoint.
+            "ANTHROPIC_BASE_URL": endpoint.removesuffix("/v1"),
+            "ANTHROPIC_API_KEY": secret,
+            "ANTHROPIC_MODEL": ctx.model,
+            "CLAUDE_CODE_EXECUTABLE": CLAUDE_BIN.format(
+                version=self.config.version, acp_version=ACP_VERSION
+            ),
+            "CLAUDE_CONFIG_DIR": config_dir,
+            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+            "DISABLE_AUTOUPDATER": "1",
+            "IS_SANDBOX": "1",
+        }
+        if tool_interception_url is None:
+            return env
+        env.update(
+            await configure_tool_hook(
+                runtime,
+                f"{config_dir}/settings.json",
+                tool_interception_url,
+                secret,
+                "claude",
+                ("PreToolUse", "PostToolUse", "PostToolUseFailure"),
+            )
+        )
+        return env
 
     async def cleanup(self, trace: Trace, runtime: Runtime) -> None:
         result = await runtime.run(["rm", "-rf", self.config_dir(trace)], {})

--- a/verifiers/v1/harnesses/codex/harness.py
+++ b/verifiers/v1/harnesses/codex/harness.py
@@ -14,6 +14,7 @@ from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.harness import Harness, HarnessSession
 from verifiers.v1.harnesses.node import NODE_BIN_DIR, ensure_node
+from verifiers.v1.interception.tool import configure_tool_hook, prepare_tool_hook
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
@@ -55,6 +56,7 @@ class CodexHarness(Harness[CodexHarnessConfig]):
     SUPPORTS_MCP = True
     SUPPORTS_RESUME = True
     SUPPORTS_SKILLS = True
+    SUPPORTS_TOOL_INTERCEPTION = True
 
     async def setup(self, runtime: Runtime) -> None:
         await self.install_skills(runtime, SKILLS_DIR)
@@ -91,6 +93,9 @@ class CodexHarness(Harness[CodexHarnessConfig]):
             raise RuntimeError(f"codex install failed: {install.stderr.strip()[-500:]}")
         await CODEX_ACP.setup(self, runtime)
 
+    async def setup_tool_interception(self, runtime: Runtime) -> None:
+        await prepare_tool_hook(runtime)
+
     async def session(
         self,
         ctx: ModelContext,
@@ -100,16 +105,32 @@ class CodexHarness(Harness[CodexHarnessConfig]):
         secret: str,
         mcp_urls: dict[str, str],
         data: TaskData,
+        tool_interception_url: str | None = None,
     ) -> HarnessSession:
         if not runtime.supports_live_processes:
             return await super().session(
-                ctx, trace, runtime, endpoint, secret, mcp_urls, data
+                ctx,
+                trace,
+                runtime,
+                endpoint,
+                secret,
+                mcp_urls,
+                data,
+                tool_interception_url,
             )
         if data.system_prompt is not None and not isinstance(data.prompt, str):
             system_prompt, prompt = data.system_prompt, data.prompt
         else:
             system_prompt, prompt = self.resolve_prompt(data)
-        env = await self.build_env(ctx, trace, runtime, endpoint, secret, mcp_urls)
+        env = await self.build_env(
+            ctx,
+            trace,
+            runtime,
+            endpoint,
+            secret,
+            mcp_urls,
+            tool_interception_url,
+        )
         return CODEX_ACP.session(
             self,
             ctx,
@@ -137,6 +158,7 @@ class CodexHarness(Harness[CodexHarnessConfig]):
         secret: str,
         mcp_urls: dict[str, str],
         data: TaskData,
+        tool_interception_url: str | None = None,
     ) -> ProgramResult:
         if (
             data.system_prompt is not None
@@ -146,7 +168,15 @@ class CodexHarness(Harness[CodexHarnessConfig]):
             system_prompt, prompt = data.system_prompt, data.prompt
         else:
             system_prompt, prompt = self.resolve_prompt(data)
-        env = await self.build_env(ctx, trace, runtime, endpoint, secret, mcp_urls)
+        env = await self.build_env(
+            ctx,
+            trace,
+            runtime,
+            endpoint,
+            secret,
+            mcp_urls,
+            tool_interception_url,
+        )
         return await CODEX_ACP.run(
             runtime,
             env,
@@ -178,6 +208,7 @@ class CodexHarness(Harness[CodexHarnessConfig]):
         endpoint: str,
         secret: str,
         mcp_urls: dict[str, str],
+        tool_interception_url: str | None = None,
     ) -> dict[str, str]:
         home = self.trace_home(trace)
         created = await runtime.run(["mkdir", "-p", home], {})
@@ -232,6 +263,16 @@ class CodexHarness(Harness[CodexHarnessConfig]):
                     dict.fromkeys(direct_mcp_namespaces)
                 )
             }
+        tool_env = await configure_tool_hook(
+            runtime,
+            f"{home}/hooks.json",
+            tool_interception_url,
+            secret,
+            "codex",
+            ("PreToolUse", "PostToolUse"),
+        )
+        if tool_env:
+            features["hooks"] = True
         config = {
             "model": ctx.model,
             "model_provider": PROVIDER,
@@ -246,7 +287,9 @@ class CodexHarness(Harness[CodexHarnessConfig]):
             },
             "features": features,
         }
-        return {
+        if tool_env:
+            config["bypass_hook_trust"] = True
+        env = {
             **self.config.resolved_env,
             "CODEX_API_KEY": secret,
             KEY_VAR: secret,
@@ -258,3 +301,5 @@ class CodexHarness(Harness[CodexHarnessConfig]):
             "MODEL_PROVIDER": PROVIDER,
             "NO_BROWSER": "1",
         }
+        env.update(tool_env)
+        return env

--- a/verifiers/v1/interception/tool.py
+++ b/verifiers/v1/interception/tool.py
@@ -1,10 +1,50 @@
 """Typed wire payload for native harness tool hooks."""
 
-from typing import Literal
+import json
+import shlex
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel
 
 from verifiers.v1.types import ToolMessage
+
+if TYPE_CHECKING:
+    from verifiers.v1.runtimes import Runtime
+
+TOOL_HOOK_SOURCE = Path(__file__).with_name("tool_hook.py").read_text()
+
+
+async def prepare_tool_hook(runtime: "Runtime") -> str:
+    """Install the shared native-hook bridge and return its shell command."""
+    return shlex.join(await runtime.prepare_uv_script(TOOL_HOOK_SOURCE))
+
+
+async def configure_tool_hook(
+    runtime: "Runtime",
+    path: str,
+    url: str | None,
+    secret: str,
+    adapter: Literal["claude", "codex"],
+    events: tuple[str, ...],
+) -> dict[str, str]:
+    """Install one native hook config and return the bridge environment."""
+    if url is None:
+        return {}
+    handler = {
+        "type": "command",
+        "command": await prepare_tool_hook(runtime),
+        "timeout": 35,
+    }
+    hooks = {
+        "hooks": {event: [{"matcher": "*", "hooks": [handler]}] for event in events}
+    }
+    await runtime.write(path, json.dumps(hooks).encode())
+    return {
+        "VF_TOOL_INTERCEPTION_ADAPTER": adapter,
+        "VF_TOOL_INTERCEPTION_SECRET": secret,
+        "VF_TOOL_INTERCEPTION_URL": url,
+    }
 
 
 class ToolHookRequest(BaseModel):

--- a/verifiers/v1/interception/tool_hook.py
+++ b/verifiers/v1/interception/tool_hook.py
@@ -1,0 +1,158 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pydantic>=2"]
+# ///
+"""Bridge Claude Code and Codex tool hooks to the rollout interception server."""
+
+import json
+import os
+import sys
+from typing import Any, Literal
+from urllib.request import Request, urlopen
+
+from pydantic import BaseModel, TypeAdapter
+
+
+class NativeToolHook(BaseModel):
+    hook_event_name: Literal["PreToolUse", "PostToolUse", "PostToolUseFailure"]
+    tool_name: str
+    tool_use_id: str
+    tool_input: Any = None
+    tool_response: Any = None
+    error: str | None = None
+
+
+class InterceptedToolMessage(BaseModel):
+    role: Literal["tool"] = "tool"
+    tool_call_id: str
+    content: Any
+    name: str | None = None
+
+
+class ToolDecision(BaseModel):
+    action: Literal["allow", "rewrite", "stop"]
+    message: InterceptedToolMessage | None = None
+    reason: str | None = None
+
+
+def native_output(
+    adapter: Literal["claude", "codex"],
+    hook: NativeToolHook,
+    decision: ToolDecision,
+) -> dict | None:
+    if decision.action == "allow":
+        return None
+    reason = decision.reason or "Rollout terminated by interception."
+    if decision.action == "stop":
+        if adapter == "codex" and hook.hook_event_name == "PreToolUse":
+            return {"decision": "block", "reason": reason}
+        return {"continue": False, "stopReason": reason}
+
+    if decision.message is None:
+        raise ValueError("rewrite decision omitted its tool message")
+    content = decision.message.content
+    text = (
+        content if isinstance(content, str) else json.dumps(content, ensure_ascii=False)
+    )
+    if adapter == "codex":
+        return {"decision": "block", "reason": text}
+    if hook.hook_event_name == "PreToolUse":
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": text,
+            }
+        }
+    if hook.hook_event_name == "PostToolUseFailure":
+        return {"decision": "block", "reason": text}
+
+    original = hook.tool_response
+    if isinstance(original, str):
+        replacement = text
+    elif (
+        isinstance(original, dict)
+        and {
+            "stdout",
+            "stderr",
+            "interrupted",
+            "isImage",
+        }
+        <= original.keys()
+    ):
+        replacement = {**original, "stdout": text, "stderr": ""}
+    elif hook.tool_name.startswith("mcp__") and isinstance(original, dict):
+        replacement = {
+            **original,
+            "content": [{"type": "text", "text": text}],
+        }
+    elif isinstance(original, dict) and isinstance(original.get("content"), str):
+        replacement = {**original, "content": text}
+    else:
+        return {
+            "continue": False,
+            "stopReason": "Claude Code cannot safely replace this structured tool output.",
+        }
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PostToolUse",
+            "updatedToolOutput": replacement,
+        }
+    }
+
+
+def main() -> None:
+    hook = NativeToolHook.model_validate_json(sys.stdin.read())
+    adapter = TypeAdapter(Literal["claude", "codex"]).validate_python(
+        os.environ["VF_TOOL_INTERCEPTION_ADAPTER"]
+    )
+    if hook.hook_event_name == "PreToolUse":
+        content = json.dumps(hook.tool_input, ensure_ascii=False)
+    elif hook.hook_event_name == "PostToolUse":
+        content = (
+            hook.tool_response
+            if isinstance(hook.tool_response, str)
+            else json.dumps(hook.tool_response, ensure_ascii=False)
+        )
+    elif hook.hook_event_name == "PostToolUseFailure":
+        content = hook.error or "Tool execution failed."
+    payload = {
+        "phase": "before" if hook.hook_event_name == "PreToolUse" else "after",
+        "can_rewrite": hook.hook_event_name == "PreToolUse"
+        or (adapter == "claude" and hook.hook_event_name == "PostToolUse"),
+        "message": {
+            "role": "tool",
+            "tool_call_id": hook.tool_use_id,
+            "name": hook.tool_name,
+            "content": content,
+        },
+    }
+    try:
+        request = Request(
+            os.environ["VF_TOOL_INTERCEPTION_URL"],
+            data=json.dumps(payload).encode(),
+            headers={
+                "Authorization": "Bearer " + os.environ["VF_TOOL_INTERCEPTION_SECRET"],
+                "Content-Type": "application/json",
+            },
+        )
+        with urlopen(request, timeout=30) as response:
+            decision = ToolDecision.model_validate_json(response.read())
+    except Exception:  # noqa: BLE001 - native hooks must fail closed
+        decision = ToolDecision(
+            action="stop", reason="Tool interception is unavailable."
+        )
+    try:
+        output = native_output(adapter, hook, decision)
+    except Exception:  # noqa: BLE001 - malformed decisions must also fail closed
+        output = native_output(
+            adapter,
+            hook,
+            ToolDecision(action="stop", reason="Tool interception is unavailable."),
+        )
+    if output:
+        print(json.dumps(output, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -199,11 +199,16 @@ class Rollout:
                 asyncio.timeout_at(setup_deadline),
             ):
                 await invoke(self.task.setup, {"trace": self.trace, "runtime": runtime})
+            tool_interception = self.harness.SUPPORTS_TOOL_INTERCEPTION and bool(
+                self._session.request_handlers or self._session.response_handlers
+            )
             async with (
                 boundary(HarnessError, "harness setup"),
                 asyncio.timeout_at(setup_deadline),
             ):
                 await self.harness.setup(runtime)
+                if tool_interception:
+                    await self.harness.setup_tool_interception(runtime)
             async with boundary(ToolsetError, "building tool servers"):
                 toolsets = self.task.toolsets(self.task.config)
             # `base_url` is the interception server's reachable URL for this rollout.
@@ -235,11 +240,6 @@ class Rollout:
                     state_base=base_url,
                 )
             )
-            tool_interception = self.harness.SUPPORTS_TOOL_INTERCEPTION and bool(
-                self._session.request_handlers or self._session.response_handlers
-            )
-            if tool_interception:
-                await self.harness.setup_tool_interception(runtime)
             # Setup and service provisioning are complete. Apply the runtime's
             # execution policy while preserving the framework routes the agent uses.
             await runtime.prepare_execution([self._endpoint, *self._urls.values()])

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -235,6 +235,11 @@ class Rollout:
                     state_base=base_url,
                 )
             )
+            tool_interception = self.harness.SUPPORTS_TOOL_INTERCEPTION and bool(
+                self._session.request_handlers or self._session.response_handlers
+            )
+            if tool_interception:
+                await self.harness.setup_tool_interception(runtime)
             # Setup and service provisioning are complete. Apply the runtime's
             # execution policy while preserving the framework routes the agent uses.
             await runtime.prepare_execution([self._endpoint, *self._urls.values()])
@@ -277,11 +282,7 @@ class Rollout:
                 if not self._session.terminated:
                     session_kwargs = (
                         {"tool_interception_url": f"{runtime.host_url(base_url)}/tool"}
-                        if self.harness.SUPPORTS_TOOL_INTERCEPTION
-                        and (
-                            self._session.request_handlers
-                            or self._session.response_handlers
-                        )
+                        if tool_interception
                         else {}
                     )
                     self._harness_session = await self.harness.session(


### PR DESCRIPTION
## Overview

Connects Claude Code and Codex tool execution to the same Verifiers interception endpoint used by the Bash harness.

The harnesses install native tool hooks only for rollouts that define request or response handlers. A pre-tool rewrite prevents the proposed tool from running and returns replacement text to the agent. Supported post-tool rewrites replace completed output before the agent sees it. When a native event cannot replace its output—Codex after success or Claude after failure—a requested rewrite terminates cleanly instead of creating trace/harness drift. Returning `vf.Terminate` ends the rollout.

## What this PR adds

- Native Claude Code `PreToolUse`, `PostToolUse`, and `PostToolUseFailure` callbacks.
- Native Codex `PreToolUse` and `PostToolUse` callbacks.
- One typed bridge from native hook payloads to the rollout-scoped `/tool` endpoint.
- Model-visible replacement text for blocked tool calls.
- No hook setup or extra runtime work when interception is not active.

## Status

Removed from the interception stack. ACP harness integration is deferred.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Connect ACP harness tool interception for Claude Code and Codex
> - Adds a `setup_tool_interception` hook to the base `Harness` class and implements it in `ClaudeCodeHarness` and `CodexHarness` by installing a native bridge script (`tool_hook.py`) into the runtime via `prepare_tool_hook`.
> - Introduces [tool_hook.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2316/files#diff-abc19aa33fe309feffbb46fa9fe2ee6a63f389371f435bda7fb305424f588e82), a uv script that reads native hook events from stdin, forwards them to the rollout's `/tool` endpoint, and writes the translated decision (allow/stop/rewrite) back to stdout.
> - `Rollout._run` now detects when a session has interception handlers and the harness supports interception, calls `setup_tool_interception`, and passes a `tool_interception_url` into the harness session.
> - Each harness gains a `build_env` helper that writes a hook config file (`settings.json` for Claude Code, `hooks.json` for Codex) and merges `VF_TOOL_INTERCEPTION_*` env vars into the process environment when interception is active.
> - Behavioral Change: sessions with both interception handlers and a supporting harness now run with an additional hook process and modified environment; sessions without handlers are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f7a2ec1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Tool execution and rollout termination now depend on a runtime hook process and HTTP to the interception server; failures halt tools rather than passing through silently.
> 
> **Overview**
> Wires **Claude Code** and **Codex** harnesses into the rollout `/tool` interception path (same as Bash), using each agent’s **native tool hooks** instead of only the bash loop.
> 
> Rollouts that define **request or response handlers** now call **`setup_tool_interception`** before egress is locked down, install a shared **`tool_hook.py`** bridge via `prepare_tool_hook` / `configure_tool_hook`, and pass **`tool_interception_url`** into harness `session` / `launch`. Claude registers **PreToolUse**, **PostToolUse**, and **PostToolUseFailure** in `settings.json`; Codex registers **PreToolUse** and **PostToolUse** in `hooks.json` and enables hooks in config when interception is active.
> 
> The bridge reads hook JSON from stdin, POSTs to the interception server, and maps **allow / rewrite / stop** into Claude- or Codex-specific hook responses. Network or parse failures **fail closed** (block or stop the rollout). No hook provisioning runs when interception is not needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7a2ec18dfb961d525e07a3df4100e913cbf2192. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->