### PR TITLE
feat(compact): drop the forced summarize tool_choice after tool results

### DIFF
--- a/environments/compact/compact/program.py
+++ b/environments/compact/compact/program.py
@@ -6,10 +6,10 @@
 
 Each turn sends a fresh `[system, user]` — the task on the first turn, then only the
 notes the model saved via the `summarize` tool. Per turn: at most one task tool call,
-its result shown in-context, then a forced `summarize`; a plain-text reply finishes the
-run and is printed as the answer; a disallowed call ends the rollout with no answer
-(training signal). Model calls go to the interception server (OPENAI_BASE_URL/API_KEY);
-MCP servers are reached over streamable HTTP.
+its result shown in-context, then a `summarize` call to save notes; a plain-text reply
+finishes the run and is printed as the answer; a disallowed call ends the rollout with
+no answer (training signal). Model calls go to the interception server
+(OPENAI_BASE_URL/API_KEY); MCP servers are reached over streamable HTTP.
 """
 
 import asyncio
@@ -57,14 +57,12 @@ SUMMARIZE = {
 client = AsyncOpenAI()
 
 
-async def chat(
-    messages: list[dict], tools: list[dict], tool_choice: dict | None = None
-):
+async def chat(messages: list[dict], tools: list[dict]):
     completion = await client.chat.completions.create(
         model=os.environ["OPENAI_MODEL"],
         messages=messages,
         tools=tools or None,
-        tool_choice=tool_choice or "auto" if tools else None,
+        tool_choice="auto" if tools else None,
     )
     return completion.choices[0].message
 
@@ -148,13 +146,9 @@ async def main() -> None:
             messages.append(
                 {"role": "tool", "tool_call_id": call.id, "content": result}
             )
-            # After a tool result, `summarize` is forced via tool_choice — saving
-            # notes is the only action left in the turn.
-            message = await chat(
-                messages,
-                [SUMMARIZE],
-                {"type": "function", "function": {"name": "summarize"}},
-            )
+            # After a tool result, only `summarize` is advertised; the model must
+            # choose it itself — any other call ends the rollout.
+            message = await chat(messages, [SUMMARIZE])
             if not message.tool_calls:
                 print(message.content or "")  # finishing right after a result is fine
                 return


### PR DESCRIPTION
## Summary

- Drop the forced `tool_choice={"function": {"name": "summarize"}}` on the compact harness's post-tool-result model call — `summarize` stays the only advertised tool there and the system prompt still requires saving notes, but the model now has to choose the call itself
- A non-`summarize` call after a tool result still ends the rollout with no answer, so protocol violations become an observable (and trainable) negative signal instead of being mechanically prevented
- Simplify `chat()` accordingly (the `tool_choice` parameter had no other caller)

## Verification

16-task wikispeedia eval (eval split, Qwen/Qwen3-4B on a local vLLM), this branch vs the forced protocol:

- **Unforced (this PR): 0/16 solved.** 15/16 rollouts end at their first tool result by emitting another task tool call (`wiki_click_link` ×11 + one more later, `wiki_go_back` ×3) instead of `summarize` — even with only `summarize` advertised, the server-side parser extracts the call and the protocol ends the rollout. Exactly one rollout followed the click→summarize loop unforced (7 turns) and then answered wrong. Trace dashboard: https://app.primeintellect.ai/dashboard/evaluations/wk9qajkt4afdnsx95enhgqoo
- **Forced (main), same task split, concurrent 500-task run:** ~38% solve rate over the first 61 rollouts.

This reproduces the GLM-5.2 finding that motivated the forcing (advertising `summarize` alone is not enough). As-is, the unforced protocol yields no successful rollouts for Qwen3-4B — fine as a hard negative training signal, unusable for evals. If we want this behavior switchable, a `force_summarize: bool = True` knob on `CompactingHarnessConfig` is probably the better shape than removing the forcing outright.

## Breaking

- Compact-harness rollouts where the model replies to a tool result with anything other than a `summarize` call (or a plain-text finish) now end without an answer instead of being steered into `summarize`. Weaker instruction-followers will score lower under this harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
