### PR TITLE
feat: metadata-only overrides for config-plugged functions

### DIFF
--- a/docs/v1/tasksets.md
+++ b/docs/v1/tasksets.md
@@ -246,7 +246,14 @@ reply_length = { fn = "my_hooks.py:reply_length", priority = 10 }
 exact_match = { fn = "my_hooks.py:exact_match", weight = 0.5 }
 ```
 
-Plugged hooks merge with the task's decorated `@vf.stop` / `@vf.metric` / `@vf.reward` methods; a plugged hook replaces a decorated one with the same name, so an existing signal can be swapped out (like `single_turn` above). Rewards take a `weight`, and every entry takes a `priority` (higher runs first).
+Plugged hooks merge with the task's decorated `@vf.stop` / `@vf.metric` / `@vf.reward` methods; a plugged hook replaces a decorated one with the same name, so an existing signal can be swapped out (like `single_turn` above). Rewards take a `weight`, and every entry takes a `priority` (higher runs first); unset fields keep the replaced method's values.
+
+Leaving `fn` out keeps the task's own decorated method and only overrides its metadata — for example, turning an existing zero-weight reward into a training signal:
+
+```toml
+[env.taskset.task.rewards]
+exact_match = { weight = 1.0 }
+```
 
 ## Beyond one agent
 

--- a/tests/v1/test_scoring.py
+++ b/tests/v1/test_scoring.py
@@ -1,3 +1,5 @@
+import pytest
+
 import verifiers.v1 as vf
 from verifiers.v1.graph import MessageNode
 from verifiers.v1.types import AssistantMessage, UserMessage
@@ -33,6 +35,10 @@ class HookTask(vf.Task[HookData]):
     async def lcs(self, trace: vf.Trace) -> float:
         return 0.5
 
+    @vf.reward(weight=0.0)
+    async def fmt(self, trace: vf.Trace) -> float:
+        return 1.0
+
 
 async def test_config_plugged_fns_merge_and_override(tmp_path) -> None:
     fns = tmp_path / "fns.py"
@@ -43,6 +49,7 @@ async def test_config_plugged_fns_merge_and_override(tmp_path) -> None:
         rewards={
             "exact_match": vf.RewardFunctionConfig(fn=f"{fns}:exact_match", weight=0.5),
             "lcs": vf.RewardFunctionConfig(fn=f"{fns}:marker", weight=2.0),
+            "fmt": vf.RewardFunctionConfig(weight=1.0),
         },
     )
     task = HookTask(HookData(idx=0, prompt="abc", answer="cba"), config)
@@ -69,6 +76,14 @@ async def test_config_plugged_fns_merge_and_override(tmp_path) -> None:
     assert trace.rewards["exact_match"].score == 1.0
     assert trace.rewards["exact_match"].weight == 0.5
     assert trace.metrics["reply_length"] == 3.0
+    # `fmt` keeps the decorated body, only its weight is overridden (0.0 -> 1.0)
+    assert trace.rewards["fmt"].score == 1.0
+    assert trace.rewards["fmt"].weight == 1.0
+
+    # a fn-less entry must name an existing decorated method
+    config = vf.TaskConfig(rewards={"nope": vf.RewardFunctionConfig(weight=1.0)})
+    with pytest.raises(ValueError, match="no @vf.reward method named 'nope'"):
+        HookTask(HookData(idx=0, prompt="abc"), config).hooks("reward")
 
 
 def test_compare_stdout_results_accepts_token_equal_text() -> None:

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -27,7 +27,6 @@ from verifiers.v1.configs.serve import (
 )
 from verifiers.v1.configs.task import (
     DecoratedFunctionConfig,
-    FunctionConfig,
     RewardFunctionConfig,
     TaskConfig,
 )
@@ -244,7 +243,6 @@ __all__ = [  # noqa: RUF022 - grouped by public API area
     "Taskset",
     "TaskConfig",
     "TasksetConfig",
-    "FunctionConfig",
     "DecoratedFunctionConfig",
     "RewardFunctionConfig",
     "BaseConfig",

--- a/verifiers/v1/configs/task.py
+++ b/verifiers/v1/configs/task.py
@@ -11,22 +11,25 @@ from verifiers.v1.configs.judge import Judges, check_judges, resolve_judges
 class FunctionConfig(BaseConfig):
     """A function plugged in by import path."""
 
-    fn: str
+    fn: str = ""
     """Import path to the function: `pkg.module.function`, `pkg.module:function`,
-    or `path/to/file.py:function`."""
+    or `path/to/file.py:function`. Empty keeps the task's decorated method with the
+    entry's name and only overrides its metadata (priority, weight)."""
 
 
 class DecoratedFunctionConfig(FunctionConfig):
     """A plugged function standing in for a decorated task method."""
 
-    priority: int = 0
-    """Execution order, like the decorator's — higher runs first, ties break by name."""
+    priority: int | None = None
+    """Execution order, like the decorator's — higher runs first, ties break by name.
+    Unset keeps the replaced method's priority (0 for a fresh function)."""
 
 
 class RewardFunctionConfig(DecoratedFunctionConfig):
     """A plugged function standing in for a `@vf.reward` task method."""
 
-    weight: FiniteFloat = 1.0
+    weight: FiniteFloat | None = None
+    """Unset keeps the replaced method's weight (1.0 for a fresh function)."""
 
 
 class TaskConfig(BaseConfig):

--- a/verifiers/v1/configs/task.py
+++ b/verifiers/v1/configs/task.py
@@ -8,17 +8,13 @@ from pydantic_config import BaseConfig
 from verifiers.v1.configs.judge import Judges, check_judges, resolve_judges
 
 
-class FunctionConfig(BaseConfig):
-    """A function plugged in by import path."""
-
-    fn: str = ""
-    """Import path to the function: `pkg.module.function`, `pkg.module:function`,
-    or `path/to/file.py:function`. Empty keeps the task's decorated method with the
-    entry's name and only overrides its metadata (priority, weight)."""
-
-
-class DecoratedFunctionConfig(FunctionConfig):
+class DecoratedFunctionConfig(BaseConfig):
     """A plugged function standing in for a decorated task method."""
+
+    fn: str | None = None
+    """Import path to the function: `pkg.module.function`, `pkg.module:function`,
+    or `path/to/file.py:function`. Unset keeps the task's decorated method with the
+    entry's name and only overrides its metadata (priority, weight)."""
 
     priority: int | None = None
     """Execution order, like the decorator's — higher runs first, ties break by name.

--- a/verifiers/v1/task.py
+++ b/verifiers/v1/task.py
@@ -233,8 +233,8 @@ class Task(Generic[DataT, StateT, ConfigT]):
 
     def hooks(self, attr: str) -> list[Callable[..., Any]]:
         """The task's `@vf.<attr>` methods merged with the config-plugged functions —
-        a plugged function replaces a decorated method with the same name — sorted by
-        descending priority then name."""
+        a plugged function replaces a decorated method with the same name (a `fn`-less
+        entry only overrides its metadata) — sorted by descending priority then name."""
         from verifiers.v1.utils.loaders import load_plugged_fn
 
         plugged = {
@@ -244,7 +244,8 @@ class Task(Generic[DataT, StateT, ConfigT]):
         }[attr]
         merged = {fn.__name__: fn for fn in discover_decorated(self, attr)}
         merged |= {
-            name: load_plugged_fn(name, spec, attr) for name, spec in plugged.items()
+            name: load_plugged_fn(name, spec, attr, decorated=merged.get(name))
+            for name, spec in plugged.items()
         }
         fns = list(merged.values())
         fns.sort(key=lambda fn: (-getattr(fn, f"{attr}_priority", 0), fn.__name__))

--- a/verifiers/v1/utils/loaders.py
+++ b/verifiers/v1/utils/loaders.py
@@ -244,11 +244,24 @@ def plugged_fn(path: str) -> Callable[..., Any]:
 
 
 def load_plugged_fn(
-    name: str, config: DecoratedFunctionConfig, attr: str
+    name: str,
+    config: DecoratedFunctionConfig,
+    attr: str,
+    decorated: Callable[..., Any] | None = None,
 ) -> Callable[..., Any]:
-    """Build a task hook from a config entry: the imported async function wrapped
-    under the plugged `name`, tagged like its `@vf.<attr>` equivalent."""
-    fn = plugged_fn(config.fn)
+    """Build a task hook from a config entry: the imported async function — or, with
+    no `fn`, the task's `decorated` method it overrides — wrapped under the plugged
+    `name`, tagged like its `@vf.<attr>` equivalent. Unset metadata fields keep the
+    wrapped function's tags."""
+    if config.fn:
+        fn = plugged_fn(config.fn)
+    elif decorated is not None:
+        fn = decorated
+    else:
+        raise ValueError(
+            f"{attr} {name!r} plugs no `fn` and the task has no @vf.{attr} "
+            f"method named {name!r} to override"
+        )
 
     @functools.wraps(fn)
     def plugged(*args: Any, **kwargs: Any) -> Any:
@@ -256,9 +269,15 @@ def load_plugged_fn(
 
     plugged.__name__ = name
     setattr(plugged, attr, True)
-    setattr(plugged, f"{attr}_priority", config.priority)
+    priority = config.priority
+    if priority is None:
+        priority = getattr(fn, f"{attr}_priority", 0)
+    setattr(plugged, f"{attr}_priority", priority)
     if isinstance(config, RewardFunctionConfig):
-        plugged._vf_weight = config.weight
+        weight = config.weight
+        if weight is None:
+            weight = getattr(fn, "_vf_weight", 1.0)
+        plugged._vf_weight = weight
     return plugged
 
 


### PR DESCRIPTION
## Summary

Extends config-plugged functions (#2309) with metadata-only overrides: a config entry without `fn` keeps the task's own decorated method and overrides just its metadata. For example, turning an existing zero-weight reward into a training signal:

```toml
[env.taskset.task.rewards.lcs]
weight = 2.0
```

- `DecoratedFunctionConfig.fn` is now `str | None = None`; a `fn`-less entry must name an existing `@vf.stop`/`@vf.metric`/`@vf.reward` method, otherwise `Task.hooks` raises.
- `priority` and `weight` also default to `None` = "keep the replaced function's value" (0 / 1.0 for a freshly plugged `fn`), so overriding one field no longer resets the other. Plugging a new function by `fn` works as before.
- The base `FunctionConfig` (`fn` only, no other users) is folded into `DecoratedFunctionConfig`.
- Docs (`docs/v1/tasksets.md`) and the existing scoring test extended to cover metadata-only overrides and the unknown-name error.

## Verification

Ran `uv run eval reverse-text -n 2 -r 1` with a config combining a metadata-only override and a newly plugged reward:

```toml
[env.taskset.task.rewards.lcs]
weight = 2.0

[env.taskset.task.rewards.has_tags]
fn = "extra_reward.py:has_tags"
weight = 0.5
```

The trace records `lcs` scored by the taskset's decorated LCS body with the config weight, plus the new fn-plugged reward: `{"has_tags": {"score": 1.0, "weight": 0.5}, "lcs": {"score": 1.0, "weight": 2.0}}`, aggregate `reward=2.500`. A `fn`-less entry naming a nonexistent hook fails loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches reward/stop/metric hook merging and weight/priority resolution used in scoring. Behavior is additive and covered by tests, but misconfiguration could change training signals.
> 
> **Overview**
> Config-plugged stop/metric/reward hooks can now omit `fn` to keep the task's decorated method and override only metadata like `weight` or `priority`.
> 
> Unset `priority`/`weight` now preserve the replaced method's values instead of resetting them. A `fn`-less entry that doesn't match an existing decorated method raises. The unused base `FunctionConfig` is folded into `DecoratedFunctionConfig`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db4c8ee12b46b79935bac8837583ebafe03e3d52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add metadata-only overrides for config-plugged functions in task hooks
> - Config entries for stops, metrics, and rewards can now omit `fn` to keep the existing decorated method while overriding only metadata (priority, weight).
> - `load_plugged_fn` in [loaders.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2323/files#diff-8a5157fb871a453f35b062da0a08d18436b69017a5fee4885f283e7697c8fb18) accepts the decorated callable directly; if `fn` is unset and no decorated method exists, it raises `ValueError`.
> - `Task.hooks` in [task.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2323/files#diff-a1b4a5d6915beae41831864087ea497ed41f0b67b9091ad1ee614834cbfd9399) passes the current decorated method into `load_plugged_fn`, enabling fn-less config entries to inherit priority and weight from the decorated method.
> - `FunctionConfig` is removed from `verifiers.v1` public exports; callers must use `DecoratedFunctionConfig` or `RewardFunctionConfig` directly.
> - Risk: existing code importing `FunctionConfig` from `verifiers.v1` will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db4c8ee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->