### PR TITLE
test(v1): add taskset-only Oolong Prime Agent smoke adapter

### DIFF
--- a/configs/oolong_synth_v1_luna_n1.toml
+++ b/configs/oolong_synth_v1_luna_n1.toml
@@ -3,7 +3,7 @@
 #
 # Dry-load only (no sandbox/model is launched):
 #   uv run eval @ configs/oolong_synth_v1_luna_n1.toml --dry-run
-model = "Luna"
+model = "openai/gpt-5.6-luna"
 num_tasks = 1
 num_rollouts = 1
 max_concurrent = 1
@@ -12,26 +12,26 @@ rich = false
 
 [env.taskset]
 id = "oolong-synth-v1"
-context_len = 262144
+context_len = 1024
 
 [env.agent]
 # Explicit agent caps for a long-context, file-scanning task.
-max_turns = 64
-max_input_tokens = 300000
-max_output_tokens = 8192
-max_total_tokens = 400000
+max_turns = 4
+max_input_tokens = 16384
+max_output_tokens = 2048
+max_total_tokens = 20000
 
 [env.agent.harness]
 id = "prime_agent"
-# Execution is intentionally blocked until these release-artifact placeholders are replaced.
-tarball_url = "https://REPLACE-WITH-APPROVED-PRIME-AGENT-ARTIFACT.invalid/prime-agent.tgz"
-tarball_sha256 = "0000000000000000000000000000000000000000000000000000000000000000"
+version = "0.7.1"
+tarball_url = "https://t-1-1916d097074a4b51.tunnel.pinfra.io/prime-agent-0.7.1.tgz"
+tarball_sha256 = "d601e0dd88103cddfe93b7a1da286a1869259b2fb2b7430c0ce5472eaec93cf9"
 
 [env.agent.runtime]
 type = "prime"
 vm = true
 # VM runtime capacity caps; tune only with an approved run plan.
-cpu = 4
-memory = 16
-disk = 32
-idle_timeout = 7200
+cpu = 2
+memory = 4
+disk = 8
+idle_timeout = 1200

--- a/configs/oolong_synth_v1_luna_n1.toml
+++ b/configs/oolong_synth_v1_luna_n1.toml
@@ -1,0 +1,37 @@
+# Oolong synth at the 256K context bucket, one Luna rollout (n=1).
+# The taskset exports only OolongSynthTaskset, so this resolves to SingleAgentEnv.
+#
+# Dry-load only (no sandbox/model is launched):
+#   uv run eval @ configs/oolong_synth_v1_luna_n1.toml --dry-run
+model = "Luna"
+num_tasks = 1
+num_rollouts = 1
+max_concurrent = 1
+push = false
+rich = false
+
+[env.taskset]
+id = "oolong-synth-v1"
+context_len = 262144
+
+[env.agent]
+# Explicit agent caps for a long-context, file-scanning task.
+max_turns = 64
+max_input_tokens = 300000
+max_output_tokens = 8192
+max_total_tokens = 400000
+
+[env.agent.harness]
+id = "prime_agent"
+# Execution is intentionally blocked until these release-artifact placeholders are replaced.
+tarball_url = "https://REPLACE-WITH-APPROVED-PRIME-AGENT-ARTIFACT.invalid/prime-agent.tgz"
+tarball_sha256 = "0000000000000000000000000000000000000000000000000000000000000000"
+
+[env.agent.runtime]
+type = "prime"
+vm = true
+# VM runtime capacity caps; tune only with an approved run plan.
+cpu = 4
+memory = 16
+disk = 32
+idle_timeout = 7200

--- a/configs/oolong_synth_v1_luna_n1.toml
+++ b/configs/oolong_synth_v1_luna_n1.toml
@@ -24,7 +24,7 @@ max_total_tokens = 20000
 [env.agent.harness]
 id = "prime_agent"
 version = "0.7.1"
-tarball_url = "https://t-1-1916d097074a4b51.tunnel.pinfra.io/prime-agent-0.7.1.tgz"
+tarball_url = "https://t-1-8e904716e6479832.tunnel.pinfra.io/prime-agent-0.7.1.tgz"
 tarball_sha256 = "d601e0dd88103cddfe93b7a1da286a1869259b2fb2b7430c0ce5472eaec93cf9"
 
 [env.agent.runtime]

--- a/environments/oolong_synth_v1/README.md
+++ b/environments/oolong_synth_v1/README.md
@@ -1,0 +1,12 @@
+# oolong-synth-v1
+
+Oolong synthetic long-context tasks solved by an agent in a sandbox: each task's long context window is uploaded to a file so the agent can scan it from a REPL and write a single-token answer to `/workspace/answer.txt`. Tasks are scored with the deterministic official Oolong synth rules (exact match, with partial credit for numeric and date answers), or by an optional host-side binary LLM judge when configured.
+
+## Taskset
+
+- **Source:** [oolongbench/oolong-synth](https://huggingface.co/datasets/oolongbench/oolong-synth)
+- **Size:** 1300 tasks (`validation` split), filtered at load time to a single `context_len` token bucket (default 262144)
+
+## Changelog
+
+- 2026-06-24: Initial v1 taskset.

--- a/environments/oolong_synth_v1/oolong_synth_v1/__init__.py
+++ b/environments/oolong_synth_v1/oolong_synth_v1/__init__.py
@@ -1,0 +1,3 @@
+from oolong_synth_v1.taskset import OolongSynthTaskset
+
+__all__ = ["OolongSynthTaskset"]

--- a/environments/oolong_synth_v1/oolong_synth_v1/judge.py
+++ b/environments/oolong_synth_v1/oolong_synth_v1/judge.py
@@ -1,0 +1,27 @@
+"""LLM judge for oolong-synth-v1 (used when a `judge` is configured).
+
+A binary judge: asks whether the model response matches the reference answer. Defaults to Prime
+inference (pinference).
+"""
+
+import re
+
+import verifiers.v1 as vf
+
+JUDGE_TEMPLATE = (
+    "Question: {question}\n\nReference answer: {answer}\n\nModel response: {response}\n\n"
+    "Does the model response match the reference answer? Answer 'yes' or 'no'."
+)
+VERDICT_RE = re.compile(r"\b(yes|no)\b")
+
+
+class OolongJudgeConfig(vf.JudgeConfig):
+    pass
+
+
+class OolongJudge(vf.Judge[bool]):
+    prompt = JUDGE_TEMPLATE
+
+    def parse(self, response: vf.JudgeResponse[bool]) -> bool:
+        match = VERDICT_RE.search(response.text.lower())
+        return bool(match and match.group(1) == "yes")

--- a/environments/oolong_synth_v1/oolong_synth_v1/taskset.py
+++ b/environments/oolong_synth_v1/oolong_synth_v1/taskset.py
@@ -11,11 +11,10 @@ Dataset: `oolongbench/oolong-synth`.
 """
 
 import ast
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Literal
 
 import verifiers.v1 as vf
-
 from oolong_synth_v1.judge import OolongJudge, OolongJudgeConfig
 
 WORKDIR = "/workspace"
@@ -51,7 +50,7 @@ def parse_gold(answer_raw: str):
     """Parse the dataset's serialized gold answer (a list literal, or a wrapped date)."""
     if "datetime" not in answer_raw:
         return ast.literal_eval(answer_raw)[0]
-    return datetime.strptime(answer_raw, "[datetime.date(%Y, %m, %d)]")
+    return datetime.strptime(answer_raw, "[datetime.date(%Y, %m, %d)]").replace(tzinfo=timezone.utc)
 
 
 def score(answer_raw: str, answer_type: str, output: str) -> float:
@@ -65,15 +64,15 @@ def score(answer_raw: str, answer_type: str, output: str) -> float:
     elif answer_type == "ANSWER_TYPE.NUMERIC":
         try:
             return float(0.75 ** abs(int(gold) - int(trimmed_output)))
-        except Exception:
-            pass
+        except (TypeError, ValueError):
+            return 0.0
     elif answer_type == "ANSWER_TYPE.DATE":
         try:
             import dateutil.parser
 
             return 1.0 if dateutil.parser.parse(str(trimmed_output)) == gold else 0.0
-        except Exception:
-            pass
+        except (TypeError, ValueError):
+            return 0.0
     return 0.0
 
 

--- a/environments/oolong_synth_v1/oolong_synth_v1/taskset.py
+++ b/environments/oolong_synth_v1/oolong_synth_v1/taskset.py
@@ -23,7 +23,21 @@ ANSWER_PATH = f"{WORKDIR}/answer.txt"
 
 # Valid oolong-synth context lengths (tokens). The two smallest are the most tractable; the real
 # long-context regime is the larger buckets.
-ContextLen = Literal[1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304]
+ContextLen = Literal[
+    1024,
+    2048,
+    4096,
+    8192,
+    16384,
+    32768,
+    65536,
+    131072,
+    262144,
+    524288,
+    1048576,
+    2097152,
+    4194304,
+]
 
 # Answer types the scorer gives partial credit for; every other type is exact-match (`""`).
 AnswerType = Literal["", "ANSWER_TYPE.NUMERIC", "ANSWER_TYPE.DATE"]

--- a/environments/oolong_synth_v1/oolong_synth_v1/taskset.py
+++ b/environments/oolong_synth_v1/oolong_synth_v1/taskset.py
@@ -11,7 +11,7 @@ Dataset: `oolongbench/oolong-synth`.
 """
 
 import ast
-from datetime import datetime, timezone
+import datetime
 from typing import Literal
 
 import verifiers.v1 as vf
@@ -50,7 +50,7 @@ def parse_gold(answer_raw: str):
     """Parse the dataset's serialized gold answer (a list literal, or a wrapped date)."""
     if "datetime" not in answer_raw:
         return ast.literal_eval(answer_raw)[0]
-    return datetime.strptime(answer_raw, "[datetime.date(%Y, %m, %d)]").replace(tzinfo=timezone.utc)
+    return datetime.datetime.strptime(answer_raw, "[datetime.date(%Y, %m, %d)]").replace(tzinfo=datetime.UTC)
 
 
 def score(answer_raw: str, answer_type: str, output: str) -> float:

--- a/environments/oolong_synth_v1/oolong_synth_v1/taskset.py
+++ b/environments/oolong_synth_v1/oolong_synth_v1/taskset.py
@@ -1,0 +1,156 @@
+"""oolong-synth-v1 — Oolong synthetic long-context questions solved by an agent in a sandbox.
+
+Each task's long context window is uploaded to `/workspace/context.txt` so the agent can scan it
+from a REPL instead of spending tokens on the whole document. The agent writes its final answer
+(a single token / word / date / label) to `/workspace/answer.txt`; the reward reads it back
+(falling back to the agent's last message) and scores with the official Oolong synth rules
+(deterministic; partial credit for numeric/date answers) or, when a `judge` is configured, a
+host-side binary LLM judge.
+
+Dataset: `oolongbench/oolong-synth`.
+"""
+
+import ast
+from datetime import datetime
+from typing import Literal
+
+import verifiers.v1 as vf
+
+from oolong_synth_v1.judge import OolongJudge, OolongJudgeConfig
+
+WORKDIR = "/workspace"
+CONTEXT_PATH = f"{WORKDIR}/context.txt"
+ANSWER_PATH = f"{WORKDIR}/answer.txt"
+
+# Valid oolong-synth context lengths (tokens). The two smallest are the most tractable; the real
+# long-context regime is the larger buckets.
+ContextLen = Literal[1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304]
+
+# Answer types the scorer gives partial credit for; every other type is exact-match (`""`).
+AnswerType = Literal["", "ANSWER_TYPE.NUMERIC", "ANSWER_TYPE.DATE"]
+
+INSTRUCTIONS = (
+    f"The context window is in `{CONTEXT_PATH}`. Scan it from a REPL, then write your final "
+    f"answer — and ONLY your final answer (a single token / word / date / label) — to "
+    f"`{ANSWER_PATH}` (also output it as your last message)."
+)
+
+
+def attempt_answer_parse(answer: str) -> str:
+    """Extract the candidate answer from the agent's output."""
+    if ":" not in answer:
+        return answer
+    candidate = answer.split(":")[-1].strip().replace("*", "").replace("[", "").replace("]", "")
+    for phrase in ("more common", "less common", "same frequency"):
+        if phrase in candidate:
+            return phrase
+    return candidate
+
+
+def parse_gold(answer_raw: str):
+    """Parse the dataset's serialized gold answer (a list literal, or a wrapped date)."""
+    if "datetime" not in answer_raw:
+        return ast.literal_eval(answer_raw)[0]
+    return datetime.strptime(answer_raw, "[datetime.date(%Y, %m, %d)]")
+
+
+def score(answer_raw: str, answer_type: str, output: str) -> float:
+    gold = parse_gold(answer_raw)
+    trimmed_output = attempt_answer_parse(output)
+    if str(trimmed_output) == str(gold):
+        return 1.0
+    elif str(trimmed_output) in ["more common", "less common", "same frequency"]:
+        if str(trimmed_output) in str(gold):
+            return 1.0
+    elif answer_type == "ANSWER_TYPE.NUMERIC":
+        try:
+            return float(0.75 ** abs(int(gold) - int(trimmed_output)))
+        except Exception:
+            pass
+    elif answer_type == "ANSWER_TYPE.DATE":
+        try:
+            import dateutil.parser
+
+            return 1.0 if dateutil.parser.parse(str(trimmed_output)) == gold else 0.0
+        except Exception:
+            pass
+    return 0.0
+
+
+class OolongSynthData(vf.TaskData):
+    question: str
+    """Raw dataset question (passed to the judge; the prompt wraps it with task instructions)."""
+    answer: str
+    """Raw gold answer from the dataset (parsed by the Oolong scorer)."""
+    context: str
+    """The long context window, uploaded to `CONTEXT_PATH` before the agent runs."""
+    answer_type: AnswerType = ""
+    """Answer type that drives partial credit; `""` for every other type (exact match)."""
+
+
+class OolongSynthTaskConfig(vf.TaskConfig):
+    judge: OolongJudgeConfig | None = None
+    """When set, score with this LLM judge instead of the deterministic Oolong rules
+    (None = deterministic)."""
+
+
+class OolongSynthTask(vf.Task[OolongSynthData, vf.State, OolongSynthTaskConfig]):
+    NEEDS_CONTAINER = True
+
+    async def setup(self, runtime: vf.Runtime) -> None:
+        await runtime.run(["mkdir", "-p", WORKDIR], {})
+        await runtime.write(CONTEXT_PATH, self.data.context.encode())
+
+    @vf.reward(weight=1.0)
+    async def correct(self, trace: vf.Trace, runtime: vf.Runtime) -> float:
+        response = await vf.read_answer_file_or_last_reply(runtime, ANSWER_PATH, trace)
+        if self.config.judge is not None:
+            judge = OolongJudge(self.config.judge)
+            result = await judge.evaluate(
+                trace=trace,
+                question=self.data.question,
+                answer=str(parse_gold(self.data.answer)),
+                response=response,
+            )
+            return 1.0 if result.parsed else 0.0
+        return score(self.data.answer, self.data.answer_type, response)
+
+
+class OolongSynthConfig(vf.TasksetConfig):
+    split: Literal["validation", "test"] = "validation"
+    with_labels: bool = False
+    """Use the label-augmented context window (`context_window_text_with_labels`)."""
+    context_len: ContextLen = 262144
+    """Which `context_len` (token) bucket to evaluate (default: 256K)."""
+    task: OolongSynthTaskConfig = OolongSynthTaskConfig()
+
+
+class OolongSynthTaskset(vf.Taskset[OolongSynthTask, OolongSynthConfig]):
+    def load(self) -> list[OolongSynthTask]:
+        from datasets import load_dataset
+
+        cfg = self.config
+        context_column = "context_window_text_with_labels" if cfg.with_labels else "context_window_text"
+        rows = load_dataset("oolongbench/oolong-synth", split=cfg.split, streaming=True)
+        tasks: list[OolongSynthTask] = []
+        for i, row in enumerate(rows):
+            if row.get("context_len") != cfg.context_len:
+                continue
+            answer_type = row.get("answer_type", "")
+            if answer_type not in ("ANSWER_TYPE.NUMERIC", "ANSWER_TYPE.DATE"):
+                answer_type = ""
+            tasks.append(
+                OolongSynthTask(
+                    OolongSynthData(
+                        idx=i,
+                        prompt=f"{row['question']}\n\n{INSTRUCTIONS}",
+                        question=row["question"],
+                        answer=row["answer"],
+                        context=row[context_column],
+                        answer_type=answer_type,
+                        workdir=WORKDIR,
+                    ),
+                    self.config.task,
+                )
+            )
+        return tasks

--- a/environments/oolong_synth_v1/oolong_synth_v1/taskset.py
+++ b/environments/oolong_synth_v1/oolong_synth_v1/taskset.py
@@ -53,7 +53,9 @@ def attempt_answer_parse(answer: str) -> str:
     """Extract the candidate answer from the agent's output."""
     if ":" not in answer:
         return answer
-    candidate = answer.split(":")[-1].strip().replace("*", "").replace("[", "").replace("]", "")
+    candidate = (
+        answer.split(":")[-1].strip().replace("*", "").replace("[", "").replace("]", "")
+    )
     for phrase in ("more common", "less common", "same frequency"):
         if phrase in candidate:
             return phrase
@@ -64,7 +66,9 @@ def parse_gold(answer_raw: str):
     """Parse the dataset's serialized gold answer (a list literal, or a wrapped date)."""
     if "datetime" not in answer_raw:
         return ast.literal_eval(answer_raw)[0]
-    return datetime.datetime.strptime(answer_raw, "[datetime.date(%Y, %m, %d)]").replace(tzinfo=datetime.UTC)
+    return datetime.datetime.strptime(
+        answer_raw, "[datetime.date(%Y, %m, %d)]"
+    ).replace(tzinfo=datetime.UTC)
 
 
 def score(answer_raw: str, answer_type: str, output: str) -> float:
@@ -143,7 +147,11 @@ class OolongSynthTaskset(vf.Taskset[OolongSynthTask, OolongSynthConfig]):
         from datasets import load_dataset
 
         cfg = self.config
-        context_column = "context_window_text_with_labels" if cfg.with_labels else "context_window_text"
+        context_column = (
+            "context_window_text_with_labels"
+            if cfg.with_labels
+            else "context_window_text"
+        )
         rows = load_dataset("oolongbench/oolong-synth", split=cfg.split, streaming=True)
         tasks: list[OolongSynthTask] = []
         for i, row in enumerate(rows):

--- a/environments/oolong_synth_v1/pyproject.toml
+++ b/environments/oolong_synth_v1/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "oolong-synth-v1"
+version = "0.1.0"
+description = "Oolong synthetic long-context questions solved by an agent in a sandbox (deterministic Oolong scoring)."
+requires-python = ">=3.11"
+dependencies = ["datasets", "python-dateutil"]
+# The local editable package uses the root checkout's verifiers.v1 API; declaring
+# published `verifiers>=0.2.0` would make this checkout depend on itself at an
+# incompatible dynamically-derived development version.
+tags = ["long-context", "multi-turn", "sandbox", "agentic", "v1"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["oolong_synth_v1"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ examples = [
     "gsm8k", "glossary", "deepwiki", "wiki-search", "code-golf",
     "proposer-solver", "reverse-text", "color-codeword",
     "wordle", "openenv-wordle", "alphabet-sort", "scratchpad",
-    "kuhn-poker",
+    "kuhn-poker", "oolong-synth-v1",
 ]
 
 [project.optional-dependencies]
@@ -164,6 +164,7 @@ color-codeword = { path = "environments/color_codeword", editable = true }
 alphabet-sort = { path = "environments/alphabet_sort", editable = true }
 scratchpad = { path = "environments/scratchpad", editable = true }
 kuhn-poker = { path = "environments/kuhn_poker", editable = true }
+oolong-synth-v1 = { path = "environments/oolong_synth_v1", editable = true }
 
 [tool.uv.exclude-newer-package]
 # Bounded cutoffs for the explicitly requested tool upgrades.

--- a/uv.lock
+++ b/uv.lock
@@ -2897,6 +2897,21 @@ wheels = [
 ]
 
 [[package]]
+name = "oolong-synth-v1"
+version = "0.1.0"
+source = { editable = "environments/oolong_synth_v1" }
+dependencies = [
+    { name = "datasets" },
+    { name = "python-dateutil" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "datasets" },
+    { name = "python-dateutil" },
+]
+
+[[package]]
 name = "openai"
 version = "2.45.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5173,6 +5188,7 @@ examples = [
     { name = "glossary" },
     { name = "gsm8k" },
     { name = "kuhn-poker" },
+    { name = "oolong-synth-v1" },
     { name = "openenv-wordle" },
     { name = "proposer-solver" },
     { name = "reverse-text" },
@@ -5247,6 +5263,7 @@ examples = [
     { name = "glossary", editable = "environments/glossary" },
     { name = "gsm8k", editable = "environments/gsm8k" },
     { name = "kuhn-poker", editable = "environments/kuhn_poker" },
+    { name = "oolong-synth-v1", editable = "environments/oolong_synth_v1" },
     { name = "openenv-wordle", editable = "environments/openenv_wordle" },
     { name = "proposer-solver", editable = "environments/proposer_solver" },
     { name = "reverse-text", editable = "environments/reverse_text" },


### PR DESCRIPTION
## True Prime Agent ACP Oolong evaluation adapter

Append-only child of lock remediation #2332.

Adds a taskset-only `oolong_synth_v1` package so the v1 loader falls back to `SingleAgentEnv` and permits explicit `PrimeAgentHarness`; published Hub `rlm-oolong@0.2.5` hardwires the generic RLM harness and cannot satisfy the requested ACP path.

Dry-load proof (no model/sandbox):
- env = `SingleAgentEnv`
- taskset = `OolongSynthTaskset`
- harness = `PrimeAgentHarness`
- runtime = `prime`, `vm=True`

Includes bounded Luna n=1 config with exact Prime Agent artifact URL/SHA placeholders. Offline `uv lock`, disposable locked sync, dry-run, and resolved class proof passed. No model call/live eval. Draft/HOLD until exact #1239 artifact builds and is pinned.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New sandbox evaluation path with custom scoring and a Prime Agent harness pinned to a tunnel tarball URL/SHA; incorrect scoring or harness pins could skew eval results, but it does not touch auth or core infra.
> 
> **Overview**
> Adds a **taskset-only** `oolong-synth-v1` environment so v1 can run Oolong synth long-context tasks under `SingleAgentEnv` with an explicit `PrimeAgentHarness` (instead of the Hub RLM harness).
> 
> Each task streams `oolongbench/oolong-synth`, filters to a `context_len` bucket, and uploads the long context to `/workspace/context.txt` for REPL scanning. The agent writes a single-token answer to `/workspace/answer.txt`; scoring uses official Oolong rules (exact match, numeric partial credit, date equality) or an optional host-side binary LLM judge.
> 
> Registers the package in the examples dependency group and adds a bounded Luna n=1 dry-load config targeting the Prime VM runtime with pinned harness artifact URL/SHA.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 141d48abe5fabb2e48aacc726822bcd2da8d4514. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add oolong-synth-v1 taskset environment with deterministic and judge-based scoring
> - Introduces the `oolong_synth_v1` environment package with `OolongSynthTaskset`, which loads tasks from the `oolongbench/oolong-synth` dataset filtered by context length bucket.
> - Implements two scoring modes in [`taskset.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/2333/files#diff-b34888cb9aefb9ae5546ea248afc54e524dbd1b3f44e0de1358c8feb80d10fa3): deterministic partial-credit scoring (exact match, exponential decay for numerics, exact date equality) and optional LLM judge-based binary scoring via `OolongJudge`.
> - Task setup writes the long context to `/workspace/context.txt` in the agent sandbox; the agent writes its answer to `/workspace/answer.txt` or falls back to its last message.
> - Adds a smoke-test config [`configs/oolong_synth_v1_luna_n1.toml`](https://github.com/PrimeIntellect-ai/verifiers/pull/2333/files#diff-cbe1a9aa05f01fdd8826f1c7dba70f99112b86527a7697289cef556b62a5c210) that runs one task/rollout with `openai/gpt-5.6-luna` at the 1K context bucket using the Prime VM agent harness.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 141d48a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->