### PR TITLE
chore(deps): reconcile authoritative main lock

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 4
+revision = 3
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'win32'",
@@ -167,6 +167,12 @@ name = "alphabet-sort"
 version = "0.1.0"
 source = { editable = "environments/alphabet_sort" }
 dependencies = [
+    { name = "datasets" },
+    { name = "verifiers" },
+]
+
+[package.metadata]
+requires-dist = [
     { name = "datasets" },
     { name = "verifiers" },
 ]
@@ -720,12 +726,21 @@ dependencies = [
     { name = "verifiers" },
 ]
 
+[package.metadata]
+requires-dist = [{ name = "verifiers" }]
+
 [[package]]
 name = "color-codeword"
 version = "0.1.0"
 source = { editable = "environments/color_codeword" }
 dependencies = [
     { name = "pillow" },
+    { name = "verifiers" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pillow", specifier = ">=11.0.0" },
     { name = "verifiers" },
 ]
 
@@ -745,6 +760,9 @@ source = { editable = "environments/compact" }
 dependencies = [
     { name = "verifiers" },
 ]
+
+[package.metadata]
+requires-dist = [{ name = "verifiers" }]
 
 [[package]]
 name = "connect-python"
@@ -1037,6 +1055,9 @@ source = { editable = "environments/deepwiki" }
 dependencies = [
     { name = "verifiers" },
 ]
+
+[package.metadata]
+requires-dist = [{ name = "verifiers" }]
 
 [[package]]
 name = "defusedxml"
@@ -1441,6 +1462,9 @@ dependencies = [
     { name = "verifiers" },
 ]
 
+[package.metadata]
+requires-dist = [{ name = "verifiers" }]
+
 [[package]]
 name = "googleapis-common-protos"
 version = "1.75.0"
@@ -1597,6 +1621,9 @@ source = { editable = "environments/gsm8k" }
 dependencies = [
     { name = "datasets" },
 ]
+
+[package.metadata]
+requires-dist = [{ name = "datasets" }]
 
 [[package]]
 name = "h11"
@@ -2179,6 +2206,9 @@ source = { editable = "environments/kuhn_poker" }
 dependencies = [
     { name = "verifiers" },
 ]
+
+[package.metadata]
+requires-dist = [{ name = "verifiers" }]
 
 [[package]]
 name = "latex2sympy2-extended"
@@ -2973,6 +3003,9 @@ dependencies = [
     { name = "verifiers", extra = ["openenv"] },
 ]
 
+[package.metadata]
+requires-dist = [{ name = "verifiers", extras = ["openenv"] }]
+
 [[package]]
 name = "opentelemetry-api"
 version = "1.43.0"
@@ -3412,6 +3445,9 @@ source = { editable = "environments/proposer_solver" }
 dependencies = [
     { name = "verifiers" },
 ]
+
+[package.metadata]
+requires-dist = [{ name = "verifiers" }]
 
 [[package]]
 name = "protobuf"
@@ -4256,6 +4292,9 @@ dependencies = [
     { name = "datasets" },
 ]
 
+[package.metadata]
+requires-dist = [{ name = "datasets" }]
+
 [[package]]
 name = "rich"
 version = "15.0.0"
@@ -4428,6 +4467,9 @@ source = { editable = "environments/scratchpad" }
 dependencies = [
     { name = "verifiers" },
 ]
+
+[package.metadata]
+requires-dist = [{ name = "verifiers" }]
 
 [[package]]
 name = "secretstorage"
@@ -5139,6 +5181,80 @@ examples = [
     { name = "wordle" },
 ]
 
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp", specifier = ">=3.9.0" },
+    { name = "aiolimiter", specifier = ">=1.2.1" },
+    { name = "anthropic", specifier = ">=0.78.0" },
+    { name = "datasets", specifier = ">=3.3.0,<6.0.0" },
+    { name = "gepa", specifier = ">=0.0.6" },
+    { name = "harbor", marker = "python_full_version >= '3.12' and extra == 'harbor'", specifier = "==0.20.0" },
+    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "loguru", specifier = ">=0.7.0" },
+    { name = "math-verify", specifier = ">=0.8.0" },
+    { name = "mcp", specifier = ">=1.24.0,<2" },
+    { name = "modal", marker = "extra == 'modal'", specifier = ">=1.4.0" },
+    { name = "msgpack", specifier = ">=1.1.2" },
+    { name = "nemo-gym", marker = "python_full_version >= '3.12' and extra == 'nemo-gym'", specifier = "==0.4.0" },
+    { name = "nest-asyncio", marker = "extra == 'notebook'", specifier = ">=1.6.0" },
+    { name = "nltk", marker = "extra == 'ta'", specifier = ">=3.9.2" },
+    { name = "numpy", specifier = ">=2.1.0" },
+    { name = "openai", specifier = ">=2.9.0" },
+    { name = "openai-agents", specifier = ">=0.8.2" },
+    { name = "openenv", marker = "extra == 'openenv'", specifier = ">=0.4.1" },
+    { name = "prime-pydantic-config", extras = ["toml"], specifier = ">=0.4.2" },
+    { name = "prime-sandboxes", specifier = ">=0.2.35" },
+    { name = "prime-tunnel", specifier = ">=0.1.8" },
+    { name = "pydantic", specifier = ">=2.12.3" },
+    { name = "python-dotenv", marker = "extra == 'browser'", specifier = ">=1.0.0" },
+    { name = "pyzmq", specifier = ">=27.1.0" },
+    { name = "reasoning-gym", marker = "extra == 'rg'", specifier = ">=0.1.8" },
+    { name = "renderers", specifier = ">=0.1.9" },
+    { name = "requests" },
+    { name = "rich", specifier = ">=11.0.0" },
+    { name = "setproctitle", specifier = ">=1.3.0" },
+    { name = "stagehand", marker = "extra == 'browser'", specifier = ">=3.4.0" },
+    { name = "tenacity", specifier = ">=8.5.0" },
+    { name = "textarena", marker = "extra == 'ta'", specifier = "==0.7.4" },
+    { name = "tomli-w", specifier = ">=1.0.0" },
+    { name = "typing-extensions", specifier = ">=4.12.2" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'", specifier = ">=0.21.0" },
+]
+provides-extras = ["browser", "harbor", "modal", "nemo-gym", "notebook", "openenv", "rg", "ta"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "nest-asyncio", specifier = ">=1.6.0" },
+    { name = "nltk", specifier = ">=3.9.2" },
+    { name = "pre-commit", specifier = ">=2.19.0" },
+    { name = "pytest", specifier = ">=7.0.0,<9.1.0" },
+    { name = "pytest-asyncio", specifier = ">=0.21.0" },
+    { name = "pytest-cov", specifier = ">=4.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "reasoning-gym", specifier = ">=0.1.8" },
+    { name = "ruff", specifier = ">=0.16.0" },
+    { name = "stagehand", specifier = ">=3.4.0" },
+    { name = "textarena", specifier = "==0.7.4" },
+    { name = "ty", specifier = ">=0.0.63" },
+]
+examples = [
+    { name = "alphabet-sort", editable = "environments/alphabet_sort" },
+    { name = "code-golf", editable = "environments/code_golf" },
+    { name = "color-codeword", editable = "environments/color_codeword" },
+    { name = "compact", editable = "environments/compact" },
+    { name = "deepwiki", editable = "environments/deepwiki" },
+    { name = "glossary", editable = "environments/glossary" },
+    { name = "gsm8k", editable = "environments/gsm8k" },
+    { name = "kuhn-poker", editable = "environments/kuhn_poker" },
+    { name = "openenv-wordle", editable = "environments/openenv_wordle" },
+    { name = "proposer-solver", editable = "environments/proposer_solver" },
+    { name = "reverse-text", editable = "environments/reverse_text" },
+    { name = "scratchpad", editable = "environments/scratchpad" },
+    { name = "wiki-search", editable = "environments/wiki_search" },
+    { name = "wordle", editable = "environments/wordle" },
+]
+
 [[package]]
 name = "virtualenv"
 version = "21.6.1"
@@ -5311,6 +5427,13 @@ dependencies = [
     { name = "verifiers" },
 ]
 
+[package.metadata]
+requires-dist = [
+    { name = "chromadb", specifier = ">=0.4.13" },
+    { name = "datasets" },
+    { name = "verifiers" },
+]
+
 [[package]]
 name = "win32-setctime"
 version = "1.2.0"
@@ -5327,6 +5450,9 @@ source = { editable = "environments/wordle" }
 dependencies = [
     { name = "verifiers", extra = ["ta"] },
 ]
+
+[package.metadata]
+requires-dist = [{ name = "verifiers", extras = ["ta"] }]
 
 [[package]]
 name = "xxhash"


### PR DESCRIPTION
## Replacement remediation

Append-only child of #2328, based on exact replacement N5 `10608006dd5f996c884249ee4fe5f4399401c8b9`.

This is the narrow authoritative-main lock reconciliation required because `uv sync --locked` refused c2820's stale `uv.lock` relative to its unchanged `pyproject.toml`.

Scope: **only `uv.lock`** (127 insertions / 1 deletion). `uv lock` resolved the same 269-package set with no additions/removals/version changes; it regenerated lock revision/provenance metadata for editable packages. `pyproject.toml` is unchanged. A disposable `uv sync --locked` subsequently succeeded and the environment/cache was deleted.

No live evaluation and no contributor branch mutation. Draft/HOLD pending replacement-chain tests and review.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reconcile authoritative main lock file
> Updates [uv.lock](https://github.com/PrimeIntellect-ai/verifiers/pull/2332/files#diff-84321598744d84dbee2318e634c74c9aae39a1c253f1c4bd17ebf9ef2f807b11) to reflect the latest resolved dependency versions for the main branch.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 66d4bf3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only metadata reconciliation with no reported package additions, removals, or version bumps.
> 
> **Overview**
> **Regenerates `uv.lock` so it matches the current workspace without changing resolved package versions.** The stale lock was blocking `uv sync --locked` even though `pyproject.toml` was unchanged.
> 
> The diff mainly adds **`[package.metadata]`** blocks (with `requires-dist`, and for the root **`verifiers`** package also `provides-extras`, `requires-dev`, and `examples`) for editable environment packages and the main project. Lock **revision** moves from 4 to 3 as part of that regeneration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66d4bf38bf09ae308c51a4a73853db6556cb6f2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->