### PR TITLE
Fix failed Responses and preserve live ACP deltas

### DIFF
--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -40,8 +40,9 @@ import pytest
 import verifiers.v1 as vf
 from verifiers.v1.cli.eval.runner import run_eval
 from verifiers.v1.configs.cli.eval import EvalConfig
+from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.trace import Trace
-from verifiers.v1.utils.loaders import load_environment
+from verifiers.v1.utils.loaders import harness_config_type, load_environment
 
 CI_MODEL = "openai/gpt-5.6-luna"
 
@@ -74,8 +75,9 @@ def tool_runtime(request) -> dict:
 # dependencies at rollout.
 # `compact` (an example harness) and `terminus-2` (drives the host tmux) are excluded from e2e.
 @pytest.fixture
-def harness(request) -> str:
-    return request.param
+def harness(request) -> HarnessConfig:
+    config = {"id": request.param} if isinstance(request.param, str) else request.param
+    return harness_config_type(config["id"]).model_validate(config)
 
 
 def pytest_configure(config) -> None:
@@ -119,7 +121,7 @@ def _eval_config(
     taskset: str,
     *,
     output_dir: Path,
-    harness: str | dict[str, object] | None = "null",
+    harness: str | HarnessConfig | None = "null",
     n: int = 1,
     num_tasks: int = 1,
     max_tokens: int = 2048,
@@ -144,7 +146,9 @@ def _eval_config(
     _configure_prime_runtimes(taskset_cfg)
     if harness:
         env_cfg.setdefault("agent", {})["harness"] = (
-            {"id": harness} if isinstance(harness, str) else dict(harness)
+            harness_config_type(harness)(id=harness)
+            if isinstance(harness, str)
+            else harness
         )
     if runtime:
         runtime_cfg = dict(runtime)

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -43,7 +43,7 @@ from verifiers.v1.configs.cli.eval import EvalConfig
 from verifiers.v1.trace import Trace
 from verifiers.v1.utils.loaders import load_environment
 
-CI_MODEL = "openai/gpt-5.6-luna"
+CI_MODEL = "openai/gpt-5.6-sol"
 
 # Fixture tasksets (echo-v1, echo-agentic-v1) live in tests/v1/fixtures, added to the
 # path via `pythonpath` in pyproject so the loader resolves them by id (no install).
@@ -119,7 +119,7 @@ def _eval_config(
     taskset: str,
     *,
     output_dir: Path,
-    harness: str | None = "null",
+    harness: str | dict[str, object] | None = "null",
     n: int = 1,
     num_tasks: int = 1,
     max_tokens: int = 2048,
@@ -143,7 +143,9 @@ def _eval_config(
     env_cfg = dict(env or {})
     _configure_prime_runtimes(taskset_cfg)
     if harness:
-        env_cfg.setdefault("agent", {})["harness"] = {"id": harness}
+        env_cfg.setdefault("agent", {})["harness"] = (
+            {"id": harness} if isinstance(harness, str) else dict(harness)
+        )
     if runtime:
         runtime_cfg = dict(runtime)
         _configure_prime_runtimes(runtime_cfg)

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -43,7 +43,7 @@ from verifiers.v1.configs.cli.eval import EvalConfig
 from verifiers.v1.trace import Trace
 from verifiers.v1.utils.loaders import load_environment
 
-CI_MODEL = "openai/gpt-5.6-sol"
+CI_MODEL = "openai/gpt-5.6-luna"
 
 # Fixture tasksets (echo-v1, echo-agentic-v1) live in tests/v1/fixtures, added to the
 # path via `pythonpath` in pyproject so the loader resolves them by id (no install).

--- a/tests/v1/fixtures/echo_acp_resume_v1.py
+++ b/tests/v1/fixtures/echo_acp_resume_v1.py
@@ -1,8 +1,9 @@
-"""Two-segment ACP continuation with an MCP call after resume."""
+"""Two-segment ACP continuation with a multi-message delta and resumed MCP call."""
 
 import verifiers.v1 as vf
 
 CODEWORD = "violet-cascade-731"
+SECOND_CODEWORD = "amber-harbor-284"
 TOOL_STAMP = "resume-ok-9d2"
 
 
@@ -42,8 +43,10 @@ class ACPResumeTask(vf.Task[vf.TaskData, vf.State, ACPResumeTaskConfig]):
         return float(
             bool(first["last_reply"].strip())
             and _key(CODEWORD) in _key(second["last_reply"])
+            and _key(SECOND_CODEWORD) in _key(second["last_reply"])
             and _key(TOOL_STAMP) in _key(second["last_reply"])
             and _key(CODEWORD) in _key(resumed_tool_output)
+            and _key(SECOND_CODEWORD) in _key(resumed_tool_output)
             and _key(TOOL_STAMP) in _key(resumed_tool_output)
             and "tool" in second["roles"]
         )
@@ -59,8 +62,23 @@ class ACPResumeEnv(vf.SingleAgentEnv):
             if not first.terminated:
                 segments.append(
                     await interaction.turn(
-                        "Call `resume_recall` with the codeword from my previous "
-                        "message, then reply with exactly the tool result."
+                        [
+                            vf.UserMessage(
+                                content=(
+                                    "The second codeword for this turn is "
+                                    f"{SECOND_CODEWORD}."
+                                )
+                            ),
+                            vf.AssistantMessage(content="Acknowledged."),
+                            vf.UserMessage(
+                                content=(
+                                    "Call `resume_recall` with both codewords: first the "
+                                    "one from the previous turn, then the second codeword "
+                                    "introduced earlier in this turn, joined by `/`. Reply "
+                                    "with exactly the tool result."
+                                )
+                            ),
+                        ]
                     )
                 )
             interaction.trace.info["acp_segments"] = [

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -235,6 +235,7 @@ async def test_acp_resume_with_tool(run_v1, harness, harness_runtime, tmp_path):
     assert len(segments) == 2
     assert segments[0]["terminated"] is False
     assert segments[1]["terminated"] is False
+    assert trace.num_branches == 1
     # Native MCP tools need not appear in the intercepted model request that
     # populates trace.tools; the ACP transcript is the source of truth for use.
     assert "tool" in segments[1]["roles"]

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -255,12 +255,14 @@ async def test_acp_resume_with_tool(run_v1, harness, harness_runtime, tmp_path):
     assert len(segments) == 2
     assert segments[0]["terminated"] is False
     assert segments[1]["terminated"] is False
-    assert trace.num_branches == 1
+    # Kimi Code is broken upstream: its Responses adapter drops message `phase` on replay.
+    if harness.id != "kimi-code":
+        assert trace.num_branches == 1
     # Native MCP tools need not appear in the intercepted model request that
     # populates trace.tools; the ACP transcript is the source of truth for use.
     assert "tool" in segments[1]["roles"]
     assert segments[1]["tool_outputs"]
-    if harness == "rlm":
+    if harness.id == "rlm":
         assert "turns_since_last_compaction" in trace.metrics
 
 

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -23,7 +23,12 @@ CHAT_PLACEMENTS = [
     pair("null", "subprocess", "null-harness-in-subprocess"),
     pair("bash", "docker", "bash-harness-in-docker"),
     pair("rlm", "docker", "rlm-harness-in-docker"),
-    pair("kimi-code", "docker", "kimi-code-harness-in-docker"),
+    pytest.param(
+        {"id": "kimi-code", "transport": "responses"},
+        "docker",
+        marks=[mark.kimi_code, mark.docker],
+        id="kimi-code-responses-harness-in-docker",
+    ),
     pair("bash", "prime", "bash-harness-in-prime"),
     pair("bash", "modal", "bash-harness-in-modal"),
 ]
@@ -34,7 +39,12 @@ CHAT_PLACEMENTS = [
 AGENTIC_PLACEMENTS = [
     pair("bash", "subprocess", "bash-harness-in-subprocess"),
     pair("rlm", "docker", "rlm-harness-in-docker"),
-    pair("kimi-code", "docker", "kimi-code-harness-in-docker"),
+    pytest.param(
+        {"id": "kimi-code", "transport": "responses"},
+        "docker",
+        marks=[mark.kimi_code, mark.docker],
+        id="kimi-code-responses-harness-in-docker",
+    ),
     pair("codex", "docker", "codex-harness-in-docker"),
     pair("claude-code", "docker", "claude-code-harness-in-docker"),
     pair("hermes-agent", "docker", "hermes-agent-harness-in-docker"),
@@ -59,8 +69,18 @@ ACP_RESUME_PLACEMENTS = [
     pair("claude-code", "docker", "claude-code-acp-in-docker"),
     pair("hermes-agent", "docker", "hermes-agent-acp-in-docker"),
     pair("rlm", "docker", "rlm-acp-in-docker"),
-    pair("kimi-code", "docker", "kimi-code-acp-in-docker"),
-    pair("pi", "docker", "pi-acp-in-docker"),
+    pytest.param(
+        {"id": "kimi-code", "transport": "responses"},
+        "docker",
+        marks=[mark.kimi_code, mark.docker],
+        id="kimi-code-responses-acp-in-docker",
+    ),
+    pytest.param(
+        {"id": "pi", "transport": "responses"},
+        "docker",
+        marks=[mark.pi, mark.docker],
+        id="pi-responses-acp-in-docker",
+    ),
     pair("pool", "docker", "pool-acp-in-docker"),
     pair("openclaw", "docker", "openclaw-acp-in-docker"),
     pair("pool", "prime", "pool-acp-in-prime"),

--- a/tests/v1/test_envs.py
+++ b/tests/v1/test_envs.py
@@ -47,7 +47,7 @@ def test_eval(taskset: str):
         pytest.skip(f"{taskset} can't run a plain-CI smoke eval")
     if os.getenv("PRIME_API_KEY"):
         model = [
-            "-m", "openai/gpt-5.6-sol",
+            "-m", "openai/gpt-5.6-luna",
             "--client.base-url", "https://api.pinference.ai/api/v1",
             "--client.api-key-var", "PRIME_API_KEY",
         ]  # fmt: skip

--- a/tests/v1/test_envs.py
+++ b/tests/v1/test_envs.py
@@ -47,7 +47,7 @@ def test_eval(taskset: str):
         pytest.skip(f"{taskset} can't run a plain-CI smoke eval")
     if os.getenv("PRIME_API_KEY"):
         model = [
-            "-m", "openai/gpt-5.6-luna",
+            "-m", "openai/gpt-5.6-sol",
             "--client.base-url", "https://api.pinference.ai/api/v1",
             "--client.api-key-var", "PRIME_API_KEY",
         ]  # fmt: skip

--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -4,10 +4,14 @@ import asyncio
 import contextlib
 import json
 import secrets
+from abc import abstractmethod
 from collections.abc import AsyncIterator
+from dataclasses import dataclass
 from pathlib import Path
+from typing import TypeVar
 
 from verifiers.v1.clients import ModelContext
+from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.dialects.chat import message_to_wire
 from verifiers.v1.errors import HarnessError
 from verifiers.v1.harness import Harness, HarnessSession
@@ -20,7 +24,23 @@ from verifiers.v1.utils.aio import run_shielded
 ACP_SOURCE = (Path(__file__).resolve().parent / "runner.py").read_text()
 MAX_PACKET_BYTES = 128 * 1024 * 1024
 
-__all__ = ["ACP"]
+__all__ = ["ACP", "ACPConfig", "ACPHarness"]
+
+ConfigT = TypeVar("ConfigT", bound=HarnessConfig)
+
+
+@dataclass
+class ACPConfig:
+    """One harness's prepared ACP process and prompt."""
+
+    env: dict[str, str]
+    command: list[str]
+    prompt: str | Messages | None
+    mcp_urls: dict[str, str] | None = None
+    system_prompt: str | None = None
+    session_path: str | None = None
+    session_meta: dict | None = None
+    allow_empty_tool_reply: bool = False
 
 
 class ACP:
@@ -47,8 +67,9 @@ class ACP:
         prompt: str | Messages | None,
         system_prompt: str | None = None,
         session_meta: dict | None = None,
+        allow_empty_tool_reply: bool = False,
     ) -> "ACPHarnessSession":
-        """Create a persistent ACP-backed handle owned by one rollout."""
+        """Create a live ACP-backed handle owned by one rollout."""
         return ACPHarnessSession(
             harness,
             ctx,
@@ -63,6 +84,7 @@ class ACP:
             prompt=prompt,
             system_prompt=system_prompt,
             session_meta=session_meta,
+            allow_empty_tool_reply=allow_empty_tool_reply,
         )
 
     async def run(
@@ -72,6 +94,7 @@ class ACP:
         command: list[str],
         prompt: str | Messages | None,
         *,
+        trace: Trace,
         mcp_urls: dict[str, str] | None = None,
         system_prompt: str | None = None,
         session_path: str | None = None,
@@ -79,31 +102,7 @@ class ACP:
         allow_empty_tool_reply: bool = False,
     ) -> ProgramResult:
         """Run one ACP segment without retaining its process."""
-        return await self._run(
-            runtime,
-            env,
-            command,
-            prompt,
-            mcp_urls=mcp_urls,
-            system_prompt=system_prompt,
-            session_path=session_path,
-            session_meta=session_meta,
-            allow_empty_tool_reply=allow_empty_tool_reply,
-        )
-
-    async def _run(
-        self,
-        runtime: Runtime,
-        env: dict[str, str],
-        command: list[str],
-        prompt: str | Messages | None,
-        *,
-        mcp_urls: dict[str, str] | None = None,
-        system_prompt: str | None = None,
-        session_path: str | None = None,
-        session_meta: dict | None = None,
-        allow_empty_tool_reply: bool = False,
-    ) -> ProgramResult:
+        calls_before = len(trace.calls)
         if prompt is None:
             raise ValueError("ACP requires a prompt")
         messages = (
@@ -132,9 +131,90 @@ class ACP:
         path = f"{directory}/config.json"
         try:
             await runtime.write(path, json.dumps(config).encode())
-            return await runtime.run_program([*program, "once", path], env)
+            result = await runtime.run_program([*program, "once", path], env)
         finally:
             await run_shielded(runtime.run(["rm", "-rf", directory], {}))
+        _require_model_turn(trace, calls_before, result)
+        return result
+
+
+class ACPHarness(Harness[ConfigT]):
+    """Harness whose execution is completely described by an ACP configuration."""
+
+    acp = ACP()
+
+    @abstractmethod
+    async def prepare_acp(
+        self,
+        ctx: ModelContext,
+        trace: Trace,
+        runtime: Runtime,
+        endpoint: str,
+        secret: str,
+        mcp_urls: dict[str, str],
+        data: TaskData,
+    ) -> ACPConfig:
+        pass
+
+    async def session(
+        self,
+        ctx: ModelContext,
+        trace: Trace,
+        runtime: Runtime,
+        endpoint: str,
+        secret: str,
+        mcp_urls: dict[str, str],
+        data: TaskData,
+    ) -> HarnessSession:
+        if not runtime.supports_live_processes:
+            return HarnessSession(
+                self, ctx, trace, runtime, endpoint, secret, mcp_urls, data
+            )
+        config = await self.prepare_acp(
+            ctx, trace, runtime, endpoint, secret, mcp_urls, data
+        )
+        return self.acp.session(
+            self,
+            ctx,
+            trace,
+            runtime,
+            endpoint,
+            secret,
+            mcp_urls if config.mcp_urls is None else config.mcp_urls,
+            data,
+            env=config.env,
+            command=config.command,
+            prompt=config.prompt,
+            system_prompt=config.system_prompt,
+            session_meta=config.session_meta,
+            allow_empty_tool_reply=config.allow_empty_tool_reply,
+        )
+
+    async def launch(
+        self,
+        ctx: ModelContext,
+        trace: Trace,
+        runtime: Runtime,
+        endpoint: str,
+        secret: str,
+        mcp_urls: dict[str, str],
+        data: TaskData,
+    ) -> ProgramResult:
+        config = await self.prepare_acp(
+            ctx, trace, runtime, endpoint, secret, mcp_urls, data
+        )
+        return await self.acp.run(
+            runtime,
+            config.env,
+            config.command,
+            config.prompt,
+            trace=trace,
+            mcp_urls=mcp_urls if config.mcp_urls is None else config.mcp_urls,
+            system_prompt=config.system_prompt,
+            session_path=config.session_path,
+            session_meta=config.session_meta,
+            allow_empty_tool_reply=config.allow_empty_tool_reply,
+        )
 
 
 def _packet(value: dict) -> bytes:
@@ -142,6 +222,17 @@ def _packet(value: dict) -> bytes:
     if len(data) > MAX_PACKET_BYTES:
         raise ValueError(f"ACP session packet is too large: {len(data)} bytes")
     return len(data).to_bytes(8, "big") + data
+
+
+def _require_model_turn(trace: Trace, calls_before: int, result: ProgramResult) -> None:
+    if (
+        result.exit_code
+        or trace.stop_condition is not None
+        or any(call.node is not None for call in trace.calls[calls_before:])
+    ):
+        return
+    detail = (result.stderr or result.stdout).strip()[-500:] or "<no output>"
+    raise RuntimeError("ACP agent completed without committing a model turn: " + detail)
 
 
 class _PacketReader:
@@ -184,6 +275,7 @@ class ACPHarnessSession(HarnessSession):
         prompt: str | Messages | None,
         system_prompt: str | None,
         session_meta: dict | None,
+        allow_empty_tool_reply: bool,
     ) -> None:
         super().__init__(harness, ctx, trace, runtime, endpoint, secret, mcp_urls, data)
         self.env = env
@@ -191,6 +283,7 @@ class ACPHarnessSession(HarnessSession):
         self.prompt = prompt
         self.system_prompt = system_prompt
         self.session_meta = session_meta or {}
+        self.allow_empty_tool_reply = allow_empty_tool_reply
         self._process: RuntimeProcess | None = None
         self._reader: _PacketReader | None = None
         self._stderr_tail = bytearray()
@@ -234,6 +327,7 @@ class ACPHarnessSession(HarnessSession):
             "system_prompt": self.system_prompt or "",
             "session_path": None,
             "session_meta": self.session_meta,
+            "allow_empty_tool_reply": self.allow_empty_tool_reply,
         }
         async with self._lock:
             if self._closed:
@@ -244,6 +338,7 @@ class ACPHarnessSession(HarnessSession):
                 await self._start()
             assert self._process is not None
             assert self._reader is not None
+            calls_before = len(self.trace.calls)
             try:
                 await self._process.write(
                     _packet({"operation": "prompt", "config": config})
@@ -257,7 +352,9 @@ class ACPHarnessSession(HarnessSession):
             if stderr := self._stderr():
                 detail = f"{detail}\n\nACP process stderr:\n{stderr}"
             raise RuntimeError(detail)
-        return ProgramResult(exit_code=0, stdout=response.get("reply", ""), stderr="")
+        result = ProgramResult(exit_code=0, stdout=response.get("reply", ""), stderr="")
+        _require_model_turn(self.trace, calls_before, result)
+        return result
 
     async def _stop(self, *, graceful: bool) -> None:
         process, self._process = self._process, None

--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -8,7 +8,7 @@ from abc import abstractmethod
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TypeVar
+from typing import TypeAlias, TypeVar
 
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
@@ -27,6 +27,10 @@ MAX_PACKET_BYTES = 128 * 1024 * 1024
 __all__ = ["ACP", "ACPConfig", "ACPHarness"]
 
 ConfigT = TypeVar("ConfigT", bound=HarnessConfig)
+JsonValue: TypeAlias = (
+    str | int | float | bool | None | list["JsonValue"] | dict[str, "JsonValue"]
+)
+JsonObject: TypeAlias = dict[str, JsonValue]
 
 
 @dataclass
@@ -39,7 +43,7 @@ class ACPConfig:
     mcp_urls: dict[str, str] | None = None
     system_prompt: str | None = None
     session_path: str | None = None
-    session_meta: dict | None = None
+    session_meta: JsonObject | None = None
     allow_empty_tool_reply: bool = False
 
 
@@ -66,7 +70,7 @@ class ACP:
         command: list[str],
         prompt: str | Messages | None,
         system_prompt: str | None = None,
-        session_meta: dict | None = None,
+        session_meta: JsonObject | None = None,
         allow_empty_tool_reply: bool = False,
     ) -> "ACPHarnessSession":
         """Create a live ACP-backed handle owned by one rollout."""
@@ -98,7 +102,7 @@ class ACP:
         mcp_urls: dict[str, str] | None = None,
         system_prompt: str | None = None,
         session_path: str | None = None,
-        session_meta: dict | None = None,
+        session_meta: JsonObject | None = None,
         allow_empty_tool_reply: bool = False,
     ) -> ProgramResult:
         """Run one ACP segment without retaining its process."""
@@ -217,7 +221,7 @@ class ACPHarness(Harness[ConfigT]):
         )
 
 
-def _packet(value: dict) -> bytes:
+def _packet(value: JsonObject) -> bytes:
     data = json.dumps(value, ensure_ascii=False).encode()
     if len(data) > MAX_PACKET_BYTES:
         raise ValueError(f"ACP session packet is too large: {len(data)} bytes")
@@ -250,7 +254,7 @@ class _PacketReader:
         del self._buffer[:size]
         return data
 
-    async def read(self) -> dict:
+    async def read(self) -> JsonObject:
         size = int.from_bytes(await self._readexactly(8), "big")
         if size > MAX_PACKET_BYTES:
             raise ValueError(f"ACP session packet is too large: {size} bytes")
@@ -274,7 +278,7 @@ class ACPHarnessSession(HarnessSession):
         command: list[str],
         prompt: str | Messages | None,
         system_prompt: str | None,
-        session_meta: dict | None,
+        session_meta: JsonObject | None,
         allow_empty_tool_reply: bool,
     ) -> None:
         super().__init__(harness, ctx, trace, runtime, endpoint, secret, mcp_urls, data)

--- a/verifiers/v1/acp/runner.py
+++ b/verifiers/v1/acp/runner.py
@@ -135,9 +135,11 @@ def mcp_servers(config: dict) -> list[HttpMcpServer]:
     ]
 
 
-def segment_messages(config: dict, is_new: bool) -> list[dict]:
+def segment_messages(
+    config: dict, *, is_new: bool, replayed_transcript: bool
+) -> list[dict]:
     messages = config["messages"]
-    if not is_new:
+    if replayed_transcript:
         last_assistant = max(
             (
                 index
@@ -163,10 +165,18 @@ async def prompt(
     config: dict,
     *,
     is_new: bool,
+    replayed_transcript: bool,
 ) -> str:
     prompt_capabilities = capabilities and capabilities.prompt_capabilities
     supports_images = bool(prompt_capabilities and prompt_capabilities.image)
-    blocks = content_blocks(segment_messages(config, is_new), supports_images)
+    blocks = content_blocks(
+        segment_messages(
+            config,
+            is_new=is_new,
+            replayed_transcript=replayed_transcript,
+        ),
+        supports_images,
+    )
     if not blocks:
         raise ValueError("ACP prompt has no content")
     client.reset()
@@ -261,6 +271,7 @@ async def run_once(config: dict) -> str:
             session_id,
             config,
             is_new=is_new,
+            replayed_transcript=not is_new,
         )
         if session_path and is_new:
             session_path.parent.mkdir(parents=True, exist_ok=True)
@@ -339,6 +350,9 @@ class LiveACPSession:
             self.session_id,
             config,
             is_new=self.is_new,
+            # HarnessSession.turn() already passes only this interaction's new
+            # messages; unlike run_once resume, this is not a replayed transcript.
+            replayed_transcript=False,
         )
         self.is_new = False
         return reply

--- a/verifiers/v1/acp/runner.py
+++ b/verifiers/v1/acp/runner.py
@@ -95,9 +95,9 @@ def content_blocks(messages: list[dict], supports_images: bool) -> list:
     for message in messages:
         if transcript:
             separator = "\n\n" if blocks else ""
-            blocks.append(
-                text_block(f"{separator}[{message.get('role', 'message')}]\n")
-            )
+            role = message.get("role", "message")
+            label = "(system)" if role == "system" else f"[{role}]"
+            blocks.append(text_block(f"{separator}{label}\n"))
         content = message.get("content") or ""
         parts = (
             [{"type": "text", "text": content}] if isinstance(content, str) else content
@@ -149,7 +149,10 @@ def segment_messages(config: dict, is_new: bool) -> list[dict]:
         messages = messages[last_assistant + 1 :]
     if is_new and config["system_prompt"]:
         messages = [
-            {"role": "system", "content": config["system_prompt"]},
+            {
+                "role": "system",
+                "content": config["system_prompt"],
+            },
             *messages,
         ]
     return messages

--- a/verifiers/v1/acp/runner.py
+++ b/verifiers/v1/acp/runner.py
@@ -149,10 +149,7 @@ def segment_messages(config: dict, is_new: bool) -> list[dict]:
         messages = messages[last_assistant + 1 :]
     if is_new and config["system_prompt"]:
         messages = [
-            {
-                "role": "system",
-                "content": config["system_prompt"],
-            },
+            {"role": "system", "content": config["system_prompt"]},
             *messages,
         ]
     return messages

--- a/verifiers/v1/clients/eval.py
+++ b/verifiers/v1/clients/eval.py
@@ -37,6 +37,8 @@ _BLOCKED_REQUEST_HEADERS = frozenset(
         "te",
         "trailer",
         "upgrade",
+        # Provider affinity must not compete with the rollout-wide session header below.
+        "session_id",
         # The eval owns the model and sampling settings, so it changes those JSON fields before
         # sending upstream. Hashes and signatures calculated from the intercepted body are stale.
         "content-digest",

--- a/verifiers/v1/dialects/anthropic.py
+++ b/verifiers/v1/dialects/anthropic.py
@@ -40,13 +40,20 @@ STOP_REASONS = {
     "tool_use": "tool_calls",
     "stop_sequence": "stop",
 }
-THINKING = ("thinking", "redacted_thinking")
+# Claude may reorder mixed thinking block types between a response and its replay.
+THINKING = ("redacted_thinking", "thinking")
 
 
 def parse_content(content) -> str | list[ContentPart]:
     """Anthropic user-side content (text + image blocks) -> typed content parts."""
     if isinstance(content, str):
         return content
+    if (
+        isinstance(content, list)
+        and len(content) == 1
+        and content[0].get("type") == "text"
+    ):
+        return content[0].get("text", "")
     parts: list[ContentPart] = []
     for block in content or []:
         if block.get("type") == "text":
@@ -77,6 +84,7 @@ def parse_messages(body: dict) -> Messages:
                 else content or []
             )
             state = [block for block in blocks if block["type"] in THINKING]
+            state.sort(key=lambda block: THINKING.index(block["type"]))
             text = "".join(b.get("text", "") for b in blocks if b.get("type") == "text")
             reasoning = "".join(
                 b.get("thinking", "") for b in blocks if b.get("type") == "thinking"
@@ -125,6 +133,7 @@ def response_from_wire(message: AnthropicMessage) -> Response:
     data = message.model_dump()
     blocks = data.get("content") or []
     state = [block for block in blocks if block["type"] in THINKING]
+    state.sort(key=lambda block: THINKING.index(block["type"]))
     content: list[str] = []
     reasoning: list[str] = []
     calls: list[ToolCall] = []

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -215,7 +215,9 @@ class ChatStreamParser(StreamParser):
     tool_calls: dict[int, dict] = dataclass_field(default_factory=dict)
     tool_arguments: dict[int, list[str]] = dataclass_field(default_factory=dict)
     reasoning_details: list[dict] = dataclass_field(default_factory=list)
-    reasoning_detail_parts: dict[int, list[str]] = dataclass_field(default_factory=dict)
+    reasoning_detail_parts: dict[int, tuple[str, list[str]]] = dataclass_field(
+        default_factory=dict
+    )
     finish_reason: str | None = None
     usage: dict | None = None
     head: dict | None = None
@@ -237,15 +239,29 @@ class ChatStreamParser(StreamParser):
                     self.message_parts[key].append(delta[key])
             for detail in delta.get("reasoning_details") or []:
                 previous = self.reasoning_details[-1] if self.reasoning_details else {}
-                if detail.get("type") == previous.get("type") == "reasoning.text":
+                detail_type = detail.get("type")
+                content_field = {
+                    "reasoning.summary": "summary",
+                    "reasoning.text": "text",
+                }.get(detail_type)
+                if (
+                    content_field
+                    and detail_type == previous.get("type")
+                    and all(
+                        previous.get(field_name) is None
+                        or detail.get(field_name) is None
+                        or previous[field_name] == detail[field_name]
+                        for field_name in ("id", "index", "format")
+                    )
+                ):
                     self.reasoning_detail_parts.setdefault(
                         len(self.reasoning_details) - 1,
-                        [previous.get("text") or ""],
-                    ).append(detail.get("text") or "")
-                    for field_name in ("signature", "format"):
-                        previous[field_name] = previous.get(field_name) or detail.get(
-                            field_name
-                        )
+                        (content_field, [previous.get(content_field) or ""]),
+                    )[1].append(detail.get(content_field) or "")
+                    for field_name in ("id", "index", "signature", "format"):
+                        value = previous.get(field_name) or detail.get(field_name)
+                        if value is not None:
+                            previous[field_name] = value
                 else:
                     self.reasoning_details.append(detail)
             for tool_call in delta.get("tool_calls") or []:
@@ -266,8 +282,8 @@ class ChatStreamParser(StreamParser):
         for key, parts in self.message_parts.items():
             if parts:
                 self.message[key] = "".join(parts)
-        for index, parts in self.reasoning_detail_parts.items():
-            self.reasoning_details[index]["text"] = "".join(parts)
+        for index, (content_field, parts) in self.reasoning_detail_parts.items():
+            self.reasoning_details[index][content_field] = "".join(parts)
         for index, parts in self.tool_arguments.items():
             self.tool_calls[index]["function"]["arguments"] = "".join(parts)
         if self.tool_calls:

--- a/verifiers/v1/dialects/responses.py
+++ b/verifiers/v1/dialects/responses.py
@@ -16,6 +16,7 @@ from openai.types.responses import (
 from pydantic import BaseModel, ConfigDict
 
 from verifiers.v1.dialects.base import Dialect, StreamParser, iter_sse_reverse
+from verifiers.v1.errors import model_error
 from verifiers.v1.types import (
     AssistantMessage,
     ContentPart,
@@ -136,6 +137,23 @@ def response_from_wire(response: OpenAIResponse) -> Response:
     """An OpenAI Responses object -> a vf `Response` (its `output` items folded into one
     assistant message)."""
     data = response.model_dump()
+    status = data.get("status")
+    if status not in (None, "completed", "incomplete"):
+        error = data.get("error") or {}
+        code = error.get("code") if isinstance(error, dict) else None
+        message = error.get("message") if isinstance(error, dict) else None
+        detail = ": ".join(str(value) for value in (status, code, message) if value)
+        status_code = (
+            429
+            if code in ("rate_limit_exceeded", "rate_limit_error")
+            else 400
+            if code in ("context_length_exceeded", "invalid_prompt")
+            else 502
+        )
+        raise model_error(
+            f"upstream Responses request did not complete: {detail}",
+            status_code=status_code,
+        )
     content = ""
     reasoning: list[str] = []
     calls: list[ToolCall] = []

--- a/verifiers/v1/harnesses/claude_code/harness.py
+++ b/verifiers/v1/harnesses/claude_code/harness.py
@@ -86,13 +86,15 @@ class ClaudeCodeHarness(ACPHarness[ClaudeCodeHarnessConfig]):
         system_prompt, prompt = self.resolve_prompt(data)
         config_dir = self.config_dir(trace)
         versions = {"version": self.config.version, "acp_version": ACP_VERSION}
-        options: dict[str, object] = {
-            "strictMcpConfig": True,
-            "disallowedTools": self.config.disabled_tools or [],
+        session_meta = {
+            "claudeCode": {
+                "options": {
+                    "strictMcpConfig": True,
+                    "disallowedTools": self.config.disabled_tools or [],
+                }
+            },
+            **({"systemPrompt": {"append": system_prompt}} if system_prompt else {}),
         }
-        session_meta: dict[str, object] = {"claudeCode": {"options": options}}
-        if system_prompt:
-            session_meta["systemPrompt"] = {"append": system_prompt}
         env = {
             **self.config.resolved_env,
             "ANTHROPIC_BASE_URL": endpoint.removesuffix("/v1"),

--- a/verifiers/v1/harnesses/claude_code/harness.py
+++ b/verifiers/v1/harnesses/claude_code/harness.py
@@ -4,12 +4,11 @@ import shlex
 
 from pydantic import Field
 
-from verifiers.v1.acp import ACP
+from verifiers.v1.acp import ACPConfig, ACPHarness
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
-from verifiers.v1.harness import Harness, HarnessSession
 from verifiers.v1.harnesses.node import NODE_BIN_DIR, ensure_node
-from verifiers.v1.runtimes import ProgramResult, Runtime
+from verifiers.v1.runtimes import Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
 
@@ -31,15 +30,13 @@ npm install --prefix {packages} --no-audit --no-fund \
 touch {ready}
 """
 
-CLAUDE_ACP = ACP()
-
 
 class ClaudeCodeHarnessConfig(HarnessConfig):
     version: str = Field(default="2.1.223", pattern=r"^[A-Za-z0-9._+-]+$")
     """Claude Code release to install, pinned for reproducibility."""
 
 
-class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
+class ClaudeCodeHarness(ACPHarness[ClaudeCodeHarnessConfig]):
     APPENDS_SYSTEM_PROMPT = True
     SUPPORTS_MCP = True
     SUPPORTS_RESUME = True
@@ -74,9 +71,9 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
         if acp_result.exit_code != 0:
             detail = (acp_result.stderr or acp_result.stdout).strip()[-500:]
             raise RuntimeError(f"Claude Agent ACP install failed: {detail}")
-        await CLAUDE_ACP.setup(self, runtime)
+        await self.acp.setup(self, runtime)
 
-    async def session(
+    async def prepare_acp(
         self,
         ctx: ModelContext,
         trace: Trace,
@@ -85,11 +82,7 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
         secret: str,
         mcp_urls: dict[str, str],
         data: TaskData,
-    ) -> HarnessSession:
-        if not runtime.supports_live_processes:
-            return await super().session(
-                ctx, trace, runtime, endpoint, secret, mcp_urls, data
-            )
+    ) -> ACPConfig:
         system_prompt, prompt = self.resolve_prompt(data)
         config_dir = self.config_dir(trace)
         versions = {"version": self.config.version, "acp_version": ACP_VERSION}
@@ -111,60 +104,10 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
             "DISABLE_AUTOUPDATER": "1",
             "IS_SANDBOX": "1",
         }
-        return CLAUDE_ACP.session(
-            self,
-            ctx,
-            trace,
-            runtime,
-            endpoint,
-            secret,
-            mcp_urls,
-            data,
+        return ACPConfig(
             env=env,
             command=[f"{NODE_BIN_DIR}/node", ACP_BIN.format(**versions)],
             prompt=prompt or "",
-            session_meta=session_meta,
-        )
-
-    async def launch(
-        self,
-        ctx: ModelContext,
-        trace: Trace,
-        runtime: Runtime,
-        endpoint: str,
-        secret: str,
-        mcp_urls: dict[str, str],
-        data: TaskData,
-    ) -> ProgramResult:
-        system_prompt, prompt = self.resolve_prompt(data)
-        config_dir = self.config_dir(trace)
-        versions = {"version": self.config.version, "acp_version": ACP_VERSION}
-
-        options: dict[str, object] = {
-            "strictMcpConfig": True,
-            "disallowedTools": self.config.disabled_tools or [],
-        }
-        session_meta: dict[str, object] = {"claudeCode": {"options": options}}
-        if system_prompt:
-            session_meta["systemPrompt"] = {"append": system_prompt}
-        env = {
-            **self.config.resolved_env,
-            # Claude appends /v1/messages; give it the interception root, not the model endpoint.
-            "ANTHROPIC_BASE_URL": endpoint.removesuffix("/v1"),
-            "ANTHROPIC_API_KEY": secret,
-            "ANTHROPIC_MODEL": ctx.model,
-            "CLAUDE_CODE_EXECUTABLE": CLAUDE_BIN.format(**versions),
-            "CLAUDE_CONFIG_DIR": config_dir,
-            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
-            "DISABLE_AUTOUPDATER": "1",
-            "IS_SANDBOX": "1",
-        }
-        return await CLAUDE_ACP.run(
-            runtime,
-            env,
-            [f"{NODE_BIN_DIR}/node", ACP_BIN.format(**versions)],
-            prompt or "",
-            mcp_urls=mcp_urls,
             session_path=f"{config_dir}/acp-session",
             session_meta=session_meta,
         )

--- a/verifiers/v1/harnesses/codex/harness.py
+++ b/verifiers/v1/harnesses/codex/harness.py
@@ -19,9 +19,6 @@ from verifiers.v1.trace import Trace
 
 logger = logging.getLogger(__name__)
 
-PROVIDER = "intercept"
-KEY_VAR = "CODEX_INTERCEPT_KEY"
-
 CODEX_DIR = "/var/tmp/vf-codex-{version}-{acp_version}"
 PACKAGES_DIR = f"{CODEX_DIR}/acp"
 ACP_VERSION = "1.1.10"
@@ -191,27 +188,24 @@ class CodexHarness(ACPHarness[CodexHarnessConfig]):
             }
         config = {
             "model": ctx.model,
-            "model_provider": PROVIDER,
-            "model_providers": {
-                PROVIDER: {
-                    "name": PROVIDER,
-                    "base_url": endpoint,
-                    "env_key": KEY_VAR,
-                    "wire_api": "responses",
-                    "requires_openai_auth": False,
-                }
-            },
             "features": features,
         }
         return {
             **self.config.resolved_env,
-            "CODEX_API_KEY": secret,
-            KEY_VAR: secret,
-            "APP_SERVER_LOGS": f"{home}/logs",
             "CODEX_CONFIG": json.dumps(config),
             "CODEX_HOME": home,
-            "DEFAULT_AUTH_REQUEST": json.dumps({"methodId": "api-key"}),
+            "DEFAULT_AUTH_REQUEST": json.dumps(
+                {
+                    "methodId": "gateway",
+                    "_meta": {
+                        "gateway": {
+                            "baseUrl": endpoint,
+                            "headers": {"Authorization": f"Bearer {secret}"},
+                            "providerName": "Verifiers",
+                        }
+                    },
+                }
+            ),
             "INITIAL_AGENT_MODE": "agent-full-access",
-            "MODEL_PROVIDER": PROVIDER,
             "NO_BROWSER": "1",
         }

--- a/verifiers/v1/harnesses/codex/harness.py
+++ b/verifiers/v1/harnesses/codex/harness.py
@@ -9,12 +9,11 @@ from collections import Counter
 
 from pydantic import Field
 
-from verifiers.v1.acp import ACP
+from verifiers.v1.acp import ACPConfig, ACPHarness
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
-from verifiers.v1.harness import Harness, HarnessSession
 from verifiers.v1.harnesses.node import NODE_BIN_DIR, ensure_node
-from verifiers.v1.runtimes import ProgramResult, Runtime
+from verifiers.v1.runtimes import Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
 
@@ -40,8 +39,6 @@ npm install --prefix {packages} --ignore-scripts --no-audit --no-fund \
 touch {ready}
 """
 
-CODEX_ACP = ACP()
-
 
 class CodexHarnessConfig(HarnessConfig):
     version: str = Field(default="0.146.1", pattern=r"^[A-Za-z0-9._+-]+$")
@@ -50,7 +47,7 @@ class CodexHarnessConfig(HarnessConfig):
     """Enable Codex's native multi-agent v2 tools."""
 
 
-class CodexHarness(Harness[CodexHarnessConfig]):
+class CodexHarness(ACPHarness[CodexHarnessConfig]):
     APPENDS_SYSTEM_PROMPT = False  # TODO
     SUPPORTS_MCP = True
     SUPPORTS_RESUME = True
@@ -89,9 +86,9 @@ class CodexHarness(Harness[CodexHarnessConfig]):
         )
         if install.exit_code != 0:
             raise RuntimeError(f"codex install failed: {install.stderr.strip()[-500:]}")
-        await CODEX_ACP.setup(self, runtime)
+        await self.acp.setup(self, runtime)
 
-    async def session(
+    async def prepare_acp(
         self,
         ctx: ModelContext,
         trace: Trace,
@@ -100,61 +97,21 @@ class CodexHarness(Harness[CodexHarnessConfig]):
         secret: str,
         mcp_urls: dict[str, str],
         data: TaskData,
-    ) -> HarnessSession:
-        if not runtime.supports_live_processes:
-            return await super().session(
-                ctx, trace, runtime, endpoint, secret, mcp_urls, data
-            )
+    ) -> ACPConfig:
         if data.system_prompt is not None and not isinstance(data.prompt, str):
             system_prompt, prompt = data.system_prompt, data.prompt
         else:
             system_prompt, prompt = self.resolve_prompt(data)
         env = await self.build_env(ctx, trace, runtime, endpoint, secret, mcp_urls)
-        return CODEX_ACP.session(
-            self,
-            ctx,
-            trace,
-            runtime,
-            endpoint,
-            secret,
-            {},
-            data,
+        return ACPConfig(
             env=env,
             command=[
                 f"{NODE_BIN_DIR}/node",
                 ACP_BIN.format(version=self.config.version, acp_version=ACP_VERSION),
             ],
             prompt=prompt,
-            system_prompt=system_prompt,
-        )
-
-    async def launch(
-        self,
-        ctx: ModelContext,
-        trace: Trace,
-        runtime: Runtime,
-        endpoint: str,
-        secret: str,
-        mcp_urls: dict[str, str],
-        data: TaskData,
-    ) -> ProgramResult:
-        if (
-            data.system_prompt is not None
-            and data.prompt is not None
-            and not isinstance(data.prompt, str)
-        ):
-            system_prompt, prompt = data.system_prompt, data.prompt
-        else:
-            system_prompt, prompt = self.resolve_prompt(data)
-        env = await self.build_env(ctx, trace, runtime, endpoint, secret, mcp_urls)
-        return await CODEX_ACP.run(
-            runtime,
-            env,
-            [
-                f"{NODE_BIN_DIR}/node",
-                ACP_BIN.format(version=self.config.version, acp_version=ACP_VERSION),
-            ],
-            prompt,
+            # Codex reads MCP servers from the config written by build_env().
+            mcp_urls={},
             system_prompt=system_prompt,
             session_path=f"{self.trace_home(trace)}/acp-session",
         )

--- a/verifiers/v1/harnesses/hermes_agent/harness.py
+++ b/verifiers/v1/harnesses/hermes_agent/harness.py
@@ -51,9 +51,15 @@ class HermesAgentHarness(ACPHarness[HermesAgentHarnessConfig]):
         home = f"/tmp/vf-hermes/{trace.id}"
         # Keep interception routing separate from vendor names that Hermes may resolve
         # to built-in cloud providers instead of the configured endpoint.
-        model: dict[str, object] = {"provider": "openai", "default": ctx.model}
-        if ctx.sampling.max_tokens is not None:
-            model["max_tokens"] = ctx.sampling.max_tokens
+        model = {
+            "provider": "openai",
+            "default": ctx.model,
+            **(
+                {"max_tokens": ctx.sampling.max_tokens}
+                if ctx.sampling.max_tokens is not None
+                else {}
+            ),
+        }
         provider = {
             "api": endpoint,
             "api_key": secret,

--- a/verifiers/v1/harnesses/hermes_agent/harness.py
+++ b/verifiers/v1/harnesses/hermes_agent/harness.py
@@ -49,7 +49,8 @@ class HermesAgentHarness(ACPHarness[HermesAgentHarnessConfig]):
             raise ValueError("Hermes Agent ACP does not support disabling tools")
 
         home = f"/tmp/vf-hermes/{trace.id}"
-        model: dict[str, object] = {"provider": "intercept", "default": ctx.model}
+        provider_name = ctx.model.partition("/")[0] if "/" in ctx.model else "openai"
+        model: dict[str, object] = {"provider": provider_name, "default": ctx.model}
         if ctx.sampling.max_tokens is not None:
             model["max_tokens"] = ctx.sampling.max_tokens
         provider = {
@@ -66,7 +67,7 @@ class HermesAgentHarness(ACPHarness[HermesAgentHarnessConfig]):
             "approvals": {"mode": "off"},
             # Session titles are UI metadata, not part of the agent conversation.
             "auxiliary": {"title_generation": {"enabled": False}},
-            "providers": {"intercept": provider},
+            "providers": {provider_name: provider},
         }
         await runtime.write(f"{home}/config.yaml", json.dumps(config).encode())
         if not self.config.use_bundled_skill:

--- a/verifiers/v1/harnesses/hermes_agent/harness.py
+++ b/verifiers/v1/harnesses/hermes_agent/harness.py
@@ -49,8 +49,9 @@ class HermesAgentHarness(ACPHarness[HermesAgentHarnessConfig]):
             raise ValueError("Hermes Agent ACP does not support disabling tools")
 
         home = f"/tmp/vf-hermes/{trace.id}"
-        provider_name = ctx.model.partition("/")[0] if "/" in ctx.model else "openai"
-        model: dict[str, object] = {"provider": provider_name, "default": ctx.model}
+        # Keep interception routing separate from vendor names that Hermes may resolve
+        # to built-in cloud providers instead of the configured endpoint.
+        model: dict[str, object] = {"provider": "openai", "default": ctx.model}
         if ctx.sampling.max_tokens is not None:
             model["max_tokens"] = ctx.sampling.max_tokens
         provider = {
@@ -67,7 +68,7 @@ class HermesAgentHarness(ACPHarness[HermesAgentHarnessConfig]):
             "approvals": {"mode": "off"},
             # Session titles are UI metadata, not part of the agent conversation.
             "auxiliary": {"title_generation": {"enabled": False}},
-            "providers": {provider_name: provider},
+            "providers": {"openai": provider},
         }
         await runtime.write(f"{home}/config.yaml", json.dumps(config).encode())
         if not self.config.use_bundled_skill:
@@ -87,6 +88,7 @@ class HermesAgentHarness(ACPHarness[HermesAgentHarnessConfig]):
             ),
             prompt=prompt,
             system_prompt=system_prompt,
+            session_path=f"{home}/acp-session",
         )
 
     async def cleanup(self, trace: Trace, runtime: Runtime) -> None:

--- a/verifiers/v1/harnesses/hermes_agent/harness.py
+++ b/verifiers/v1/harnesses/hermes_agent/harness.py
@@ -1,24 +1,18 @@
 """Run Hermes Agent against interception through its native ACP server."""
 
 import json
-import logging
 from pathlib import Path
 
 from pydantic import Field
 
-from verifiers.v1.acp import ACP
+from verifiers.v1.acp import ACPConfig, ACPHarness
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
-from verifiers.v1.harness import Harness
-from verifiers.v1.runtimes import ProgramResult, Runtime
+from verifiers.v1.runtimes import Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
 
 PROGRAM_SOURCE = (Path(__file__).resolve().parent / "program.py").read_text()
-SKILLS_DIR = ".vf-hermes-skills"
-HERMES_ACP = ACP()
-PROVIDER = "intercept"
-logger = logging.getLogger(__name__)
 
 
 class HermesAgentHarnessConfig(HarnessConfig):
@@ -28,22 +22,20 @@ class HermesAgentHarnessConfig(HarnessConfig):
     """Enable Hermes Agent's bundled skill catalog in addition to uploaded skills."""
 
 
-class HermesAgentHarness(Harness[HermesAgentHarnessConfig]):
+class HermesAgentHarness(ACPHarness[HermesAgentHarnessConfig]):
     APPENDS_SYSTEM_PROMPT = True
     SUPPORTS_MCP = True
     SUPPORTS_RESUME = True
     SUPPORTS_SKILLS = True
 
     async def setup(self, runtime: Runtime) -> None:
-        await self.install_skills(runtime, SKILLS_DIR)
-        logger.info(
-            "hermes-agent: ensuring Hermes Agent %s is installed", self.config.version
+        await runtime.prepare_uv_script(
+            PROGRAM_SOURCE.replace("{version}", self.config.version),
+            self.config.resolved_env,
         )
-        source = PROGRAM_SOURCE.replace("{version}", self.config.version)
-        await runtime.prepare_uv_script(source, self.config.resolved_env)
-        await HERMES_ACP.setup(self, runtime)
+        await self.acp.setup(self, runtime)
 
-    async def launch(
+    async def prepare_acp(
         self,
         ctx: ModelContext,
         trace: Trace,
@@ -52,89 +44,53 @@ class HermesAgentHarness(Harness[HermesAgentHarnessConfig]):
         secret: str,
         mcp_urls: dict[str, str],
         data: TaskData,
-    ) -> ProgramResult:
+    ) -> ACPConfig:
         if self.config.disabled_tools:
             raise ValueError("Hermes Agent ACP does not support disabling tools")
 
-        system_prompt, prompt = self.resolve_prompt(data)
-        home = self._home(trace)
-        model: dict[str, object] = {
-            "provider": PROVIDER,
-            "default": ctx.model,
-            "base_url": endpoint,
-            "api_mode": "chat_completions",
-        }
+        home = f"/tmp/vf-hermes/{trace.id}"
+        model: dict[str, object] = {"provider": "intercept", "default": ctx.model}
         if ctx.sampling.max_tokens is not None:
             model["max_tokens"] = ctx.sampling.max_tokens
-        await runtime.write(
-            f"{home}/config.yaml",
-            json.dumps(
-                {
-                    "model": model,
-                    # The ACP client already approves tool requests. Avoid routing Hermes'
-                    # redundant smart-approval model calls through interception as turns.
-                    "approvals": {"mode": "off"},
-                    "providers": {
-                        PROVIDER: {
-                            "api": endpoint,
-                            "api_key": secret,
-                            "transport": "chat_completions",
-                            "discover_models": False,
-                            "models": [ctx.model],
-                        }
-                    },
-                }
-            ).encode(),
-        )
+        provider = {
+            "api": endpoint,
+            "api_key": secret,
+            "discover_models": False,
+        }
+        if ctx.client.type == "eval":
+            provider["transport"] = "${HERMES_INTERCEPT_TRANSPORT}"
+        config = {
+            "model": model,
+            # The ACP client already approves tool requests. Avoid routing Hermes'
+            # redundant smart-approval model calls through interception as turns.
+            "approvals": {"mode": "off"},
+            # Session titles are UI metadata, not part of the agent conversation.
+            "auxiliary": {"title_generation": {"enabled": False}},
+            "providers": {"intercept": provider},
+        }
+        await runtime.write(f"{home}/config.yaml", json.dumps(config).encode())
         if not self.config.use_bundled_skill:
-            await runtime.write(
-                f"{home}/.no-bundled-skills",
-                b"Verifiers supplies evaluation skills explicitly.\n",
-            )
-
-        if self.config.skills:
-            skill_home = f"{home}/skills"
-            for command in (
-                ["rm", "-rf", skill_home],
-                ["cp", "-R", SKILLS_DIR, skill_home],
-            ):
-                copied = await runtime.run(command, {})
-                if copied.exit_code != 0:
-                    raise RuntimeError(
-                        f"failed to stage Hermes skills: {copied.stderr.strip()[-500:]}"
-                    )
+            await runtime.write(f"{home}/.no-bundled-skills", b"")
+        await self.install_skills(runtime, f"{home}/skills")
 
         env = {
             **self.config.resolved_env,
             "HERMES_HOME": home,
-            "HERMES_ACP_SKIP_CONFIGURED_MCP": "1",
+            "HERMES_INFERENCE_MODEL": ctx.model,
         }
-        source = PROGRAM_SOURCE.replace("{version}", self.config.version)
-        command = await runtime.prepare_uv_script(source, env)
-        calls_before = len(trace.calls)
-        result = await HERMES_ACP.run(
-            runtime,
-            env,
-            command,
-            prompt,
-            mcp_urls=mcp_urls,
+        system_prompt, prompt = self.resolve_prompt(data)
+        return ACPConfig(
+            env=env,
+            command=await runtime.prepare_uv_script(
+                PROGRAM_SOURCE.replace("{version}", self.config.version), env
+            ),
+            prompt=prompt,
             system_prompt=system_prompt,
-            session_path=f"{home}/acp-session",
         )
-        if not any(call.node is not None for call in trace.calls[calls_before:]):
-            detail = (result.stderr or result.stdout).strip()[-500:] or "<no output>"
-            raise RuntimeError(
-                "Hermes Agent completed without committing a model turn: " + detail
-            )
-        return result
 
     async def cleanup(self, trace: Trace, runtime: Runtime) -> None:
-        result = await runtime.run(["rm", "-rf", self._home(trace)], {})
-        if result.exit_code != 0:
+        result = await runtime.run(["rm", "-rf", f"/tmp/vf-hermes/{trace.id}"], {})
+        if result.exit_code:
             raise RuntimeError(
                 f"failed to clean up Hermes home: {result.stderr.strip()[-500:]}"
             )
-
-    @staticmethod
-    def _home(trace: Trace) -> str:
-        return f"/tmp/vf-hermes/{trace.id}"

--- a/verifiers/v1/harnesses/hermes_agent/program.py
+++ b/verifiers/v1/harnesses/hermes_agent/program.py
@@ -4,6 +4,15 @@
 # ///
 """Start Hermes Agent's native ACP server."""
 
+import os
+
+from hermes_cli.models import detect_provider_for_model
+from hermes_cli.providers import determine_api_mode
+
+model = os.environ["HERMES_INFERENCE_MODEL"].rsplit("/", 1)[-1]
+provider, _ = detect_provider_for_model(model, "auto") or ("auto", model)
+os.environ.setdefault("HERMES_INTERCEPT_TRANSPORT", determine_api_mode(provider))
+
 from acp_adapter.entry import main
 
 if __name__ == "__main__":

--- a/verifiers/v1/harnesses/kimi_code/harness.py
+++ b/verifiers/v1/harnesses/kimi_code/harness.py
@@ -1,7 +1,8 @@
-"""Kimi receives interception through an isolated provider and runs through native ACP."""
+"""Run Kimi Code's native ACP server against interception."""
 
 import logging
 import shlex
+from typing import Literal
 
 import tomli_w
 from pydantic import Field
@@ -40,6 +41,10 @@ env \
 class KimiCodeHarnessConfig(HarnessConfig):
     version: str = Field(default="0.34.0", pattern=r"^[A-Za-z0-9._+-]+$")
     """Kimi Code release to install, pinned for reproducibility."""
+    transport: Literal["chat_completions", "responses", "anthropic_messages"] = (
+        "chat_completions"
+    )
+    """Model API transport."""
 
 
 class KimiCodeHarness(ACPHarness[KimiCodeHarnessConfig]):
@@ -77,25 +82,18 @@ class KimiCodeHarness(ACPHarness[KimiCodeHarnessConfig]):
         data: TaskData,
     ) -> ACPConfig:
         kimi_home = f"{KIMI_HOME}/{trace.id}"
-        # Anthropic preserves signed reasoning and tool identity across history replay.
+        provider_type = {
+            "chat_completions": "kimi",
+            "responses": "openai_responses",
+            "anthropic_messages": "anthropic",
+        }[self.config.transport]
+        base_url = (
+            endpoint.removesuffix("/v1")
+            if self.config.transport == "anthropic_messages"
+            else endpoint
+        )
         config: dict[str, object] = {
-            "default_model": "intercept",
             "extra_skill_dirs": [SKILLS_DIR] if self.config.skills else [],
-            "providers": {
-                "intercept": {
-                    "type": "anthropic",
-                    "api_key": secret,
-                    "base_url": endpoint.removesuffix("/v1"),
-                }
-            },
-            "models": {
-                "intercept": {
-                    "provider": "intercept",
-                    "model": ctx.model,
-                    "max_context_size": 262144,
-                    "capabilities": ["tool_use"],
-                }
-            },
         }
         if self.config.disabled_tools:
             config["permission"] = {
@@ -116,8 +114,10 @@ class KimiCodeHarness(ACPHarness[KimiCodeHarnessConfig]):
             env={
                 **self.config.resolved_env,
                 "KIMI_CODE_HOME": kimi_home,
-                # Kimi's env-model overlay cannot select the configured provider.
-                "KIMI_MODEL_NAME": "",
+                "KIMI_MODEL_NAME": ctx.model,
+                "KIMI_MODEL_API_KEY": secret,
+                "KIMI_MODEL_BASE_URL": base_url,
+                "KIMI_MODEL_PROVIDER_TYPE": provider_type,
                 "KIMI_DISABLE_TELEMETRY": "1",
                 "KIMI_CODE_NO_AUTO_UPDATE": "1",
             },

--- a/verifiers/v1/harnesses/kimi_code/harness.py
+++ b/verifiers/v1/harnesses/kimi_code/harness.py
@@ -83,7 +83,7 @@ class KimiCodeHarness(ACPHarness[KimiCodeHarnessConfig]):
     ) -> ACPConfig:
         kimi_home = f"{KIMI_HOME}/{trace.id}"
         provider_type = {
-            "chat_completions": "kimi",
+            "chat_completions": "openai",
             "responses": "openai_responses",
             "anthropic_messages": "anthropic",
         }[self.config.transport]

--- a/verifiers/v1/harnesses/kimi_code/harness.py
+++ b/verifiers/v1/harnesses/kimi_code/harness.py
@@ -92,21 +92,26 @@ class KimiCodeHarness(ACPHarness[KimiCodeHarnessConfig]):
             if self.config.transport == "anthropic_messages"
             else endpoint
         )
-        config: dict[str, object] = {
+        config = {
             "extra_skill_dirs": [SKILLS_DIR] if self.config.skills else [],
-        }
-        if self.config.disabled_tools:
-            config["permission"] = {
-                "rules": [
-                    {
-                        "decision": "deny",
-                        "scope": "user",
-                        "pattern": tool,
-                        "reason": "Disabled by Verifiers harness configuration.",
+            **(
+                {
+                    "permission": {
+                        "rules": [
+                            {
+                                "decision": "deny",
+                                "scope": "user",
+                                "pattern": tool,
+                                "reason": "Disabled by Verifiers harness configuration.",
+                            }
+                            for tool in self.config.disabled_tools
+                        ]
                     }
-                    for tool in self.config.disabled_tools
-                ]
-            }
+                }
+                if self.config.disabled_tools
+                else {}
+            ),
+        }
         await runtime.write(f"{kimi_home}/config.toml", tomli_w.dumps(config).encode())
 
         system_prompt, prompt = self.resolve_prompt(data)

--- a/verifiers/v1/harnesses/kimi_code/harness.py
+++ b/verifiers/v1/harnesses/kimi_code/harness.py
@@ -1,16 +1,15 @@
-"""Kimi receives interception through `KIMI_MODEL_*` and runs through native ACP."""
+"""Kimi receives interception through an isolated provider and runs through native ACP."""
 
-import json
 import logging
 import shlex
 
+import tomli_w
 from pydantic import Field
 
-from verifiers.v1.acp import ACP
+from verifiers.v1.acp import ACPConfig, ACPHarness
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
-from verifiers.v1.harness import Harness
-from verifiers.v1.runtimes import ProgramResult, Runtime
+from verifiers.v1.runtimes import Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
 
@@ -18,11 +17,7 @@ logger = logging.getLogger(__name__)
 
 BINARY = "/tmp/vf-kimi-code/bin/kimi"
 KIMI_HOME = ".vf-kimi-code"
-ACP_COMMAND = [
-    "sh",
-    "-c",
-    f'KIMI_CODE_HOME="$PWD/$KIMI_CODE_HOME" exec {BINARY} acp',
-]
+ACP_COMMAND = [BINARY, "acp"]
 SKILLS_DIR = f"{KIMI_HOME}/skills"
 
 INSTALL = r"""
@@ -41,15 +36,13 @@ env \
     bash "$installer"
 """
 
-KIMI_ACP = ACP()
-
 
 class KimiCodeHarnessConfig(HarnessConfig):
     version: str = Field(default="0.34.0", pattern=r"^[A-Za-z0-9._+-]+$")
     """Kimi Code release to install, pinned for reproducibility."""
 
 
-class KimiCodeHarness(Harness[KimiCodeHarnessConfig]):
+class KimiCodeHarness(ACPHarness[KimiCodeHarnessConfig]):
     APPENDS_SYSTEM_PROMPT = True
     SUPPORTS_MCP = True
     SUPPORTS_RESUME = True
@@ -71,9 +64,9 @@ class KimiCodeHarness(Harness[KimiCodeHarnessConfig]):
             raise RuntimeError(
                 f"Kimi Code install failed: {install.stderr.strip()[-500:]}"
             )
-        await KIMI_ACP.setup(self, runtime)
+        await self.acp.setup(self, runtime)
 
-    async def launch(
+    async def prepare_acp(
         self,
         ctx: ModelContext,
         trace: Trace,
@@ -82,54 +75,54 @@ class KimiCodeHarness(Harness[KimiCodeHarnessConfig]):
         secret: str,
         mcp_urls: dict[str, str],
         data: TaskData,
-    ) -> ProgramResult:
-        system_prompt, prompt = self.resolve_prompt(data)
+    ) -> ACPConfig:
         kimi_home = f"{KIMI_HOME}/{trace.id}"
-        if self.config.skills:
-            skill_home = f"{kimi_home}/skills"
-            for command in (
-                ["rm", "-rf", skill_home],
-                ["mkdir", "-p", kimi_home],
-                ["cp", "-R", SKILLS_DIR, skill_home],
-            ):
-                copied = await runtime.run(command, {})
-                if copied.exit_code != 0:
-                    raise RuntimeError(
-                        f"failed to stage Kimi skills: {copied.stderr.strip()[-500:]}"
-                    )
-        env = {
-            **self.config.resolved_env,
-            "KIMI_CODE_HOME": kimi_home,
-            "KIMI_MODEL_NAME": ctx.model,
-            "KIMI_MODEL_API_KEY": secret,
-            "KIMI_MODEL_PROVIDER_TYPE": "openai",
-            "KIMI_MODEL_BASE_URL": endpoint,
-            "KIMI_MODEL_CAPABILITIES": "tool_use",
-            "KIMI_DISABLE_TELEMETRY": "1",
-            "KIMI_CODE_NO_AUTO_UPDATE": "1",
+        # Anthropic preserves signed reasoning and tool identity across history replay.
+        config: dict[str, object] = {
+            "default_model": "intercept",
+            "extra_skill_dirs": [SKILLS_DIR] if self.config.skills else [],
+            "providers": {
+                "intercept": {
+                    "type": "anthropic",
+                    "api_key": secret,
+                    "base_url": endpoint.removesuffix("/v1"),
+                }
+            },
+            "models": {
+                "intercept": {
+                    "provider": "intercept",
+                    "model": ctx.model,
+                    "max_context_size": 262144,
+                    "capabilities": ["tool_use"],
+                }
+            },
         }
-        # Values are Kimi permission patterns such as `Bash` or `Bash(rm -rf*)`.
-        # https://moonshotai.github.io/kimi-code/en/configuration/config-files#permission
-        permission_rules = "\n".join(
-            "\n".join(
-                (
-                    "[[permission.rules]]",
-                    'decision = "deny"',
-                    'scope = "user"',
-                    f"pattern = {json.dumps(tool)}",
-                    'reason = "Disabled by Verifiers harness configuration."',
-                )
-            )
-            for tool in self.config.disabled_tools or []
-        )
-        if permission_rules:
-            await runtime.write(f"{kimi_home}/config.toml", permission_rules.encode())
-        return await KIMI_ACP.run(
-            runtime,
-            env,
-            ACP_COMMAND,
-            prompt,
-            mcp_urls=mcp_urls,
+        if self.config.disabled_tools:
+            config["permission"] = {
+                "rules": [
+                    {
+                        "decision": "deny",
+                        "scope": "user",
+                        "pattern": tool,
+                        "reason": "Disabled by Verifiers harness configuration.",
+                    }
+                    for tool in self.config.disabled_tools
+                ]
+            }
+        await runtime.write(f"{kimi_home}/config.toml", tomli_w.dumps(config).encode())
+
+        system_prompt, prompt = self.resolve_prompt(data)
+        return ACPConfig(
+            env={
+                **self.config.resolved_env,
+                "KIMI_CODE_HOME": kimi_home,
+                # Kimi's env-model overlay cannot select the configured provider.
+                "KIMI_MODEL_NAME": "",
+                "KIMI_DISABLE_TELEMETRY": "1",
+                "KIMI_CODE_NO_AUTO_UPDATE": "1",
+            },
+            command=ACP_COMMAND,
+            prompt=prompt,
             system_prompt=system_prompt,
-            session_path=f"{kimi_home}/acp-session",
+            session_path=f"{KIMI_HOME}/{trace.id}/acp-session",
         )

--- a/verifiers/v1/harnesses/openclaw/harness.py
+++ b/verifiers/v1/harnesses/openclaw/harness.py
@@ -159,6 +159,7 @@ class OpenClawHarness(ACPHarness[OpenClawHarnessConfig]):
                     "token": "${OPENCLAW_GATEWAY_TOKEN}",
                 },
             },
+            "messages": {"queue": {"mode": "interrupt"}},
             "agents": {
                 "defaults": {
                     "workspace": ".",

--- a/verifiers/v1/harnesses/openclaw/harness.py
+++ b/verifiers/v1/harnesses/openclaw/harness.py
@@ -1,22 +1,17 @@
 """Run OpenClaw's Gateway-backed ACP agent against interception."""
 
 import asyncio
-import fcntl
 import json
 import logging
 import secrets
 import shlex
-from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
-from pathlib import Path
 
 from pydantic import Field
 
-from verifiers.v1.acp import ACP
+from verifiers.v1.acp import ACPConfig, ACPHarness
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
-from verifiers.v1.harness import Harness
-from verifiers.v1.runtimes import DockerRuntime, ProgramResult, Runtime
+from verifiers.v1.runtimes import Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
 
@@ -31,26 +26,59 @@ command -v curl >/dev/null || (apt-get update -qq && apt-get install -y -qq curl
 curl -fsSL --proto '=https' --tlsv1.2 https://openclaw.ai/install-cli.sh | bash -s -- --prefix {dir} --version {version} --no-onboard
 """
 
-OPENCLAW_ACP = ACP()
-
-
-@asynccontextmanager
-async def _gateway_start_lock(runtime: Runtime) -> AsyncIterator[None]:
-    if not isinstance(runtime, DockerRuntime) or runtime.network_restricted:
-        yield
-        return
-    # Unrestricted Docker containers share the host network across server workers.
-    with Path("/tmp/vf-openclaw-gateway.lock").open("a") as lock:  # noqa: ASYNC230
-        while True:
-            try:
-                fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                break
-            except BlockingIOError:
-                await asyncio.sleep(0.1)
-        try:
-            yield
-        finally:
-            fcntl.flock(lock, fcntl.LOCK_UN)
+OPENCLAW_COMMAND = [
+    "sh",
+    "-c",
+    r"""
+set -eu
+exec 3<&0
+gateway_pid=
+acp_pid=
+cleanup() {
+    trap - EXIT HUP INT TERM
+    [ -z "$acp_pid" ] || kill -TERM -"$acp_pid" 2>/dev/null || true
+    [ -z "$gateway_pid" ] || kill -TERM -"$gateway_pid" 2>/dev/null || true
+    [ -z "$acp_pid$gateway_pid" ] || sleep 1
+    [ -z "$acp_pid" ] || kill -KILL -"$acp_pid" 2>/dev/null || true
+    [ -z "$gateway_pid" ] || kill -KILL -"$gateway_pid" 2>/dev/null || true
+    [ -z "$acp_pid" ] || wait "$acp_pid" 2>/dev/null || true
+    [ -z "$gateway_pid" ] || wait "$gateway_pid" 2>/dev/null || true
+}
+trap cleanup EXIT
+trap 'exit 143' HUP INT TERM
+root=${VF_OPENCLAW_BIN%/bin/openclaw}
+gateway_attempt=0
+while [ "$gateway_attempt" -lt 5 ]; do
+    port=$("$root/tools/node/bin/node" -e 'const net=require("node:net");const server=net.createServer();server.listen(0,"127.0.0.1",()=>{process.stdout.write(String(server.address().port));server.close();});')
+    export OPENCLAW_GATEWAY_PORT="$port"
+    # OpenClaw respawns Node; separate groups let the trap reap both process trees.
+    setsid "$VF_OPENCLAW_BIN" gateway run </dev/null >"$OPENCLAW_STATE_DIR/gateway.log" &
+    gateway_pid=$!
+    attempt=0
+    while ! curl -fsS "http://127.0.0.1:$port/readyz" >/dev/null 2>&1; do
+        if ! kill -0 "$gateway_pid" 2>/dev/null; then
+            wait "$gateway_pid" 2>/dev/null || true
+            gateway_pid=
+            break
+        fi
+        attempt=$((attempt + 1))
+        [ "$attempt" -lt 120 ] || { tail -100 "$OPENCLAW_STATE_DIR/gateway.log" >&2; exit 1; }
+        sleep 1
+    done
+    [ -n "$gateway_pid" ] && break
+    # The probe releases its socket before Gateway binds, so retry early exits
+    # when concurrent host-network rollouts select the same port.
+    gateway_attempt=$((gateway_attempt + 1))
+done
+if [ -z "$gateway_pid" ]; then
+    tail -100 "$OPENCLAW_STATE_DIR/gateway.log" >&2
+    exit 1
+fi
+setsid "$VF_OPENCLAW_BIN" acp --verbose --session "agent:main:acp-bridge:$OPENCLAW_GATEWAY_TOKEN" --no-prefix-cwd <&3 >&1 &
+acp_pid=$!
+wait "$acp_pid"
+""",
+]
 
 
 class OpenClawHarnessConfig(HarnessConfig):
@@ -60,7 +88,7 @@ class OpenClawHarnessConfig(HarnessConfig):
     """Enable OpenClaw's bundled skill catalog in addition to uploaded harness skills."""
 
 
-class OpenClawHarness(Harness[OpenClawHarnessConfig]):
+class OpenClawHarness(ACPHarness[OpenClawHarnessConfig]):
     APPENDS_SYSTEM_PROMPT = True
     SUPPORTS_MCP = True
     SUPPORTS_RESUME = True
@@ -104,9 +132,9 @@ class OpenClawHarness(Harness[OpenClawHarnessConfig]):
         if result.exit_code != 0:
             detail = (result.stderr or result.stdout).strip()[-500:]
             raise RuntimeError(f"OpenClaw install failed: {detail}")
-        await OPENCLAW_ACP.setup(self, runtime)
+        await self.acp.setup(self, runtime)
 
-    async def launch(
+    async def prepare_acp(
         self,
         ctx: ModelContext,
         trace: Trace,
@@ -115,22 +143,28 @@ class OpenClawHarness(Harness[OpenClawHarnessConfig]):
         secret: str,
         mcp_urls: dict[str, str],
         data: TaskData,
-    ) -> ProgramResult:
+    ) -> ACPConfig:
         system_prompt, prompt = self.resolve_prompt(data)
         # Opt-in via sampling: OpenClaw redacts persisted encrypted reasoning, so resumed sessions 400 replaying it.
         reasoning = ctx.sampling.reasoning_effort not in (None, "none")
-        directory = OPENCLAW_DIR.format(version=self.config.version)
         state_dir = f".vf-openclaw/{trace.id}"
         config_path = f"{state_dir}/openclaw.json"
-        skills_dir = f"{state_dir}/skills"
         config = {
-            "gateway": {"mode": "local"},
+            "gateway": {
+                "mode": "local",
+                "bind": "loopback",
+                "auth": {
+                    "mode": "token",
+                    "token": "${OPENCLAW_GATEWAY_TOKEN}",
+                },
+            },
             "agents": {
                 "defaults": {
                     "workspace": ".",
                     "skipBootstrap": True,
+                    "heartbeat": {"every": "0m"},
                     "sandbox": {"mode": "off"},
-                    "model": {"primary": f"intercept/{ctx.model}"},
+                    "model": {"primary": f"anthropic/{ctx.model}"},
                 }
             },
             "tools": {
@@ -142,15 +176,16 @@ class OpenClawHarness(Harness[OpenClawHarnessConfig]):
             "models": {
                 "mode": "replace",
                 "providers": {
-                    "intercept": {
+                    "anthropic": {
                         "baseUrl": endpoint,
                         "apiKey": "${OPENCLAW_INTERCEPT_KEY}",
-                        "api": "openai-responses",
+                        "api": "anthropic-messages",
                         "authHeader": True,
                         "models": [
                             {
                                 "id": ctx.model,
                                 "name": ctx.model,
+                                "maxTokens": ctx.sampling.max_tokens or 8192,
                                 "reasoning": reasoning,
                                 "input": ["text", "image"],
                             }
@@ -170,155 +205,30 @@ class OpenClawHarness(Harness[OpenClawHarnessConfig]):
                 }
             },
         }
-        created = await runtime.run(["mkdir", "-p", state_dir], {})
-        if created.exit_code != 0:
-            raise RuntimeError(
-                f"OpenClaw state directory failed: {created.stderr.strip()[-500:]}"
-            )
         if self.config.skills:
-            exists = await runtime.run(["test", "-d", skills_dir], {})
-            if exists.exit_code != 0:
-                copied = await runtime.run(
-                    ["cp", "-R", self._staged_skills_dir, skills_dir], {}
-                )
-                if copied.exit_code != 0:
-                    raise RuntimeError(
-                        f"failed to stage OpenClaw skills: {copied.stderr.strip()[-500:]}"
-                    )
-            config["skills"] = {"load": {"extraDirs": [skills_dir]}}
+            config["skills"] = {"load": {"extraDirs": [self._staged_skills_dir]}}
         if not self.config.use_bundled_skill:
             # OpenClaw treats an empty allowlist as all; a no-match key disables the catalog.
             config.setdefault("skills", {})["allowBundled"] = ["__none__"]
         await runtime.write(config_path, json.dumps(config).encode())
 
-        binary = OPENCLAW_BIN.format(version=self.config.version)
-        node = f"{directory}/tools/node/bin/node"
-        allocate_port = shlex.join(
-            [
-                node,
-                "-e",
-                (
-                    'const net=require("node:net");const server=net.createServer();'
-                    'server.listen(0,"127.0.0.1",()=>{'
-                    "process.stdout.write(String(server.address().port));server.close();});"
-                ),
-            ]
-        )
-        log_path = f"{state_dir}/gateway.log"
-        pid_path = f"{state_dir}/gateway.pid"
         env = {
             **self.config.resolved_env,
             "OPENCLAW_CONFIG_PATH": config_path,
             "OPENCLAW_STATE_DIR": state_dir,
+            "OPENCLAW_GATEWAY_TOKEN": trace.id,
             "OPENCLAW_INTERCEPT_KEY": secret,
             "OPENCLAW_HIDE_BANNER": "1",
             "OPENCLAW_SUPPRESS_NOTES": "1",
             "NO_COLOR": "1",
+            "VF_OPENCLAW_BIN": OPENCLAW_BIN.format(version=self.config.version),
         }
-        async with _gateway_start_lock(runtime):
-            allocated = await runtime.run(["sh", "-c", allocate_port], {})
-            if allocated.exit_code != 0:
-                raise RuntimeError(
-                    f"OpenClaw port allocation failed: {allocated.stderr.strip()[-500:]}"
-                )
-            gateway_port = allocated.stdout.strip()
-            port_probe = shlex.join(
-                [
-                    node,
-                    "-e",
-                    (
-                        'const net=require("node:net");'
-                        f'const socket=net.connect({{host:"127.0.0.1",port:{gateway_port}}});'
-                        'socket.on("connect",()=>socket.end());'
-                        'socket.on("error",()=>process.exit(1));'
-                    ),
-                ]
-            )
-            await runtime.run_background(
-                [
-                    "sh",
-                    "-c",
-                    (
-                        f"echo $$ >{shlex.quote(pid_path)}; "
-                        f"exec {shlex.quote(binary)} gateway run "
-                        f"--port {shlex.quote(gateway_port)} --bind loopback "
-                        f"--auth token --token {shlex.quote(trace.id)} "
-                        "--allow-unconfigured"
-                    ),
-                ],
-                env,
-                log_path,
-            )
-            bound = await runtime.run(
-                [
-                    "sh",
-                    "-c",
-                    (
-                        "attempt=0; "
-                        f"until [ -s {shlex.quote(pid_path)} ] && "
-                        f'kill -0 "$(cat {shlex.quote(pid_path)})" 2>/dev/null && '
-                        f"{port_probe} >/dev/null 2>&1; do "
-                        f"if [ -s {shlex.quote(pid_path)} ] && "
-                        f'! kill -0 "$(cat {shlex.quote(pid_path)})" 2>/dev/null; then '
-                        f"tail -100 {shlex.quote(log_path)} >&2; exit 1; fi; "
-                        "attempt=$((attempt + 1)); "
-                        f'[ "$attempt" -lt 1200 ] || {{ tail -100 {shlex.quote(log_path)} >&2; exit 1; }}; '
-                        "sleep 0.1; done"
-                    ),
-                ],
-                {},
-            )
-            if bound.exit_code != 0:
-                detail = (bound.stderr or bound.stdout).strip()[-2000:]
-                raise RuntimeError(f"OpenClaw gateway failed to bind: {detail}")
-        readiness = await runtime.run(
-            [
-                "sh",
-                "-c",
-                (
-                    "attempt=0; "
-                    f"until [ -s {shlex.quote(pid_path)} ] && "
-                    f'kill -0 "$(cat {shlex.quote(pid_path)})" 2>/dev/null && '
-                    f'curl -fsS "http://127.0.0.1:{gateway_port}/healthz" '
-                    ">/dev/null 2>&1; do "
-                    f"if [ -s {shlex.quote(pid_path)} ] && "
-                    f'! kill -0 "$(cat {shlex.quote(pid_path)})" 2>/dev/null; then '
-                    f"tail -100 {shlex.quote(log_path)} >&2; exit 1; fi; "
-                    "attempt=$((attempt + 1)); "
-                    f'[ "$attempt" -lt 120 ] || {{ tail -100 {shlex.quote(log_path)} >&2; exit 1; }}; '
-                    "sleep 1; done"
-                ),
-            ],
-            {},
-        )
-        if readiness.exit_code != 0:
-            detail = (readiness.stderr or readiness.stdout).strip()[-2000:]
-            raise RuntimeError(f"OpenClaw gateway failed to start: {detail}")
-        command = [
-            "sh",
-            "-c",
-            (
-                "set -eu; "
-                f"gateway_pid=$(cat {shlex.quote(pid_path)}); "
-                f'trap \'kill "$gateway_pid" 2>/dev/null || true; '
-                'attempt=0; while kill -0 "$gateway_pid" 2>/dev/null && '
-                ' [ "$attempt" -lt 50 ]; do attempt=$((attempt + 1)); sleep 0.1; done; '
-                'kill -9 "$gateway_pid" 2>/dev/null || true; '
-                'while kill -0 "$gateway_pid" 2>/dev/null; do sleep 0.1; done; '
-                f"rm -f {shlex.quote(pid_path)}' EXIT; "
-                f'{shlex.quote(binary)} acp --url "ws://127.0.0.1:{gateway_port}" '
-                f"--token {shlex.quote(trace.id)} "
-                f"--session {shlex.quote(f'agent:main:acp-bridge:{trace.id}')} "
-                "--no-prefix-cwd"
-            ),
-        ]
         # OpenClaw rejects ACP per-session MCP declarations; the isolated Gateway
-        # config above owns the equivalent task-scoped server definitions.
-        return await OPENCLAW_ACP.run(
-            runtime,
-            env,
-            command,
-            prompt,
+        # config owns the equivalent task-scoped server definitions.
+        return ACPConfig(
+            env=env,
+            command=OPENCLAW_COMMAND,
+            prompt=prompt,
             mcp_urls={},
             system_prompt=system_prompt,
             session_path=f"{state_dir}/acp-session",
@@ -328,24 +238,7 @@ class OpenClawHarness(Harness[OpenClawHarnessConfig]):
 
     async def cleanup(self, trace: Trace, runtime: Runtime) -> None:
         state_dir = f".vf-openclaw/{trace.id}"
-        pid_path = f"{state_dir}/gateway.pid"
-        result = await runtime.run(
-            [
-                "sh",
-                "-c",
-                (
-                    f"if [ -s {shlex.quote(pid_path)} ]; then "
-                    f"gateway_pid=$(cat {shlex.quote(pid_path)}); "
-                    'kill "$gateway_pid" 2>/dev/null || true; '
-                    'attempt=0; while kill -0 "$gateway_pid" 2>/dev/null && '
-                    ' [ "$attempt" -lt 50 ]; do attempt=$((attempt + 1)); sleep 0.1; done; '
-                    'kill -9 "$gateway_pid" 2>/dev/null || true; '
-                    'while kill -0 "$gateway_pid" 2>/dev/null; do sleep 0.1; done; fi; '
-                    f"rm -rf {shlex.quote(state_dir)}"
-                ),
-            ],
-            {},
-        )
+        result = await runtime.run(["rm", "-rf", state_dir], {})
         if result.exit_code != 0:
             raise RuntimeError(
                 f"failed to clean up OpenClaw state: {result.stderr.strip()[-500:]}"

--- a/verifiers/v1/harnesses/openclaw/harness.py
+++ b/verifiers/v1/harnesses/openclaw/harness.py
@@ -145,11 +145,12 @@ class OpenClawHarness(ACPHarness[OpenClawHarnessConfig]):
         data: TaskData,
     ) -> ACPConfig:
         system_prompt, prompt = self.resolve_prompt(data)
-        # Opt-in via sampling: OpenClaw redacts persisted encrypted reasoning, so resumed sessions 400 replaying it.
-        reasoning = ctx.sampling.reasoning_effort not in (None, "none")
+        provider, _, _ = ctx.model.partition("/")
         state_dir = f".vf-openclaw/{trace.id}"
         config_path = f"{state_dir}/openclaw.json"
         config = {
+            # Provider replay state must remain byte-exact in this isolated rollout transcript.
+            "logging": {"redactSensitive": "off"},
             "gateway": {
                 "mode": "local",
                 "bind": "loopback",
@@ -164,7 +165,7 @@ class OpenClawHarness(ACPHarness[OpenClawHarnessConfig]):
                     "skipBootstrap": True,
                     "heartbeat": {"every": "0m"},
                     "sandbox": {"mode": "off"},
-                    "model": {"primary": f"anthropic/{ctx.model}"},
+                    "model": {"primary": ctx.model},
                 }
             },
             "tools": {
@@ -174,22 +175,10 @@ class OpenClawHarness(ACPHarness[OpenClawHarnessConfig]):
                 "deny": self.config.disabled_tools or [],
             },
             "models": {
-                "mode": "replace",
                 "providers": {
-                    "anthropic": {
+                    provider: {
                         "baseUrl": endpoint,
                         "apiKey": "${OPENCLAW_INTERCEPT_KEY}",
-                        "api": "anthropic-messages",
-                        "authHeader": True,
-                        "models": [
-                            {
-                                "id": ctx.model,
-                                "name": ctx.model,
-                                "maxTokens": ctx.sampling.max_tokens or 8192,
-                                "reasoning": reasoning,
-                                "input": ["text", "image"],
-                            }
-                        ],
                     }
                 },
             },

--- a/verifiers/v1/harnesses/pi/harness.py
+++ b/verifiers/v1/harnesses/pi/harness.py
@@ -6,20 +6,17 @@ import shlex
 
 from pydantic import Field
 
-from verifiers.v1.acp import ACP
+from verifiers.v1.acp import ACPConfig, ACPHarness
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
-from verifiers.v1.harness import Harness
 from verifiers.v1.harnesses.node import NODE_BIN_DIR, ensure_node
-from verifiers.v1.runtimes import ProgramResult, Runtime
+from verifiers.v1.runtimes import Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
 
 logger = logging.getLogger(__name__)
 
-PROVIDER = "intercept"
 KEY_VAR = "PI_INTERCEPT_KEY"
-HOME_VAR = "VF_PI_ORIGINAL_HOME"
 
 PI_DIR = "/var/tmp/vf-pi"
 PACKAGES_DIR = f"{PI_DIR}/mcp"
@@ -29,16 +26,7 @@ MCP_VERSION = "2.20.1"
 ACP_VERSION = "0.0.33"
 MCP_ADAPTER = f"{PACKAGES_DIR}/node_modules/pi-mcp-adapter/index.ts"
 ACP_BIN = f"{PACKAGES_DIR}/node_modules/.bin/pi-acp"
-ACP_COMMAND = [
-    "sh",
-    "-c",
-    (
-        f'export {HOME_VAR}="$HOME"; '
-        'PI_CODING_AGENT_DIR="$PWD/$PI_CODING_AGENT_DIR"; '
-        'export PI_CODING_AGENT_DIR HOME="$PI_CODING_AGENT_DIR"; '
-        f'export PATH="{NODE_BIN_DIR}:$PATH"; exec {ACP_BIN}'
-    ),
-]
+ACP_COMMAND = [f"{NODE_BIN_DIR}/node", ACP_BIN]
 
 INSTALL = r"""
 set -e
@@ -55,44 +43,13 @@ if [ "$(cat "$packages/.versions" 2>/dev/null)" != "$versions" ]; then
 fi
 """
 
-# Isolate pi-mcp-adapter discovery while it registers, then restore the task home.
-MCP_WRAPPER = f"""
-export default async function isolatedMcp(pi) {{
-  const agentDir = process.env.PI_CODING_AGENT_DIR;
-  const cwd = process.cwd();
-  process.chdir(agentDir);
-  process.env.HOME = agentDir;
-  try {{
-    const {{ default: mcpAdapter }} = await import("{MCP_ADAPTER}");
-    const isolatedPi = {{
-      ...pi,
-      on(event, handler) {{
-        pi.on(
-          event,
-          event === "session_start"
-            ? (event, ctx) => handler(event, {{ ...ctx, cwd: agentDir }})
-            : handler,
-        );
-      }},
-    }};
-    mcpAdapter(isolatedPi);
-  }} finally {{
-    process.chdir(cwd);
-    process.env.HOME = process.env.{HOME_VAR};
-    delete process.env.{HOME_VAR};
-  }}
-}}
-""".strip()
-
-PI_ACP = ACP()
-
 
 class PiHarnessConfig(HarnessConfig):
     version: str = Field(default="0.84.0", pattern=r"^[A-Za-z0-9._+-]+$")
     """Pi release to install, pinned for reproducibility."""
 
 
-class PiHarness(Harness[PiHarnessConfig]):
+class PiHarness(ACPHarness[PiHarnessConfig]):
     APPENDS_SYSTEM_PROMPT = True
     SUPPORTS_MCP = True
     SUPPORTS_RESUME = True
@@ -129,9 +86,9 @@ class PiHarness(Harness[PiHarnessConfig]):
         )
         if install.exit_code != 0:
             raise RuntimeError(f"pi install failed: {install.stderr.strip()[-500:]}")
-        await PI_ACP.setup(self, runtime)
+        await self.acp.setup(self, runtime)
 
-    async def launch(
+    async def prepare_acp(
         self,
         ctx: ModelContext,
         trace: Trace,
@@ -140,22 +97,25 @@ class PiHarness(Harness[PiHarnessConfig]):
         secret: str,
         mcp_urls: dict[str, str],
         data: TaskData,
-    ) -> ProgramResult:
+    ) -> ACPConfig:
         system_prompt, prompt = self.resolve_prompt(data)
         agent_dir = f".vf-pi-agent-{trace.id}"
         reasoning = ctx.sampling.reasoning_effort not in (
             None,
             "none",
         ) or ctx.model.rsplit("/", 1)[-1].startswith(("gpt-5", "o1", "o3", "o4"))
+        provider, separator, model = ctx.model.partition("/")
+        if not separator:
+            provider, model = "intercept", ctx.model
         models = {
             "providers": {
-                PROVIDER: {
-                    "baseUrl": endpoint,
-                    "api": "openai-completions",
+                provider: {
+                    "baseUrl": endpoint.removesuffix("/v1"),
+                    "api": "anthropic-messages",
                     "apiKey": f"${KEY_VAR}",
                     "models": [
                         {
-                            "id": ctx.model,
+                            "id": model,
                             "reasoning": reasoning,
                             "input": ["text", "image"],
                         }
@@ -166,7 +126,6 @@ class PiHarness(Harness[PiHarnessConfig]):
         await runtime.write(f"{agent_dir}/models.json", json.dumps(models).encode())
 
         mcp_args: list[str] = []
-        restore_home = f'export HOME="${HOME_VAR}"; unset {HOME_VAR}; '
         if mcp_urls:
             extension_path = f"{agent_dir}/mcp.js"
             mcp = {
@@ -175,15 +134,13 @@ class PiHarness(Harness[PiHarnessConfig]):
                     for name, url in mcp_urls.items()
                 }
             }
-            await runtime.write(f"{agent_dir}/mcp.json", json.dumps(mcp).encode())
-            await runtime.write(extension_path, MCP_WRAPPER.encode())
-            mcp_args = [
-                "--extension",
-                extension_path,
-                "--mcp-config",
-                f"{agent_dir}/mcp.json",
-            ]
-            restore_home = ""
+            extension = (
+                f'import {{ createMcpAdapter }} from "{MCP_ADAPTER}";\n'
+                "export default createMcpAdapter({ config: "
+                f"JSON.parse({json.dumps(json.dumps(mcp))}) }});\n"
+            )
+            await runtime.write(extension_path, extension.encode())
+            mcp_args = ["--extension", extension_path]
 
         env = {
             **self.config.resolved_env,
@@ -202,9 +159,9 @@ class PiHarness(Harness[PiHarnessConfig]):
             PI_BIN,
             "--no-approve",
             "--provider",
-            PROVIDER,
+            provider,
             "--model",
-            ctx.model,
+            model,
             *mcp_args,
             *skill_args,
         ]
@@ -215,15 +172,16 @@ class PiHarness(Harness[PiHarnessConfig]):
         pi_wrapper = f"{agent_dir}/pi"
         await runtime.write(
             pi_wrapper,
-            f'#!/bin/sh\n{restore_home}exec {shlex.join(pi_args)} "$@"\n'.encode(),
+            f'#!/bin/sh\nexec {NODE_BIN_DIR}/node {shlex.join(pi_args)} "$@"\n'.encode(),
         )
         await runtime.run(["chmod", "+x", pi_wrapper], {})
         env["PI_ACP_PI_COMMAND"] = pi_wrapper
-        return await PI_ACP.run(
-            runtime,
-            env,
-            ACP_COMMAND,
-            prompt,
+        return ACPConfig(
+            env=env,
+            command=ACP_COMMAND,
+            prompt=prompt,
+            # Pi's extension owns the task-scoped MCP configuration.
+            mcp_urls={},
             session_path=f"{agent_dir}/acp-session",
             # Pi can end after its final tool completes without a text message.
             allow_empty_tool_reply=True,

--- a/verifiers/v1/harnesses/pi/harness.py
+++ b/verifiers/v1/harnesses/pi/harness.py
@@ -122,19 +122,23 @@ class PiHarness(ACPHarness[PiHarnessConfig]):
             if self.config.transport == "anthropic_messages"
             else endpoint
         )
+        model_config = {
+            "id": model,
+            "reasoning": reasoning,
+            "input": ["text", "image"],
+            **(
+                {"compat": {"sessionAffinityFormat": "openai-nosession"}}
+                if self.config.transport == "responses"
+                else {}
+            ),
+        }
         models = {
             "providers": {
                 provider: {
                     "baseUrl": base_url,
                     "api": api,
                     "apiKey": f"${KEY_VAR}",
-                    "models": [
-                        {
-                            "id": model,
-                            "reasoning": reasoning,
-                            "input": ["text", "image"],
-                        }
-                    ],
+                    "models": [model_config],
                 }
             }
         }

--- a/verifiers/v1/harnesses/pi/harness.py
+++ b/verifiers/v1/harnesses/pi/harness.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import shlex
+from typing import Literal
 
 from pydantic import Field
 
@@ -47,6 +48,10 @@ fi
 class PiHarnessConfig(HarnessConfig):
     version: str = Field(default="0.84.0", pattern=r"^[A-Za-z0-9._+-]+$")
     """Pi release to install, pinned for reproducibility."""
+    transport: Literal["chat_completions", "responses", "anthropic_messages"] = (
+        "chat_completions"
+    )
+    """Model API transport."""
 
 
 class PiHarness(ACPHarness[PiHarnessConfig]):
@@ -106,12 +111,22 @@ class PiHarness(ACPHarness[PiHarnessConfig]):
         ) or ctx.model.rsplit("/", 1)[-1].startswith(("gpt-5", "o1", "o3", "o4"))
         provider, separator, model = ctx.model.partition("/")
         if not separator:
-            provider, model = "intercept", ctx.model
+            provider, model = "openai", ctx.model
+        api = {
+            "chat_completions": "openai-completions",
+            "responses": "openai-responses",
+            "anthropic_messages": "anthropic-messages",
+        }[self.config.transport]
+        base_url = (
+            endpoint.removesuffix("/v1")
+            if self.config.transport == "anthropic_messages"
+            else endpoint
+        )
         models = {
             "providers": {
                 provider: {
-                    "baseUrl": endpoint.removesuffix("/v1"),
-                    "api": "anthropic-messages",
+                    "baseUrl": base_url,
+                    "api": api,
                     "apiKey": f"${KEY_VAR}",
                     "models": [
                         {

--- a/verifiers/v1/harnesses/pool/harness.py
+++ b/verifiers/v1/harnesses/pool/harness.py
@@ -99,6 +99,7 @@ class PoolHarness(Harness[PoolHarnessConfig]):
             env,
             command,
             prompt,
+            trace=trace,
             mcp_urls=mcp_urls,
             system_prompt=system_prompt,
             session_path=f"{pool_home}/acp-session",

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -8,11 +8,10 @@ from typing import Literal
 
 from pydantic import Field, PositiveInt, model_validator
 
-from verifiers.v1.acp import ACP
+from verifiers.v1.acp import ACPConfig, ACPHarness
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
-from verifiers.v1.harness import Harness, HarnessSession
-from verifiers.v1.runtimes import ProgramResult, Runtime
+from verifiers.v1.runtimes import Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
 from verifiers.v1.utils.decorators import metric
@@ -26,7 +25,6 @@ RLM_DIR = "/tmp/vf-rlm"
 RLM_BIN = f"{RLM_DIR}/bin/rlm"
 SKILLS_DIR = "/task/rlm-skills"
 RLM_STATE_DIR = ".vf-rlm"
-RLM_ACP = ACP()
 
 
 class RLMHarnessConfig(HarnessConfig):
@@ -63,7 +61,7 @@ class RLMHarnessConfig(HarnessConfig):
         return self
 
 
-class RLMHarness(Harness[RLMHarnessConfig]):
+class RLMHarness(ACPHarness[RLMHarnessConfig]):
     APPENDS_SYSTEM_PROMPT = True
     SUPPORTS_MCP = True
     SUPPORTS_RESUME = True
@@ -90,7 +88,7 @@ class RLMHarness(Harness[RLMHarnessConfig]):
         result = await runtime.run(["sh", "-c", guarded], env)
         if result.exit_code != 0:
             raise RuntimeError(f"rlm install failed: {result.stderr.strip()[-500:]}")
-        await RLM_ACP.setup(self, runtime)
+        await self.acp.setup(self, runtime)
 
     def summarize_threshold(self, task_idx: int | None) -> str:
         """The `RLM_SUMMARIZE_AT_TOKENS` value: a range draws per-group (seeded by task index —
@@ -128,7 +126,7 @@ class RLMHarness(Harness[RLMHarnessConfig]):
             env["RLM_SKILLS"] = ",".join(self.config.builtin_skills)
         return env
 
-    async def session(
+    async def prepare_acp(
         self,
         ctx: ModelContext,
         trace: Trace,
@@ -137,44 +135,12 @@ class RLMHarness(Harness[RLMHarnessConfig]):
         secret: str,
         mcp_urls: dict[str, str],
         data: TaskData,
-    ) -> HarnessSession:
-        if not runtime.supports_live_processes:
-            return await super().session(
-                ctx, trace, runtime, endpoint, secret, mcp_urls, data
-            )
+    ) -> ACPConfig:
         system_prompt, prompt = self.resolve_prompt(data)
-        return RLM_ACP.session(
-            self,
-            ctx,
-            trace,
-            runtime,
-            endpoint,
-            secret,
-            mcp_urls,
-            data,
+        return ACPConfig(
             env=self._env(ctx, trace, endpoint, secret, data, system_prompt),
             command=[RLM_BIN, "--acp"],
             prompt=prompt,
-        )
-
-    async def launch(
-        self,
-        ctx: ModelContext,
-        trace: Trace,
-        runtime: Runtime,
-        endpoint: str,
-        secret: str,
-        mcp_urls: dict[str, str],
-        data: TaskData,
-    ) -> ProgramResult:
-        """Run one standalone ACP segment through the default session adapter."""
-        system_prompt, prompt = self.resolve_prompt(data)
-        return await RLM_ACP.run(
-            runtime,
-            self._env(ctx, trace, endpoint, secret, data, system_prompt),
-            [RLM_BIN, "--acp"],
-            prompt,
-            mcp_urls=mcp_urls,
         )
 
     @metric

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -679,6 +679,14 @@ class InterceptionServer(Interception):
                         await resp.write(event)
                     await resp.write_eof()
             return resp
+        except RolloutError as e:
+            # A streamed terminal provider failure is discovered only after the
+            # response body has been relayed. Keep it off the graph and preserve
+            # the typed cause for the rollout if the native SDK does not retry it.
+            if node is None:
+                error = e
+                session.error = e
+            raise
         except BaseException as e:
             # Anything that propagates (a mid-relay upstream failure, a parser or commit
             # error, a cancellation) ends a real exchange; couple it to the record unless

--- a/verifiers/v1/utils/loaders.py
+++ b/verifiers/v1/utils/loaders.py
@@ -291,10 +291,7 @@ def taskset_config_type(taskset_id: str) -> type[TasksetConfig]:
 
 def harness_config_type(harness_id: str) -> type[HarnessConfig]:
     """Resolve the harness's config specialization through its MRO."""
-    return (
-        concrete_type(harness_class(harness_id), HarnessConfig, origin=Harness)
-        or HarnessConfig
-    )
+    return concrete_type(harness_class(harness_id), HarnessConfig) or HarnessConfig
 
 
 def judge_config_type(judge_id: str) -> type[JudgeConfig]:


### PR DESCRIPTION
## Summary

- reject non-terminal Responses statuses (including `response.failed`) as provider errors before graph commit
- preserve typed provider failures discovered at the end of streamed responses
- forward live ACP continuation deltas intact instead of trimming through their last assistant message
- strengthen the existing ACP resume E2E with a `user → assistant → user` continuation that requires context from both segments

## Root cause

A top-level Responses object with `status: "failed"` was parsed as `finish_reason: "stop"`, so empty rate-limit failures were committed as sampled assistant nodes before native agents retried. Separately, live ACP sessions already receive only the new interaction delta, but the shared runner treated that delta like a replayed full transcript and discarded every message through its last assistant.

## Validation

- focused synthetic JSON and streamed `response.failed` probes: passed
- `uv run pytest tests/v1/ -m "not e2e" -q`: passed
- full deterministic `tests/` suite: passed with temporary git signing disabled for test repositories
- strengthened Prime VM ACP E2E: Codex, Hermes, OpenClaw, and Pi/Responses all passed with reward 1, one branch, and no empty sampled nodes
- push hooks: Ruff, Ruff format, and CI-parity Ty passed

Stacked on #2291; this PR intentionally targets `fix/hermes-acp-resume`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix failed Responses API errors and preserve live ACP session deltas across harnesses
> - Introduces `ACPConfig` and `ACPHarness` abstractions that standardize how harnesses prepare and launch ACP processes; all major harnesses (Claude Code, Pi, RLM, Hermes, OpenClaw, Codex, Kimi Code) are migrated to return `ACPConfig` from a `prepare_acp` method instead of managing ACP instances directly.
> - Adds `transport` field to Pi and Kimi Code harness configs, enabling selection between `chat_completions`, `responses`, and `anthropic_messages` API transports; e2e tests updated to use `responses` transport for kimi-code.
> - `ACP.run` now requires a `Trace` argument and raises `RuntimeError` if no model turn is committed after the agent completes, preventing silent failures.
> - `response_from_wire` in the Responses dialect now raises a structured `model_error` when the upstream response returns an error status, with HTTP status codes mapped from upstream error codes.
> - Live ACP session turns no longer incorrectly trim prior messages (`replayed_transcript=False`), fixing delta preservation in resumed sessions.
> - Fixes deterministic ordering of Anthropic thinking blocks and correct field assignment for `reasoning.summary` vs `reasoning.text` deltas in the streaming chat parser.
> - Risk: harnesses that previously relied on module-level ACP singletons now delegate lifecycle to `ACPHarness`; any harness not migrated will break at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 32e1cb7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes model parsing, streamed turn commit, and ACP prompt assembly on critical rollout paths; scope is narrow and aligned with existing retry/error handling.
> 
> **Overview**
> Fixes two rollout bugs: **failed OpenAI Responses** were parsed as successful `stop` turns, and **live ACP turns** dropped intra-turn context when the runner treated new deltas like resumed full transcripts.
> 
> **Responses dialect** — `response_from_wire` now raises a typed provider error (HTTP status mapped from upstream error codes) when `status` is neither completed nor incomplete, so empty `response.failed` payloads are not committed to the trace graph.
> 
> **ACP runner** — `segment_messages` takes an explicit `replayed_transcript` flag: transcript trimming after the last assistant applies only to `run_once` resume (`replayed_transcript=True`); `LiveACPSession` passes `replayed_transcript=False` so multi-message turn deltas (e.g. user → assistant → user) reach the agent intact.
> 
> **Interception streaming** — If the terminal SSE event parses to a `RolloutError` after bytes were already relayed, the turn is not committed when `node` is still unset; `session.error` keeps the typed failure for the rollout.
> 
> **E2E** — The ACP resume fixture’s second turn is a three-message delta and checks both codewords in the reply and tool output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32e1cb72506b1b327f1568450597b8b802d2f7cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->