### PR TITLE
fix(legacy): read JudgeRubric questions from Pydantic messages

### DIFF
--- a/verifiers/legacy/rubrics/judge_rubric.py
+++ b/verifiers/legacy/rubrics/judge_rubric.py
@@ -62,11 +62,10 @@ class JudgeRubric(Rubric):
         state: State | None = None,
     ) -> str:
         if isinstance(prompt, list):
+            # Rollouts normalize prompts to Pydantic Messages (not raw dicts).
             last_msg = prompt[-1]
-            if isinstance(last_msg, dict) and "content" in last_msg:
-                question = str(last_msg["content"])
-            else:
-                question = ""
+            content = self.parser._message_field(last_msg, "content", "")
+            question = self.parser._content_to_text(content)
         else:
             question = str(prompt)
         response = self.parser.parse_answer(completion)


### PR DESCRIPTION
Supersedes #2005 — same fix after #2303 moved v0 rubrics to `verifiers/legacy/`.

## Summary
- `JudgeRubric.judge()` only extracted `question` from dict prompts (`isinstance(..., dict)`).
- Rollouts normalize prompts to Pydantic `Message` objects, so the Question block was silently empty.
- Read content via parser helpers (`_message_field` / `_content_to_text`) for dict and Message prompts.

## Test plan
- [x] Manual: dict prompt still yields last user content as `{question}`
- [x] Manual: Pydantic-like message with `.content` no longer produces empty Question
- [x] Manual: multimodal text parts joined into question string

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `JudgeRubric.judge` to read question content from Pydantic messages
> Previously, `JudgeRubric.judge` in [judge_rubric.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2341/files#diff-130b7175dccaeb92c0d248bc6737a3e37e124e01af0dbdb0a611f81c8933c158) extracted the last message's content via raw dict access, which failed for Pydantic message objects. It now uses `self.parser._message_field` and `self.parser._content_to_text` to normalize the content, consistent with how the rest of the parser handles messages. Behavioral Change: the extracted question string used to format `judge_prompt` (and its cache key) may differ when prompts contain Pydantic message objects.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized adb8c94.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->