### PR TITLE
fix: keep host paths out of shared /tmp

### DIFF
--- a/verifiers/v1/harnesses/openclaw/harness.py
+++ b/verifiers/v1/harnesses/openclaw/harness.py
@@ -8,7 +8,6 @@ import secrets
 import shlex
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from pathlib import Path
 
 from pydantic import Field
 
@@ -19,6 +18,7 @@ from verifiers.v1.harness import Harness
 from verifiers.v1.runtimes import DockerRuntime, ProgramResult, Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
+from verifiers.v1.utils.paths import CACHE_DIR
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +40,9 @@ async def _gateway_start_lock(runtime: Runtime) -> AsyncIterator[None]:
         yield
         return
     # Unrestricted Docker containers share the host network across server workers.
-    with Path("/tmp/vf-openclaw-gateway.lock").open("a") as lock:  # noqa: ASYNC230
+    lock_path = CACHE_DIR / "openclaw-gateway.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a") as lock:
         while True:
             try:
                 fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)

--- a/verifiers/v1/harnesses/openclaw/harness.py
+++ b/verifiers/v1/harnesses/openclaw/harness.py
@@ -40,7 +40,7 @@ async def _gateway_start_lock(runtime: Runtime) -> AsyncIterator[None]:
         yield
         return
     # Unrestricted Docker containers share the host network across server workers.
-    lock_path = CACHE_DIR / "openclaw-gateway.lock"
+    lock_path = CACHE_DIR / "harnesses" / "openclaw" / "gateway.lock"
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     with lock_path.open("a") as lock:
         while True:

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -20,8 +20,13 @@ from pydantic_config import BaseConfig
 
 from verifiers.v1.errors import SandboxError
 from verifiers.v1.utils.aio import run_shielded
+from verifiers.v1.utils.paths import CACHE_DIR
 
 logger = logging.getLogger(__name__)
+
+# Digest-keyed cache of prepared PEP 723 scripts. Every runtime's `write` creates parent
+# directories, so the path also works inside containers and sandboxes.
+SCRIPTS_DIR = str(CACHE_DIR / "runtimes" / "scripts")
 
 # Ensure the latest `uv` is available for our PEP 723 scripts: prefer pip on Python images,
 # then fall back to the standalone installer (curl/wget), installing curl + CA certs when a
@@ -176,12 +181,6 @@ class Runtime(ABC):
     subprocess and Docker (directly or through Docker's policy proxy); remote runtimes
     override to False and use a host `Tunnel` inward plus `expose` outward."""
 
-    scripts_dir: ClassVar[str] = "/tmp/vf-scripts"
-    """In-runtime directory caching prepared uv scripts, keyed by content digest.
-    Containers and sandboxes own their /tmp; runtimes that share the host filesystem
-    override with a user-scoped path — a fixed /tmp name collides across users on a
-    shared machine."""
-
     info: BaseRuntimeInfo
 
     @property
@@ -283,7 +282,7 @@ class Runtime(ABC):
         """
         data = script.encode() if isinstance(script, str) else script
         digest = hashlib.sha256(data).hexdigest()
-        path = f"{self.scripts_dir}/{digest}.py"
+        path = f"{SCRIPTS_DIR}/{digest}.py"
         if digest not in self._uv_interpreters:
             async with self._uv_script_locks.setdefault(digest, asyncio.Lock()):
                 if digest not in self._uv_interpreters:

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -176,6 +176,12 @@ class Runtime(ABC):
     subprocess and Docker (directly or through Docker's policy proxy); remote runtimes
     override to False and use a host `Tunnel` inward plus `expose` outward."""
 
+    scripts_dir: ClassVar[str] = "/tmp/vf-scripts"
+    """In-runtime directory caching prepared uv scripts, keyed by content digest.
+    Containers and sandboxes own their /tmp; runtimes that share the host filesystem
+    override with a user-scoped path — a fixed /tmp name collides across users on a
+    shared machine."""
+
     info: BaseRuntimeInfo
 
     @property
@@ -277,7 +283,7 @@ class Runtime(ABC):
         """
         data = script.encode() if isinstance(script, str) else script
         digest = hashlib.sha256(data).hexdigest()
-        path = f"/tmp/vf-scripts/{digest}.py"
+        path = f"{self.scripts_dir}/{digest}.py"
         if digest not in self._uv_interpreters:
             async with self._uv_script_locks.setdefault(digest, asyncio.Lock()):
                 if digest not in self._uv_interpreters:

--- a/verifiers/v1/runtimes/subprocess.py
+++ b/verifiers/v1/runtimes/subprocess.py
@@ -76,10 +76,6 @@ class SubprocessProcess(RuntimeProcess):
 
 
 class SubprocessRuntime(Runtime):
-    # Host paths live under the user cache, not /tmp: fixed /tmp names collide
-    # across users on a shared machine.
-    scripts_dir: ClassVar[str] = str(CACHE_DIR / "scripts")
-
     # Share prepared script environments across the worker's per-rollout runtimes.
     _interpreters: ClassVar[dict[str, str]] = {}
     _locks: ClassVar[dict[str, asyncio.Lock]] = {}
@@ -94,7 +90,7 @@ class SubprocessRuntime(Runtime):
         self._background: list[asyncio.subprocess.Process] = []
 
     async def start(self) -> None:
-        self.workdir = CACHE_DIR / "workdirs" / self.name
+        self.workdir = CACHE_DIR / "runtimes" / "subprocess" / self.name
         self.workdir.mkdir(parents=True)
         self.info.id = str(self.workdir)
 

--- a/verifiers/v1/runtimes/subprocess.py
+++ b/verifiers/v1/runtimes/subprocess.py
@@ -17,6 +17,7 @@ from verifiers.v1.runtimes.base import (
     Runtime,
     RuntimeProcess,
 )
+from verifiers.v1.utils.paths import CACHE_DIR
 
 _BACKGROUND_STOP_TIMEOUT = 5
 
@@ -75,6 +76,10 @@ class SubprocessProcess(RuntimeProcess):
 
 
 class SubprocessRuntime(Runtime):
+    # Host paths live under the user cache, not /tmp: fixed /tmp names collide
+    # across users on a shared machine.
+    scripts_dir: ClassVar[str] = str(CACHE_DIR / "scripts")
+
     # Share prepared script environments across the worker's per-rollout runtimes.
     _interpreters: ClassVar[dict[str, str]] = {}
     _locks: ClassVar[dict[str, asyncio.Lock]] = {}
@@ -89,8 +94,8 @@ class SubprocessRuntime(Runtime):
         self._background: list[asyncio.subprocess.Process] = []
 
     async def start(self) -> None:
-        self.workdir = Path("/tmp") / self.name
-        self.workdir.mkdir()
+        self.workdir = CACHE_DIR / "workdirs" / self.name
+        self.workdir.mkdir(parents=True)
         self.info.id = str(self.workdir)
 
     async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:

--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -37,6 +37,7 @@ import zmq.asyncio
 from verifiers.v1.configs.env import EnvConfig
 from verifiers.v1.serve.server import EnvServer
 from verifiers.v1.serve.types import HealthResponse
+from verifiers.v1.utils.paths import CACHE_DIR
 
 logger = logging.getLogger(__name__)
 
@@ -105,10 +106,12 @@ class EnvServerPool:
         self.address = self.frontend.getsockopt_string(zmq.LAST_ENDPOINT)
 
     def _worker_path(self, i: int) -> str:
-        return f"/tmp/vf-pool-{self.session}-{i}"
+        # Under the user cache, not /tmp: /tmp is shared across users on a cluster.
+        return str(CACHE_DIR / "ipc" / f"pool-{self.session}-{i}")
 
     def _spawn_worker(self) -> None:
         i = len(self.workers)  # upscale-only, so the next index is the current count
+        os.makedirs(CACHE_DIR / "ipc", exist_ok=True)
         address = f"ipc://{self._worker_path(i)}"
         parent_conn, child_conn = self._mpctx.Pipe()
         proc = self._mpctx.Process(

--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -90,8 +90,6 @@ class EnvServerPool:
         self.multiplex = multiplex
         self.elastic = elastic
         self.log_setup = log_setup
-        # A private (0700) directory keeps the socket paths short — Unix socket
-        # paths cap at ~107 bytes, so they cannot live under a home-based dir.
         self._ipc_dir = tempfile.mkdtemp(prefix="vf-pool-")
         self.workers: list[dict] = []
         self._mpctx = mp.get_context("spawn")

--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -26,8 +26,8 @@ import logging
 import multiprocessing as mp
 import os
 import signal
+import tempfile
 import threading
-import uuid
 from collections.abc import Callable
 
 import msgpack
@@ -37,7 +37,6 @@ import zmq.asyncio
 from verifiers.v1.configs.env import EnvConfig
 from verifiers.v1.serve.server import EnvServer
 from verifiers.v1.serve.types import HealthResponse
-from verifiers.v1.utils.paths import CACHE_DIR
 
 logger = logging.getLogger(__name__)
 
@@ -91,7 +90,9 @@ class EnvServerPool:
         self.multiplex = multiplex
         self.elastic = elastic
         self.log_setup = log_setup
-        self.session = uuid.uuid4().hex[:12]
+        # A private (0700) directory keeps the socket paths short — Unix socket
+        # paths cap at ~107 bytes, so they cannot live under a home-based dir.
+        self._ipc_dir = tempfile.mkdtemp(prefix="vf-pool-")
         self.workers: list[dict] = []
         self._mpctx = mp.get_context("spawn")
         self._poller: zmq.asyncio.Poller | None = None
@@ -106,12 +107,10 @@ class EnvServerPool:
         self.address = self.frontend.getsockopt_string(zmq.LAST_ENDPOINT)
 
     def _worker_path(self, i: int) -> str:
-        # Under the user cache, not /tmp: /tmp is shared across users on a cluster.
-        return str(CACHE_DIR / "ipc" / f"pool-{self.session}-{i}")
+        return f"{self._ipc_dir}/{i}"
 
     def _spawn_worker(self) -> None:
         i = len(self.workers)  # upscale-only, so the next index is the current count
-        os.makedirs(CACHE_DIR / "ipc", exist_ok=True)
         address = f"ipc://{self._worker_path(i)}"
         parent_conn, child_conn = self._mpctx.Pipe()
         proc = self._mpctx.Process(
@@ -244,6 +243,8 @@ class EnvServerPool:
                 w["dealer"].close()
             with contextlib.suppress(OSError):
                 os.unlink(self._worker_path(w["index"]))
+        with contextlib.suppress(OSError):
+            os.rmdir(self._ipc_dir)
         self.frontend.close()
         self.ctx.term()
         logger.info("EnvServerPool down")


### PR DESCRIPTION
## Summary

On a shared cluster `/tmp` is common to all users, so fixed-name paths collide across users. Concretely: `prepare_uv_script` hardcoded `/tmp/vf-scripts/{digest}.py`, and once one user owns that directory, every other user on the box fails to prepare scripts. This PR moves host-side fixed-name paths under the per-user verifiers cache (`~/.cache/verifiers`, already used by the creation-rate limiters), each module in its own subtree:

- **Prepared uv scripts** (all runtimes): `~/.cache/verifiers/runtimes/scripts/{digest}.py`, a single module-level `SCRIPTS_DIR`. Every runtime's `write` creates parent directories, so the same path works inside containers and sandboxes.
- **Subprocess runtime workdirs**: `/tmp/{name}` → `~/.cache/verifiers/runtimes/subprocess/{name}`.
- **OpenClaw gateway start lock**: `/tmp/vf-openclaw-gateway.lock` → `~/.cache/verifiers/harnesses/openclaw/gateway.lock`. The old fixed name was also broken cross-user: a second user cannot open another user's lock file for append. (The `noqa: ASYNC230` is dropped because ruff no longer detects the sync open through a variable and flags the directive as unused via RUF100.)
- **Env-pool IPC sockets**: `/tmp/vf-pool-{session}-{i}` → `{mkdtemp}/{i}`. Unix socket paths cap at ~107 bytes, so they cannot live under a home-based cache path; a per-pool `mkdtemp` directory keeps them short while staying private (0700) and user-owned on a shared `/tmp`. The pool removes the directory on shutdown.

Left alone, deliberately:

- Paths inside containers/sandboxes (harness install dirs, artifact tars, docker pidfiles, lean/harbor taskset paths) — each rollout owns its `/tmp`.
- uuid-unique host files directly in `/tmp` (MCP port files, debug scripts) — unique names cannot collide across users, and the sticky bit permits creation.
- `verifiers/legacy/`.

## Verification

On a box where `/tmp/vf-scripts` exists with a fixed owner, `prepare_uv_script` on the subprocess runtime previously failed with a permission error on `mv`. After this change, a smoke run (`SubprocessRuntime.start` → `prepare_uv_script` → run) succeeds and places the script at `~/.cache/verifiers/runtimes/scripts/{digest}.py` with the workdir at `~/.cache/verifiers/runtimes/subprocess/{name}`. `ruff check` / `ruff format --check` (pinned 0.16.0) pass on the touched files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Path relocation only; behavior is unchanged aside from avoiding shared-/tmp ownership issues. Pool IPC cleanup adds rmdir on shutdown.
> 
> **Overview**
> Fixes cross-user collisions on shared clusters where fixed paths under `/tmp` caused permission failures (e.g. another user owning `/tmp/vf-scripts`).
> 
> **Prepared uv scripts** now use `~/.cache/verifiers/runtimes/scripts/{digest}.py` via a shared `SCRIPTS_DIR` in `base.py` instead of `/tmp/vf-scripts/`. **Subprocess runtime workdirs** move from `/tmp/{name}` to `~/.cache/verifiers/runtimes/subprocess/{name}` with `parents=True` on mkdir.
> 
> **OpenClaw gateway start lock** is relocated from `/tmp/vf-openclaw-gateway.lock` to `~/.cache/verifiers/harnesses/openclaw/gateway.lock`, with parent dirs created before open.
> 
> **Env server pool IPC** drops the uuid session prefix under `/tmp` in favor of a per-pool `tempfile.mkdtemp(prefix="vf-pool-")` directory; worker socket paths are `{ipc_dir}/{i}` and the directory is removed on shutdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 043a2b1eb872afc16e13ab78cbf99adc7c3cc713. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move runtime and IPC paths out of shared /tmp into cache directory hierarchy
> - PEP 723 prepared scripts are written to `SCRIPTS_DIR` (`CACHE_DIR/runtimes/scripts/{digest}.py`) instead of `/tmp/vf-scripts/`
> - Subprocess runtime working directories are created under `CACHE_DIR/runtimes/subprocess/{runtime_name}` instead of `/tmp`
> - The gateway start lock in the openclaw harness moves to `CACHE_DIR/harnesses/openclaw/gateway.lock`, with parent dirs created before locking
> - Each `EnvServerPool` now gets a unique temp IPC directory via `tempfile.mkdtemp(prefix="vf-pool-")` and cleans it up on shutdown, replacing the `/tmp/vf-pool-{uuid}-{i}` socket pattern
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 043a2b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->