### PR TITLE
fix(legacy): align RubricGroup.score_group metrics and advantages with score_rollout

### DIFF
--- a/verifiers/legacy/rubrics/rubric_group.py
+++ b/verifiers/legacy/rubrics/rubric_group.py
@@ -114,12 +114,31 @@ class RubricGroup(Rubric):
     async def score_group(self, states: list[State]):
         """
         Evaluate all reward functions in-place for a group of rollouts.
+
+        Mirrors ``score_rollout`` for metrics (full replace) and ``Rubric.score_group``
+        for advantages: child rubrics may write per-rubric advantages/trajectory fields,
+        so the group recomputes state advantages from aggregated rewards and only fills
+        trajectory fields that are still ``None`` (preserving intentional step values).
         """
-        aggregated_rewards = [0.0] * len(states)
+        num_states = len(states)
+        if num_states == 0:
+            self.logger.warning("No states to score")
+            return
+
+        aggregated_rewards = [0.0] * num_states
         aggregated_metrics: dict[str, list[float]] = {}
         original_rewards = [state.get("reward", 0.0) for state in states]
         original_metrics = [
             state.get("metrics", {}).copy() if state.get("metrics") else {}
+            for state in states
+        ]
+        original_advantages = [state.get("advantage") for state in states]
+        # Snapshot traj fields so child if-None fills can be rolled back between rubrics.
+        original_traj_fields = [
+            [
+                (step.get("reward"), step.get("advantage"))
+                for step in state.get("trajectory") or []
+            ]
             for state in states
         ]
         for rubric in self.rubrics:
@@ -132,14 +151,28 @@ class RubricGroup(Rubric):
                 aggregated_rewards[i] += rubric_reward
                 for key, value in rubric_metrics.items():
                     if key not in aggregated_metrics:
-                        aggregated_metrics[key] = [0.0] * len(states)
+                        aggregated_metrics[key] = [0.0] * num_states
                     aggregated_metrics[key][i] += value
+                # Restore so the next rubric sees the same pre-group inputs.
                 state["reward"] = original_rewards[i]
                 state["metrics"] = original_metrics[i].copy()
+                state["advantage"] = original_advantages[i]
+                for step, (reward, advantage) in zip(
+                    state.get("trajectory") or [], original_traj_fields[i]
+                ):
+                    step["reward"] = reward
+                    step["advantage"] = advantage
+
+        avg_reward = sum(aggregated_rewards) / num_states
         for i, state in enumerate(states):
             state["reward"] = aggregated_rewards[i]
-            if aggregated_metrics:
-                if "metrics" not in state:
-                    state["metrics"] = {}
-                for key, values in aggregated_metrics.items():
-                    state["metrics"][key] = values[i]
+            state["advantage"] = aggregated_rewards[i] - avg_reward
+            # Same as Rubric.score_group: fill only unset traj fields.
+            for step in state.get("trajectory") or []:
+                if step.get("advantage") is None:
+                    step["advantage"] = state["advantage"]
+                if step.get("reward") is None:
+                    step["reward"] = state["reward"]
+            state["metrics"] = {
+                key: values[i] for key, values in aggregated_metrics.items()
+            }


### PR DESCRIPTION
Supersedes #2009 — same fix, rebased onto current `main` after #2303 moved v0 rubrics to `verifiers/legacy/`.

## Summary
- `RubricGroup.score_group` summed child rewards correctly but left per-child `advantage` on state and often left stale trajectory `advantage`/`reward` from earlier children.
- Metrics were merged into preexisting keys, unlike `score_rollout` and `Rubric.score_group`, which fully replace `state["metrics"]`.
- After aggregation: recompute `advantage` from summed rewards, fill trajectory fields only when still `None`, and replace metrics entirely.
- Restore `advantage` and trajectory fields between child rubrics so partial writes do not leak.

## Risk / notes
- Aggregate **rewards** were already correct; this is contract/consistency cleanup for legacy group scoring.
- Default `Rubric.has_advantages` is still `False`; trainers that recompute advantages from rewards are largely unaffected.

## Test plan
- [x] Manual: children `[[1,0],[0,1]]` → rewards `[1,1]`, advantages `[0,0]`
- [x] Manual: preset trajectory step reward preserved; unset steps still get aggregate fill
- [x] Manual: preexisting stale metrics cleared after group scoring
- [x] Manual: child with empty metrics → `state["metrics"] == {}`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `RubricGroup.score_group` to align metrics and advantages with `score_rollout`
> - Adds an early return with a warning when `score_group` receives zero states.
> - Snapshots each state's reward, metrics, advantage, and per-step trajectory values before invoking child rubrics, then restores them after each child so all rubrics see identical inputs.
> - Accumulates rewards and metrics across child rubrics, then writes the final aggregated reward to each state and sets `state['advantage']` as `aggregated_reward - average_reward`.
> - Per-step trajectory reward and advantage are only written when currently `None`, matching `score_rollout` behavior.
> - Behavioral Change: metrics aggregation now always writes a fresh dict per state rather than conditionally merging into an existing one.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b07b7f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->