### PR TITLE
[v0.8 replacement 1/5] add Prime Agent harness on current main

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,9 @@ def pytest_configure(config) -> None:
     config.addinivalue_line(
         "markers", "hermes_agent: v1 e2e cases on the hermes-agent harness"
     )
+    config.addinivalue_line(
+        "markers", "prime_agent: v1 e2e cases on the prime-agent harness"
+    )
 
 
 @pytest.fixture

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -25,7 +25,7 @@ Every combination carries its axes' pytest marks, so subsets select with `-m`:
 
 Marks: runtimes `subprocess` / `docker` / `prime` / `modal`, placement `colocated`,
 harnesses `null` / `bash` / `rlm` / `kimi_code` / `pi` / `pool` / `openclaw` / `codex` /
-`claude_code` / `hermes_agent`.
+`claude_code` / `hermes_agent` / `prime_agent`.
 A mark is applied per axis, so it selects every case touching that value on ANY axis; for one exact
 combination use `-k` on the test id (e.g. `-k "harness-in-docker-with-tool-in-subprocess"`).
 prime/modal provision real remote sandboxes (slow, infra-flaky, need setup), so they're local-only.

--- a/tests/v1/fixtures/prime_agent_failed_turn_v1.py
+++ b/tests/v1/fixtures/prime_agent_failed_turn_v1.py
@@ -1,0 +1,39 @@
+"""A Prime Agent ACP turn that fails at the provider boundary."""
+
+import verifiers.v1 as vf
+
+
+def has_raised_provider_failure(trace: vf.Trace) -> bool:
+    """The failed ACP request surfaced as a rollout error, not a clean stop."""
+    # A provider failure ends the rollout as an error, so `stop_condition` is
+    # "error" rather than None, and the request may fail before any ModelCall is
+    # recorded -- `trace.calls` can be empty. What must hold is that the failure
+    # is visible as a ProviderError and the rollout did NOT report success.
+    if trace.ok or not trace.errors:
+        return False
+    if trace.stop_condition not in (None, "error"):
+        return False
+    recorded = [*trace.errors, *(c.error for c in trace.calls if c.error is not None)]
+    return any(getattr(error, "type", None) == "ProviderError" for error in recorded)
+
+
+class PrimeAgentFailedTurnTask(vf.Task):
+    pass
+
+
+class PrimeAgentFailedTurnTaskset(
+    vf.Taskset[PrimeAgentFailedTurnTask, vf.TasksetConfig]
+):
+    def load(self) -> list[PrimeAgentFailedTurnTask]:
+        return [
+            PrimeAgentFailedTurnTask(
+                vf.TaskData(
+                    idx=0,
+                    prompt="Reply with exactly READY.",
+                    system_prompt="Follow the instruction exactly.",
+                )
+            )
+        ]
+
+
+__all__ = ["PrimeAgentFailedTurnTaskset", "has_raised_provider_failure"]

--- a/tests/v1/fixtures/prime_agent_ipython_cell_v1.py
+++ b/tests/v1/fixtures/prime_agent_ipython_cell_v1.py
@@ -1,0 +1,95 @@
+"""Prime Agent IPython cell invocation shape through native ACP."""
+
+import json
+
+import verifiers.v1 as vf
+
+SENTINEL = "prime-agent-acp-cell-ok"
+CELL = f"print('{SENTINEL}')"
+
+
+def _segment_info(segment: vf.Segment) -> dict:
+    return {
+        "last_reply": segment.last_reply,
+        "tool_calls": [
+            {"name": call.name, "arguments": call.arguments}
+            for message in segment.messages
+            if isinstance(message, vf.AssistantMessage)
+            for call in message.tool_calls or []
+        ],
+        "tool_outputs": [
+            str(message.content)
+            for message in segment.messages
+            if isinstance(message, vf.ToolMessage)
+        ],
+        "terminated": segment.terminated,
+    }
+
+
+def has_ipython_cell_call(trace: vf.Trace) -> bool:
+    """Whether the model ran the requested cell and the kernel actually executed it.
+
+    Both halves matter. A fabricated tool call plus the right reply text must not
+    score, so the cell prints a sentinel and the tool RESULT has to contain it:
+    only a real kernel execution produces that output.
+    """
+    segments = trace.info.get("prime_agent_segments", [])
+    if len(segments) != 1:
+        return False
+    segment = segments[0]
+    if segment["terminated"] or segment["last_reply"].strip() != "DONE":
+        return False
+    invoked = False
+    for call in segment["tool_calls"]:
+        try:
+            arguments = json.loads(call["arguments"])
+        except (KeyError, TypeError, json.JSONDecodeError):
+            continue
+        # Exact equality, so an extra reconstruction statement cannot sneak in.
+        if call.get("name") == "ipython" and arguments == {"code": CELL}:
+            invoked = True
+            break
+    if not invoked:
+        return False
+    return any(SENTINEL in output for output in segment["tool_outputs"])
+
+
+class PrimeAgentIpythonCellTask(vf.Task):
+    @vf.reward(weight=1.0)
+    async def ipython_cell(self, trace: vf.Trace) -> float:
+        return float(has_ipython_cell_call(trace))
+
+
+class PrimeAgentIpythonCellEnv(vf.SingleAgentEnv):
+    async def run(self, task, agents):
+        async with agents.agent.interaction(task) as interaction:
+            segment = await interaction.turn(
+                "Use IPython to execute exactly this cell:\n\n"
+                f"{CELL}\n\n"
+                "Then reply with exactly DONE."
+            )
+            interaction.trace.info["prime_agent_segments"] = [_segment_info(segment)]
+
+
+class PrimeAgentIpythonCellTaskset(
+    vf.Taskset[PrimeAgentIpythonCellTask, vf.TasksetConfig]
+):
+    def load(self) -> list[PrimeAgentIpythonCellTask]:
+        return [
+            PrimeAgentIpythonCellTask(
+                vf.TaskData(
+                    idx=0,
+                    prompt=None,
+                    system_prompt=(
+                        "Follow each instruction exactly. Use IPython when requested."
+                    ),
+                )
+            )
+        ]
+
+
+__all__ = [
+    "PrimeAgentIpythonCellEnv",
+    "PrimeAgentIpythonCellTaskset",
+    "has_ipython_cell_call",
+]

--- a/tests/v1/fixtures/prime_agent_persistence_v1.py
+++ b/tests/v1/fixtures/prime_agent_persistence_v1.py
@@ -1,0 +1,105 @@
+"""Two-segment Prime Agent interaction that requires one live IPython kernel."""
+
+import hashlib
+import re
+
+import verifiers.v1 as vf
+
+TOKEN = re.compile(r"\b[0-9a-f]{64}\b")
+FIRST_CELL = "import secrets\n_vf_marker = secrets.token_hex(32)\nprint(_vf_marker)"
+SECOND_CELL = "print(_vf_marker)"
+
+
+def _segment_info(segment: vf.Segment) -> dict:
+    return {
+        "last_reply": segment.last_reply,
+        "tool_outputs": [
+            str(message.content)
+            for message in segment.messages
+            if isinstance(message, vf.ToolMessage)
+        ],
+        "tool_calls": [
+            call.arguments
+            for message in segment.messages
+            if isinstance(message, vf.AssistantMessage)
+            for call in message.tool_calls or []
+        ],
+        "terminated": segment.terminated,
+    }
+
+
+class PrimeAgentPersistenceTask(vf.Task):
+    @vf.reward(weight=1.0)
+    async def persisted(self, trace: vf.Trace) -> float:
+        segments = trace.info.get("prime_agent_segments", [])
+        if len(segments) != 2:
+            return 0.0
+        first, second = segments
+        first_tokens = set(TOKEN.findall("\n".join(first["tool_outputs"])))
+        second_tokens = set(TOKEN.findall("\n".join(second["tool_outputs"])))
+        second_calls = "\n".join(second["tool_calls"])
+        return float(
+            bool(first_tokens & second_tokens)
+            and "_vf_marker" in second_calls
+            and "secrets" not in second_calls
+            and "NameError" not in "\n".join(second["tool_outputs"])
+            and first["last_reply"].strip() == "READY"
+            and not first["terminated"]
+            and not second["terminated"]
+        )
+
+
+class PrimeAgentPersistenceEnv(vf.SingleAgentEnv):
+    async def run(self, task, agents):
+        # Keep the runtime alive after the rollout so cleanup is directly observable.
+        async with agents.agent.provision(task) as runtime:
+            async with agents.agent.interaction(task, runtime=runtime) as interaction:
+                first = await interaction.turn(
+                    "Use IPython to execute exactly this cell:\n\n"
+                    f"{FIRST_CELL}\n\n"
+                    "Then reply with exactly READY. Do not include the printed value."
+                )
+                segments = [first]
+                if not first.terminated:
+                    segments.append(
+                        await interaction.turn(
+                            "Use IPython to execute exactly this cell without defining, "
+                            f"assigning, or reconstructing anything:\n\n{SECOND_CELL}\n\n"
+                            "Then reply with exactly the printed value."
+                        )
+                    )
+                trace = interaction.trace
+                trace.info["prime_agent_segments"] = [
+                    _segment_info(segment) for segment in segments
+                ]
+            # Record that the per-trace state EXISTS while the session is live.
+            # Cleanup runs during rollout close (rollout.py calls
+            # harness.cleanup after this body returns), so asserting removal here
+            # would demand the harness delete the session it is still running.
+            state = (
+                "/tmp/vf-prime-agent-state/"
+                f"{hashlib.sha256(trace.id.encode()).hexdigest()[:32]}"
+            )
+            present = await runtime.run(["test", "-e", state], {})
+            trace.info["prime_agent_state_present_during_run"] = present.exit_code == 0
+
+
+class PrimeAgentPersistenceTaskset(
+    vf.Taskset[PrimeAgentPersistenceTask, vf.TasksetConfig]
+):
+    def load(self) -> list[PrimeAgentPersistenceTask]:
+        return [
+            PrimeAgentPersistenceTask(
+                vf.TaskData(
+                    idx=0,
+                    prompt=None,
+                    system_prompt=(
+                        "Follow every instruction exactly. Use IPython when requested, "
+                        "and never reconstruct missing kernel state from conversation text."
+                    ),
+                )
+            )
+        ]
+
+
+__all__ = ["PrimeAgentPersistenceEnv", "PrimeAgentPersistenceTaskset"]

--- a/tests/v1/fixtures/prime_agent_persistence_v1.py
+++ b/tests/v1/fixtures/prime_agent_persistence_v1.py
@@ -72,16 +72,16 @@ class PrimeAgentPersistenceEnv(vf.SingleAgentEnv):
                 trace.info["prime_agent_segments"] = [
                     _segment_info(segment) for segment in segments
                 ]
-            # Record that the per-trace state EXISTS while the session is live.
-            # Cleanup runs during rollout close (rollout.py calls
-            # harness.cleanup after this body returns), so asserting removal here
-            # would demand the harness delete the session it is still running.
-            state = (
-                "/tmp/vf-prime-agent-state/"
-                f"{hashlib.sha256(trace.id.encode()).hexdigest()[:32]}"
-            )
-            present = await runtime.run(["test", "-e", state], {})
-            trace.info["prime_agent_state_present_during_run"] = present.exit_code == 0
+                # Record state before the interaction's close path runs: the
+                # live session still owns the daemon and its IPython kernel here.
+                state = (
+                    "/tmp/vf-prime-agent-state/"
+                    f"{hashlib.sha256(trace.id.encode()).hexdigest()[:32]}"
+                )
+                present = await runtime.run(["test", "-e", state], {})
+                trace.info["prime_agent_state_present_during_run"] = (
+                    present.exit_code == 0
+                )
 
 
 class PrimeAgentPersistenceTaskset(

--- a/tests/v1/fixtures/prime_agent_persistence_v1.py
+++ b/tests/v1/fixtures/prime_agent_persistence_v1.py
@@ -52,36 +52,38 @@ class PrimeAgentPersistenceTask(vf.Task):
 class PrimeAgentPersistenceEnv(vf.SingleAgentEnv):
     async def run(self, task, agents):
         # Keep the runtime alive after the rollout so cleanup is directly observable.
-        async with agents.agent.provision(task) as runtime:
-            async with agents.agent.interaction(task, runtime=runtime) as interaction:
-                first = await interaction.turn(
-                    "Use IPython to execute exactly this cell:\n\n"
-                    f"{FIRST_CELL}\n\n"
-                    "Then reply with exactly READY. Do not include the printed value."
-                )
-                segments = [first]
-                if not first.terminated:
-                    segments.append(
-                        await interaction.turn(
-                            "Use IPython to execute exactly this cell without defining, "
-                            f"assigning, or reconstructing anything:\n\n{SECOND_CELL}\n\n"
-                            "Then reply with exactly the printed value."
-                        )
+        async with (
+            agents.agent.provision(task) as runtime,
+            agents.agent.interaction(task, runtime=runtime) as interaction,
+        ):
+            first = await interaction.turn(
+                "Use IPython to execute exactly this cell:\n\n"
+                f"{FIRST_CELL}\n\n"
+                "Then reply with exactly READY. Do not include the printed value."
+            )
+            segments = [first]
+            if not first.terminated:
+                segments.append(
+                    await interaction.turn(
+                        "Use IPython to execute exactly this cell without defining, "
+                        f"assigning, or reconstructing anything:\n\n{SECOND_CELL}\n\n"
+                        "Then reply with exactly the printed value."
                     )
-                trace = interaction.trace
-                trace.info["prime_agent_segments"] = [
-                    _segment_info(segment) for segment in segments
-                ]
-                # Record state before the interaction's close path runs: the
-                # live session still owns the daemon and its IPython kernel here.
-                state = (
-                    "/tmp/vf-prime-agent-state/"
-                    f"{hashlib.sha256(trace.id.encode()).hexdigest()[:32]}"
                 )
-                present = await runtime.run(["test", "-e", state], {})
-                trace.info["prime_agent_state_present_during_run"] = (
-                    present.exit_code == 0
-                )
+            trace = interaction.trace
+            trace.info["prime_agent_segments"] = [
+                _segment_info(segment) for segment in segments
+            ]
+            # Record state before the interaction's close path runs: the
+            # live session still owns the daemon and its IPython kernel here.
+            state = (
+                "/tmp/vf-prime-agent-state/"
+                f"{hashlib.sha256(trace.id.encode()).hexdigest()[:32]}"
+            )
+            present = await runtime.run(["test", "-e", state], {})
+            trace.info["prime_agent_state_present_during_run"] = (
+                present.exit_code == 0
+            )
 
 
 class PrimeAgentPersistenceTaskset(

--- a/tests/v1/fixtures/prime_agent_persistence_v1.py
+++ b/tests/v1/fixtures/prime_agent_persistence_v1.py
@@ -81,9 +81,7 @@ class PrimeAgentPersistenceEnv(vf.SingleAgentEnv):
                 f"{hashlib.sha256(trace.id.encode()).hexdigest()[:32]}"
             )
             present = await runtime.run(["test", "-e", state], {})
-            trace.info["prime_agent_state_present_during_run"] = (
-                present.exit_code == 0
-            )
+            trace.info["prime_agent_state_present_during_run"] = present.exit_code == 0
 
 
 class PrimeAgentPersistenceTaskset(

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -244,6 +244,126 @@ async def test_acp_resume_with_tool(run_v1, harness, harness_runtime, tmp_path):
 
 
 @pytest.mark.e2e
+@pytest.mark.docker
+@pytest.mark.prime_agent
+async def test_prime_agent_persists_ipython_kernel(run_v1, tmp_path):
+    """Prime Agent retains its native ACP session and live IPython kernel."""
+    (trace,) = await run_v1(
+        "prime-agent-persistence-v1",
+        harness="prime-agent",
+        runtime={"type": "docker"},
+        output_dir=tmp_path,
+        max_turns=8,
+        max_tokens=8192,
+        rollout_timeout=600,
+    )
+    assert trace.ok, trace.errors
+    assert trace.stop_condition == "user_closed"
+    # Surface what the fixture actually captured: a 0.0 here means the agent ran
+    # but the segment view lacked the tool evidence, which is a different bug from
+    # the agent failing, and the log otherwise shows neither.
+    assert trace.rewards["persisted"].score == 1.0, trace.info.get(
+        "prime_agent_segments"
+    )
+    # State lives while the session runs; removal happens in harness.cleanup()
+    # during rollout close, after this env body has already returned.
+    assert trace.info["prime_agent_state_present_during_run"] is True
+
+
+@pytest.mark.e2e
+@pytest.mark.docker
+@pytest.mark.prime_agent
+async def test_prime_agent_ipython_cell_acp_shape(run_v1, tmp_path):
+    """IPython calls expose the ACP title and `{code}` raw input contract."""
+    from prime_agent_ipython_cell_v1 import (
+        has_ipython_cell_call,
+    )
+
+    (trace,) = await run_v1(
+        "prime-agent-ipython-cell-v1",
+        harness="prime-agent",
+        runtime={"type": "docker"},
+        output_dir=tmp_path,
+        max_turns=6,
+        max_tokens=8192,
+        # First-run setup in a cold container installs Node, uv, and the kernel
+        # before the agent gets a turn, so this shares the 900s budget its
+        # sibling kernel tests use rather than racing the default.
+        rollout_timeout=900,
+    )
+    assert trace.ok, trace.errors
+    assert trace.stop_condition == "user_closed"
+    assert trace.rewards["ipython_cell"].score == 1.0
+    # Asserting the ACP-native title/rawInput shape (acp-events.ts:144-155) needs
+    # inbound `_meta` preservation, which lands separately; until then this fixture
+    # proves the cell was submitted verbatim AND executed by a real kernel.
+    assert has_ipython_cell_call(trace), trace.info.get("prime_agent_segments")
+
+
+@pytest.mark.e2e
+@pytest.mark.docker
+@pytest.mark.prime_agent
+async def test_prime_agent_solves_gsm8k(run_v1, tmp_path):
+    """Prime Agent scores on a real benchmark, not a synthetic capability probe.
+
+    The other Prime Agent tests prove the transport carries IPython, kernel state,
+    and failures. None of them shows the agent doing useful work: they assert on
+    plumbing the harness itself produces. GSM8K grades an actual answer against
+    ground truth in the runtime, so a passing score here means the whole path --
+    ACP transport, live kernel, interception, scoring -- carried a real task.
+    """
+    (trace,) = await run_v1(
+        "gsm8k-v1",
+        harness="prime-agent",
+        runtime={"type": "docker"},
+        output_dir=tmp_path,
+        max_turns=6,
+        max_tokens=8192,
+        rollout_timeout=900,
+    )
+    assert trace.ok, trace.errors
+    # Exact-match grading, so this is the agent's answer being right -- not the
+    # harness reporting that it ran.
+    assert trace.reward == 1.0, trace.rewards
+
+
+@pytest.mark.e2e
+@pytest.mark.docker
+@pytest.mark.prime_agent
+async def test_prime_agent_failed_turn_raises(run_v1, tmp_path):
+    """A rejected provider request is a rollout error, never an ACP clean stop."""
+    from prime_agent_failed_turn_v1 import has_raised_provider_failure
+
+    (trace,) = await run_v1(
+        "prime-agent-failed-turn-v1",
+        harness="prime-agent",
+        runtime={"type": "docker"},
+        output_dir=tmp_path,
+        max_turns=2,
+        rollout_timeout=600,
+        # The host-side interception client reaches this intentionally unavailable
+        # endpoint, so Prime Agent's request fails before any model can answer.
+        env={
+            "agent": {
+                "client": {
+                    "type": "eval",
+                    "base_url": "http://127.0.0.1:1/v1",
+                    "api_key_var": "VF_MISSING_PRIME_AGENT_KEY",
+                }
+            }
+        },
+    )
+    assert has_raised_provider_failure(trace), trace.errors
+    # An errored rollout is not scored, so no reward is recorded.
+    assert trace.rewards == {}
+    # The dead endpoint must stay confined to this rollout: if a sibling test ever
+    # inherits it, that shows up here as the wrong base_url on this trace.
+    assert any(
+        getattr(error, "type", None) == "ProviderError" for error in trace.errors
+    ), trace.errors
+
+
+@pytest.mark.e2e
 @pytest.mark.parametrize("harness_runtime,tool_runtime", TOOL_PLACEMENTS, indirect=True)
 async def test_tool(run_v1, harness_runtime, tool_runtime, tmp_path):
     """A `vf.Toolset` (an echo tool) across its placement (`tool_runtime`: colocated in

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -313,7 +313,7 @@ async def test_prime_agent_solves_gsm8k(run_v1, tmp_path):
     ACP transport, live kernel, interception, scoring -- carried a real task.
     """
     (trace,) = await run_v1(
-        "gsm8k-v1",
+        "gsm8k",
         harness="prime-agent",
         runtime={"type": "docker"},
         output_dir=tmp_path,

--- a/tests/v1/test_prime_agent_fixtures.py
+++ b/tests/v1/test_prime_agent_fixtures.py
@@ -1,0 +1,345 @@
+"""Deterministic guard tests for the Prime Agent live capability fixtures."""
+
+import hashlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from prime_agent_failed_turn_v1 import has_raised_provider_failure
+from prime_agent_ipython_cell_v1 import CELL, SENTINEL, has_ipython_cell_call
+
+
+def test_failed_turn_guard_rejects_a_clean_stop_reason():
+    """A provider failure must be visible even when no ModelCall was recorded.
+
+    The request can fail before any call is committed, and an errored rollout
+    reports stop_condition "error" rather than None -- so requiring a recorded
+    call, or None, rejected the very failure this fixture exists to prove.
+    """
+    provider_error = SimpleNamespace(type="ProviderError")
+    failed = SimpleNamespace(
+        ok=False,
+        errors=[provider_error],
+        stop_condition="error",
+        calls=[],
+    )
+    assert has_raised_provider_failure(failed)
+
+    # Also valid: the failure recorded on a committed call.
+    on_call = SimpleNamespace(
+        ok=False,
+        errors=[provider_error],
+        stop_condition=None,
+        calls=[SimpleNamespace(error=provider_error)],
+    )
+    assert has_raised_provider_failure(on_call)
+
+    # A successful rollout must never satisfy it.
+    assert not has_raised_provider_failure(
+        SimpleNamespace(ok=True, errors=[], stop_condition="agent_completed", calls=[])
+    )
+    # Nor a clean agent stop that merely lacks errors.
+    assert not has_raised_provider_failure(
+        SimpleNamespace(ok=False, errors=[], stop_condition="error", calls=[])
+    )
+    # Nor a non-provider failure, which would mean something else broke.
+    assert not has_raised_provider_failure(
+        SimpleNamespace(
+            ok=False,
+            errors=[SimpleNamespace(type="HarnessError")],
+            stop_condition="error",
+            calls=[],
+        )
+    )
+
+
+def test_ipython_cell_guard_requires_verbatim_code_and_real_execution():
+    """A fabricated call plus the right reply must not score.
+
+    The reward needs both halves: the cell submitted verbatim AND the sentinel in
+    a tool RESULT, which only a real kernel execution produces.
+    """
+
+    def trace_with(code: str, outputs: list[str]) -> SimpleNamespace:
+        return SimpleNamespace(
+            info={
+                "prime_agent_segments": [
+                    {
+                        "last_reply": "DONE",
+                        "terminated": False,
+                        "tool_calls": [
+                            {"name": "ipython", "arguments": json.dumps({"code": code})}
+                        ],
+                        "tool_outputs": outputs,
+                    }
+                ]
+            }
+        )
+
+    assert has_ipython_cell_call(trace_with(CELL, [SENTINEL]))
+    # Claimed but never executed: no tool result carries the sentinel.
+    assert not has_ipython_cell_call(trace_with(CELL, []))
+    assert not has_ipython_cell_call(trace_with(CELL, ["something else"]))
+    # Executed something else, even if it printed the sentinel itself.
+    assert not has_ipython_cell_call(trace_with(f"{CELL}\nprint('extra')", [SENTINEL]))
+
+
+class _AsyncContext:
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+
+class _PersistenceRuntime:
+    def __init__(self, existing_paths: set[str]):
+        self.existing_paths = existing_paths
+        self.calls: list[tuple[list[str], dict]] = []
+
+    async def run(self, command: list[str], environment: dict):
+        self.calls.append((command, environment))
+        # `test -e PATH` exits 0 when the path EXISTS.
+        return SimpleNamespace(exit_code=0 if command[-1] in self.existing_paths else 1)
+
+
+class _PersistenceAgent:
+    def __init__(self, runtime, interaction):
+        self.runtime = runtime
+        self._interaction = interaction
+
+    def provision(self, task):
+        return _AsyncContext(self.runtime)
+
+    def interaction(self, task, *, runtime):
+        assert runtime is self.runtime
+        return _AsyncContext(self._interaction)
+
+
+class _PersistenceInteraction:
+    def __init__(self, trace):
+        self.trace = trace
+        self._segments = [
+            SimpleNamespace(last_reply="READY", messages=[], terminated=False),
+            SimpleNamespace(last_reply="marker", messages=[], terminated=False),
+        ]
+
+    async def turn(self, prompt):
+        return self._segments.pop(0)
+
+
+def _prime_agent_trace_root(trace_id: str) -> str:
+    return (
+        "/tmp/vf-prime-agent-state/"
+        f"{hashlib.sha256(trace_id.encode()).hexdigest()[:32]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_persistence_fixture_sees_state_present_while_the_session_runs():
+    from prime_agent_persistence_v1 import PrimeAgentPersistenceEnv
+
+    trace = SimpleNamespace(id="trace-that-remains", info={})
+    root = _prime_agent_trace_root(trace.id)
+    runtime = _PersistenceRuntime(existing_paths={root})
+    interaction = _PersistenceInteraction(trace)
+    agents = SimpleNamespace(agent=_PersistenceAgent(runtime, interaction))
+
+    await PrimeAgentPersistenceEnv.run(
+        object.__new__(PrimeAgentPersistenceEnv), None, agents
+    )
+
+    assert runtime.calls == [(["test", "-e", root], {})]
+    assert trace.info["prime_agent_state_present_during_run"] is True
+
+
+class _GuardRuntime:
+    supports_live_processes = False
+
+    def __init__(self, wrapper: str | None = None):
+        self.wrapper = wrapper
+        self.calls: list[list[str]] = []
+
+    async def run(self, command, environment):
+        self.calls.append(command)
+        failed = self.wrapper is not None and command == ["chmod", "700", self.wrapper]
+        return SimpleNamespace(
+            exit_code=1 if failed else 0, stderr="chmod denied", stdout=""
+        )
+
+    async def write(self, path, content):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_prime_agent_refuses_non_live_runtime_before_fresh_relaunch():
+    from verifiers.v1.harnesses.prime_agent.harness import (
+        PrimeAgentHarness,
+        PrimeAgentHarnessConfig,
+    )
+
+    harness = PrimeAgentHarness(PrimeAgentHarnessConfig(id="prime-agent"))
+    with pytest.raises(RuntimeError, match="requires runtime live-process support"):
+        await harness.session(
+            None, None, _GuardRuntime(), "endpoint", "secret", {}, None
+        )
+
+
+@pytest.mark.asyncio
+async def test_prime_agent_wrapper_chmod_failure_is_reported():
+    from verifiers.v1.harnesses.prime_agent.harness import (
+        PrimeAgentHarness,
+        PrimeAgentHarnessConfig,
+    )
+
+    harness = PrimeAgentHarness(PrimeAgentHarnessConfig(id="prime-agent"))
+    trace = SimpleNamespace(id="chmod-guard")
+    runtime = _GuardRuntime(f"{harness.trace_root(trace)}/prime-agent")
+    ctx = SimpleNamespace(model="model", sampling=SimpleNamespace(max_tokens=None))
+    with pytest.raises(RuntimeError, match="wrapper permissions failed"):
+        await harness._prepare(ctx, trace, runtime, "endpoint", None)
+
+
+@pytest.mark.asyncio
+async def test_prime_agent_launch_preserves_typed_rollout_error(monkeypatch):
+    from verifiers.v1.errors import SandboxError
+    from verifiers.v1.harnesses.prime_agent.harness import (
+        PrimeAgentHarness,
+        PrimeAgentHarnessConfig,
+    )
+
+    harness = PrimeAgentHarness(PrimeAgentHarnessConfig(id="prime-agent"))
+    error = SandboxError("sandbox unavailable")
+
+    async def prepare(*args, **kwargs):
+        return ["prime-agent"]
+
+    async def run(*args, **kwargs):
+        raise error
+
+    async def tail(*args, **kwargs):
+        return "daemon tail"
+
+    monkeypatch.setattr(harness, "_prepare", prepare)
+    monkeypatch.setattr(harness, "daemon_log_tail", tail)
+    monkeypatch.setattr(
+        "verifiers.v1.harnesses.prime_agent.harness.PRIME_AGENT_ACP.run", run
+    )
+    data = SimpleNamespace(prompt="hello", system_prompt=None)
+    trace = SimpleNamespace(id="typed-error")
+    with pytest.raises(SandboxError) as raised:
+        await harness.launch(None, trace, object(), "endpoint", "secret", {}, data)
+    assert raised.value is error
+
+
+def test_prime_agent_installer_bootstraps_https_certificates_and_tools():
+    """CA roots must accompany the tools, or every HTTPS download fails."""
+    installer = Path("verifiers/v1/harnesses/prime_agent/install.sh").read_text()
+    # Both package managers install CA roots alongside whatever is missing.
+    assert (
+        "apt-get install -y --no-install-recommends ca-certificates $missing"
+        in installer
+    )
+    assert "apk add --no-cache ca-certificates $missing" in installer
+    # git is provisioned too: a coding taskset that clones fails deep inside a
+    # rollout without it, which reads as a bad score rather than a setup gap.
+    assert 'command -v git >/dev/null 2>&1 || missing="$missing git"' in installer
+    # uv must be pinned through the versioned installer URL; the generic
+    # installer ignores UV_VERSION and would silently install a different build.
+    assert "https://astral.sh/uv/${uv_version}/install.sh" in installer
+
+
+def test_prime_agent_installer_handles_musl_without_glibc_download():
+    installer = Path("verifiers/v1/harnesses/prime_agent/install.sh").read_text()
+    assert "ldd --version 2>&1 | grep -qi musl" in installer
+    assert "apk add --no-cache nodejs-current npm" in installer
+    assert "Alpine/musl requires nodejs-current and npm" in installer
+
+
+@pytest.mark.asyncio
+async def test_prime_agent_setup_forwards_resolved_environment(monkeypatch):
+    from verifiers.v1.harnesses.prime_agent.harness import (
+        PrimeAgentHarness,
+        PrimeAgentHarnessConfig,
+    )
+
+    harness = PrimeAgentHarness(
+        PrimeAgentHarnessConfig(id="prime-agent", env={"HTTPS_PROXY": "http://proxy"})
+    )
+    calls = []
+
+    async def run(command, environment):
+        calls.append((command, environment))
+        return SimpleNamespace(exit_code=0, stderr="", stdout="")
+
+    async def setup(*args):
+        return None
+
+    runtime = SimpleNamespace(run=run)
+    monkeypatch.setattr(
+        "verifiers.v1.harnesses.prime_agent.harness.PRIME_AGENT_ACP.setup", setup
+    )
+    await harness.setup(runtime)
+    command, environment = calls[0]
+    assert environment["HTTPS_PROXY"] == "http://proxy"
+
+    # With a command argument, flock's operand is a lock-file path, not an
+    # already-open descriptor. It must therefore name the shared install lock,
+    # rather than the accidental relative file named "9".
+    guarded = command[-1]
+    assert "flock -x 9 sh -c" not in guarded
+    assert guarded.startswith(
+        "mkdir -p /var/tmp/vf-prime-agent && "
+        "flock -x /var/tmp/vf-prime-agent/install.lock sh -c "
+    )
+    assert "9>/var/tmp/vf-prime-agent/install.lock" not in guarded
+
+
+def test_prime_agent_cleanup_removes_state_and_tmpdir_together():
+    source = Path("verifiers/v1/harnesses/prime_agent/harness.py").read_text()
+    assert 'runtime.run(["rm", "-rf", root, self.tmp_dir(trace)]' in source
+
+
+def test_version_validator_rejects_malformed_semver():
+    """A bad version becomes a 404 on the release URL instead of a clear error.
+
+    The permissive suffix pattern accepted empty dot-separated identifiers, so
+    values like "1.2.3-." validated and then failed as a download error far from
+    the actual mistake.
+    """
+    from pydantic import ValidationError
+
+    from verifiers.v1.utils.loaders import harness_config_type
+
+    config = harness_config_type("prime-agent")
+    digest = "a" * 64
+    for good in ("0.7.0", "1.2.3-rc.1", "1.2.3+build.5"):
+        config(id="x", version=good, tarball_sha256=digest)
+    for bad in ("1.2.3-.", "1.2.3-foo..bar", "1.2.3+.", "01.2.3", "1.2"):
+        with pytest.raises(ValidationError):
+            config(id="x", version=bad, tarball_sha256=digest)
+
+
+@pytest.mark.asyncio
+async def test_daemon_log_tail_never_masks_the_original_failure():
+    """Diagnostics run on the failure path, so they must not raise themselves.
+
+    A sandbox that is already gone would otherwise replace the real error with a
+    SandboxError from the log read, losing the attribution entirely.
+    """
+    from verifiers.v1.harnesses.prime_agent.harness import (
+        PrimeAgentHarness,
+        PrimeAgentHarnessConfig,
+    )
+
+    class _DeadRuntime:
+        async def run(self, command, environment):
+            raise RuntimeError("sandbox is gone")
+
+    harness = PrimeAgentHarness(PrimeAgentHarnessConfig(id="prime-agent"))
+    trace = SimpleNamespace(id="trace-for-log-tail")
+    assert await harness.daemon_log_tail(_DeadRuntime(), trace) == ""

--- a/tests/v1/test_prime_agent_fixtures.py
+++ b/tests/v1/test_prime_agent_fixtures.py
@@ -343,3 +343,115 @@ async def test_daemon_log_tail_never_masks_the_original_failure():
     harness = PrimeAgentHarness(PrimeAgentHarnessConfig(id="prime-agent"))
     trace = SimpleNamespace(id="trace-for-log-tail")
     assert await harness.daemon_log_tail(_DeadRuntime(), trace) == ""
+
+
+class _CleanupRuntime:
+    def __init__(
+        self,
+        *,
+        socket_exists: bool,
+        stop_exit_code: int = 0,
+        rm_exit_code: int = 0,
+    ):
+        self.socket_exists = socket_exists
+        self.stop_exit_code = stop_exit_code
+        self.rm_exit_code = rm_exit_code
+        self.calls: list[list[str]] = []
+
+    async def run(self, command, environment):
+        self.calls.append(command)
+        if command[:2] == ["test", "-S"]:
+            return SimpleNamespace(
+                exit_code=0 if self.socket_exists else 1, stderr="", stdout=""
+            )
+        if command[:2] == ["rm", "-rf"]:
+            return SimpleNamespace(
+                exit_code=self.rm_exit_code, stderr="rm denied", stdout=""
+            )
+        return SimpleNamespace(
+            exit_code=self.stop_exit_code, stderr="stop denied", stdout=""
+        )
+
+
+@pytest.mark.asyncio
+async def test_prime_agent_cleanup_skips_missing_socket_and_remains_idempotent():
+    from verifiers.v1.harnesses.prime_agent.harness import (
+        PrimeAgentHarness,
+        PrimeAgentHarnessConfig,
+    )
+
+    harness = PrimeAgentHarness(PrimeAgentHarnessConfig(id="prime-agent"))
+    trace = SimpleNamespace(id="no-daemon")
+    runtime = _CleanupRuntime(socket_exists=False)
+
+    await harness.cleanup(trace, runtime)
+    await harness.cleanup(trace, runtime)
+
+    assert [call[:2] for call in runtime.calls] == [
+        ["test", "-S"],
+        ["rm", "-rf"],
+        ["test", "-S"],
+        ["rm", "-rf"],
+    ]
+
+
+@pytest.mark.asyncio
+async def test_prime_agent_cleanup_retains_state_when_stop_or_rm_fails():
+    from verifiers.v1.harnesses.prime_agent.harness import (
+        PrimeAgentHarness,
+        PrimeAgentHarnessConfig,
+    )
+
+    harness = PrimeAgentHarness(PrimeAgentHarnessConfig(id="prime-agent"))
+    trace = SimpleNamespace(id="cleanup-errors")
+    stop_failed = _CleanupRuntime(socket_exists=True, stop_exit_code=1)
+    with pytest.raises(RuntimeError, match="stopping the trace daemon failed"):
+        await harness.cleanup(trace, stop_failed)
+    assert not any(call[:2] == ["rm", "-rf"] for call in stop_failed.calls)
+
+    rm_failed = _CleanupRuntime(socket_exists=False, rm_exit_code=1)
+    with pytest.raises(RuntimeError, match="state cleanup failed"):
+        await harness.cleanup(trace, rm_failed)
+
+
+@pytest.mark.asyncio
+async def test_prime_agent_stateful_turn_errors_include_daemon_log_and_keep_rollout_type(
+    monkeypatch,
+):
+    from verifiers.v1.errors import SandboxError
+    from verifiers.v1.harnesses.prime_agent.harness import (
+        PrimeAgentHarness,
+        PrimeAgentHarnessConfig,
+    )
+
+    harness = PrimeAgentHarness(PrimeAgentHarnessConfig(id="prime-agent"))
+    trace = SimpleNamespace(id="stateful-turn")
+
+    async def prepare(*args, **kwargs):
+        return ["prime-agent"]
+
+    async def tail(*args, **kwargs):
+        return "daemon tail"
+
+    def session(*args, **kwargs):
+        return kwargs["on_error"]
+
+    monkeypatch.setattr(harness, "_prepare", prepare)
+    monkeypatch.setattr(harness, "daemon_log_tail", tail)
+    monkeypatch.setattr(
+        "verifiers.v1.harnesses.prime_agent.harness.PRIME_AGENT_ACP.session", session
+    )
+    callback = await harness.session(
+        SimpleNamespace(model="model", sampling=SimpleNamespace(max_tokens=None)),
+        trace,
+        SimpleNamespace(supports_live_processes=True),
+        "endpoint",
+        "secret",
+        {},
+        SimpleNamespace(prompt="hello", system_prompt=None),
+    )
+    with pytest.raises(RuntimeError, match="prime-agent daemon log:\\ndaemon tail"):
+        await callback(RuntimeError("ACP failed"))
+
+    typed = SandboxError("sandbox unavailable")
+    assert await callback(typed) is None

--- a/tests/v1/test_prime_agent_fixtures.py
+++ b/tests/v1/test_prime_agent_fixtures.py
@@ -1,5 +1,6 @@
 """Deterministic guard tests for the Prime Agent live capability fixtures."""
 
+import asyncio
 import hashlib
 import json
 from pathlib import Path
@@ -518,3 +519,23 @@ async def test_stateful_turn_callback_failure_preserves_typed_rollout_error():
     with pytest.raises(SandboxError) as raised:
         await ACPHarnessSession._raise_error(session, original)
     assert raised.value is original
+
+
+@pytest.mark.asyncio
+async def test_stateful_turn_cancellation_skips_error_diagnostics():
+    from verifiers.v1.acp import ACPHarnessSession
+
+    original = asyncio.CancelledError()
+    callback_invoked = False
+
+    async def failed_diagnostic(error):
+        nonlocal callback_invoked
+        callback_invoked = True
+        raise RuntimeError("diagnostic failure")
+
+    session = SimpleNamespace(on_error=failed_diagnostic)
+    with pytest.raises(asyncio.CancelledError) as raised:
+        await ACPHarnessSession._raise_error(session, original)
+    assert raised.value is original
+    assert type(raised.value) is asyncio.CancelledError
+    assert not callback_invoked

--- a/tests/v1/test_prime_agent_fixtures.py
+++ b/tests/v1/test_prime_agent_fixtures.py
@@ -350,10 +350,12 @@ class _CleanupRuntime:
         self,
         *,
         socket_exists: bool,
+        socket_exit_code: int | None = None,
         stop_exit_code: int = 0,
         rm_exit_code: int = 0,
     ):
         self.socket_exists = socket_exists
+        self.socket_exit_code = socket_exit_code
         self.stop_exit_code = stop_exit_code
         self.rm_exit_code = rm_exit_code
         self.calls: list[list[str]] = []
@@ -362,7 +364,13 @@ class _CleanupRuntime:
         self.calls.append(command)
         if command[:2] == ["test", "-S"]:
             return SimpleNamespace(
-                exit_code=0 if self.socket_exists else 1, stderr="", stdout=""
+                exit_code=(
+                    self.socket_exit_code
+                    if self.socket_exit_code is not None
+                    else (0 if self.socket_exists else 1)
+                ),
+                stderr="socket check denied",
+                stdout="",
             )
         if command[:2] == ["rm", "-rf"]:
             return SimpleNamespace(
@@ -455,3 +463,58 @@ async def test_prime_agent_stateful_turn_errors_include_daemon_log_and_keep_roll
 
     typed = SandboxError("sandbox unavailable")
     assert await callback(typed) is None
+
+
+@pytest.mark.asyncio
+async def test_prime_agent_cleanup_retains_state_when_socket_preflight_is_indeterminate():
+    from verifiers.v1.harnesses.prime_agent.harness import (
+        PrimeAgentHarness,
+        PrimeAgentHarnessConfig,
+    )
+
+    harness = PrimeAgentHarness(PrimeAgentHarnessConfig(id="prime-agent"))
+    runtime = _CleanupRuntime(socket_exists=False, socket_exit_code=2)
+    with pytest.raises(RuntimeError, match="checking the trace daemon socket failed"):
+        await harness.cleanup(SimpleNamespace(id="indeterminate-socket"), runtime)
+    assert not any(call[:2] == ["rm", "-rf"] for call in runtime.calls)
+
+
+@pytest.mark.asyncio
+async def test_stateful_turn_tail_failure_preserves_original_error(monkeypatch):
+    from verifiers.v1.acp import ACPHarnessSession
+    from verifiers.v1.harnesses.prime_agent.harness import (
+        PrimeAgentHarness,
+        PrimeAgentHarnessConfig,
+    )
+
+    original = RuntimeError("ACP failed")
+    harness = PrimeAgentHarness(PrimeAgentHarnessConfig(id="prime-agent"))
+
+    async def failed_tail(*args, **kwargs):
+        raise RuntimeError("sandbox is gone")
+
+    monkeypatch.setattr(harness, "daemon_log_tail", failed_tail)
+    session = SimpleNamespace(
+        on_error=lambda error: harness._session_error(
+            SimpleNamespace(), SimpleNamespace(id="tail-failure"), error
+        )
+    )
+    with pytest.raises(RuntimeError) as raised:
+        await ACPHarnessSession._raise_error(session, original)
+    assert raised.value is original
+
+
+@pytest.mark.asyncio
+async def test_stateful_turn_callback_failure_preserves_typed_rollout_error():
+    from verifiers.v1.acp import ACPHarnessSession
+    from verifiers.v1.errors import SandboxError
+
+    original = SandboxError("sandbox unavailable")
+
+    async def failed_diagnostic(error):
+        raise RuntimeError("diagnostic failure")
+
+    session = SimpleNamespace(on_error=failed_diagnostic)
+    with pytest.raises(SandboxError) as raised:
+        await ACPHarnessSession._raise_error(session, original)
+    assert raised.value is original

--- a/tests/v1/test_prime_agent_socket_paths.py
+++ b/tests/v1/test_prime_agent_socket_paths.py
@@ -1,0 +1,37 @@
+"""The daemon's derived socket paths must stay inside the unix sun_path limit."""
+
+from types import SimpleNamespace
+
+from verifiers.v1.harnesses.prime_agent.harness import (
+    PrimeAgentHarness,
+    PrimeAgentHarnessConfig,
+)
+
+# AF_UNIX sun_path is 108 bytes on Linux and 104 on macOS; use the stricter one.
+SUN_PATH_LIMIT = 104
+# $TMPDIR/prime-agent-<uid>/worker-<12>-<12>.sock, per
+# daemon-supervisor.ts workerSocketPath().
+WORKER_SUFFIX = "/prime-agent-0/worker-abcdefabcdef-123456789012.sock"
+
+
+def harness() -> PrimeAgentHarness:
+    return PrimeAgentHarness(PrimeAgentHarnessConfig(id="prime-agent"))
+
+
+def test_worker_socket_path_fits_sun_path():
+    """A too-long TMPDIR makes listen() fail with EINVAL.
+
+    The supervisor then blocks for its full 30s worker timeout, and the only
+    symptom is an opaque ACP `create` timeout -- which is exactly how this cost a
+    full live-E2E cycle to diagnose. The supervisor socket alone fit; the derived
+    worker socket did not.
+    """
+    trace = SimpleNamespace(id="0123456789abcdef0123456789abcdef0123456789abcdef")
+    derived = harness().tmp_dir(trace) + WORKER_SUFFIX
+    assert len(derived) <= SUN_PATH_LIMIT, f"{len(derived)} bytes: {derived}"
+
+
+def test_tmp_dir_is_unique_per_trace():
+    a = SimpleNamespace(id="trace-a")
+    b = SimpleNamespace(id="trace-b")
+    assert harness().tmp_dir(a) != harness().tmp_dir(b)

--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.dialects.chat import message_to_wire
-from verifiers.v1.errors import HarnessError
+from verifiers.v1.errors import HarnessError, RolloutError
 from verifiers.v1.harness import Harness, HarnessSession
 from verifiers.v1.runtimes import ProgramResult, Runtime, RuntimeProcess
 from verifiers.v1.task import TaskData
@@ -224,7 +224,15 @@ class ACPHarnessSession(HarnessSession):
 
     async def _raise_error(self, error: BaseException) -> None:
         if self.on_error is not None:
-            await self.on_error(error)
+            try:
+                await self.on_error(error)
+            except Exception:
+                # Diagnostics must never replace the rollout's authoritative
+                # attribution. Untyped errors may intentionally be enriched by
+                # the callback, but a typed error is already ready for capture.
+                if isinstance(error, RolloutError):
+                    raise error
+                raise
         raise error
 
     async def _run(self, messages: Messages | None) -> ProgramResult:

--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -223,6 +223,8 @@ class ACPHarnessSession(HarnessSession):
         return self._stderr_tail.decode(errors="replace").strip()
 
     async def _raise_error(self, error: BaseException) -> None:
+        if not isinstance(error, Exception):
+            raise error
         if self.on_error is not None:
             try:
                 await self.on_error(error)

--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -4,7 +4,7 @@ import asyncio
 import contextlib
 import json
 import secrets
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from pathlib import Path
 
 from verifiers.v1.clients import ModelContext
@@ -47,6 +47,7 @@ class ACP:
         prompt: str | Messages | None,
         system_prompt: str | None = None,
         session_meta: dict | None = None,
+        on_error: Callable[[BaseException], Awaitable[None]] | None = None,
     ) -> "ACPHarnessSession":
         """Create a persistent ACP-backed handle owned by one rollout."""
         return ACPHarnessSession(
@@ -63,6 +64,7 @@ class ACP:
             prompt=prompt,
             system_prompt=system_prompt,
             session_meta=session_meta,
+            on_error=on_error,
         )
 
     async def run(
@@ -184,6 +186,7 @@ class ACPHarnessSession(HarnessSession):
         prompt: str | Messages | None,
         system_prompt: str | None,
         session_meta: dict | None,
+        on_error: Callable[[BaseException], Awaitable[None]] | None,
     ) -> None:
         super().__init__(harness, ctx, trace, runtime, endpoint, secret, mcp_urls, data)
         self.env = env
@@ -191,6 +194,7 @@ class ACPHarnessSession(HarnessSession):
         self.prompt = prompt
         self.system_prompt = system_prompt
         self.session_meta = session_meta or {}
+        self.on_error = on_error
         self._process: RuntimeProcess | None = None
         self._reader: _PacketReader | None = None
         self._stderr_tail = bytearray()
@@ -217,6 +221,11 @@ class ACPHarnessSession(HarnessSession):
 
     def _stderr(self) -> str:
         return self._stderr_tail.decode(errors="replace").strip()
+
+    async def _raise_error(self, error: BaseException) -> None:
+        if self.on_error is not None:
+            await self.on_error(error)
+        raise error
 
     async def _run(self, messages: Messages | None) -> ProgramResult:
         prompt = self.prompt if messages is None else messages
@@ -249,14 +258,14 @@ class ACPHarnessSession(HarnessSession):
                     _packet({"operation": "prompt", "config": config})
                 )
                 response = await self._reader.read()
-            except BaseException:
+            except BaseException as error:
                 await run_shielded(self._stop(graceful=False))
-                raise
+                await self._raise_error(error)
         if not response.get("ok"):
             detail = response.get("error") or "ACP session request failed"
             if stderr := self._stderr():
                 detail = f"{detail}\n\nACP process stderr:\n{stderr}"
-            raise RuntimeError(detail)
+            await self._raise_error(RuntimeError(detail))
         return ProgramResult(exit_code=0, stdout=response.get("reply", ""), stderr="")
 
     async def _stop(self, *, graceful: bool) -> None:

--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -266,7 +266,7 @@ class ACPHarnessSession(HarnessSession):
                     _packet({"operation": "prompt", "config": config})
                 )
                 response = await self._reader.read()
-            except BaseException as error:
+            except BaseException as error:  # noqa: BLE001 - shield cleanup, then re-raise
                 await run_shielded(self._stop(graceful=False))
                 await self._raise_error(error)
         if not response.get("ok"):

--- a/verifiers/v1/harnesses/__init__.py
+++ b/verifiers/v1/harnesses/__init__.py
@@ -21,6 +21,10 @@ from verifiers.v1.harnesses.null import NullHarness, NullHarnessConfig
 from verifiers.v1.harnesses.openclaw import OpenClawHarness, OpenClawHarnessConfig
 from verifiers.v1.harnesses.pi import PiHarness, PiHarnessConfig
 from verifiers.v1.harnesses.pool import PoolHarness, PoolHarnessConfig
+from verifiers.v1.harnesses.prime_agent import (
+    PrimeAgentHarness,
+    PrimeAgentHarnessConfig,
+)
 from verifiers.v1.harnesses.rlm import RLMHarness, RLMHarnessConfig
 from verifiers.v1.harnesses.terminus_2 import Terminus2Harness, Terminus2HarnessConfig
 
@@ -47,6 +51,8 @@ __all__ = [
     "PiHarnessConfig",
     "PoolHarness",
     "PoolHarnessConfig",
+    "PrimeAgentHarness",
+    "PrimeAgentHarnessConfig",
     "RLMHarness",
     "RLMHarnessConfig",
     "Terminus2Harness",

--- a/verifiers/v1/harnesses/prime_agent/__init__.py
+++ b/verifiers/v1/harnesses/prime_agent/__init__.py
@@ -1,0 +1,6 @@
+from verifiers.v1.harnesses.prime_agent.harness import (
+    PrimeAgentHarness,
+    PrimeAgentHarnessConfig,
+)
+
+__all__ = ["PrimeAgentHarness", "PrimeAgentHarnessConfig"]

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -1,0 +1,480 @@
+"""Run Prime Agent against interception through its native ACP mode."""
+
+import hashlib
+import json
+import logging
+import re
+import shlex
+from pathlib import Path
+
+from pydantic import Field, field_validator, model_validator
+
+from verifiers.v1.acp import ACP
+from verifiers.v1.clients import ModelContext
+from verifiers.v1.configs.harness import HarnessConfig
+from verifiers.v1.errors import RolloutError
+from verifiers.v1.harness import Harness, HarnessSession
+from verifiers.v1.runtimes import ProgramResult, Runtime
+from verifiers.v1.task import TaskData
+from verifiers.v1.trace import Trace
+
+logger = logging.getLogger(__name__)
+
+INSTALL_SOURCE = (Path(__file__).resolve().parent / "install.sh").read_text()
+
+PRIME_AGENT_ACP = ACP()
+PROVIDER = "intercept"
+# models.json stores this variable NAME, never the secret: Prime Agent resolves
+# `process.env[apiKey] || apiKey`, so the token reaches the agent only through
+# the process environment.
+KEY_VAR = "PRIME_AGENT_INTERCEPT_KEY"
+# Prime Agent reads its agent directory from its packaged config name.
+ENV_AGENT_DIR = "PRIME_AGENT_CODING_AGENT_DIR"
+
+DEFAULT_VERSION = "0.7.0"
+DEFAULT_TARBALL_SHA256 = (
+    "88b6578518c72cd51a825bc80f28e0fef9a64c67de4a7d6fd7afd7ca1b34da0b"
+)
+RELEASE_BASE_URL = "https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev"
+NODE_VERSION = "22.19.0"
+
+INSTALL_ROOT = "/var/tmp/vf-prime-agent"
+STATE_ROOT = "/tmp/vf-prime-agent-state"
+# The daemon builds worker sockets as
+# $TMPDIR/prime-agent-<uid>/worker-<12>-<12>.sock, which adds 54 characters. A
+# per-trace TMPDIR under STATE_ROOT pushed that past the 108-byte sun_path limit,
+# so listen() returned EINVAL and the supervisor blocked for its full 30s worker
+# timeout -- surfacing only as an opaque ACP "create" timeout. Keep the socket
+# root short and separate from the (longer) state root.
+TMP_ROOT = "/tmp/vfpa"
+
+THINKING_LEVELS = ("off", "minimal", "low", "medium", "high", "xhigh", "max")
+# Prime Agent's model-facing tool surface is IPython; there is no per-tool
+# disable flag, only the allowlist forms (--tools/--no-tools/--no-builtin-tools).
+KNOWN_TOOLS = ("ipython",)
+
+
+class PrimeAgentHarnessConfig(HarnessConfig):
+    version: str = Field(default=DEFAULT_VERSION)
+    """Prime Agent release to install, pinned for reproducibility."""
+
+    tarball_url: str | None = None
+    """Override the release tarball URL. Requires `tarball_sha256`."""
+
+    tarball_sha256: str | None = None
+    """SHA-256 digest for a non-default release or a custom tarball."""
+
+    thinking: str | None = None
+    """Reasoning level passed as `--thinking`; Prime Agent has no `--effort`."""
+
+    autonomous: bool = False
+    """Run with `--autonomous` so the agent continues until its limits or gates stop it."""
+
+    gates: list[str] = Field(default_factory=list)
+    """Autonomous quality-gate commands. Requires `autonomous`."""
+
+    @field_validator("version")
+    @classmethod
+    def _semver(cls, value: str) -> str:
+        if not re.fullmatch(
+            # Follow semver strictly: dot-separated identifiers may not be
+            # empty. A permissive suffix accepted values like "1.2.3-." that
+            # then produce a 404 on the release URL instead of a clear error.
+            r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+            r"(?:-(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)"
+            r"(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*)?"
+            r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?",
+            value,
+        ):
+            raise ValueError("version must be a semantic version, e.g. 0.7.0")
+        return value
+
+    @field_validator("tarball_sha256")
+    @classmethod
+    def _digest(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        digest = value.strip().lower()
+        if len(digest) != 64 or any(c not in "0123456789abcdef" for c in digest):
+            raise ValueError("tarball_sha256 must be a 64-character hexadecimal digest")
+        return digest
+
+    @field_validator("thinking")
+    @classmethod
+    def _thinking(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if value not in THINKING_LEVELS:
+            raise ValueError(f"thinking must be one of {', '.join(THINKING_LEVELS)}")
+        return value
+
+    @model_validator(mode="after")
+    def _consistent(self) -> "PrimeAgentHarnessConfig":
+        # An unpinned artifact must never be installed unverified.
+        if self.tarball_url and not self.tarball_sha256:
+            raise ValueError("tarball_url requires tarball_sha256")
+        if self.version != DEFAULT_VERSION and not self.tarball_sha256:
+            raise ValueError("a non-default version requires tarball_sha256")
+        if self.gates and not self.autonomous:
+            raise ValueError("prime-agent gates require autonomous=true")
+        unknown = set(self.disabled_tools or []) - set(KNOWN_TOOLS)
+        if unknown:
+            raise ValueError(
+                "prime-agent has no per-tool disable flag; unknown tools: "
+                + ", ".join(sorted(unknown))
+            )
+        return self
+
+
+class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
+    APPENDS_SYSTEM_PROMPT = True
+    # Prime Agent's ACP mode ignores `session/new` mcpServers on the pinned
+    # release, so claiming support would let a tool-bearing taskset run with its
+    # tools silently absent. Once a release advertises
+    # `agentCapabilities.mcpCapabilities.http`, sniff it rather than hardcoding.
+    SUPPORTS_MCP = False
+    SUPPORTS_RESUME = True
+    SUPPORTS_SKILLS = True
+
+    def tarball_url(self) -> str:
+        if self.config.tarball_url:
+            return self.config.tarball_url
+        version = self.config.version
+        return f"{RELEASE_BASE_URL}/releases/v{version}/prime-agent-{version}.tgz"
+
+    def tarball_sha256(self) -> str:
+        return self.config.tarball_sha256 or DEFAULT_TARBALL_SHA256
+
+    def install_dir(self) -> str:
+        # Key the shared install on version+digest so a changed pin cannot reuse
+        # whatever an earlier rollout left behind.
+        return f"{INSTALL_ROOT}/{self.config.version}-{self.tarball_sha256()[:16]}"
+
+    def node_root(self) -> str:
+        return f"{INSTALL_ROOT}/node-{NODE_VERSION}"
+
+    def prime_agent_bin(self) -> str:
+        return f"{self.install_dir()}/node_modules/.bin/prime-agent"
+
+    def trace_key(self, trace: Trace) -> str:
+        # Hash the trace id: it is untrusted input for a filesystem path.
+        return hashlib.sha256(trace.id.encode()).hexdigest()[:32]
+
+    def tmp_dir(self, trace: Trace) -> str:
+        """Short per-trace TMPDIR, sized for the daemon's worker socket paths.
+
+        16 hex characters keep the longest derived socket well inside sun_path
+        while still being collision-free in practice for concurrent rollouts.
+        """
+        return f"{TMP_ROOT}/{self.trace_key(trace)[:16]}"
+
+    def trace_root(self, trace: Trace) -> str:
+        return f"{STATE_ROOT}/{self.trace_key(trace)}"
+
+    async def setup(self, runtime: Runtime) -> None:
+        logger.info("prime-agent: ensuring %s is installed", self.config.version)
+        lock = f"{INSTALL_ROOT}/install.lock"
+        # flock only; a mkdir-based fallback leaves a stale lock directory after
+        # SIGKILL that blocks every later install.
+        guarded = (
+            f"mkdir -p {shlex.quote(INSTALL_ROOT)} && "
+            f"flock -x {shlex.quote(lock)} sh -c {shlex.quote(INSTALL_SOURCE)}"
+        )
+        result = await runtime.run(
+            ["sh", "-c", guarded],
+            {
+                **self.config.resolved_env,
+                "VF_PA_INSTALL_DIR": self.install_dir(),
+                "VF_PA_TARBALL_URL": self.tarball_url(),
+                "VF_PA_TARBALL_SHA256": self.tarball_sha256(),
+                "VF_PA_NODE_ROOT": self.node_root(),
+                "VF_PA_NODE_VERSION": NODE_VERSION,
+                "VF_PA_UV_VERSION": "0.8.17",
+            },
+        )
+        if result.exit_code != 0:
+            raise RuntimeError(
+                f"prime-agent install failed: {result.stderr.strip()[-500:]}"
+            )
+        await PRIME_AGENT_ACP.setup(self, runtime)
+
+    async def session(
+        self,
+        ctx: ModelContext,
+        trace: Trace,
+        runtime: Runtime,
+        endpoint: str,
+        secret: str,
+        mcp_urls: dict[str, str],
+        data: TaskData,
+    ) -> HarnessSession:
+        # One live ACP process per trace keeps a single Prime Agent session, and
+        # with it one IPython kernel, across turns. Prime Agent advertises
+        # `loadSession: false` and refuses a second `session/new`, so a relaunch
+        # per segment cannot preserve kernel state.
+        #
+        # ACP.session has no allow_empty_tool_reply option (unlike ACP.run).
+        # The live handle owns turn requests directly, so do not invent or pass
+        # that one-shot runner kwarg here.
+        # This live path exists only because ACP sessions are currently
+        # client-owned: the worker stops when the client disconnects. When Prime
+        # Agent gains a resident ACP lifecycle, deleting this override restores
+        # the plain per-segment shape.
+        if not runtime.supports_live_processes:
+            raise RuntimeError(
+                "prime-agent harness requires runtime live-process support: "
+                "without it, each segment would launch a fresh ACP process and "
+                "lose the persistent IPython kernel"
+            )
+        system_prompt, prompt = self.resolve_prompt(data)
+        try:
+            command = await self._prepare(ctx, trace, runtime, endpoint, system_prompt)
+        except Exception as error:
+            # Same diagnostic as launch(): a daemon that never answers surfaces
+            # as an opaque ACP timeout, and its log dies with the sandbox.
+            tail = await self.daemon_log_tail(runtime, trace)
+            if tail and not isinstance(error, RolloutError):
+                raise RuntimeError(
+                    f"{error}\n\nprime-agent daemon log:\n{tail}"
+                ) from error
+            raise
+        return PRIME_AGENT_ACP.session(
+            self,
+            ctx,
+            trace,
+            runtime,
+            endpoint,
+            secret,
+            mcp_urls,
+            data,
+            env=self._run_env(trace, secret),
+            command=command,
+            prompt=prompt,
+        )
+
+    async def launch(
+        self,
+        ctx: ModelContext,
+        trace: Trace,
+        runtime: Runtime,
+        endpoint: str,
+        secret: str,
+        mcp_urls: dict[str, str],
+        data: TaskData,
+    ) -> ProgramResult:
+        system_prompt, prompt = self.resolve_prompt(data)
+        command = await self._prepare(ctx, trace, runtime, endpoint, system_prompt)
+        try:
+            return await PRIME_AGENT_ACP.run(
+                runtime,
+                self._run_env(trace, secret),
+                command,
+                prompt,
+                allow_empty_tool_reply=True,
+            )
+        except Exception as error:
+            # ACP reports a daemon that never answers as an opaque 30s "create"
+            # timeout, and the daemon log dies with the sandbox. Attach it so the
+            # failure is diagnosable from CI output alone.
+            tail = await self.daemon_log_tail(runtime, trace)
+            if tail:
+                # A typed rollout error already carries the authoritative
+                # attribution (for example SandboxError). Do not replace it
+                # with a generic RuntimeError merely to attach diagnostics.
+                if isinstance(error, RolloutError):
+                    raise
+                raise RuntimeError(
+                    f"{error}\n\nprime-agent daemon log:\n{tail}"
+                ) from error
+            raise
+
+    def _run_env(self, trace: Trace, secret: str) -> dict[str, str]:
+        root = self.trace_root(trace)
+        return {
+            **self.config.resolved_env,
+            KEY_VAR: secret,
+            ENV_AGENT_DIR: f"{root}/agent",
+            "HOME": f"{root}/agent",
+            # The daemon derives its socket from TMPDIR
+            # (defaultDaemonSocketDir joins tmpdir with prime-agent-<uid>), so a
+            # per-trace TMPDIR already isolates the socket without naming a path.
+            "TMPDIR": self.tmp_dir(trace),
+            # The ACP launch wrapper must resolve uv for daemon workers too;
+            # setup()'s subprocess PATH cannot modify this later environment.
+            "PATH": f"{self.install_dir()}.uv/bin:{self.node_root()}/bin:"
+            + self.config.resolved_env.get(
+                "PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+            ),
+            "PRIME_AGENT_TELEMETRY": "0",
+        }
+
+    async def _prepare(
+        self,
+        ctx: ModelContext,
+        trace: Trace,
+        runtime: Runtime,
+        endpoint: str,
+        system_prompt: str | None,
+    ) -> list[str]:
+        root = self.trace_root(trace)
+        agent_dir = f"{root}/agent"
+        created = await runtime.run(
+            ["mkdir", "-p", "-m", "700", root, agent_dir, self.tmp_dir(trace)], {}
+        )
+        if created.exit_code != 0:
+            raise RuntimeError(
+                f"prime-agent state directory failed: {created.stderr.strip()[-500:]}"
+            )
+
+        skills_dir = f"{agent_dir}/skills"
+        if self.config.skills:
+            await self.install_skills(runtime, skills_dir)
+
+        thinking = self.config.thinking
+        reasoning = thinking not in (None, "off") or ctx.model.rsplit("/", 1)[
+            -1
+        ].startswith(("gpt-5", "o1", "o3", "o4"))
+        models = {
+            "providers": {
+                PROVIDER: {
+                    "baseUrl": endpoint,
+                    "api": "openai-completions",
+                    # The variable name, not the secret. Never interpolate
+                    # untrusted text here: a leading "!" is executed as a command.
+                    "apiKey": KEY_VAR,
+                    "models": [
+                        {
+                            "id": ctx.model,
+                            "reasoning": reasoning,
+                            "input": ["text", "image"],
+                            **(
+                                {"maxTokens": ctx.sampling.max_tokens}
+                                if ctx.sampling.max_tokens is not None
+                                else {}
+                            ),
+                        }
+                    ],
+                }
+            }
+        }
+        models_path = f"{agent_dir}/models.json"
+        await runtime.write(models_path, json.dumps(models).encode())
+        # The endpoint the agent must reach is rewritten by the runtime
+        # (127.0.0.1 becomes a proxy-only alias under egress restriction), and a
+        # rollout that cannot reach it fails as an opaque provider error. Log it
+        # so a failure names the address that was actually configured.
+        logger.info(
+            "prime-agent: model endpoint for trace %s is %s", trace.id, endpoint
+        )
+        for command in (
+            ["chmod", "700", root, agent_dir, self.tmp_dir(trace)],
+            ["chmod", "600", models_path],
+        ):
+            restricted = await runtime.run(command, {})
+            if restricted.exit_code != 0:
+                raise RuntimeError(
+                    f"prime-agent permissions failed: {restricted.stderr.strip()[-500:]}"
+                )
+
+        args = [
+            self.prime_agent_bin(),
+            "--mode",
+            "acp",
+            "--provider",
+            PROVIDER,
+            "--model",
+            ctx.model,
+            "--daemon-socket",
+            self.trace_root(trace) + "/daemon.sock",
+        ]
+        if self.config.disabled_tools:
+            args.append("--no-builtin-tools")
+        if thinking is not None:
+            args += ["--thinking", thinking]
+        for skill in self.config.skills:
+            args += ["--skill", f"{skills_dir}/{skill.resolve().name}"]
+        if self.config.autonomous:
+            args.append("--autonomous")
+            for gate in self.config.gates:
+                args += ["--autonomous-gate", gate]
+        if system_prompt:
+            # Sent once per launch as a flag. Folding it into the transcript
+            # would re-apply it on every resumed segment.
+            args += ["--append-system-prompt", system_prompt]
+
+        # The bundled Node is beside the install, not on the image PATH.
+        node_bin = f"{self.node_root()}/bin"
+        command = (
+            f'export PATH={shlex.quote(node_bin)}:"$PATH"\n'
+            f'exec {shlex.join(args)} "$@"\n'
+        )
+        wrapper = f"{root}/prime-agent"
+        await runtime.write(wrapper, f"#!/bin/sh\nset -eu\n{command}".encode())
+        wrapper_mode = await runtime.run(["chmod", "700", wrapper], {})
+        if wrapper_mode.exit_code != 0:
+            raise RuntimeError(
+                "prime-agent wrapper permissions failed: "
+                f"{wrapper_mode.stderr.strip()[-500:]}"
+            )
+
+        return ["sh", "-c", f"exec {shlex.quote(wrapper)}"]
+
+    async def daemon_log_tail(self, runtime: Runtime, trace: Trace) -> str:
+        """Best-effort daemon log, for explaining an opaque ACP startup timeout.
+
+        Never raises: this runs on a failure path, and a sandbox that is already
+        gone would otherwise replace the original error with its own.
+        """
+        try:
+            return await self._daemon_log_tail(runtime, trace)
+        except Exception:  # noqa: BLE001 - diagnostics must not mask the failure
+            return ""
+
+    async def _daemon_log_tail(self, runtime: Runtime, trace: Trace) -> str:
+        result = await runtime.run(
+            [
+                "sh",
+                "-c",
+                f"tail -n 40 {shlex.quote(self.trace_root(trace))}/agent/logs/*.log 2>/dev/null || true",
+            ],
+            {},
+        )
+        return result.stdout.strip()[-1500:]
+
+    async def cleanup(self, trace: Trace, runtime: Runtime) -> None:
+        root = self.trace_root(trace)
+        socket = f"{root}/daemon.sock"
+        try:
+            # Stop this trace's daemon before deleting its state: a live worker
+            # would keep writing into a removed directory. `daemon` is in the
+            # CLI's REMOVED_COMMAND_NAMES, so the subcommand is plain `stop`.
+            stopped = await runtime.run(
+                [
+                    "sh",
+                    "-c",
+                    # Prepend the bundled Node inside the shell rather than passing
+                    # PATH in env: `docker exec --env PATH=...` REPLACES the image
+                    # PATH, and resolved_env usually has no PATH to fall back on.
+                    (
+                        f'export PATH={shlex.quote(f"{self.node_root()}/bin")}:"$PATH"\n'
+                        f"exec {shlex.quote(self.prime_agent_bin())} stop "
+                        f"--daemon-socket {shlex.quote(socket)}"
+                    ),
+                ],
+                self._run_env(trace, ""),
+            )
+            if stopped.exit_code != 0:
+                # Keep the state directory: a failed stop may leave a live
+                # worker writing to it. Do not turn that failure into silent
+                # data loss by deleting the directory.
+                raise RuntimeError(
+                    "prime-agent: stopping the trace daemon failed "
+                    f"(exit {stopped.exit_code}): {stopped.stderr.strip()[-300:]}"
+                )
+        except Exception:
+            logger.exception("prime-agent: daemon cleanup failed; retaining %s", root)
+            raise
+        else:
+            # Remove only this trace's state and its per-trace socket directory;
+            # never remove the shared install. TMPDIR is created only in _prepare.
+            await runtime.run(["rm", "-rf", root, self.tmp_dir(trace)], {})

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -257,7 +257,10 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
         self, runtime: Runtime, trace: Trace, error: BaseException
     ) -> None:
         """Attach Prime Agent daemon output to untyped live ACP turn failures."""
-        tail = await self.daemon_log_tail(runtime, trace)
+        try:
+            tail = await self.daemon_log_tail(runtime, trace)
+        except Exception:  # noqa: BLE001 - diagnostics must not mask the failure
+            return
         if tail and not isinstance(error, RolloutError):
             raise RuntimeError(f"{error}\n\nprime-agent daemon log:\n{tail}") from error
 
@@ -455,9 +458,15 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
         socket = f"{root}/daemon.sock"
         try:
             # Cleanup is also called after a failed launch, before a daemon ever
-            # creates its socket. Skip stop in that normal idempotent case, but
-            # retain state whenever an existing daemon cannot be stopped.
+            # creates its socket. Exit 1 from `test -S` is the one normal,
+            # idempotent absence case; an execution error is indeterminate, so
+            # retain state rather than risk deleting a live daemon's directory.
             exists = await runtime.run(["test", "-S", socket], {})
+            if exists.exit_code not in (0, 1):
+                raise RuntimeError(
+                    "prime-agent: checking the trace daemon socket failed "
+                    f"(exit {exists.exit_code}): {exists.stderr.strip()[-300:]}"
+                )
             if exists.exit_code == 0:
                 # Stop this trace's daemon before deleting its state: a live worker
                 # would keep writing into a removed directory. `daemon` is in the
@@ -485,14 +494,14 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
                         "prime-agent: stopping the trace daemon failed "
                         f"(exit {stopped.exit_code}): {stopped.stderr.strip()[-300:]}"
                     )
+            # Remove only this trace's state and its per-trace socket directory;
+            # never remove the shared install. TMPDIR is created only in _prepare.
+            removed = await runtime.run(["rm", "-rf", root, self.tmp_dir(trace)], {})
+            if removed.exit_code != 0:
+                raise RuntimeError(
+                    "prime-agent: state cleanup failed "
+                    f"(exit {removed.exit_code}): {removed.stderr.strip()[-300:]}"
+                )
         except Exception:
             logger.exception("prime-agent: daemon cleanup failed; retaining %s", root)
             raise
-        # Remove only this trace's state and its per-trace socket directory;
-        # never remove the shared install. TMPDIR is created only in _prepare.
-        removed = await runtime.run(["rm", "-rf", root, self.tmp_dir(trace)], {})
-        if removed.exit_code != 0:
-            raise RuntimeError(
-                "prime-agent: state cleanup failed "
-                f"(exit {removed.exit_code}): {removed.stderr.strip()[-300:]}"
-            )

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -250,7 +250,16 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
             env=self._run_env(trace, secret),
             command=command,
             prompt=prompt,
+            on_error=lambda error: self._session_error(runtime, trace, error),
         )
+
+    async def _session_error(
+        self, runtime: Runtime, trace: Trace, error: BaseException
+    ) -> None:
+        """Attach Prime Agent daemon output to untyped live ACP turn failures."""
+        tail = await self.daemon_log_tail(runtime, trace)
+        if tail and not isinstance(error, RolloutError):
+            raise RuntimeError(f"{error}\n\nprime-agent daemon log:\n{tail}") from error
 
     async def launch(
         self,
@@ -445,36 +454,45 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
         root = self.trace_root(trace)
         socket = f"{root}/daemon.sock"
         try:
-            # Stop this trace's daemon before deleting its state: a live worker
-            # would keep writing into a removed directory. `daemon` is in the
-            # CLI's REMOVED_COMMAND_NAMES, so the subcommand is plain `stop`.
-            stopped = await runtime.run(
-                [
-                    "sh",
-                    "-c",
-                    # Prepend the bundled Node inside the shell rather than passing
-                    # PATH in env: `docker exec --env PATH=...` REPLACES the image
-                    # PATH, and resolved_env usually has no PATH to fall back on.
-                    (
-                        f'export PATH={shlex.quote(f"{self.node_root()}/bin")}:"$PATH"\n'
-                        f"exec {shlex.quote(self.prime_agent_bin())} stop "
-                        f"--daemon-socket {shlex.quote(socket)}"
-                    ),
-                ],
-                self._run_env(trace, ""),
-            )
-            if stopped.exit_code != 0:
-                # Keep the state directory: a failed stop may leave a live
-                # worker writing to it. Do not turn that failure into silent
-                # data loss by deleting the directory.
-                raise RuntimeError(
-                    "prime-agent: stopping the trace daemon failed "
-                    f"(exit {stopped.exit_code}): {stopped.stderr.strip()[-300:]}"
+            # Cleanup is also called after a failed launch, before a daemon ever
+            # creates its socket. Skip stop in that normal idempotent case, but
+            # retain state whenever an existing daemon cannot be stopped.
+            exists = await runtime.run(["test", "-S", socket], {})
+            if exists.exit_code == 0:
+                # Stop this trace's daemon before deleting its state: a live worker
+                # would keep writing into a removed directory. `daemon` is in the
+                # CLI's REMOVED_COMMAND_NAMES, so the subcommand is plain `stop`.
+                stopped = await runtime.run(
+                    [
+                        "sh",
+                        "-c",
+                        # Prepend the bundled Node inside the shell rather than passing
+                        # PATH in env: `docker exec --env PATH=...` REPLACES the image
+                        # PATH, and resolved_env usually has no PATH to fall back on.
+                        (
+                            f'export PATH={shlex.quote(f"{self.node_root()}/bin")}:"$PATH"\n'
+                            f"exec {shlex.quote(self.prime_agent_bin())} stop "
+                            f"--daemon-socket {shlex.quote(socket)}"
+                        ),
+                    ],
+                    self._run_env(trace, ""),
                 )
+                if stopped.exit_code != 0:
+                    # Keep the state directory: a failed stop may leave a live
+                    # worker writing to it. Do not turn that failure into silent
+                    # data loss by deleting the directory.
+                    raise RuntimeError(
+                        "prime-agent: stopping the trace daemon failed "
+                        f"(exit {stopped.exit_code}): {stopped.stderr.strip()[-300:]}"
+                    )
         except Exception:
             logger.exception("prime-agent: daemon cleanup failed; retaining %s", root)
             raise
-        else:
-            # Remove only this trace's state and its per-trace socket directory;
-            # never remove the shared install. TMPDIR is created only in _prepare.
-            await runtime.run(["rm", "-rf", root, self.tmp_dir(trace)], {})
+        # Remove only this trace's state and its per-trace socket directory;
+        # never remove the shared install. TMPDIR is created only in _prepare.
+        removed = await runtime.run(["rm", "-rf", root, self.tmp_dir(trace)], {})
+        if removed.exit_code != 0:
+            raise RuntimeError(
+                "prime-agent: state cleanup failed "
+                f"(exit {removed.exit_code}): {removed.stderr.strip()[-300:]}"
+            )

--- a/verifiers/v1/harnesses/prime_agent/install.sh
+++ b/verifiers/v1/harnesses/prime_agent/install.sh
@@ -1,0 +1,163 @@
+
+set -eu
+root="$VF_PA_INSTALL_DIR"
+digest="$VF_PA_TARBALL_SHA256"
+stamp="$root/.installed"
+node_root="$VF_PA_NODE_ROOT"
+uv_root="${root}.uv"
+uv_bin="$uv_root/bin/uv"
+# Pin the installer input so all rollouts resolve the same uv artifact.
+uv_version="${VF_PA_UV_VERSION:-0.8.17}"
+export PATH="$uv_root/bin:$node_root/bin:$PATH"
+
+ensure_base_tools() {
+    # curl fetches Node/uv/the tarball. git is not needed by prime-agent itself,
+    # but a coding taskset that clones or diffs fails deep inside a rollout
+    # without it, which reads as a bad score rather than a missing dependency.
+    missing=""
+    command -v curl >/dev/null 2>&1 || missing="$missing curl"
+    command -v git >/dev/null 2>&1 || missing="$missing git"
+    [ -z "$missing" ] && return 0
+    if command -v apt-get >/dev/null 2>&1; then
+        apt-get update -qq && apt-get install -y --no-install-recommends ca-certificates $missing
+    elif command -v apk >/dev/null 2>&1; then
+        apk add --no-cache ca-certificates $missing
+    else
+        echo "prime-agent install needs$missing; neither apt-get nor apk is available" >&2
+        exit 1
+    fi
+    command -v curl >/dev/null 2>&1 || {
+        echo "prime-agent install requires curl, but installation did not provide it" >&2
+        exit 1
+    }
+}
+
+node_ok() {
+    command -v node >/dev/null 2>&1 || return 1
+    command -v npm >/dev/null 2>&1 || return 1
+    node -e 'const [a,b]=process.versions.node.split(".").map(Number); process.exit(a>22||(a===22&&b>=8)?0:1)'
+}
+
+bundled_node_ok() {
+    [ -x "$node_root/bin/node" ] || return 1
+    [ -x "$node_root/bin/npm" ] || return 1
+    [ "$("$node_root/bin/node" --version 2>/dev/null)" = "v$VF_PA_NODE_VERSION" ] || return 1
+    "$node_root/bin/npm" --version >/dev/null 2>&1
+}
+
+ensure_base_tools
+
+# The Node.js release archives are glibc-linked and cannot execute on Alpine/musl.
+# Prefer the image's distro Node rather than downloading an unusable archive.
+if [ "$(uname -s)" = Linux ] && ldd --version 2>&1 | grep -qi musl; then
+    if ! node_ok; then
+        if command -v apk >/dev/null 2>&1; then
+            apk add --no-cache nodejs-current npm
+        fi
+    fi
+    node_ok || {
+        echo "prime-agent: Alpine/musl requires nodejs-current and npm; install them in the image" >&2
+        exit 1
+    }
+fi
+
+install_uv() {
+    if [ -x "$uv_bin" ] && "$uv_bin" --version 2>/dev/null | grep -F "uv $uv_version" >/dev/null 2>&1; then
+        return 0
+    fi
+    tmp="${uv_root}.staging.$$"
+    rm -rf "$tmp"
+    mkdir -p "$tmp/bin"
+    # The official installer honors UV_VERSION and UV_INSTALL_DIR. Download it
+    # while setup still has network, then publish the verified executable atomically.
+    # Pin through the versioned installer URL: the generic installer ignores
+    # UV_VERSION (verified -- it installed 0.12.2 when asked for 0.8.17), which
+    # both defeats the pin and makes the cache check below never match, so every
+    # setup re-downloads uv. UV_NO_MODIFY_PATH keeps it from writing shell rc
+    # files into the per-trace HOME.
+    if ! curl -fsSL "https://astral.sh/uv/${uv_version}/install.sh" \
+        | UV_INSTALL_DIR="$tmp/bin" UV_NO_MODIFY_PATH=1 sh; then
+        echo "prime-agent: official uv installer failed for uv $uv_version" >&2
+        exit 1
+    fi
+    if [ ! -x "$tmp/bin/uv" ]; then
+        echo "prime-agent: official uv installer did not provide $tmp/bin/uv" >&2
+        exit 1
+    fi
+    rm -rf "$uv_root"
+    mv "$tmp" "$uv_root"
+}
+
+verify_uv() {
+    [ -x "$uv_bin" ] || { echo "prime-agent: uv missing at $uv_bin" >&2; exit 1; }
+    actual_uv="$($uv_bin --version 2>&1)" || { echo "prime-agent: uv --version failed after installation: $actual_uv" >&2; exit 1; }
+    printf '%s\n' "$actual_uv" | grep -F "uv $uv_version" >/dev/null 2>&1 || { echo "prime-agent: uv version mismatch; expected uv $uv_version, got $actual_uv" >&2; exit 1; }
+}
+
+if ! node_ok; then
+    case "$(uname -s)" in
+        Linux) node_os=linux ;;
+        Darwin) node_os=darwin ;;
+        *) echo "prime-agent: unsupported OS $(uname -s)" >&2; exit 1 ;;
+    esac
+    # Reject unknown machines instead of guessing x64: a wrong archive yields a
+    # node binary that cannot exec, failing much later and far less clearly.
+    case "$(uname -m)" in
+        aarch64|arm64) node_arch=arm64 ;;
+        x86_64|amd64) node_arch=x64 ;;
+        *) echo "prime-agent: unsupported architecture $(uname -m)" >&2; exit 1 ;;
+    esac
+    if ! bundled_node_ok; then
+        rm -rf "$node_root"
+        mkdir -p "$node_root"
+        curl -fsSL "https://nodejs.org/dist/v$VF_PA_NODE_VERSION/node-v$VF_PA_NODE_VERSION-${node_os}-${node_arch}.tar.gz" \
+            | tar -xz -C "$node_root" --strip-components=1
+    fi
+    node_ok || { echo "prime-agent requires Node.js 22.8 or newer with npm" >&2; exit 1; }
+fi
+
+install_uv
+verify_uv
+
+# The install is shared, so key the stamp on the verified digest: a changed
+# version or tarball must reinstall rather than reuse another rollout's tree.
+if [ -x "$root/node_modules/.bin/prime-agent" ] \
+    && [ "$(cat "$stamp" 2>/dev/null)" = "$digest" ] \
+    && [ -x "$uv_bin" ] \
+    && "$uv_bin" --version 2>/dev/null | grep -F "uv $uv_version" >/dev/null 2>&1; then
+    exit 0
+fi
+
+staging="${root}.staging.$$"
+rm -rf "$staging"
+mkdir -p "$staging"
+cleanup() { rm -rf "$staging"; }
+trap cleanup EXIT
+
+curl -fsSL "$VF_PA_TARBALL_URL" -o "$staging/prime-agent.tgz"
+if command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "$staging/prime-agent.tgz" | cut -d' ' -f1)"
+else
+    actual="$(shasum -a 256 "$staging/prime-agent.tgz" | cut -d' ' -f1)"
+fi
+if [ "$actual" != "$digest" ]; then
+    echo "prime-agent tarball digest mismatch: expected $digest, got $actual" >&2
+    exit 1
+fi
+
+npm install --no-audit --no-fund --prefix "$staging" "$staging/prime-agent.tgz" >/dev/null
+rm -f "$staging/prime-agent.tgz"
+printf %s "$digest" > "$staging/.installed"
+
+# Publish atomically: a partially installed tree must never be observable, and
+# a concurrent rollout either sees the old tree or the complete new one.
+rm -rf "${root}.prev"
+if [ -d "$root" ]; then
+    mv "$root" "${root}.prev"
+fi
+if ! mv "$staging" "$root"; then
+    if [ -d "${root}.prev" ]; then mv "${root}.prev" "$root"; fi
+    echo "prime-agent: failed to publish install" >&2
+    exit 1
+fi
+rm -rf "${root}.prev"


### PR DESCRIPTION
## Replacement stack

Node 1/5 in a fresh append-only v0.8 replacement chain rooted at authoritative `main` commit `c2820d3679e6318f9c3d0155c823d6908b4e1faa`.

- **Base branch:** `main`
- **Head branch:** `v080/main-replacement-prime-harness`
- **Exact head:** `f4a32c192fd9dabefe6938e36b6893bf86f9e49c`

## Scope

Exact coherent #2285 Prime Agent harness/test delta: 12 paths; no dependency or lockfile changes.

The old contributor PR branches remain untouched. This branch was published non-force from a fresh owned repository. Independent Luna semantic review **APPROVED** the full N1→N5 chain and found no structural scope leakage; authoritative-main renderer provenance is retained and `pyproject.toml` / `uv.lock` are unchanged across replacement nodes.

> [!WARNING]
> **TEST BLOCKED — do not merge or mark ready.** Authoritative `c2820d` has a stale `uv.lock` relative to `pyproject.toml`. A disposable `uv sync --locked` correctly refused before tests, without changing repository files. The only previously approved interpreter also cannot import current main because `pydantic_config` is absent. Testing/remediation continues on GitHub; this draft does not claim green.

No live, hosted, Docker, sandbox, model, or paid evaluation was run.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Prime Agent harness for running agents via ACP with persistent IPython kernel support
> - Adds `PrimeAgentHarness` in [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2324/files#diff-20ba08f960d62f6e395d3eb05c3a6b051e309727747f31f1a381d7aa7396323b) that installs and runs Prime Agent via ACP, supporting both one-shot and live-session modes with a persistent IPython kernel across turns.
> - Includes [install.sh](https://github.com/PrimeIntellect-ai/verifiers/pull/2324/files#diff-00984acbd41bc39901f7bf6f95c030a0625b58ea064d0369534cdc855c567c23), a shell script that pins and verifies uv, Node.js (22.8+), and the Prime Agent tarball via SHA-256, with Alpine/musl support.
> - `ACPHarnessSession` gains an `on_error` callback so harnesses can attach daemon log diagnostics to untyped errors while preserving typed `RolloutError` exceptions.
> - Adds four e2e test fixtures and tests covering: IPython cell execution shape, kernel state persistence across turns, provider failure propagation, and GSM8K task solving.
> - Risk: the harness manages per-trace directories, daemon processes, and flock-guarded installs — cleanup failures retain state and raise errors rather than silently continuing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e3bfc4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new harness plus a shared ACP session error-path change; carefully preserves typed rollout errors, but install/runtime behavior and live-process semantics are infra-sensitive.
> 
> **Overview**
> Adds a **Prime Agent** harness that runs the agent through native ACP with a **persistent live session** (one IPython kernel across turns), pinned install/setup, daemon diagnostics, and careful cleanup.
> 
> Extends shared `ACPHarnessSession` with an optional `on_error` callback so turn failures can attach daemon logs without replacing typed `RolloutError`s (or masking cancellation).
> 
> Adds `prime_agent`-marked Docker e2e coverage for kernel persistence, verbatim IPython cell execution, GSM8K scoring, and provider-failure surfacing, plus deterministic unit guards for install/cleanup/error and unix socket path limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e3bfc4a15bfbf79e72d22afe825e56c3676ca54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->