### PR TITLE
test(acp): consume canonical correlation fixture

### DIFF
--- a/tests/v1/fixtures/acp-correlation-transcripts.json
+++ b/tests/v1/fixtures/acp-correlation-transcripts.json
@@ -1,0 +1,86 @@
+{
+  "schema": "ai.primeintellect.prime-agent/v1",
+  "notes": "Exact JSON rendering of V3 acp_correlation_transcripts fixture; end_turn is deliberately absent because transport stop reasons are never causal.",
+  "cases": {
+    "success": [
+      {
+        "promptTurnId": 1,
+        "eventSequence": 11,
+        "phase": "event",
+        "kind": "progress"
+      },
+      {
+        "promptTurnId": 1,
+        "eventSequence": 12,
+        "phase": "responseBoundary",
+        "outcome": "result"
+      },
+      {
+        "promptTurnId": 1,
+        "eventSequence": 13,
+        "phase": "terminalQuiescence",
+        "outcome": "result",
+        "quiescence": {
+          "outstandingSubagents": 0,
+          "remainingAutonomousContinuations": 0
+        }
+      }
+    ],
+    "error_terminal": [
+      {
+        "promptTurnId": 1,
+        "eventSequence": 21,
+        "phase": "responseBoundary",
+        "outcome": "error"
+      },
+      {
+        "promptTurnId": 1,
+        "eventSequence": 22,
+        "phase": "terminalQuiescence",
+        "outcome": "error",
+        "quiescence": {
+          "outstandingSubagents": 0,
+          "remainingAutonomousContinuations": 0
+        }
+      }
+    ],
+    "error_incomplete": [
+      {
+        "promptTurnId": 1,
+        "eventSequence": 31,
+        "phase": "responseBoundary",
+        "outcome": "error"
+      }
+    ],
+    "cancelled": [],
+    "late_child": [
+      {
+        "promptTurnId": 1,
+        "eventSequence": 41,
+        "phase": "event",
+        "child": {
+          "id": "late",
+          "status": "done"
+        }
+      }
+    ],
+    "global_sequence_turn_two": [
+      {
+        "promptTurnId": 2,
+        "eventSequence": 51,
+        "phase": "responseBoundary",
+        "outcome": "result"
+      },
+      {
+        "promptTurnId": 2,
+        "eventSequence": 52,
+        "phase": "terminalQuiescence",
+        "outcome": "result",
+        "quiescence": {
+          "outstandingSubagents": 0,
+          "remainingAutonomousContinuations": 0
+        }
+      }
+    ]
+  }
+}

--- a/tests/v1/test_acp.py
+++ b/tests/v1/test_acp.py
@@ -1,7 +1,9 @@
 """ACP metadata accumulation preserves ordered, namespaced extension events."""
 
 import asyncio
+import hashlib
 import importlib.util
+import json
 import sys
 import types
 from pathlib import Path
@@ -91,6 +93,85 @@ def test_acp_run_forwards_trace_to_the_recording_path() -> None:
     assert "trace=trace" in source, (
         "ACP.run accepts trace but never forwards it to _run"
     )
+
+
+CANONICAL_TRANSCRIPT = (
+    Path(__file__).parent / "fixtures" / "acp-correlation-transcripts.json"
+)
+CANONICAL_TRANSCRIPT_SHA256 = (
+    "cacde7827aadf186db2ce1af1ea6f3b6d109504fa94945633bd9c0d96106b882"
+)
+
+
+def canonical_cases() -> dict[str, list[dict]]:
+    raw = CANONICAL_TRANSCRIPT.read_bytes()
+    assert hashlib.sha256(raw).hexdigest() == CANONICAL_TRANSCRIPT_SHA256
+    document = json.loads(raw)
+    assert document["schema"] == "ai.primeintellect.prime-agent/v1"
+    return document["cases"]
+
+
+def test_canonical_p2_fixture_is_exact_bytes_and_all_cases() -> None:
+    cases = canonical_cases()
+    assert set(cases) == {
+        "success",
+        "error_terminal",
+        "error_incomplete",
+        "cancelled",
+        "late_child",
+        "global_sequence_turn_two",
+    }
+
+
+def test_canonical_cases_preserve_reviewed_named_transcripts() -> None:
+    cases = canonical_cases()
+
+    success = cases["success"]
+    assert [event["phase"] for event in success] == [
+        "event",
+        "responseBoundary",
+        "terminalQuiescence",
+    ]
+    assert success[-1]["outcome"] == "result"
+    assert success[-1]["quiescence"] == {
+        "outstandingSubagents": 0,
+        "remainingAutonomousContinuations": 0,
+    }
+
+    error_terminal = cases["error_terminal"]
+    assert [event["phase"] for event in error_terminal] == [
+        "responseBoundary",
+        "terminalQuiescence",
+    ]
+    assert [event["outcome"] for event in error_terminal] == ["error", "error"]
+
+    error_incomplete = cases["error_incomplete"]
+    assert error_incomplete == [
+        {
+            "promptTurnId": 1,
+            "eventSequence": 31,
+            "phase": "responseBoundary",
+            "outcome": "error",
+        }
+    ]
+
+    assert cases["cancelled"] == []
+    assert cases["late_child"] == [
+        {
+            "promptTurnId": 1,
+            "eventSequence": 41,
+            "phase": "event",
+            "child": {"id": "late", "status": "done"},
+        }
+    ]
+
+    global_sequence_turn_two = cases["global_sequence_turn_two"]
+    assert [event["promptTurnId"] for event in global_sequence_turn_two] == [2, 2]
+    assert [event["eventSequence"] for event in global_sequence_turn_two] == [51, 52]
+    assert [event["phase"] for event in global_sequence_turn_two] == [
+        "responseBoundary",
+        "terminalQuiescence",
+    ]
 
 
 def load_runner_without_acp_dependency(monkeypatch: pytest.MonkeyPatch):

--- a/tests/v1/test_acp.py
+++ b/tests/v1/test_acp.py
@@ -315,3 +315,53 @@ async def test_prompt_starts_metadata_collection_at_the_prompt_boundary(monkeypa
 
     assert reply == "reply"
     assert client.turn_acp_meta == {"ns": [{"from_prompt": True}]}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("case", "terminal_events"),
+    [
+        (
+            "success",
+            [("responseBoundary", "result"), ("terminalQuiescence", "result")],
+        ),
+        (
+            "error_terminal",
+            [("responseBoundary", "error"), ("terminalQuiescence", "error")],
+        ),
+        ("error_incomplete", [("responseBoundary", "error")]),
+        ("cancelled", []),
+        ("late_child", []),
+        (
+            "global_sequence_turn_two",
+            [("responseBoundary", "result"), ("terminalQuiescence", "result")],
+        ),
+    ],
+)
+async def test_canonical_cases_reach_runner_metadata_storage(
+    monkeypatch, case, terminal_events
+):
+    """Named fixture cases exercise the runner's real metadata update path.
+
+    The runner receives each transcript as ACP SessionInfoUpdate events, rather
+    than the test only inspecting the parsed fixture. This maps every named case
+    to the stored response-boundary/terminal evidence, including the incomplete
+    error's boundary-only state and the cases with no terminal evidence.
+    """
+    runner = load_runner_without_acp_dependency(monkeypatch)
+    client = runner.VerifiersACPClient()
+    namespace = "ai.primeintellect.prime-agent"
+    transcript = canonical_cases()[case]
+
+    for event in transcript:
+        update = runner.SessionInfoUpdate()
+        update.field_meta = {namespace: event}
+        await client.session_update("session", update)
+
+    assert client.acp_meta.get(namespace, []) == transcript
+    assert client.turn_acp_meta.get(namespace, []) == transcript
+    assert [
+        (event["phase"], event["outcome"])
+        for event in client.turn_acp_meta.get(namespace, [])
+        if event.get("phase") in {"responseBoundary", "terminalQuiescence"}
+    ] == terminal_events


### PR DESCRIPTION
## Stack

V3 child of #2310 only.

- **V2 / base:** #2310 (`v080/prime-agent-harness`) at `69be56804cae01a1a624b7a6e5efb80102b37cef`
- **V3 head:** `799dd10e65921241773c2072e246dd07383a716b`

## Scope

Test-only canonical ACP correlation corpus and consumer coverage. The pinned fixture is consumed through the runner metadata path across all six named cases. No production or e2e changes.

## Verification

- independent static review: APPROVE
- exact fixture blob `208e9ca1ee5bf05e242861b805c8370880c271ba`
- SHA-256 `cacde7827aadf186db2ce1af1ea6f3b6d109504fa94945633bd9c0d96106b882`
- cumulative scope exactly two test paths
- diff check and clean status

No live or paid evaluation was run. Runtime tests were intentionally not executed during post-incident worktree recovery; normal CI is authoritative.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add canonical ACP correlation fixture and tests for runner metadata storage
> - Adds a canonical fixture file [acp-correlation-transcripts.json](https://github.com/PrimeIntellect-ai/verifiers/pull/2320/files#diff-46145be5f42fdedf0bbf9df12ba3d72c839196f7833fdbbacc75c8365d5a4bbf) containing six named transcript cases (`success`, `error_terminal`, `error_incomplete`, `cancelled`, `late_child`, `global_sequence_turn_two`).
> - Adds a `canonical_cases` helper in [test_acp.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2320/files#diff-fc095c3e17c7efbbbcd9e3dd169acdd994642458c182f8cbcfb44999ed626c24) that enforces an exact SHA-256 digest and schema identifier before returning cases, locking the fixture to specific bytes.
> - Adds tests asserting exact event ordering and field values for each named case, and a parametrized async test that feeds events through the runner's `VerifiersACPClient` and validates per-namespace `acp_meta` and terminal event tuples.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 799dd10.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->