### PR TITLE
v1: reject duplicate artifact sources before collection

### DIFF
--- a/verifiers/v1/utils/artifacts.py
+++ b/verifiers/v1/utils/artifacts.py
@@ -54,6 +54,7 @@ async def collect(
         a.model_copy(update={"source": str(workdir / a.source)})
         for a in artifacts or []
     ]
+    _reject_duplicate_sources(artifacts or [], declared)
     convention = PurePosixPath(ARTIFACTS_DIR)
     declared_paths = [PurePosixPath(artifact.source) for artifact in declared]
     if convention in declared_paths:
@@ -129,6 +130,32 @@ async def restore(runtime: Runtime, collected: dict[str, bytes | None]) -> None:
             f"tar -xf {shlex.quote(path)} -C / && rm -f {shlex.quote(path)}",
             f"restore artifact {root!r}",
         )
+
+
+def _reject_duplicate_sources(
+    requested: list[Artifact], resolved: list[Artifact]
+) -> None:
+    """Refuse two declarations that resolve to the same path, before anything is tarred.
+
+    `collect` keys its result by resolved source, so a duplicate archives the same tree
+    twice — charging the byte budget for both — and then lets the later entry overwrite
+    the earlier one. With differing `exclude` patterns the archive that survives depends
+    on declaration order, which makes grading order-dependent. Rejecting here keeps the
+    budget equal to what is actually returned.
+
+    Resolution is lexical, so `..` segments are left intact: collapsing them is only
+    sound without symlinks. Two sources differing only by a `..` are not caught here.
+    """
+    first_seen: dict[str, str] = {}
+    for original, entry in zip(requested, resolved, strict=True):
+        if (earlier := first_seen.get(entry.source)) is not None:
+            raise ValueError(
+                f"duplicate artifact source {entry.source!r}, declared as "
+                f"{earlier!r} and {original.source!r}. A path can only be collected "
+                "once — merge them into a single declaration, combining their "
+                "`exclude` patterns."
+            )
+        first_seen[entry.source] = original.source
 
 
 async def _tar_out(runtime: Runtime, artifact: Artifact, budget: int) -> bytes:


### PR DESCRIPTION
Fixes #2198.

## What

`collect()` keys its result by resolved source. Two declarations that resolve to the same path therefore:

- archive the same tree twice, charging `budget` for both, so the byte ceiling no longer corresponds to what is returned;
- overwrite each other in `collected`, silently discarding the first archive;
- with differing `exclude` patterns, produce a result that depends on declaration order.

The docstring already promised "a path cannot be collected twice" — nothing enforced it.

## Approach

The issue allows either rejection or documented merge semantics. This takes rejection: merge semantics for two differing `exclude` lists have no obviously correct answer (union changes what each declaration asked for; intersection silently widens the archive), and rejecting is what the existing docstring already claims.

Validation runs **after** workdir resolution and **before** the convention sweep, so `./out`, `out/`, `/work//out` and `/work/out` are all caught, and nothing is tarred before the rejection — which is what keeps the budget equal to the returned collection.

`ValueError` rather than `RuntimeError`: this is an invalid declaration detected before the runtime is touched, and it matches the surrounding Harbor conversion path, which already raises `ValueError` for invalid declarations.

## Verified

Checked with a throwaway script (not committed, per `AGENTS.md` on unit tests):

- duplicates rejected for identical strings, `./out`, absolute vs relative, trailing slash, double slash — each raising `ValueError`, naming the resolved path, **with no archive created**;
- differing `exclude` patterns raise rather than silently picking one;
- distinct sources still collect normally, convention sweep included;
- returned bytes exactly equal archived bytes (budget accounting is now exact);
- single declaration and the no-declarations case unchanged.

`ruff check` and `ruff format --check` clean on the touched file.

I could not run `uv run pytest tests/` end to end: the dev group builds `pycosat` (via `reasoning-gym`), which needs a C toolchain I do not have here. The change is confined to one pure function with no I/O, so I would appreciate CI confirming it.

## Blast radius

A Harbor task that declares the same source twice now fails loudly instead of silently dropping one archive. That is the intended behaviour change, but it is a behaviour change for any such task that exists today.

## Out of scope

`..` segments are deliberately not collapsed — doing so lexically is only sound without symlinks — so two sources differing only by a `..` are not treated as duplicates. Happy to revisit if you would rather resolve those too.

Also happy to switch to normalization, change the exception type, or move the check into a validator on the declaration model if you prefer any of those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject duplicate artifact sources in `artifacts.collect` before archiving begins
> Adds a precondition check in [`artifacts.collect`](https://github.com/PrimeIntellect-ai/verifiers/pull/2337/files#diff-0d082bad54931be61d7ef55ddce0757034be3013f69ae71cb803cd8416df9138) that calls the new helper `_reject_duplicate_sources` to scan resolved artifact paths before any archiving occurs. If two declarations resolve to the same source path, a `ValueError` is raised identifying both the original and conflicting declarations. Risk: existing callers with duplicate artifact sources will now fail with `ValueError` instead of silently overwriting or double-archiving files.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 834e16e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->