### PR TITLE
fix: compact harness runs without a container

### DIFF
--- a/environments/compact/compact/harness.py
+++ b/environments/compact/compact/harness.py
@@ -25,6 +25,8 @@ class CompactingHarnessConfig(HarnessConfig):
 
 class CompactingHarness(Harness[CompactingHarnessConfig]):
     SUPPORTS_MCP = True
+    EXECUTES_CODE = False
+    NEEDS_CONTAINER = False
 
     async def setup(self, runtime: Runtime) -> None:
         await runtime.prepare_uv_script(PROGRAM_SOURCE, self.config.env)


### PR DESCRIPTION
## Summary

- `CompactingHarness` inherited `NEEDS_CONTAINER = True` from the `Harness` base, so subprocess-runtime runs were rejected at compile time.
- The compact program is a chat loop like `null`'s: it talks to the model API and the MCP tool servers over HTTP only. It has no filesystem tools and no model-directed local execution.
- Set `EXECUTES_CODE = False` and `NEEDS_CONTAINER = False` on `CompactingHarness`, matching the `null` harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix compact harness to run without a container
> Sets `EXECUTES_CODE = False` and `NEEDS_CONTAINER = False` on `CompactingHarness` in [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2329/files#diff-8de861ba57dd4d2ef672fe67eff870e714ac76dffe9799f1070b3d746b2d6a8a). The `launch` method now prepares a uv script via `runtime.prepare_uv_script` and executes it with `runtime.run_program`, returning the resulting `ProgramResult`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ffb12c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two capability flags on a non-critical harness; no auth, data, or runtime behavior changes beyond allowing subprocess runs.
> 
> **Overview**
> Allows `CompactingHarness` to run under the subprocess runtime by setting `EXECUTES_CODE = False` and `NEEDS_CONTAINER = False`, matching the `null` harness.
> 
> Previously it inherited the base `Harness` defaults (`True` for both), so container-free runs were rejected even though the compact program is an HTTP-only chat loop with no local code execution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ffb12c282a50550e0824c498431d076ee56271c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->