### PR TITLE
feat: record the task data hash on the trace

### DIFF
--- a/verifiers/v1/cli/debug.py
+++ b/verifiers/v1/cli/debug.py
@@ -193,7 +193,7 @@ async def run_action(runtime: Runtime, config: DebugConfig) -> dict[str, Any]:
 
 async def debug_task(task: Task, config: DebugConfig) -> tuple[Trace, bool]:
     trace = Trace(
-        task=TraceTask(type=type(task).__name__, data=task.data),
+        task=TraceTask(type=type(task).__name__, data=task.data, hash=task.hash),
         state=state_cls(type(task))(),
         # No agent plays here (no model, no harness): the seat records the
         # runtime policy, and the provisioned box lands on it below (id, resolved

--- a/verifiers/v1/cli/debug.py
+++ b/verifiers/v1/cli/debug.py
@@ -193,7 +193,7 @@ async def run_action(runtime: Runtime, config: DebugConfig) -> dict[str, Any]:
 
 async def debug_task(task: Task, config: DebugConfig) -> tuple[Trace, bool]:
     trace = Trace(
-        task=TraceTask(type=type(task).__name__, data=task.data, hash=task.hash),
+        task=TraceTask(type=type(task).__name__, data=task.data),
         state=state_cls(type(task))(),
         # No agent plays here (no model, no harness): the seat records the
         # runtime policy, and the provisioned box lands on it below (id, resolved

--- a/verifiers/v1/cli/eval/resume.py
+++ b/verifiers/v1/cli/eval/resume.py
@@ -19,9 +19,9 @@ from pathlib import Path
 from pydantic_core import from_json
 
 from verifiers.v1.cli.output import CONFIG_FILE, TRACES_FILE, sniff_episode
-from verifiers.v1.cli.resume import task_key
 from verifiers.v1.configs.cli.eval import EvalConfig
 from verifiers.v1.episode import Episode, WireEpisode
+from verifiers.v1.task import task_key
 from verifiers.v1.trace import WireTrace
 
 

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -12,7 +12,7 @@ from verifiers.v1.cli.output import (
     output_path,
     save_config,
 )
-from verifiers.v1.cli.resume import distribute, task_key
+from verifiers.v1.cli.resume import distribute
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.cli.eval import EvalConfig
 from verifiers.v1.env import Env, RunSlot
@@ -45,9 +45,7 @@ async def run_eval(env: Env, config: EvalConfig) -> list[Episode]:
     # Kept on-disk rollouts rejoin the run as finished episodes; only owed ones re-run.
     finished: list[Episode] = []
     if config.resume is not None:
-        keys = [
-            task_key(t.data.model_dump(mode="json", exclude_none=True)) for t in tasks
-        ]
+        keys = [task.hash for task in tasks]
         finished, owed = resume.load(out, keys, config.num_rollouts, env.complete)
         if not owed:  # already complete - report it and exit successfully
             print(resume.nothing_to_resume_msg(out, len(tasks), config.num_rollouts))
@@ -163,7 +161,7 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
         client = EnvClient(address=address)
         await client.wait_for_server_startup(timeout=600)
         # A run dispatches — and resumes — tasks by content: the client owns them,
-        # and `task_key` is their identity.
+        # and `task.hash` is their identity.
         plan = [
             ({"task_data": task.data.model_dump(mode="json")}, config.num_rollouts)
             for task in tasks
@@ -171,10 +169,7 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
         out = output_path(config)
         finished: list[Episode] = []
         if config.resume is not None:
-            keys = [
-                task_key(t.data.model_dump(mode="json", exclude_none=True))
-                for t in tasks
-            ]
+            keys = [task.hash for task in tasks]
             finished, owed = resume.load(out, keys, config.num_rollouts)
             counts = distribute(keys, owed, config.num_rollouts)
             if not owed:  # already complete - report it and exit successfully

--- a/verifiers/v1/cli/resume.py
+++ b/verifiers/v1/cli/resume.py
@@ -1,14 +1,6 @@
 """Resume primitives shared by eval-like CLIs."""
 
-import hashlib
-import json
-from collections.abc import Mapping
 from pathlib import Path
-
-
-def task_key(data: Mapping) -> str:
-    """Content identity for task wire data, independent of field order."""
-    return hashlib.sha256(json.dumps(data, sort_keys=True).encode()).hexdigest()
 
 
 def distribute(

--- a/verifiers/v1/cli/validate.py
+++ b/verifiers/v1/cli/validate.py
@@ -247,7 +247,7 @@ async def _run_gold(task: Task, config: ValidateConfig) -> ResultRow:
     valid, exc = False, None
     try:
         trace = Trace(
-            task=TraceTask(type=type(task).__name__, data=task.data),
+            task=TraceTask(type=type(task).__name__, data=task.data, hash=task.hash),
             state=state_cls(type(task))(),
             # No agent runs here — the info only records the runtime policy.
             agent=vf.AgentInfo(
@@ -288,7 +288,7 @@ async def _run_setup(task: Task, config: ValidateConfig) -> ResultRow:
     valid, exc = False, None
     try:
         trace = Trace(
-            task=TraceTask(type=type(task).__name__, data=task.data),
+            task=TraceTask(type=type(task).__name__, data=task.data, hash=task.hash),
             state=state_cls(type(task))(),
             # No agent runs here — the info only records the runtime policy.
             agent=vf.AgentInfo(

--- a/verifiers/v1/cli/validate.py
+++ b/verifiers/v1/cli/validate.py
@@ -26,7 +26,7 @@ from verifiers.v1.cli.resolve import (
     references_config_file,
     with_positional_taskset,
 )
-from verifiers.v1.cli.resume import distribute, split_resume, task_key
+from verifiers.v1.cli.resume import distribute, split_resume
 from verifiers.v1.configs.cli.validate import ValidateConfig
 from verifiers.v1.runtimes import make_runtime
 from verifiers.v1.state import state_cls
@@ -247,7 +247,7 @@ async def _run_gold(task: Task, config: ValidateConfig) -> ResultRow:
     valid, exc = False, None
     try:
         trace = Trace(
-            task=TraceTask(type=type(task).__name__, data=task.data),
+            task=TraceTask(type=type(task).__name__, data=task.data, hash=task.hash),
             state=state_cls(type(task))(),
             # No agent runs here — the info only records the runtime policy.
             agent=vf.AgentInfo(
@@ -288,7 +288,7 @@ async def _run_setup(task: Task, config: ValidateConfig) -> ResultRow:
     valid, exc = False, None
     try:
         trace = Trace(
-            task=TraceTask(type=type(task).__name__, data=task.data),
+            task=TraceTask(type=type(task).__name__, data=task.data, hash=task.hash),
             state=state_cls(type(task))(),
             # No agent runs here — the info only records the runtime policy.
             agent=vf.AgentInfo(
@@ -380,9 +380,7 @@ async def run_validate(config: ValidateConfig) -> list[dict]:
     mode = validation_mode(config)
     checks = "gold+setup" if mode == "all" else mode
     out = output_path(config)
-    selected_keys = [
-        task_key(task.data.model_dump(mode="json", exclude_none=True)) for task in tasks
-    ]
+    selected_keys = [task.hash for task in tasks]
     if config.resume is None:
         save_run(config, out, len(tasks))
         rows: list[ResultRow] = []

--- a/verifiers/v1/cli/validate.py
+++ b/verifiers/v1/cli/validate.py
@@ -247,7 +247,7 @@ async def _run_gold(task: Task, config: ValidateConfig) -> ResultRow:
     valid, exc = False, None
     try:
         trace = Trace(
-            task=TraceTask(type=type(task).__name__, data=task.data, hash=task.hash),
+            task=TraceTask(type=type(task).__name__, data=task.data),
             state=state_cls(type(task))(),
             # No agent runs here — the info only records the runtime policy.
             agent=vf.AgentInfo(
@@ -288,7 +288,7 @@ async def _run_setup(task: Task, config: ValidateConfig) -> ResultRow:
     valid, exc = False, None
     try:
         trace = Trace(
-            task=TraceTask(type=type(task).__name__, data=task.data, hash=task.hash),
+            task=TraceTask(type=type(task).__name__, data=task.data),
             state=state_cls(type(task))(),
             # No agent runs here — the info only records the runtime policy.
             agent=vf.AgentInfo(

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -83,7 +83,6 @@ class Rollout:
             task=TraceTask(
                 type=type(task).__name__,
                 data=task.data,
-                hash=task.hash,
             ),
             state=state_cls(type(task))(),
             # The seat's resolved config, role overrides included — the agent

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -83,6 +83,7 @@ class Rollout:
             task=TraceTask(
                 type=type(task).__name__,
                 data=task.data,
+                hash=task.hash,
             ),
             state=state_cls(type(task))(),
             # The seat's resolved config, role overrides included — the agent

--- a/verifiers/v1/task.py
+++ b/verifiers/v1/task.py
@@ -10,7 +10,9 @@ initializes a task instance. Rides on `trace.task.data` in `traces.jsonl`.
 from __future__ import annotations
 
 import copy
+import hashlib
 import inspect
+import json
 import logging
 from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, Self
@@ -38,6 +40,11 @@ if TYPE_CHECKING:
     from verifiers.v1.trace import Trace
 
 logger = logging.getLogger(__name__)
+
+
+def task_key(data: Mapping) -> str:
+    """Content identity for task wire data, independent of field order."""
+    return hashlib.sha256(json.dumps(data, sort_keys=True).encode()).hexdigest()
 
 
 class TaskResources(BaseModel):
@@ -133,6 +140,12 @@ class Task(Generic[DataT, StateT, ConfigT]):
     def __init__(self, data: DataT, config: ConfigT | None = None) -> None:
         self.data = data
         self.config = config if config is not None else self.config_type()()
+
+    @property
+    def hash(self) -> str:
+        """Content hash of the task's wire data — the identity that matches saved
+        rollouts to tasks; recorded on the trace as `task.hash`."""
+        return task_key(self.data.model_dump(mode="json", exclude_none=True))
 
     def with_system_prompt(self, system_prompt: str) -> Self:
         clone = copy.copy(self)

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -121,6 +121,8 @@ class TraceTask(BaseModel, Generic[DataT]):
     """The Task class name (`type(task).__name__`)."""
     data: DataT
     """The (immutable) row being solved."""
+    hash: str | None = None
+    """Content hash of `data` (`Task.hash`) — the task's identity across runs."""
 
 
 class Reward(BaseModel):

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -7,7 +7,7 @@ from collections.abc import Callable, Iterable, Iterator, Mapping
 from typing import TYPE_CHECKING, Annotated, Any, Generic, Literal
 
 import numpy as np
-from pydantic import BaseModel, Field, PrivateAttr
+from pydantic import BaseModel, Field, PrivateAttr, model_validator
 from renderers.base import MultiModalData
 from typing_extensions import TypeVar
 
@@ -20,7 +20,7 @@ from verifiers.v1.errors import ProviderError
 from verifiers.v1.graph import MessageNode
 from verifiers.v1.runtimes import RuntimeInfo
 from verifiers.v1.state import State, StateT
-from verifiers.v1.task import DataT, WireTaskData
+from verifiers.v1.task import DataT, WireTaskData, task_key
 from verifiers.v1.types import (
     AssistantMessage,
     FinishReason,
@@ -121,8 +121,20 @@ class TraceTask(BaseModel, Generic[DataT]):
     """The Task class name (`type(task).__name__`)."""
     data: DataT
     """The (immutable) row being solved."""
-    hash: str | None = None
+    hash: str
     """Content hash of `data` (`Task.hash`) — the task's identity across runs."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _backfill_hash(cls, values: Any) -> Any:
+        """Traces predating `hash` recompute it from their wire data."""
+        if isinstance(values, dict) and not values.get("hash"):
+            data = values.get("data")
+            if isinstance(data, BaseModel):
+                data = data.model_dump(mode="json", exclude_none=True)
+            if isinstance(data, Mapping):
+                values = {**values, "hash": task_key(data)}
+        return values
 
 
 class Reward(BaseModel):

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -7,7 +7,7 @@ from collections.abc import Callable, Iterable, Iterator, Mapping
 from typing import TYPE_CHECKING, Annotated, Any, Generic, Literal
 
 import numpy as np
-from pydantic import BaseModel, Field, PrivateAttr, model_validator
+from pydantic import BaseModel, Field, PrivateAttr
 from renderers.base import MultiModalData
 from typing_extensions import TypeVar
 
@@ -20,7 +20,7 @@ from verifiers.v1.errors import ProviderError
 from verifiers.v1.graph import MessageNode
 from verifiers.v1.runtimes import RuntimeInfo
 from verifiers.v1.state import State, StateT
-from verifiers.v1.task import DataT, WireTaskData, task_key
+from verifiers.v1.task import DataT, WireTaskData
 from verifiers.v1.types import (
     AssistantMessage,
     FinishReason,
@@ -121,20 +121,8 @@ class TraceTask(BaseModel, Generic[DataT]):
     """The Task class name (`type(task).__name__`)."""
     data: DataT
     """The (immutable) row being solved."""
-    hash: str
+    hash: str | None = None
     """Content hash of `data` (`Task.hash`) — the task's identity across runs."""
-
-    @model_validator(mode="before")
-    @classmethod
-    def _backfill_hash(cls, values: Any) -> Any:
-        """Traces predating `hash` recompute it from their wire data."""
-        if isinstance(values, dict) and not values.get("hash"):
-            data = values.get("data")
-            if isinstance(data, BaseModel):
-                data = data.model_dump(mode="json", exclude_none=True)
-            if isinstance(data, Mapping):
-                values = {**values, "hash": task_key(data)}
-        return values
 
 
 class Reward(BaseModel):


### PR DESCRIPTION
## Summary

- Add a `hash` property to `Task`: the sha256 content hash of the task's wire data (`data.model_dump(mode="json", exclude_none=True)`), reusable by any consumer that needs a task identity (eval/validate resume, prime-rl).
- Record it on every minted trace as `task.hash` (`TraceTask.hash`, optional so traces predating the field still parse) — in `Rollout`, `validate`, and `debug`.
- Move `task_key` from `verifiers.v1.cli.resume` to `verifiers.v1.task` and switch the eval/validate resume key computations to `task.hash`. The hash algorithm is unchanged, so resuming runs written before this change still matches.

## Verification

- Parsed 3993 real pre-change traces (train `traces.jsonl` from a recent prime-rl run) through `WireTrace`/`WireEpisode`: all parse with `task.hash is None`.
- Round-trip check: `task.hash` on a serialized trace equals `task_key(row["task"]["data"])` recomputed from the wire row (the resume matching path).
- `uv run pytest tests/v1/test_trace.py tests/v1/test_graph.py tests/v1/test_scoring.py tests/v1/test_taskset.py tests/v1/test_configs.py tests/v1/test_judges.py` — all pass.
- `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive trace field and a refactor to a single identity helper; resume keys are algorithmically unchanged, with low risk beyond consumers that might start relying on `task.hash` on disk.
> 
> **Overview**
> Introduces a **`Task.hash`** property (SHA-256 of canonical JSON wire data) and stores it on every new trace as **`TraceTask.hash`** (optional so older `traces.jsonl` rows still parse). Trace creation in **rollout**, **debug**, and **validate** now passes `hash=task.hash`.
> 
> Moves **`task_key`** from `verifiers.v1.cli.resume` to **`verifiers.v1.task`** and replaces duplicated `model_dump` + `task_key` calls in **eval** and **validate** runners with **`task.hash`**. The hash algorithm is unchanged, so resume matching against traces that only have `task.data` should behave the same as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1a1bdd76762e73463d159f4a9244565aead970b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Record task data hash on traces and Task model
> - Adds a `hash` property to `Task` (in [task.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2339/files#diff-a1b4a5d6915beae41831864087ea497ed41f0b67b9091ad1ee614834cbfd9399)) that returns a deterministic SHA-256 of the JSON-serialized task data, and moves the `task_key` utility there from [resume.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2339/files#diff-610bd9ffa7e243b153cd2e7637ae155056c9453b37236e6d4a706f0064f157c1).
> - Adds an optional `hash` field to `TraceTask` in [trace.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2339/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e) so serialized traces carry the content hash.
> - Populates `hash=task.hash` in `TraceTask` across rollouts, debug, and validation flows.
> - Resume logic in [runner.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2339/files#diff-65be4a576330571f2729a3bbcdbe92ac81bbcba450c313597c1bdca3a1c3f2e4) and [validate.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2339/files#diff-f9da541290540aab599f22057f02b6cfcd418d89dfa7bf9cbe3c325d970d5a67) now derives resume keys from `task.hash` instead of recomputing `task_key` from raw data at call sites.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e1a1bdd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->