### PR TITLE
[v0.8 replacement 3/5] reconcile harness lifecycle

### DIFF
--- a/tests/v1/test_harness_model_ids.py
+++ b/tests/v1/test_harness_model_ids.py
@@ -49,18 +49,17 @@ def _context(model: str) -> ModelContext:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("model", "provider", "primary"),
+    "model",
     [
-        ("gpt-5.6-luna", "openai", "openai/gpt-5.6-luna"),
-        (
-            "openrouter/meta-llama/llama-3.3-70b",
-            "openrouter",
-            "openrouter/meta-llama/llama-3.3-70b",
-        ),
+        "gpt-5.6-luna",
+        "openai/gpt-5.6-luna",
+        "internal/glm-5.2-fast",
+        "custom/non-catalog-model-v1",
+        "openrouter/meta-llama/llama-3.3-70b",
     ],
 )
-async def test_openclaw_launch_normalizes_bare_model_ids(
-    monkeypatch: pytest.MonkeyPatch, model: str, provider: str, primary: str
+async def test_openclaw_launch_isolates_every_model_id(
+    monkeypatch: pytest.MonkeyPatch, model: str
 ) -> None:
     import verifiers.v1.harnesses.openclaw.harness as openclaw
 
@@ -77,26 +76,39 @@ async def test_openclaw_launch_normalizes_bare_model_ids(
     )
 
     config = json.loads(runtime.writes[".vf-openclaw/trace/openclaw.json"])
-    assert config["agents"]["defaults"]["model"]["primary"] == primary
+    assert config["agents"]["defaults"]["model"]["primary"] == f"intercept/{model}"
+    assert config["models"]["mode"] == "replace"
     assert config["models"]["providers"] == {
-        provider: {"baseUrl": "http://intercept", "apiKey": "${OPENCLAW_INTERCEPT_KEY}"}
+        "intercept": {
+            "baseUrl": "http://intercept",
+            "apiKey": "${OPENCLAW_INTERCEPT_KEY}",
+            "api": "openai-responses",
+            "authHeader": True,
+            "models": [
+                {
+                    "id": model,
+                    "name": model,
+                    "reasoning": False,
+                    "input": ["text", "image"],
+                }
+            ],
+        }
     }
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("model", "provider", "remainder"),
+    "model",
     [
-        ("gpt-5.6-luna", "openai", "gpt-5.6-luna"),
-        (
-            "openrouter/meta-llama/llama-3.3-70b",
-            "openrouter",
-            "meta-llama/llama-3.3-70b",
-        ),
+        "gpt-5.6-luna",
+        "openai/gpt-5.6-luna",
+        "internal/glm-5.2-fast",
+        "custom/non-catalog-model-v1",
+        "openrouter/meta-llama/llama-3.3-70b",
     ],
 )
-async def test_pi_launch_normalizes_bare_model_ids(
-    monkeypatch: pytest.MonkeyPatch, model: str, provider: str, remainder: str
+async def test_pi_launch_isolates_every_model_id(
+    monkeypatch: pytest.MonkeyPatch, model: str
 ) -> None:
     import verifiers.v1.harnesses.pi.harness as pi
 
@@ -114,7 +126,20 @@ async def test_pi_launch_normalizes_bare_model_ids(
 
     models = json.loads(runtime.writes[".vf-pi-agent-trace/models.json"])
     assert models["providers"] == {
-        provider: {"baseUrl": "http://intercept", "apiKey": "$PI_INTERCEPT_KEY"}
+        "intercept": {
+            "baseUrl": "http://intercept",
+            "api": "openai-completions",
+            "apiKey": "$PI_INTERCEPT_KEY",
+            "models": [
+                {
+                    "id": model,
+                    "reasoning": model.rsplit("/", 1)[-1].startswith(
+                        ("gpt-5", "o1", "o3", "o4")
+                    ),
+                    "input": ["text", "image"],
+                }
+            ],
+        }
     }
     wrapper = runtime.writes[".vf-pi-agent-trace/pi"].decode()
-    assert f"--provider {provider} --model {remainder}" in wrapper
+    assert f"--provider intercept --model {model}" in wrapper

--- a/tests/v1/test_harness_model_ids.py
+++ b/tests/v1/test_harness_model_ids.py
@@ -1,0 +1,120 @@
+"""Offline model-ID launch contracts for native agent harnesses."""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from verifiers.v1.clients import EvalClientConfig, ModelContext
+from verifiers.v1.harnesses.openclaw.harness import (
+    OpenClawHarness,
+    OpenClawHarnessConfig,
+)
+from verifiers.v1.harnesses.pi.harness import PiHarness, PiHarnessConfig
+from verifiers.v1.task import TaskData
+
+
+class _Runtime:
+    def __init__(self) -> None:
+        self.writes: dict[str, bytes] = {}
+        self.runs: list[list[str]] = []
+        self.background: list[list[str]] = []
+
+    async def write(self, path: str, data: bytes) -> None:
+        self.writes[path] = data
+
+    async def run(self, command: list[str], environment: dict[str, str]):
+        del environment
+        self.runs.append(command)
+        return SimpleNamespace(exit_code=0, stdout="12345", stderr="")
+
+    async def run_background(
+        self,
+        command: list[str],
+        environment: dict[str, str],
+        log_path: str,
+    ) -> None:
+        del environment, log_path
+        self.background.append(command)
+
+
+async def _capture_acp(*args, **kwargs):
+    del args, kwargs
+    return SimpleNamespace(exit_code=0, stdout="", stderr="")
+
+
+def _context(model: str) -> ModelContext:
+    return ModelContext(model=model, client=EvalClientConfig())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("model", "provider", "primary"),
+    [
+        ("gpt-5.6-luna", "openai", "openai/gpt-5.6-luna"),
+        (
+            "openrouter/meta-llama/llama-3.3-70b",
+            "openrouter",
+            "openrouter/meta-llama/llama-3.3-70b",
+        ),
+    ],
+)
+async def test_openclaw_launch_normalizes_bare_model_ids(
+    monkeypatch: pytest.MonkeyPatch, model: str, provider: str, primary: str
+) -> None:
+    import verifiers.v1.harnesses.openclaw.harness as openclaw
+
+    monkeypatch.setattr(openclaw.OPENCLAW_ACP, "run", _capture_acp)
+    runtime = _Runtime()
+    await OpenClawHarness(OpenClawHarnessConfig()).launch(
+        _context(model),
+        SimpleNamespace(id="trace"),
+        runtime,
+        "http://intercept",
+        "secret",
+        {},
+        TaskData(prompt="hello"),
+    )
+
+    config = json.loads(runtime.writes[".vf-openclaw/trace/openclaw.json"])
+    assert config["agents"]["defaults"]["model"]["primary"] == primary
+    assert config["models"]["providers"] == {
+        provider: {"baseUrl": "http://intercept", "apiKey": "${OPENCLAW_INTERCEPT_KEY}"}
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("model", "provider", "remainder"),
+    [
+        ("gpt-5.6-luna", "openai", "gpt-5.6-luna"),
+        (
+            "openrouter/meta-llama/llama-3.3-70b",
+            "openrouter",
+            "meta-llama/llama-3.3-70b",
+        ),
+    ],
+)
+async def test_pi_launch_normalizes_bare_model_ids(
+    monkeypatch: pytest.MonkeyPatch, model: str, provider: str, remainder: str
+) -> None:
+    import verifiers.v1.harnesses.pi.harness as pi
+
+    monkeypatch.setattr(pi.PI_ACP, "run", _capture_acp)
+    runtime = _Runtime()
+    await PiHarness(PiHarnessConfig()).launch(
+        _context(model),
+        SimpleNamespace(id="trace"),
+        runtime,
+        "http://intercept",
+        "secret",
+        {},
+        TaskData(prompt="hello"),
+    )
+
+    models = json.loads(runtime.writes[".vf-pi-agent-trace/models.json"])
+    assert models["providers"] == {
+        provider: {"baseUrl": "http://intercept", "apiKey": "$PI_INTERCEPT_KEY"}
+    }
+    wrapper = runtime.writes[".vf-pi-agent-trace/pi"].decode()
+    assert f"--provider {provider} --model {remainder}" in wrapper

--- a/tests/v1/test_harness_skills.py
+++ b/tests/v1/test_harness_skills.py
@@ -1,0 +1,109 @@
+"""Hermetic skill-staging contracts shared by native harnesses."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from verifiers.v1.configs.harness import HarnessConfig
+from verifiers.v1.harness import Harness
+from verifiers.v1.runtimes import ProgramResult
+
+
+class _SkillHarness(Harness[HarnessConfig]):
+    async def launch(self, *args, **kwargs) -> ProgramResult:
+        del args, kwargs
+        return ProgramResult(exit_code=0, stdout="", stderr="")
+
+
+class _Runtime:
+    def __init__(self) -> None:
+        self.writes: list[tuple[str, bytes]] = []
+        self.runs: list[list[str]] = []
+
+    async def write(self, path: str, data: bytes) -> None:
+        self.writes.append((path, data))
+
+    async def run(self, command: list[str], environment: dict[str, str]):
+        del environment
+        self.runs.append(command)
+        return SimpleNamespace(exit_code=0, stdout="", stderr="")
+
+
+def _skill(root: Path, name: str, contents: str) -> Path:
+    skill = root / name
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text(contents)
+    return skill
+
+
+@pytest.mark.asyncio
+async def test_skill_staging_rejects_distinct_folders_with_the_same_basename(
+    tmp_path: Path,
+) -> None:
+    first = _skill(tmp_path / "one", "review", "one")
+    second = _skill(tmp_path / "two", "review", "two")
+    harness = _SkillHarness(HarnessConfig(skills=[first, second]))
+    runtime = _Runtime()
+
+    with pytest.raises(
+        ValueError, match=r"duplicate skill folder name 'review'"
+    ) as raised:
+        await harness.install_skills(runtime, "/skills")
+
+    message = str(raised.value)
+    assert str(first.resolve()) in message
+    assert str(second.resolve()) in message
+    assert runtime.writes == []
+    assert runtime.runs == []
+
+
+@pytest.mark.asyncio
+async def test_skill_staging_rejects_the_same_folder_twice(tmp_path: Path) -> None:
+    skill = _skill(tmp_path, "review", "contents")
+    harness = _SkillHarness(HarnessConfig(skills=[skill, skill]))
+    runtime = _Runtime()
+
+    with pytest.raises(ValueError, match=r"duplicate skill folder name 'review'"):
+        await harness.install_skills(runtime, "/skills")
+
+    assert runtime.writes == []
+
+
+@pytest.mark.asyncio
+async def test_skill_staging_keeps_unique_names_and_executable_modes(
+    tmp_path: Path,
+) -> None:
+    first = _skill(tmp_path, "first", "first")
+    script = first / "scripts" / "run.sh"
+    script.parent.mkdir()
+    script.write_text("#!/bin/sh\nexit 0\n")
+    script.chmod(0o700)
+    second = _skill(tmp_path, "second", "second")
+    harness = _SkillHarness(HarnessConfig(skills=[first, second]))
+    runtime = _Runtime()
+
+    await harness.install_skills(runtime, "/skills")
+
+    assert runtime.writes == [
+        ("/skills/first/SKILL.md", b"first"),
+        ("/skills/first/scripts/run.sh", b"#!/bin/sh\nexit 0\n"),
+        ("/skills/second/SKILL.md", b"second"),
+    ]
+    assert runtime.runs == [["chmod", "+x", "/skills/first/scripts/run.sh"]]
+
+
+def test_prime_agent_rejects_duplicate_skill_basenames_before_cli_construction(
+    tmp_path: Path,
+) -> None:
+    from verifiers.v1.harnesses.prime_agent.harness import (
+        PrimeAgentHarness,
+        PrimeAgentHarnessConfig,
+    )
+
+    first = _skill(tmp_path / "one", "review", "one")
+    second = _skill(tmp_path / "two", "review", "two")
+    harness = PrimeAgentHarness(PrimeAgentHarnessConfig(skills=[first, second]))
+
+    with pytest.raises(ValueError, match=r"duplicate skill folder name 'review'"):
+        harness.resolved_skills()

--- a/tests/v1/test_prime_agent_fixtures.py
+++ b/tests/v1/test_prime_agent_fixtures.py
@@ -299,9 +299,149 @@ async def test_prime_agent_setup_forwards_resolved_environment(monkeypatch):
     assert "9>/var/tmp/vf-prime-agent/install.lock" not in guarded
 
 
-def test_prime_agent_cleanup_removes_state_and_tmpdir_together():
-    source = Path("verifiers/v1/harnesses/prime_agent/harness.py").read_text()
-    assert 'runtime.run(["rm", "-rf", root, self.tmp_dir(trace)]' in source
+class _CleanupRuntime:
+    def __init__(self, results):
+        self.results = iter(results)
+        self.calls: list[tuple[list[str], dict]] = []
+
+    async def run(self, command, environment):
+        self.calls.append((command, environment))
+        result = next(self.results)
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+
+@pytest.fixture
+def prime_agent_cleanup():
+    from verifiers.v1.harnesses.prime_agent.harness import (
+        PrimeAgentHarness,
+        PrimeAgentHarnessConfig,
+    )
+
+    harness = PrimeAgentHarness(PrimeAgentHarnessConfig(id="prime-agent"))
+    trace = SimpleNamespace(id="cleanup-trace")
+    return harness, trace
+
+
+def _cleanup_result(exit_code=0, stderr="", *, timed_out=False):
+    return SimpleNamespace(exit_code=exit_code, stderr=stderr, timed_out=timed_out)
+
+
+@pytest.mark.asyncio
+async def test_prime_agent_cleanup_checks_both_deletion_results(prime_agent_cleanup):
+    harness, trace = prime_agent_cleanup
+    runtime = _CleanupRuntime([_cleanup_result(), _cleanup_result(), _cleanup_result()])
+
+    await harness.cleanup(trace, runtime)
+
+    root = harness.trace_root(trace)
+    tmp_dir = harness.tmp_dir(trace)
+    assert [call[0] for call in runtime.calls[1:]] == [
+        ["rm", "-rf", tmp_dir],
+        ["rm", "-rf", root],
+    ]
+
+
+@pytest.mark.asyncio
+async def test_prime_agent_cleanup_first_deletion_failure_preserves_retry_paths(
+    prime_agent_cleanup,
+):
+    from verifiers.v1.errors import SandboxError
+
+    harness, trace = prime_agent_cleanup
+    runtime = _CleanupRuntime(
+        [_cleanup_result(), _cleanup_result(exit_code=23, stderr="no")]
+    )
+
+    with pytest.raises(SandboxError, match="removal of per-trace tmp") as raised:
+        await harness.cleanup(trace, runtime)
+
+    root = harness.trace_root(trace)
+    tmp_dir = harness.tmp_dir(trace)
+    assert f"state root {root}; per-trace tmp {tmp_dir}" in str(raised.value)
+    assert "Confirmed removed this attempt: none" in str(raised.value)
+    assert [call[0] for call in runtime.calls[1:]] == [["rm", "-rf", tmp_dir]]
+
+
+@pytest.mark.asyncio
+async def test_prime_agent_cleanup_second_deletion_failure_reports_partial_cleanup(
+    prime_agent_cleanup,
+):
+    from verifiers.v1.errors import SandboxError
+
+    harness, trace = prime_agent_cleanup
+    runtime = _CleanupRuntime(
+        [_cleanup_result(), _cleanup_result(), _cleanup_result(exit_code=24)]
+    )
+
+    with pytest.raises(SandboxError, match="removal of state root") as raised:
+        await harness.cleanup(trace, runtime)
+
+    root = harness.trace_root(trace)
+    tmp_dir = harness.tmp_dir(trace)
+    assert f"Retry paths: state root {root}; per-trace tmp {tmp_dir}" in str(
+        raised.value
+    )
+    assert f"Confirmed removed this attempt: {tmp_dir}" in str(raised.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("result", "reason"),
+    [
+        (None, "no authoritative result"),
+        (TimeoutError(), "timed out"),
+    ],
+)
+async def test_prime_agent_cleanup_never_treats_unknown_deletion_as_success(
+    prime_agent_cleanup, result, reason
+):
+    from verifiers.v1.errors import SandboxError
+
+    harness, trace = prime_agent_cleanup
+    runtime = _CleanupRuntime([_cleanup_result(), result])
+
+    with pytest.raises(SandboxError, match=reason):
+        await harness.cleanup(trace, runtime)
+
+    # An unknown result for the first deletion must not advance to the root.
+    assert len(runtime.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_prime_agent_cleanup_retry_is_idempotent_after_partial_failure(
+    prime_agent_cleanup,
+):
+    from verifiers.v1.errors import SandboxError
+
+    harness, trace = prime_agent_cleanup
+    # The first attempt confirms tmp removal but cannot confirm root removal.
+    first = _CleanupRuntime([_cleanup_result(), _cleanup_result(), _cleanup_result(1)])
+    with pytest.raises(SandboxError):
+        await harness.cleanup(trace, first)
+
+    # `rm -rf` makes retrying tmp safe even though the first attempt removed it.
+    retry = _CleanupRuntime([_cleanup_result(), _cleanup_result(), _cleanup_result()])
+    await harness.cleanup(trace, retry)
+    assert [call[0] for call in retry.calls[1:]] == [
+        ["rm", "-rf", harness.tmp_dir(trace)],
+        ["rm", "-rf", harness.trace_root(trace)],
+    ]
+
+
+@pytest.mark.asyncio
+async def test_prime_agent_cleanup_stop_failure_prevents_deletion(prime_agent_cleanup):
+    from verifiers.v1.errors import SandboxError
+
+    harness, trace = prime_agent_cleanup
+    runtime = _CleanupRuntime([_cleanup_result(exit_code=1, stderr="still live")])
+
+    with pytest.raises(SandboxError, match="daemon stop"):
+        await harness.cleanup(trace, runtime)
+
+    assert len(runtime.calls) == 1
+    assert runtime.calls[0][0][:2] == ["sh", "-c"]
 
 
 def test_version_validator_rejects_malformed_semver():

--- a/tests/v1/test_prime_agent_fixtures.py
+++ b/tests/v1/test_prime_agent_fixtures.py
@@ -332,7 +332,9 @@ def _cleanup_result(exit_code=0, stderr="", *, timed_out=False):
 @pytest.mark.asyncio
 async def test_prime_agent_cleanup_checks_both_deletion_results(prime_agent_cleanup):
     harness, trace = prime_agent_cleanup
-    runtime = _CleanupRuntime([_cleanup_result(1), _cleanup_result(), _cleanup_result()])
+    runtime = _CleanupRuntime(
+        [_cleanup_result(1), _cleanup_result(), _cleanup_result()]
+    )
 
     await harness.cleanup(trace, runtime)
 
@@ -436,7 +438,9 @@ async def test_prime_agent_cleanup_stop_failure_prevents_deletion(prime_agent_cl
     from verifiers.v1.errors import SandboxError
 
     harness, trace = prime_agent_cleanup
-    runtime = _CleanupRuntime([_cleanup_result(0), _cleanup_result(exit_code=1, stderr="still live")])
+    runtime = _CleanupRuntime(
+        [_cleanup_result(0), _cleanup_result(exit_code=1, stderr="still live")]
+    )
 
     with pytest.raises(SandboxError, match="daemon stop"):
         await harness.cleanup(trace, runtime)

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -4,6 +4,7 @@ import logging
 import os
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
+from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar
 
 from verifiers.v1.clients import ModelContext
@@ -94,16 +95,33 @@ class Harness(ABC, Generic[ConfigT]):
     async def setup(self, runtime: Runtime) -> None:
         """Provision this harness in `runtime` before its execution timeout starts."""
 
-    async def install_skills(self, runtime: Runtime, dest: str) -> None:
-        """Upload each `config.skills` folder into `runtime` at `dest/<folder name>` —
-        the program's fixed skill discovery location, which a supporting harness's
-        `setup` passes."""
-        for skill in self.config.skills:
+    def resolved_skills(self) -> list[Path]:
+        """Resolve configured skill folders and reject discovery-name collisions.
+
+        Harnesses stage skills under their basename, so two different source folders
+        named ``review`` would otherwise write into the same runtime directory. That
+        can leave a mixed skill tree and duplicate command-line skill arguments.
+        """
+        resolved: list[Path] = []
+        by_name: dict[str, Path] = {}
+        for configured in self.config.skills:
             # Resolve so `.`/`..` entries get their real folder name (and can't
-            # place files outside `dest`).
-            skill = skill.resolve()
+            # place files outside the destination).
+            skill = configured.resolve()
             if not skill.is_dir():
                 raise ValueError(f"skill {str(skill)!r} is not a folder")
+            if first := by_name.get(skill.name):
+                raise ValueError(
+                    f"duplicate skill folder name {skill.name!r}: "
+                    f"{str(first)!r} and {str(skill)!r}"
+                )
+            by_name[skill.name] = skill
+            resolved.append(skill)
+        return resolved
+
+    async def install_skills(self, runtime: Runtime, dest: str) -> None:
+        """Upload each unique configured skill folder into ``dest/<folder name>``."""
+        for skill in self.resolved_skills():
             executables = []
             for file in sorted(skill.rglob("*")):
                 if not file.is_file():

--- a/verifiers/v1/harnesses/openclaw/harness.py
+++ b/verifiers/v1/harnesses/openclaw/harness.py
@@ -117,9 +117,9 @@ class OpenClawHarness(Harness[OpenClawHarnessConfig]):
         data: TaskData,
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(data)
-        provider, sep, model = ctx.model.partition("/")
-        if not sep:
-            provider, model = "openai", provider
+        # Keep the evaluated model opaque behind a private provider. Native provider names
+        # can merge with OpenClaw's built-in catalog and route around interception.
+        reasoning = ctx.sampling.reasoning_effort not in (None, "none")
         directory = OPENCLAW_DIR.format(version=self.config.version)
         state_dir = f".vf-openclaw/{trace.id}"
         config_path = f"{state_dir}/openclaw.json"
@@ -131,7 +131,7 @@ class OpenClawHarness(Harness[OpenClawHarnessConfig]):
                     "workspace": ".",
                     "skipBootstrap": True,
                     "sandbox": {"mode": "off"},
-                    "model": {"primary": ctx.model if sep else f"{provider}/{model}"},
+                    "model": {"primary": f"intercept/{ctx.model}"},
                 }
             },
             "tools": {
@@ -141,10 +141,23 @@ class OpenClawHarness(Harness[OpenClawHarnessConfig]):
                 "deny": self.config.disabled_tools or [],
             },
             "models": {
+                # Do not merge with built-in providers: a matching provider can bypass
+                # this rollout's endpoint and capability token.
+                "mode": "replace",
                 "providers": {
-                    provider: {
+                    "intercept": {
                         "baseUrl": endpoint,
                         "apiKey": "${OPENCLAW_INTERCEPT_KEY}",
+                        "api": "openai-responses",
+                        "authHeader": True,
+                        "models": [
+                            {
+                                "id": ctx.model,
+                                "name": ctx.model,
+                                "reasoning": reasoning,
+                                "input": ["text", "image"],
+                            }
+                        ],
                     }
                 },
             },

--- a/verifiers/v1/harnesses/openclaw/harness.py
+++ b/verifiers/v1/harnesses/openclaw/harness.py
@@ -117,8 +117,9 @@ class OpenClawHarness(Harness[OpenClawHarnessConfig]):
         data: TaskData,
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(data)
-        # Opt-in via sampling: OpenClaw redacts persisted encrypted reasoning, so resumed sessions 400 replaying it.
-        reasoning = ctx.sampling.reasoning_effort not in (None, "none")
+        provider, sep, model = ctx.model.partition("/")
+        if not sep:
+            provider, model = "openai", provider
         directory = OPENCLAW_DIR.format(version=self.config.version)
         state_dir = f".vf-openclaw/{trace.id}"
         config_path = f"{state_dir}/openclaw.json"
@@ -130,7 +131,7 @@ class OpenClawHarness(Harness[OpenClawHarnessConfig]):
                     "workspace": ".",
                     "skipBootstrap": True,
                     "sandbox": {"mode": "off"},
-                    "model": {"primary": f"intercept/{ctx.model}"},
+                    "model": {"primary": ctx.model if sep else f"{provider}/{model}"},
                 }
             },
             "tools": {
@@ -140,21 +141,10 @@ class OpenClawHarness(Harness[OpenClawHarnessConfig]):
                 "deny": self.config.disabled_tools or [],
             },
             "models": {
-                "mode": "replace",
                 "providers": {
-                    "intercept": {
+                    provider: {
                         "baseUrl": endpoint,
                         "apiKey": "${OPENCLAW_INTERCEPT_KEY}",
-                        "api": "openai-responses",
-                        "authHeader": True,
-                        "models": [
-                            {
-                                "id": ctx.model,
-                                "name": ctx.model,
-                                "reasoning": reasoning,
-                                "input": ["text", "image"],
-                            }
-                        ],
                     }
                 },
             },

--- a/verifiers/v1/harnesses/pi/harness.py
+++ b/verifiers/v1/harnesses/pi/harness.py
@@ -17,7 +17,6 @@ from verifiers.v1.trace import Trace
 
 logger = logging.getLogger(__name__)
 
-PROVIDER = "intercept"
 KEY_VAR = "PI_INTERCEPT_KEY"
 HOME_VAR = "VF_PI_ORIGINAL_HOME"
 
@@ -143,23 +142,14 @@ class PiHarness(Harness[PiHarnessConfig]):
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(data)
         agent_dir = f".vf-pi-agent-{trace.id}"
-        reasoning = ctx.sampling.reasoning_effort not in (
-            None,
-            "none",
-        ) or ctx.model.rsplit("/", 1)[-1].startswith(("gpt-5", "o1", "o3", "o4"))
+        provider, sep, model = ctx.model.partition("/")
+        if not sep:
+            provider, model = "openai", provider
         models = {
             "providers": {
-                PROVIDER: {
+                provider: {
                     "baseUrl": endpoint,
-                    "api": "openai-completions",
                     "apiKey": f"${KEY_VAR}",
-                    "models": [
-                        {
-                            "id": ctx.model,
-                            "reasoning": reasoning,
-                            "input": ["text", "image"],
-                        }
-                    ],
                 }
             }
         }
@@ -194,17 +184,16 @@ class PiHarness(Harness[PiHarnessConfig]):
         }
         skill_args = [
             arg
-            for skill in self.config.skills
-            # Resolve like `install_skills` so the path matches what it wrote.
-            for arg in ("--skill", f"{SKILLS_DIR}/{skill.resolve().name}")
+            for skill in self.resolved_skills()
+            for arg in ("--skill", f"{SKILLS_DIR}/{skill.name}")
         ]
         pi_args = [
             PI_BIN,
             "--no-approve",
             "--provider",
-            PROVIDER,
+            provider,
             "--model",
-            ctx.model,
+            model,
             *mcp_args,
             *skill_args,
         ]

--- a/verifiers/v1/harnesses/pi/harness.py
+++ b/verifiers/v1/harnesses/pi/harness.py
@@ -17,6 +17,8 @@ from verifiers.v1.trace import Trace
 
 logger = logging.getLogger(__name__)
 
+# An isolated provider keeps Pi's native catalog from selecting a non-intercepted endpoint.
+PROVIDER = "intercept"
 KEY_VAR = "PI_INTERCEPT_KEY"
 HOME_VAR = "VF_PI_ORIGINAL_HOME"
 
@@ -142,14 +144,23 @@ class PiHarness(Harness[PiHarnessConfig]):
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(data)
         agent_dir = f".vf-pi-agent-{trace.id}"
-        provider, sep, model = ctx.model.partition("/")
-        if not sep:
-            provider, model = "openai", provider
+        reasoning = ctx.sampling.reasoning_effort not in (
+            None,
+            "none",
+        ) or ctx.model.rsplit("/", 1)[-1].startswith(("gpt-5", "o1", "o3", "o4"))
         models = {
             "providers": {
-                provider: {
+                PROVIDER: {
                     "baseUrl": endpoint,
+                    "api": "openai-completions",
                     "apiKey": f"${KEY_VAR}",
+                    "models": [
+                        {
+                            "id": ctx.model,
+                            "reasoning": reasoning,
+                            "input": ["text", "image"],
+                        }
+                    ],
                 }
             }
         }
@@ -191,9 +202,9 @@ class PiHarness(Harness[PiHarnessConfig]):
             PI_BIN,
             "--no-approve",
             "--provider",
-            provider,
+            PROVIDER,
             "--model",
-            model,
+            ctx.model,
             *mcp_args,
             *skill_args,
         ]

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -483,7 +483,9 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
             try:
                 result = await runtime.run(command, {})
             except TimeoutError as error:
-                raise infrastructure_error(operation, path, "timed out", removed) from error
+                raise infrastructure_error(
+                    operation, path, "timed out", removed
+                ) from error
             except Exception as error:
                 raise infrastructure_error(
                     operation, path, f"runtime failed: {error}", removed
@@ -497,7 +499,10 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
             exit_code = getattr(result, "exit_code", None)
             if isinstance(exit_code, bool) or not isinstance(exit_code, int):
                 raise infrastructure_error(
-                    operation, path, "runtime returned no authoritative exit status", removed
+                    operation,
+                    path,
+                    "runtime returned no authoritative exit status",
+                    removed,
                 )
             return result, exit_code
 
@@ -553,12 +558,17 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
                     ) from error
                 if stopped is None:
                     raise infrastructure_error(
-                        "daemon stop", None, "runtime returned no authoritative result", []
+                        "daemon stop",
+                        None,
+                        "runtime returned no authoritative result",
+                        [],
                     )
                 if getattr(stopped, "timed_out", False):
                     raise infrastructure_error("daemon stop", None, "timed out", [])
                 stop_exit_code = getattr(stopped, "exit_code", None)
-                if isinstance(stop_exit_code, bool) or not isinstance(stop_exit_code, int):
+                if isinstance(stop_exit_code, bool) or not isinstance(
+                    stop_exit_code, int
+                ):
                     raise infrastructure_error(
                         "daemon stop",
                         None,

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -12,7 +12,7 @@ from pydantic import Field, field_validator, model_validator
 from verifiers.v1.acp import ACP
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
-from verifiers.v1.errors import RolloutError
+from verifiers.v1.errors import RolloutError, SandboxError
 from verifiers.v1.harness import Harness, HarnessSession
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.task import TaskData
@@ -31,6 +31,8 @@ KEY_VAR = "PRIME_AGENT_INTERCEPT_KEY"
 # Prime Agent reads its agent directory from its packaged config name.
 ENV_AGENT_DIR = "PRIME_AGENT_CODING_AGENT_DIR"
 
+# Temporary artifact blocker: retain the verified 0.7.0 default until an approved
+# replacement artifact supplies its exact version, URL, and SHA-256 together.
 DEFAULT_VERSION = "0.7.0"
 DEFAULT_TARBALL_SHA256 = (
     "88b6578518c72cd51a825bc80f28e0fef9a64c67de4a7d6fd7afd7ca1b34da0b"
@@ -271,8 +273,7 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
                 command,
                 prompt,
                 allow_empty_tool_reply=True,
-                # Without this the non-live fallback records no ACP metadata at all,
-                # so any _meta-dependent reward would score a working agent as failed.
+                # Preserve ACP turn metadata for _meta-dependent consumers.
                 trace=trace,
             )
         except Exception as error:
@@ -394,8 +395,8 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
             args.append("--no-builtin-tools")
         if thinking is not None:
             args += ["--thinking", thinking]
-        for skill in self.config.skills:
-            args += ["--skill", f"{skills_dir}/{skill.resolve().name}"]
+        for skill in self.resolved_skills():
+            args += ["--skill", f"{skills_dir}/{skill.name}"]
         if self.config.autonomous:
             args.append("--autonomous")
             for gate in self.config.gates:
@@ -446,38 +447,123 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
 
     async def cleanup(self, trace: Trace, runtime: Runtime) -> None:
         root = self.trace_root(trace)
+        tmp_dir = self.tmp_dir(trace)
         socket = f"{root}/daemon.sock"
+        cleanup_paths = f"state root {root}; per-trace tmp {tmp_dir}"
+
+        def infrastructure_error(
+            operation: str, path: str | None, reason: str, removed: list[str]
+        ) -> SandboxError:
+            # `rm -rf` may have removed some children before a remote runtime loses
+            # its result. Never claim that either whole path survived; name both
+            # deterministic paths so a retry can issue the idempotent removals.
+            confirmed = ", ".join(removed) if removed else "none"
+            target = f" {path}" if path else ""
+            return SandboxError(
+                f"prime-agent cleanup infrastructure error during {operation}{target}: "
+                f"{reason}. Retry paths: {cleanup_paths}. "
+                f"Confirmed removed this attempt: {confirmed}."
+            )
+
+        async def remove(path: str, label: str, removed: list[str]) -> None:
+            try:
+                result = await runtime.run(["rm", "-rf", path], {})
+            except TimeoutError as error:
+                raise infrastructure_error(
+                    f"removal of {label}", path, "timed out", removed
+                ) from error
+            except Exception as error:
+                raise infrastructure_error(
+                    f"removal of {label}", path, f"runtime failed: {error}", removed
+                ) from error
+            if result is None:
+                raise infrastructure_error(
+                    f"removal of {label}",
+                    path,
+                    "runtime returned no authoritative result",
+                    removed,
+                )
+            if getattr(result, "timed_out", False):
+                raise infrastructure_error(
+                    f"removal of {label}", path, "timed out", removed
+                )
+            exit_code = getattr(result, "exit_code", None)
+            if isinstance(exit_code, bool) or not isinstance(exit_code, int):
+                raise infrastructure_error(
+                    f"removal of {label}",
+                    path,
+                    "runtime returned no authoritative exit status",
+                    removed,
+                )
+            if exit_code != 0:
+                stderr = str(getattr(result, "stderr", "")).strip()[-300:]
+                raise infrastructure_error(
+                    f"removal of {label}",
+                    path,
+                    f"exit {exit_code}: {stderr}",
+                    removed,
+                )
+            removed.append(path)
+
         try:
             # Stop this trace's daemon before deleting its state: a live worker
             # would keep writing into a removed directory. `daemon` is in the
             # CLI's REMOVED_COMMAND_NAMES, so the subcommand is plain `stop`.
-            stopped = await runtime.run(
-                [
-                    "sh",
-                    "-c",
-                    # Prepend the bundled Node inside the shell rather than passing
-                    # PATH in env: `docker exec --env PATH=...` REPLACES the image
-                    # PATH, and resolved_env usually has no PATH to fall back on.
-                    (
-                        f'export PATH={shlex.quote(f"{self.node_root()}/bin")}:"$PATH"\n'
-                        f"exec {shlex.quote(self.prime_agent_bin())} stop "
-                        f"--daemon-socket {shlex.quote(socket)}"
-                    ),
-                ],
-                self._run_env(trace, ""),
-            )
-            if stopped.exit_code != 0:
-                # Keep the state directory: a failed stop may leave a live
-                # worker writing to it. Do not turn that failure into silent
-                # data loss by deleting the directory.
-                raise RuntimeError(
-                    "prime-agent: stopping the trace daemon failed "
-                    f"(exit {stopped.exit_code}): {stopped.stderr.strip()[-300:]}"
+            try:
+                stopped = await runtime.run(
+                    [
+                        "sh",
+                        "-c",
+                        # Prepend the bundled Node inside the shell rather than passing
+                        # PATH in env: `docker exec --env PATH=...` REPLACES the image
+                        # PATH, and resolved_env usually has no PATH to fall back on.
+                        (
+                            f'export PATH={shlex.quote(f"{self.node_root()}/bin")}:"$PATH"\n'
+                            f"exec {shlex.quote(self.prime_agent_bin())} stop "
+                            f"--daemon-socket {shlex.quote(socket)}"
+                        ),
+                    ],
+                    self._run_env(trace, ""),
                 )
+            except TimeoutError as error:
+                raise infrastructure_error(
+                    "daemon stop", None, "timed out", []
+                ) from error
+            except Exception as error:
+                raise infrastructure_error(
+                    "daemon stop", None, f"runtime failed: {error}", []
+                ) from error
+            if stopped is None:
+                raise infrastructure_error(
+                    "daemon stop", None, "runtime returned no authoritative result", []
+                )
+            if getattr(stopped, "timed_out", False):
+                raise infrastructure_error("daemon stop", None, "timed out", [])
+            stop_exit_code = getattr(stopped, "exit_code", None)
+            if isinstance(stop_exit_code, bool) or not isinstance(stop_exit_code, int):
+                raise infrastructure_error(
+                    "daemon stop",
+                    None,
+                    "runtime returned no authoritative exit status",
+                    [],
+                )
+            if stop_exit_code != 0:
+                # Keep both directories: a failed stop may leave a live worker
+                # writing to them. Do not turn that failure into silent data loss.
+                stderr = str(getattr(stopped, "stderr", "")).strip()[-300:]
+                raise infrastructure_error(
+                    "daemon stop", None, f"exit {stop_exit_code}: {stderr}", []
+                )
+
+            # Delete the independently addressable temporary socket directory
+            # first, then the state root. Each result is checked before the next
+            # command, so a partial cleanup names exactly what is confirmed gone
+            # and what retry must remove; `rm -rf` makes that retry idempotent.
+            removed: list[str] = []
+            await remove(tmp_dir, "per-trace tmp", removed)
+            await remove(root, "state root", removed)
         except Exception:
-            logger.exception("prime-agent: daemon cleanup failed; retaining %s", root)
+            logger.exception(
+                "prime-agent: cleanup failed; retry paths are %s", cleanup_paths
+            )
             raise
-        else:
-            # Remove only this trace's state and its per-trace socket directory;
-            # never remove the shared install. TMPDIR is created only in _prepare.
-            await runtime.run(["rm", "-rf", root, self.tmp_dir(trace)], {})


### PR DESCRIPTION
## Replacement stack

Node 3/5 in a fresh append-only v0.8 replacement chain rooted at authoritative `main` commit `c2820d3679e6318f9c3d0155c823d6908b4e1faa`.

- **Base branch:** `v080/main-replacement-acp-meta`
- **Head branch:** `v080/main-replacement-harness-lifecycle`
- **Exact head:** `525a3374c54d1632bc23581a29d0e31c4c3b0c39`

## Scope

Exact coherent #2310 lifecycle/model-ID/skills delta: 7 paths; unrelated install newline drift excluded.

The old contributor PR branches remain untouched. This branch was published non-force from a fresh owned repository. Independent Luna semantic review **APPROVED** the full N1→N5 chain and found no structural scope leakage; authoritative-main renderer provenance is retained and `pyproject.toml` / `uv.lock` are unchanged across replacement nodes.

> [!WARNING]
> **TEST BLOCKED — do not merge or mark ready.** Authoritative `c2820d` has a stale `uv.lock` relative to `pyproject.toml`. A disposable `uv sync --locked` correctly refused before tests, without changing repository files. The only previously approved interpreter also cannot import current main because `pydantic_config` is absent. Testing/remediation continues on GitHub; this draft does not claim green.

No live, hosted, Docker, sandbox, model, or paid evaluation was run.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reconcile harness lifecycle with skill validation and robust cleanup in `PrimeAgentHarness`
> - Introduces `Harness.resolved_skills()` in [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2326/files#diff-05e981bb3680a934fbc6865d9dff3b25fc692d0c9970684bf8d41f4aea7ee384) to validate skill folders and raise `ValueError` on duplicate basenames; `install_skills`, `PiHarness.launch`, and `PrimeAgentHarness._prepare` now delegate to this method.
> - `OpenClawHarness.launch` now writes `models.mode='replace'` in [openclaw/harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2326/files#diff-d7278b9055ef0f18d323c2ac3010b475bc2122a03e99b44977384fab44c24362), preventing merges with built-in providers.
> - Rewrites `PrimeAgentHarness.cleanup` in [prime_agent/harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2326/files#diff-20ba08f960d62f6e395d3eb05c3a6b051e309727747f31f1a381d7aa7396323b) to delete per-trace tmp then state root in two separate steps, perform a socket existence check, and raise `SandboxError` (with retry path context) on any socket, daemon stop, or deletion failure.
> - Adds test coverage for harness model ID isolation, skill staging collision detection, and the new cleanup behavior.
> - Risk: `cleanup` now raises `SandboxError` on previously-silent failures (e.g. unknown exit codes, timeouts), changing error propagation for callers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 95cee3a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Prime Agent cleanup behavior and exception types change on rollout teardown; incorrect handling could leave daemon state or mis-attribute failures, though changes are heavily tested.
> 
> **Overview**
> Adds **`Harness.resolved_skills()`** so duplicate skill folder basenames fail before staging or CLI construction; **`install_skills`**, **Pi**, and **Prime Agent** now route skill paths through it.
> 
> **`PrimeAgentHarness.cleanup`** is reworked: socket check and daemon stop still gate deletion, but **per-trace tmp** and **state root** are removed in separate **`rm -rf`** steps with validated runtime results. Failures raise **`SandboxError`** (not **`RuntimeError`**) and include retry paths plus what was already removed. Stop failures block any **`rm`**.
> 
> New hermetic tests cover skill staging, OpenClaw/Pi model-ID intercept config, and Prime Agent cleanup edge cases (partial failure, idempotent retry, indeterminate runtime). OpenClaw/Pi comments clarify why the private **`intercept`** provider and OpenClaw **`models.mode: replace`** stay isolated from built-in catalogs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95cee3a548d3e9b6481e40fce2b483bcd5e2c407. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->