### PR TITLE
[v0.8 replacement 4/5] consume canonical ACP transcripts

### DIFF
--- a/tests/v1/fixtures/acp-correlation-transcripts.json
+++ b/tests/v1/fixtures/acp-correlation-transcripts.json
@@ -1,0 +1,86 @@
+{
+  "schema": "ai.primeintellect.prime-agent/v1",
+  "notes": "Exact JSON rendering of V3 acp_correlation_transcripts fixture; end_turn is deliberately absent because transport stop reasons are never causal.",
+  "cases": {
+    "success": [
+      {
+        "promptTurnId": 1,
+        "eventSequence": 11,
+        "phase": "event",
+        "kind": "progress"
+      },
+      {
+        "promptTurnId": 1,
+        "eventSequence": 12,
+        "phase": "responseBoundary",
+        "outcome": "result"
+      },
+      {
+        "promptTurnId": 1,
+        "eventSequence": 13,
+        "phase": "terminalQuiescence",
+        "outcome": "result",
+        "quiescence": {
+          "outstandingSubagents": 0,
+          "remainingAutonomousContinuations": 0
+        }
+      }
+    ],
+    "error_terminal": [
+      {
+        "promptTurnId": 1,
+        "eventSequence": 21,
+        "phase": "responseBoundary",
+        "outcome": "error"
+      },
+      {
+        "promptTurnId": 1,
+        "eventSequence": 22,
+        "phase": "terminalQuiescence",
+        "outcome": "error",
+        "quiescence": {
+          "outstandingSubagents": 0,
+          "remainingAutonomousContinuations": 0
+        }
+      }
+    ],
+    "error_incomplete": [
+      {
+        "promptTurnId": 1,
+        "eventSequence": 31,
+        "phase": "responseBoundary",
+        "outcome": "error"
+      }
+    ],
+    "cancelled": [],
+    "late_child": [
+      {
+        "promptTurnId": 1,
+        "eventSequence": 41,
+        "phase": "event",
+        "child": {
+          "id": "late",
+          "status": "done"
+        }
+      }
+    ],
+    "global_sequence_turn_two": [
+      {
+        "promptTurnId": 2,
+        "eventSequence": 51,
+        "phase": "responseBoundary",
+        "outcome": "result"
+      },
+      {
+        "promptTurnId": 2,
+        "eventSequence": 52,
+        "phase": "terminalQuiescence",
+        "outcome": "result",
+        "quiescence": {
+          "outstandingSubagents": 0,
+          "remainingAutonomousContinuations": 0
+        }
+      }
+    ]
+  }
+}

--- a/tests/v1/test_acp.py
+++ b/tests/v1/test_acp.py
@@ -1,7 +1,9 @@
 """ACP metadata accumulation preserves ordered, namespaced extension events."""
 
 import asyncio
+import hashlib
 import importlib.util
+import json
 import sys
 import types
 from pathlib import Path
@@ -91,6 +93,85 @@ def test_acp_run_forwards_trace_to_the_recording_path() -> None:
     assert "trace=trace" in source, (
         "ACP.run accepts trace but never forwards it to _run"
     )
+
+
+CANONICAL_TRANSCRIPT = (
+    Path(__file__).parent / "fixtures" / "acp-correlation-transcripts.json"
+)
+CANONICAL_TRANSCRIPT_SHA256 = (
+    "cacde7827aadf186db2ce1af1ea6f3b6d109504fa94945633bd9c0d96106b882"
+)
+
+
+def canonical_cases() -> dict[str, list[dict]]:
+    raw = CANONICAL_TRANSCRIPT.read_bytes()
+    assert hashlib.sha256(raw).hexdigest() == CANONICAL_TRANSCRIPT_SHA256
+    document = json.loads(raw)
+    assert document["schema"] == "ai.primeintellect.prime-agent/v1"
+    return document["cases"]
+
+
+def test_canonical_p2_fixture_is_exact_bytes_and_all_cases() -> None:
+    cases = canonical_cases()
+    assert set(cases) == {
+        "success",
+        "error_terminal",
+        "error_incomplete",
+        "cancelled",
+        "late_child",
+        "global_sequence_turn_two",
+    }
+
+
+def test_canonical_cases_preserve_reviewed_named_transcripts() -> None:
+    cases = canonical_cases()
+
+    success = cases["success"]
+    assert [event["phase"] for event in success] == [
+        "event",
+        "responseBoundary",
+        "terminalQuiescence",
+    ]
+    assert success[-1]["outcome"] == "result"
+    assert success[-1]["quiescence"] == {
+        "outstandingSubagents": 0,
+        "remainingAutonomousContinuations": 0,
+    }
+
+    error_terminal = cases["error_terminal"]
+    assert [event["phase"] for event in error_terminal] == [
+        "responseBoundary",
+        "terminalQuiescence",
+    ]
+    assert [event["outcome"] for event in error_terminal] == ["error", "error"]
+
+    error_incomplete = cases["error_incomplete"]
+    assert error_incomplete == [
+        {
+            "promptTurnId": 1,
+            "eventSequence": 31,
+            "phase": "responseBoundary",
+            "outcome": "error",
+        }
+    ]
+
+    assert cases["cancelled"] == []
+    assert cases["late_child"] == [
+        {
+            "promptTurnId": 1,
+            "eventSequence": 41,
+            "phase": "event",
+            "child": {"id": "late", "status": "done"},
+        }
+    ]
+
+    global_sequence_turn_two = cases["global_sequence_turn_two"]
+    assert [event["promptTurnId"] for event in global_sequence_turn_two] == [2, 2]
+    assert [event["eventSequence"] for event in global_sequence_turn_two] == [51, 52]
+    assert [event["phase"] for event in global_sequence_turn_two] == [
+        "responseBoundary",
+        "terminalQuiescence",
+    ]
 
 
 def load_runner_without_acp_dependency(monkeypatch: pytest.MonkeyPatch):
@@ -234,3 +315,53 @@ async def test_prompt_starts_metadata_collection_at_the_prompt_boundary(monkeypa
 
     assert reply == "reply"
     assert client.turn_acp_meta == {"ns": [{"from_prompt": True}]}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("case", "terminal_events"),
+    [
+        (
+            "success",
+            [("responseBoundary", "result"), ("terminalQuiescence", "result")],
+        ),
+        (
+            "error_terminal",
+            [("responseBoundary", "error"), ("terminalQuiescence", "error")],
+        ),
+        ("error_incomplete", [("responseBoundary", "error")]),
+        ("cancelled", []),
+        ("late_child", []),
+        (
+            "global_sequence_turn_two",
+            [("responseBoundary", "result"), ("terminalQuiescence", "result")],
+        ),
+    ],
+)
+async def test_canonical_cases_reach_runner_metadata_storage(
+    monkeypatch, case, terminal_events
+):
+    """Named fixture cases exercise the runner's real metadata update path.
+
+    The runner receives each transcript as ACP SessionInfoUpdate events, rather
+    than the test only inspecting the parsed fixture. This maps every named case
+    to the stored response-boundary/terminal evidence, including the incomplete
+    error's boundary-only state and the cases with no terminal evidence.
+    """
+    runner = load_runner_without_acp_dependency(monkeypatch)
+    client = runner.VerifiersACPClient()
+    namespace = "ai.primeintellect.prime-agent"
+    transcript = canonical_cases()[case]
+
+    for event in transcript:
+        update = runner.SessionInfoUpdate()
+        update.field_meta = {namespace: event}
+        await client.session_update("session", update)
+
+    assert client.acp_meta.get(namespace, []) == transcript
+    assert client.turn_acp_meta.get(namespace, []) == transcript
+    assert [
+        (event["phase"], event["outcome"])
+        for event in client.turn_acp_meta.get(namespace, [])
+        if event.get("phase") in {"responseBoundary", "terminalQuiescence"}
+    ] == terminal_events


### PR DESCRIPTION
## Replacement stack

Node 4/5 in a fresh append-only v0.8 replacement chain rooted at authoritative `main` commit `c2820d3679e6318f9c3d0155c823d6908b4e1faa`.

- **Base branch:** `v080/main-replacement-harness-lifecycle`
- **Head branch:** `v080/main-replacement-canonical-transcripts`
- **Exact head:** `8edc72bcba53a277d1742b46b2ffe8ac625f1903`

## Scope

Exact coherent #2320 canonical transcript delta: two test paths; fixture SHA pinned.

The old contributor PR branches remain untouched. This branch was published non-force from a fresh owned repository. Independent Luna semantic review **APPROVED** the full N1→N5 chain and found no structural scope leakage; authoritative-main renderer provenance is retained and `pyproject.toml` / `uv.lock` are unchanged across replacement nodes.

> [!WARNING]
> **TEST BLOCKED — do not merge or mark ready.** Authoritative `c2820d` has a stale `uv.lock` relative to `pyproject.toml`. A disposable `uv sync --locked` correctly refused before tests, without changing repository files. The only previously approved interpreter also cannot import current main because `pydantic_config` is absent. Testing/remediation continues on GitHub; this draft does not claim green.

No live, hosted, Docker, sandbox, model, or paid evaluation was run.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add canonical ACP transcript fixture and tests for runner metadata storage
> - Adds a canonical ACP correlation transcript fixture ([acp-correlation-transcripts.json](https://github.com/PrimeIntellect-ai/verifiers/pull/2327/files#diff-46145be5f42fdedf0bbf9df12ba3d72c839196f7833fdbbacc75c8365d5a4bbf)) with six named cases: `success`, `error_terminal`, `error_incomplete`, `cancelled`, `late_child`, and `global_sequence_turn_two`.
> - Adds tests in [test_acp.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2327/files#diff-fc095c3e17c7efbbbcd9e3dd169acdd994642458c182f8cbcfb44999ed626c24) that enforce exact fixture bytes via SHA-256 digest, validate event ordering and fields per case, and verify that events sent to the runner's `VerifiersACPClient` are stored correctly in `acp_meta` and `turn_acp_meta`.
> - The fixture integrity check uses a hardcoded SHA-256 digest, so any change to the fixture file will fail the test until the digest constant is updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 091948c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production or runtime behavior modifications.
> 
> **Overview**
> Adds **canonical ACP correlation transcript** coverage for the `ai.primeintellect.prime-agent/v1` schema: a new fixture `tests/v1/fixtures/acp-correlation-transcripts.json` with six named cases (`success`, `error_terminal`, `error_incomplete`, `cancelled`, `late_child`, `global_sequence_turn_two`), including notes that `end_turn` is intentionally omitted.
> 
> **`tests/v1/test_acp.py`** loads that fixture with a **pinned SHA-256** on the raw bytes, asserts the full case set and per-case phase/outcome/quiescence shapes, and adds a parametrized async test that replays each transcript through `VerifiersACPClient.session_update` (via the stub-loaded runner) and checks `acp_meta` / `turn_acp_meta` match the fixture, with expected `responseBoundary` / `terminalQuiescence` terminal evidence per case (including empty terminal lists for `cancelled` and `late_child`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 091948c64be4d1c9775169495ead1393c4d9527f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->