### PR TITLE
fix: pin MiniSWEAgent LiteLLM proxy dependency

### DIFF
--- a/verifiers/v1/harnesses/mini_swe_agent/program.py
+++ b/verifiers/v1/harnesses/mini_swe_agent/program.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["mini-swe-agent=={version}", "litellm[proxy]"]
+# dependencies = ["mini-swe-agent=={version}", "litellm[proxy]==1.89.2"]
 # ///
 
 from minisweagent.run.mini import app


### PR DESCRIPTION
### Motivation
- Prevent runtime unpinned resolution of `litellm[proxy]` in the MiniSWEAgent PEP 723 script to eliminate a supply-chain arbitrary-code-execution risk introduced by dynamic `uv sync` resolution.

### Description
- Pin `litellm[proxy]==1.89.2` in the harness script at `verifiers/v1/harnesses/mini_swe_agent/program.py` while preserving the existing `mini-swe-agent=={version}` placeholder and the existing launch flow.

### Testing
- Ran `uv run pre-commit install`, `uv run ruff check --fix verifiers/v1/harnesses/mini_swe_agent/program.py`, and `python -m py_compile verifiers/v1/harnesses/mini_swe_agent/program.py`, and the targeted lint/compile checks passed; a full `pre-commit` run could not complete because hook dependencies could not be fetched in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b41dd8248833282d3e1a2b6ebd113)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency pin in a harness script with no logic or auth changes. Low risk, and it reduces supply-chain exposure from unpinned installs.
> 
> **Overview**
> **Pins** `litellm[proxy]` to `==1.89.2` in the MiniSWEAgent PEP 723 script (`program.py`).
> 
> This removes unpinned runtime resolution of that dependency while keeping the existing `mini-swe-agent=={version}` placeholder and launch path unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59457c77be9535f1ff87ea3bf6e3de99704a4a38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin `litellm[proxy]` to version 1.89.2 in MiniSWEAgent harness
> Pins the `litellm[proxy]` dependency in [program.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2336/files#diff-ed829d9d3aa931d8ed409e1e7a59bd3b04a9fa7c65836ad7285a9e0a0fdd4845) to version 1.89.2 instead of using the latest available version, preventing breakage from upstream changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 59457c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->