### PR TITLE
test(acp): lock terminal correlation contract

### DIFF
--- a/tests/v1/test_acp_correlation_contract.py
+++ b/tests/v1/test_acp_correlation_contract.py
@@ -184,7 +184,10 @@ async def test_late_opaque_metadata_is_observable_but_not_trusted(monkeypatch):
 
     class Connection:
         async def prompt(self, **kwargs):
-            await client.session_update("session", opaque_update(runner, prior_turn_meta))
+            await client.session_update(
+                "session",
+                opaque_update(runner, prior_turn_meta),
+            )
             chunk = runner.AgentMessageChunk()
             chunk.content = runner.TextContentBlock()
             chunk.content.text = "P2 reply"

--- a/tests/v1/test_acp_correlation_contract.py
+++ b/tests/v1/test_acp_correlation_contract.py
@@ -9,7 +9,6 @@ producer/consumer contract using the explicitly scoped producer evidence ABI
 below.
 """
 
-import asyncio
 import importlib.util
 import sys
 import types

--- a/tests/v1/test_acp_correlation_contract.py
+++ b/tests/v1/test_acp_correlation_contract.py
@@ -1,0 +1,354 @@
+"""ACP 0.11 correlation conformance contracts.
+
+The v1 adapter makes ``SessionInfoUpdate.field_meta`` observable through global
+``acp_meta`` and prompt-scoped ``turn_acp_meta`` histories. Those histories are
+intentionally evidence, not verification: an ACP ``end_turn``, arrival order,
+a late-update grace period, or opaque metadata that merely claims a turn ID
+cannot establish trusted terminal correlation. Verification remains a
+producer/consumer contract carrying producer-issued IDs.
+"""
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def load_runner_without_acp_dependency(monkeypatch: pytest.MonkeyPatch):
+    """Load the standalone runner using local protocol-shaped test doubles only."""
+
+    class RequestError(Exception):
+        def __init__(self, data):
+            super().__init__("request failed")
+            self.data = data
+
+    acp = types.ModuleType("acp")
+    acp.PROTOCOL_VERSION = "0.11"
+    acp.Client = object
+    acp.RequestError = RequestError
+    acp.image_block = lambda data, media_type: (data, media_type)
+    acp.spawn_agent_process = None
+    acp.text_block = lambda text: text
+    schema = types.ModuleType("acp.schema")
+    for name in (
+        "AgentMessageChunk", "AllowedOutcome", "ClientCapabilities", "DeniedOutcome",
+        "HttpMcpServer", "PermissionOption", "RequestPermissionResponse",
+        "SessionInfoUpdate", "TextContentBlock", "ToolCall", "ToolCallUpdate",
+    ):
+        setattr(schema, name, type(name, (), {}))
+    monkeypatch.setitem(sys.modules, "acp", acp)
+    monkeypatch.setitem(sys.modules, "acp.schema", schema)
+    spec = importlib.util.spec_from_file_location(
+        "test_acp_correlation_contract_runner",
+        Path(__file__).parents[2] / "verifiers/v1/acp/runner.py",
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def config(*, allow_empty_tool_reply: bool = False) -> dict:
+    return {
+        "messages": [{"role": "user", "content": "do work"}],
+        "system_prompt": "",
+        "allow_empty_tool_reply": allow_empty_tool_reply,
+    }
+
+
+def opaque_update(runner, event: dict):
+    update = runner.SessionInfoUpdate()
+    update.field_meta = {"ai.primeintellect.prime-agent": event}
+    return update
+
+
+def has_verified_producer_correlation(events: list[dict]) -> bool:
+    """Model the minimum consumer claim: producer-issued IDs must be present.
+
+    ACP's extension metadata is otherwise opaque to this adapter. In particular,
+    turn-looking fields and ordering are observations only, not an authenticated
+    producer/consumer correlation contract.
+    """
+    return bool(events) and all(
+        isinstance(event.get("producerId"), str)
+        and event["producerId"]
+        and isinstance(event.get("producerEventId"), str)
+        and event["producerEventId"]
+        for event in events
+    )
+
+
+async def completed_tool_only_turn(runner, client) -> types.SimpleNamespace:
+    """Emit a normal ACP tool lifecycle, then an empty ``end_turn`` reply."""
+    tool = runner.ToolCall()
+    tool.tool_call_id = "tool-1"
+    tool.status = "pending"
+    await client.session_update("session", tool)
+    completed = runner.ToolCallUpdate()
+    completed.tool_call_id = "tool-1"
+    completed.status = "completed"
+    await client.session_update("session", completed)
+    return types.SimpleNamespace(stop_reason="end_turn")
+
+
+@pytest.mark.asyncio
+async def test_end_turn_tool_only_is_not_trusted_correlation(monkeypatch):
+    """A tool-only empty reply has no metadata evidence and no correlation proof."""
+    runner = load_runner_without_acp_dependency(monkeypatch)
+    client = runner.VerifiersACPClient()
+
+    class Connection:
+        async def prompt(self, **kwargs):
+            return await completed_tool_only_turn(runner, client)
+
+    reply = await runner.prompt(
+        client, Connection(), None, "session", config(allow_empty_tool_reply=True), is_new=True
+    )
+    assert reply == ""
+    assert client.tool_calls == {"tool-1": "completed"}
+    assert client.acp_meta == {}
+    assert client.turn_acp_meta == {}
+    assert not has_verified_producer_correlation([])
+
+
+@pytest.mark.asyncio
+async def test_end_turn_without_completed_tool_has_no_correlation_evidence(monkeypatch):
+    """A stop reason cannot make absent observable metadata trustworthy."""
+    runner = load_runner_without_acp_dependency(monkeypatch)
+    client = runner.VerifiersACPClient()
+
+    class Connection:
+        async def prompt(self, **kwargs):
+            return types.SimpleNamespace(stop_reason="end_turn")
+
+    with pytest.raises(RuntimeError, match="produced no visible reply"):
+        await runner.prompt(client, Connection(), None, "session", config(allow_empty_tool_reply=True), is_new=True)
+    assert client.acp_meta == {}
+    assert client.turn_acp_meta == {}
+    assert not has_verified_producer_correlation([])
+
+
+@pytest.mark.asyncio
+async def test_late_opaque_metadata_is_observable_but_not_trusted(monkeypatch):
+    """A delayed prior-turn-looking update is retained, not grace-window joined."""
+    runner = load_runner_without_acp_dependency(monkeypatch)
+    client = runner.VerifiersACPClient()
+    prior_turn_meta = {
+        "promptTurnId": "untrusted-P1",
+        "phase": "terminalQuiescence",
+    }
+
+    class Connection:
+        async def prompt(self, **kwargs):
+            await client.session_update("session", opaque_update(runner, prior_turn_meta))
+            chunk = runner.AgentMessageChunk()
+            chunk.content = runner.TextContentBlock()
+            chunk.content.text = "P2 reply"
+            await client.session_update("session", chunk)
+            return types.SimpleNamespace(stop_reason="end_turn")
+
+    assert await runner.prompt(client, Connection(), None, "session", config(), is_new=False) == "P2 reply"
+    namespace = "ai.primeintellect.prime-agent"
+    assert client.acp_meta[namespace] == [prior_turn_meta]
+    assert client.turn_acp_meta[namespace] == [prior_turn_meta]
+    assert not has_verified_producer_correlation(client.turn_acp_meta[namespace])
+
+
+@pytest.mark.asyncio
+async def test_arrival_order_is_observable_but_not_trusted_correlation(monkeypatch):
+    """Ordered opaque P1/P2-looking metadata is history, never proof by itself."""
+    runner = load_runner_without_acp_dependency(monkeypatch)
+    client = runner.VerifiersACPClient()
+    events = [
+        {"eventSequence": 10, "promptTurnId": "P1"},
+        {"eventSequence": 11, "promptTurnId": "P2"},
+    ]
+
+    for event in events:
+        await client.session_update("session", opaque_update(runner, event))
+
+    namespace = "ai.primeintellect.prime-agent"
+    assert client.acp_meta[namespace] == events
+    assert client.turn_acp_meta[namespace] == events
+    assert not has_verified_producer_correlation(client.turn_acp_meta[namespace])
+
+
+@pytest.mark.asyncio
+async def test_opaque_error_metadata_remains_observable_and_error_authoritative(monkeypatch):
+    """Metadata storage does not convert a provider error into end_turn success."""
+    runner = load_runner_without_acp_dependency(monkeypatch)
+    client = runner.VerifiersACPClient()
+    error_meta = {"phase": "responseBoundary", "outcome": "error"}
+
+    class Connection:
+        async def prompt(self, **kwargs):
+            await client.session_update("session", opaque_update(runner, error_meta))
+            raise runner.RequestError({"details": "provider rejected request"})
+
+    with pytest.raises(RuntimeError, match="provider rejected request"):
+        await runner.prompt(client, Connection(), None, "session", config(allow_empty_tool_reply=True), is_new=True)
+    namespace = "ai.primeintellect.prime-agent"
+    assert client.acp_meta[namespace] == [error_meta]
+    assert client.turn_acp_meta[namespace] == [error_meta]
+    assert not has_verified_producer_correlation(client.turn_acp_meta[namespace])
+
+
+# Conformance/source-level fixtures intentionally model the producer ABI rather
+# than importing P2. They lock the scoreable terminal producer-pair contract
+# without claiming that the ACP adapter can verify those producer IDs.
+P2_TERMINAL_FIXTURE = {
+    "response": {
+        "promptTurnId": 7,
+        "eventSequence": 41,
+        "phase": "responseBoundary",
+        "outcome": "result",
+    },
+    "terminal": {
+        "promptTurnId": 7,
+        "eventSequence": 42,
+        "phase": "terminalQuiescence",
+        "outcome": "result",
+        "quiescence": {
+            "outstandingSubagents": 0,
+            "remainingAutonomousContinuations": 0,
+        },
+    },
+}
+
+
+def scoreable_terminal(
+    events: list[dict], *, cancelled: bool, completion_cut_sealed: bool
+) -> bool:
+    """Conformance/source-level pure gate for P2's completion-cut contract.
+
+    A producer atomically seals a complete zero-quiescence pair *before* it
+    queues either notification. Cancellation before that cut is unscoreable;
+    cancellation after the cut, including while either notify is gated, cannot
+    relabel the durable pair as cancelled. An ACP ``end_turn`` is deliberately
+    absent because it is never causal evidence.
+    """
+    if len(events) != 2 or (cancelled and not completion_cut_sealed):
+        return False
+    response, terminal = events
+    counters = terminal.get("quiescence")
+    return (
+        response.get("phase") == "responseBoundary"
+        and response.get("outcome") == "result"
+        and terminal.get("phase") == "terminalQuiescence"
+        and terminal.get("outcome") == "result"
+        and type(response.get("promptTurnId")) is int
+        and response["promptTurnId"] > 0
+        and type(terminal.get("promptTurnId")) is int
+        and terminal["promptTurnId"] > 0
+        and terminal["promptTurnId"] == response["promptTurnId"]
+        and type(response.get("eventSequence")) is int
+        and response["eventSequence"] > 0
+        and type(terminal.get("eventSequence")) is int
+        and terminal["eventSequence"] > 0
+        and terminal["eventSequence"] > response["eventSequence"]
+        and counters
+        == {
+            "outstandingSubagents": 0,
+            "remainingAutonomousContinuations": 0,
+        }
+    )
+
+
+def test_p2_terminal_publish_fixture_requires_producer_pair_not_end_turn():
+    """A completed terminal is a producer pair, never an ACP stop reason."""
+    events = [P2_TERMINAL_FIXTURE["response"], P2_TERMINAL_FIXTURE["terminal"]]
+    assert scoreable_terminal(events, cancelled=False, completion_cut_sealed=True)
+    # ``end_turn`` is intentionally not accepted by the helper and cannot make
+    # a partial/uncorrelated transcript scoreable.
+    assert not scoreable_terminal(
+        [P2_TERMINAL_FIXTURE["terminal"]],
+        cancelled=False,
+        completion_cut_sealed=True,
+    )
+
+
+def test_cancel_before_completion_cut_is_unscoreable_and_has_no_pair():
+    """A pre-cut cancel must publish no response/terminal completion evidence."""
+    assert not scoreable_terminal([], cancelled=True, completion_cut_sealed=False)
+
+
+def test_cancel_before_completion_cut_rejects_even_a_claimed_full_pair():
+    """A consumer must not trust a pair unless producer sealing was irrevocable."""
+    events = [P2_TERMINAL_FIXTURE["response"], P2_TERMINAL_FIXTURE["terminal"]]
+    assert not scoreable_terminal(events, cancelled=True, completion_cut_sealed=False)
+
+
+def test_cancel_after_irrevocable_cut_during_response_publish_is_durable():
+    """Notify-gated response publication cannot relabel a sealed pair cancelled."""
+    events = [P2_TERMINAL_FIXTURE["response"], P2_TERMINAL_FIXTURE["terminal"]]
+    assert scoreable_terminal(events, cancelled=True, completion_cut_sealed=True)
+
+
+def test_cancel_after_irrevocable_cut_during_terminal_publish_is_durable():
+    """Terminal-drain cancellation is likewise after the producer completion cut.
+
+    P2's notify-gated production test establishes this linearization; this
+    conformance/source-level fixture locks its consumer-facing consequence.
+    """
+    events = [P2_TERMINAL_FIXTURE["response"], P2_TERMINAL_FIXTURE["terminal"]]
+    assert scoreable_terminal(events, cancelled=True, completion_cut_sealed=True)
+
+
+def test_terminal_gate_rejects_bool_nonpositive_and_foreign_ids():
+    """Opaque IDs/sequences must be strict positive integers on both records."""
+    events = [P2_TERMINAL_FIXTURE["response"], P2_TERMINAL_FIXTURE["terminal"]]
+    for record_index, field, value in (
+        (0, "promptTurnId", True),
+        (1, "promptTurnId", False),
+        (0, "promptTurnId", 0),
+        (1, "promptTurnId", -1),
+        (0, "eventSequence", True),
+        (1, "eventSequence", False),
+        (0, "eventSequence", 0),
+        (1, "eventSequence", -1),
+    ):
+        mutated = [dict(record) for record in events]
+        mutated[record_index][field] = value
+        assert not scoreable_terminal(
+            mutated, cancelled=False, completion_cut_sealed=True
+        ), (record_index, field, value)
+
+    foreign_turn = [dict(record) for record in events]
+    foreign_turn[1]["promptTurnId"] = 8
+    assert not scoreable_terminal(
+        foreign_turn, cancelled=False, completion_cut_sealed=True
+    )
+
+    nonincreasing = [dict(record) for record in events]
+    nonincreasing[1]["eventSequence"] = nonincreasing[0]["eventSequence"]
+    assert not scoreable_terminal(
+        nonincreasing, cancelled=False, completion_cut_sealed=True
+    )
+
+
+def test_error_or_nonzero_terminal_never_becomes_a_successful_completion_pair():
+    """Error and incomplete terminal transcripts stay observable but unscoreable."""
+    error_terminal = {
+        **P2_TERMINAL_FIXTURE["terminal"],
+        "outcome": "error",
+    }
+    incomplete = {
+        **P2_TERMINAL_FIXTURE["terminal"],
+        "quiescence": {
+            "outstandingSubagents": 1,
+            "remainingAutonomousContinuations": 0,
+        },
+    }
+    assert not scoreable_terminal(
+        [P2_TERMINAL_FIXTURE["response"], error_terminal],
+        cancelled=False,
+        completion_cut_sealed=True,
+    )
+    assert not scoreable_terminal(
+        [P2_TERMINAL_FIXTURE["response"], incomplete],
+        cancelled=False,
+        completion_cut_sealed=True,
+    )

--- a/tests/v1/test_acp_correlation_contract.py
+++ b/tests/v1/test_acp_correlation_contract.py
@@ -326,12 +326,14 @@ def test_producer_abi_rejects_opaque_or_partial_claims():
         [{"promptTurnId": 7, "eventSequence": 41, "phase": "responseBoundary"}]
     )
     assert not has_verified_producer_correlation(
-        [{
-            "promptTurnId": 7,
-            "eventSequence": 41,
-            "phase": "opaqueBoundary",
-            "outcome": "result",
-        }]
+        [
+            {
+                "promptTurnId": 7,
+                "eventSequence": 41,
+                "phase": "opaqueBoundary",
+                "outcome": "result",
+            }
+        ]
     )
 
 

--- a/tests/v1/test_acp_correlation_contract.py
+++ b/tests/v1/test_acp_correlation_contract.py
@@ -195,7 +195,9 @@ async def test_late_opaque_metadata_is_observable_but_not_trusted(monkeypatch):
             return types.SimpleNamespace(stop_reason="end_turn")
 
     assert (
-        await runner.prompt(client, Connection(), None, "session", config(), is_new=False)
+        await runner.prompt(
+            client, Connection(), None, "session", config(), is_new=False
+        )
         == "P2 reply"
     )
     namespace = "ai.primeintellect.prime-agent"

--- a/tests/v1/test_acp_correlation_contract.py
+++ b/tests/v1/test_acp_correlation_contract.py
@@ -34,9 +34,17 @@ def load_runner_without_acp_dependency(monkeypatch: pytest.MonkeyPatch):
     acp.text_block = lambda text: text
     schema = types.ModuleType("acp.schema")
     for name in (
-        "AgentMessageChunk", "AllowedOutcome", "ClientCapabilities", "DeniedOutcome",
-        "HttpMcpServer", "PermissionOption", "RequestPermissionResponse",
-        "SessionInfoUpdate", "TextContentBlock", "ToolCall", "ToolCallUpdate",
+        "AgentMessageChunk",
+        "AllowedOutcome",
+        "ClientCapabilities",
+        "DeniedOutcome",
+        "HttpMcpServer",
+        "PermissionOption",
+        "RequestPermissionResponse",
+        "SessionInfoUpdate",
+        "TextContentBlock",
+        "ToolCall",
+        "ToolCallUpdate",
     ):
         setattr(schema, name, type(name, (), {}))
     monkeypatch.setitem(sys.modules, "acp", acp)

--- a/tests/v1/test_acp_correlation_contract.py
+++ b/tests/v1/test_acp_correlation_contract.py
@@ -101,7 +101,10 @@ def has_verified_producer_correlation(events: list[dict]) -> bool:
         and event["promptTurnId"] > 0
         and type(event.get("eventSequence")) is int
         and event["eventSequence"] > 0
-        and (event.get("phase"), event.get("outcome"))
+        and (
+            event.get("phase"),
+            event.get("outcome"),
+        )
         in VALID_PRODUCER_PHASE_OUTCOMES
         for event in events
     )

--- a/tests/v1/test_acp_correlation_contract.py
+++ b/tests/v1/test_acp_correlation_contract.py
@@ -159,7 +159,14 @@ async def test_end_turn_without_completed_tool_has_no_correlation_evidence(monke
             return types.SimpleNamespace(stop_reason="end_turn")
 
     with pytest.raises(RuntimeError, match="produced no visible reply"):
-        await runner.prompt(client, Connection(), None, "session", config(allow_empty_tool_reply=True), is_new=True)
+        await runner.prompt(
+            client,
+            Connection(),
+            None,
+            "session",
+            config(allow_empty_tool_reply=True),
+            is_new=True,
+        )
     assert client.acp_meta == {}
     assert client.turn_acp_meta == {}
     assert not has_verified_producer_correlation([])

--- a/tests/v1/test_acp_correlation_contract.py
+++ b/tests/v1/test_acp_correlation_contract.py
@@ -226,7 +226,9 @@ async def test_arrival_order_is_observable_but_not_trusted_correlation(monkeypat
 
 
 @pytest.mark.asyncio
-async def test_opaque_error_metadata_remains_observable_and_error_authoritative(monkeypatch):
+async def test_opaque_error_metadata_remains_observable_and_error_authoritative(
+    monkeypatch,
+):
     """Metadata storage does not convert a provider error into end_turn success."""
     runner = load_runner_without_acp_dependency(monkeypatch)
     client = runner.VerifiersACPClient()

--- a/tests/v1/test_acp_correlation_contract.py
+++ b/tests/v1/test_acp_correlation_contract.py
@@ -134,7 +134,12 @@ async def test_end_turn_tool_only_is_not_trusted_correlation(monkeypatch):
             return await completed_tool_only_turn(runner, client)
 
     reply = await runner.prompt(
-        client, Connection(), None, "session", config(allow_empty_tool_reply=True), is_new=True
+        client,
+        Connection(),
+        None,
+        "session",
+        config(allow_empty_tool_reply=True),
+        is_new=True,
     )
     assert reply == ""
     assert client.tool_calls == {"tool-1": "completed"}

--- a/tests/v1/test_acp_correlation_contract.py
+++ b/tests/v1/test_acp_correlation_contract.py
@@ -5,7 +5,8 @@ The v1 adapter makes ``SessionInfoUpdate.field_meta`` observable through global
 intentionally evidence, not verification: an ACP ``end_turn``, arrival order,
 a late-update grace period, or opaque metadata that merely claims a turn ID
 cannot establish trusted terminal correlation. Verification remains a
-producer/consumer contract carrying producer-issued IDs.
+producer/consumer contract using the explicitly scoped producer evidence ABI
+below.
 """
 
 import asyncio
@@ -65,18 +66,36 @@ def opaque_update(runner, event: dict):
     return update
 
 
-def has_verified_producer_correlation(events: list[dict]) -> bool:
-    """Model the minimum consumer claim: producer-issued IDs must be present.
+# This is deliberately the complete, scoped producer ABI used by this
+# conformance file.  It does not invent a second producer-ID namespace:
+# ``promptTurnId`` and ``eventSequence`` identify an emitted producer record.
+# A candidate is trusted as structured producer evidence only when all four
+# fields are well-formed.  Whether two candidates establish a completed turn is
+# the stricter ``scoreable_terminal`` question below.
+VALID_PRODUCER_PHASE_OUTCOMES = frozenset(
+    {
+        ("responseBoundary", "result"),
+        ("responseBoundary", "error"),
+        ("terminalQuiescence", "result"),
+        ("terminalQuiescence", "error"),
+    }
+)
 
-    ACP's extension metadata is otherwise opaque to this adapter. In particular,
-    turn-looking fields and ordering are observations only, not an authenticated
-    producer/consumer correlation contract.
+
+def has_verified_producer_correlation(events: list[dict]) -> bool:
+    """Return whether every record satisfies the one producer evidence ABI.
+
+    ACP extension metadata remains opaque to the adapter: arrival order,
+    ``end_turn``, and partial or merely turn-looking claims cannot establish
+    trusted producer correlation.
     """
     return bool(events) and all(
-        isinstance(event.get("producerId"), str)
-        and event["producerId"]
-        and isinstance(event.get("producerEventId"), str)
-        and event["producerEventId"]
+        type(event.get("promptTurnId")) is int
+        and event["promptTurnId"] > 0
+        and type(event.get("eventSequence")) is int
+        and event["eventSequence"] > 0
+        and (event.get("phase"), event.get("outcome"))
+        in VALID_PRODUCER_PHASE_OUTCOMES
         for event in events
     )
 
@@ -198,7 +217,7 @@ async def test_opaque_error_metadata_remains_observable_and_error_authoritative(
 
 # Conformance/source-level fixtures intentionally model the producer ABI rather
 # than importing P2. They lock the scoreable terminal producer-pair contract
-# without claiming that the ACP adapter can verify those producer IDs.
+# without claiming that the ACP adapter can itself authenticate the producer.
 P2_TERMINAL_FIXTURE = {
     "response": {
         "promptTurnId": 7,
@@ -230,7 +249,11 @@ def scoreable_terminal(
     relabel the durable pair as cancelled. An ACP ``end_turn`` is deliberately
     absent because it is never causal evidence.
     """
-    if len(events) != 2 or (cancelled and not completion_cut_sealed):
+    if (
+        len(events) != 2
+        or (cancelled and not completion_cut_sealed)
+        or not has_verified_producer_correlation(events)
+    ):
         return False
     response, terminal = events
     counters = terminal.get("quiescence")
@@ -257,9 +280,26 @@ def scoreable_terminal(
     )
 
 
+def test_producer_abi_rejects_opaque_or_partial_claims():
+    """Only all four scoped ABI fields make an event trusted evidence."""
+    assert not has_verified_producer_correlation([{"opaque": "claim"}])
+    assert not has_verified_producer_correlation(
+        [{"promptTurnId": 7, "eventSequence": 41, "phase": "responseBoundary"}]
+    )
+    assert not has_verified_producer_correlation(
+        [{
+            "promptTurnId": 7,
+            "eventSequence": 41,
+            "phase": "opaqueBoundary",
+            "outcome": "result",
+        }]
+    )
+
+
 def test_p2_terminal_publish_fixture_requires_producer_pair_not_end_turn():
     """A completed terminal is a producer pair, never an ACP stop reason."""
     events = [P2_TERMINAL_FIXTURE["response"], P2_TERMINAL_FIXTURE["terminal"]]
+    assert has_verified_producer_correlation(events)
     assert scoreable_terminal(events, cancelled=False, completion_cut_sealed=True)
     # ``end_turn`` is intentionally not accepted by the helper and cannot make
     # a partial/uncorrelated transcript scoreable.

--- a/tests/v1/test_acp_correlation_contract.py
+++ b/tests/v1/test_acp_correlation_contract.py
@@ -194,7 +194,10 @@ async def test_late_opaque_metadata_is_observable_but_not_trusted(monkeypatch):
             await client.session_update("session", chunk)
             return types.SimpleNamespace(stop_reason="end_turn")
 
-    assert await runner.prompt(client, Connection(), None, "session", config(), is_new=False) == "P2 reply"
+    assert (
+        await runner.prompt(client, Connection(), None, "session", config(), is_new=False)
+        == "P2 reply"
+    )
     namespace = "ai.primeintellect.prime-agent"
     assert client.acp_meta[namespace] == [prior_turn_meta]
     assert client.turn_acp_meta[namespace] == [prior_turn_meta]

--- a/tests/v1/test_acp_correlation_contract.py
+++ b/tests/v1/test_acp_correlation_contract.py
@@ -240,7 +240,14 @@ async def test_opaque_error_metadata_remains_observable_and_error_authoritative(
             raise runner.RequestError({"details": "provider rejected request"})
 
     with pytest.raises(RuntimeError, match="provider rejected request"):
-        await runner.prompt(client, Connection(), None, "session", config(allow_empty_tool_reply=True), is_new=True)
+        await runner.prompt(
+            client,
+            Connection(),
+            None,
+            "session",
+            config(allow_empty_tool_reply=True),
+            is_new=True,
+        )
     namespace = "ai.primeintellect.prime-agent"
     assert client.acp_meta[namespace] == [error_meta]
     assert client.turn_acp_meta[namespace] == [error_meta]


### PR DESCRIPTION
## Stack

Conformance child of #2320 only.

- **V3 / base:** #2320 (`v080/acp-v3-correlation-final`) at `799dd10e65921241773c2072e246dd07383a716b`
- **Conformance:** `9204448b9746ac3b7deb9f72a4a618c6771009b4`

Both PRs remain draft/HOLD. The upstream live-test environment is dependency-blocked; no live or paid evaluation was run.

## Scope

One test-only conformance file. It preserves V3 observable metadata histories while requiring a single consistent producer evidence ABI for trusted terminal correlation. Stop reasons, arrival order, grace timing, opaque/partial claims, and pre-cut cancellation remain untrusted.

## Verification

- independent read-only review: APPROVE
- exact one-path cumulative scope
- clean/diff-check
- consistent promptTurnId/eventSequence/phase/outcome ABI


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add ACP 0.11 correlation conformance test suite for terminal pair scoring
> Adds [test_acp_correlation_contract.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2322/files#diff-a654e5b6f2291e12465efc6e9ef3b653860627e90b3b89d73ec84acfe189d9b3) to lock the observable-vs-trusted metadata contract and terminal pair scoring semantics for the ACP v1 adapter.
>
> - Tests cover tool-only turns, late/opaque metadata arrival, error propagation, and producer evidence ABI validation.
> - A `load_runner_without_acp_dependency` fixture monkeypatches minimal ACP doubles so the runner can be exercised in isolation.
> - `has_verified_producer_correlation` and `scoreable_terminal` helpers encode the gate logic for trusted producer evidence and irrevocable completion-cut semantics.
> - Cancellation durability tests assert that a sealed completion pair survives post-cut cancellation but is rejected if cancelled before sealing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9204448. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->