### PR TITLE
Secure Pool harness binary cache

### DIFF
--- a/verifiers/v1/harnesses/pool/harness.py
+++ b/verifiers/v1/harnesses/pool/harness.py
@@ -11,7 +11,7 @@ from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.trace import Trace
 from verifiers.v1.types import SystemMessage, TextContentPart, UserMessage
 
-POOL_DIR = "/tmp/vf-pool-{version}"
+POOL_DIR = ".vf-pool/bin-{version}"
 SETTINGS_PATH = ".poolside/settings.local.yaml"
 INSTALL = r"""
 set -e
@@ -42,11 +42,14 @@ class PoolHarness(Harness[PoolHarnessConfig]):
         script = INSTALL.replace("{version}", self.config.version).replace(
             "{dir}", directory
         )
-        ensure = shlex.quote(f"[ -x {binary} ] || ({script})")
-        # Cache the pinned binary across local rollouts; Linux has flock, macOS has lockf.
+        ensure = shlex.quote(f"[ -x {shlex.quote(binary)} ] || ({script})")
+        # Cache the pinned binary only inside this rollout workspace. Pool is
+        # launched with model-approved tools, so a shared /tmp cache would let one
+        # rollout tamper with the executable trusted by later rollouts.
+        lock = shlex.quote(f"{directory}/install.lock")
         guarded = (
-            f"mkdir -p {directory} && "
-            f'"$(command -v flock || command -v lockf)" {directory}/install.lock '
+            f"mkdir -p {shlex.quote(directory)} && "
+            f'"$(command -v flock || command -v lockf)" {lock} '
             f"bash -o pipefail -c {ensure}"
         )
         result = await runtime.run(["sh", "-c", guarded], self.config.resolved_env)


### PR DESCRIPTION
### Motivation

- Prevent a malicious Pool run from poisoning a shared cached executable and enabling persistent code execution in later rollouts by removing the predictable `/tmp` cache.
- Ensure the Pool CLI is installed into a verifier-owned, per-rollout workspace and that install checks/locks are properly quoted and scoped.

### Description

- Change the cache location from `"/tmp/vf-pool-{version}"` to a per-rollout path at `".vf-pool/bin-{version}"` by updating `POOL_DIR` in `verifiers/v1/harnesses/pool/harness.py`.
- Harden the setup step by quoting generated paths with `shlex.quote` and using a rollout-local lock file (`install.lock`) so installation and existence checks operate only inside the rollout workspace.
- Add a comment documenting the security rationale that a shared `/tmp` cache would let one rollout tamper with the executable trusted by later rollouts.

### Testing

- Ran `uv run pre-commit install` which completed successfully in the environment where it could run.
- Ran `uv run ruff check --fix verifiers/v1/harnesses/pool/harness.py` and `python -m py_compile verifiers/v1/harnesses/pool/harness.py`, both of which passed for the modified file.
- Pre-commit hooks that require fetching external packages failed in this environment due to network tunnel issues, so full hook execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d06b337e0833296e953cd0226db6a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Pool harness install/execution path, which is security-sensitive because rollouts can run with model-approved tools. The change is small and clearly reduces cross-rollout binary poisoning risk.
> 
> **Overview**
> **Hardens Pool binary install** so a malicious rollout cannot poison a shared executable used by later runs.
> 
> Moves the cached `pool` binary from shared `/tmp/vf-pool-{version}` to a **per-rollout** path at `.vf-pool/bin-{version}`, and scopes the install lock to that workspace. Also quotes install paths with `shlex.quote` and documents why a shared `/tmp` cache was unsafe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83d78c2f9d36325330953f0204ff17bd47a9c4eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move Pool binary cache from `/tmp` to workspace-local `.vf-pool/bin-{version}` and shell-quote paths
> - Changes `POOL_DIR` in [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2335/files#diff-4d23b83952cfe7fd4838fc53a8ee722fefad324e9c7fa599bbf7e9bc098af4b0) from `/tmp/vf-pool-{version}` to `.vf-pool/bin-{version}` relative to the current workspace, scoping the cache per project.
> - Shell-quotes all dynamic paths in `PoolHarness.setup` (binary path, install directory, lockfile) to handle directories with spaces or special characters.
> - Behavioral Change: the Pool binary is no longer shared across workspaces via `/tmp`; each workspace maintains its own cache directory.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 83d78c2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->