### PR TITLE
fix(v1): collect artifacts for isolated agentic-judge

### DIFF
--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -137,13 +137,15 @@ class JudgeTask(vf.Task):
         solution: vf.Trace,
         config: "JudgeTaskConfig",
         share_runtime: bool = True,
+        artifacts: dict[str, bytes | None] | None = None,
     ) -> "JudgeTask":
         """Mint the judge's task from the solver's finished trace.
 
         `share_runtime` selects both the workspace note and artifact transport. In
         the solver's box the published artifacts are already on disk, so none
-        travel; a fresh box gets the collected set, restored by `setup` at the
-        paths they had.
+        travel; a fresh box gets `artifacts` — the set the env collected off the
+        solver's box before tearing it down — restored by `setup` at the paths
+        they had.
         """
         solved = solution.task.data
         files = {TRACE_FILE: json.dumps(solution.to_record()).encode()}
@@ -170,7 +172,7 @@ class JudgeTask(vf.Task):
                 network_block=solved.network_block,
             ),
             files=files,
-            artifacts={} if share_runtime else solution.state.artifacts,
+            artifacts={} if share_runtime else dict(artifacts or {}),
         )
 
     async def setup(self, trace: vf.Trace, runtime: vf.Runtime) -> None:
@@ -342,9 +344,23 @@ class IsolatedAgenticJudgeEnv(AgenticJudgeEnv):
     """Judge only collected artifacts in a fresh box with the solver's policy."""
 
     async def run(self, task: vf.Task, agents: vf.Agents) -> None:
-        solution = await agents.solver.run(task)
-        if not solution.ok:
-            raise RuntimeError("the solver's rollout failed, so the judge never ran")
+        # The env owns the solver's box so the artifacts can be taken off it after
+        # the task finalized and before it is destroyed. Collecting here — not in a
+        # task's `finalize` — is what makes the transfer work for any task that
+        # declares paths or writes to the convention dir.
+        async with agents.solver.provision(task) as box:
+            solution = await agents.solver.run(task, runtime=box)
+            if not solution.ok:
+                raise RuntimeError(
+                    "the solver's rollout failed, so the judge never ran"
+                )
+            # A task that published its own set (harbor collects behind its hooks)
+            # already tarred this box; re-collecting would move the same bytes twice.
+            artifacts = solution.state.artifacts or await vf.collect(
+                box, task.data.artifacts
+            )
         await agents.judge.run(
-            JudgeTask.from_trace(solution, self.config.task, share_runtime=False)
+            JudgeTask.from_trace(
+                solution, self.config.task, share_runtime=False, artifacts=artifacts
+            )
         )


### PR DESCRIPTION
## Summary
- Fixes #2195 (artifact half): `IsolatedAgenticJudgeEnv` now owns the solver box, collects declared + convention artifacts after finalize, and hands that set to `JudgeTask.from_trace` instead of relying on `solution.state.artifacts`.
- Shared mode is unchanged; solver-policy inheritance for the judge runtime is unchanged (intentional after #2234).
- Skips the issue's "honor judge.runtime.image" ask: #2234 deliberately derives both modes from the solver policy, and dropping the task image would break delta-sized artifact restore (grading box boots from the task image).

## Behavioral note
Owning the solver box via `agents.solver.provision(task)` + `run(..., runtime=box)` disables **agent-level** retries on the solver (borrowed boxes are not retried — same rule shared mode already follows). Episode-level `EnvConfig.retries` still apply. This is required so collection can run after finalize and before teardown.

## Test plan
- [x] `uv run ruff check verifiers/v1/envs/agentic_judge/env.py`
- [x] `uv run pytest tests

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix artifact collection for isolated agentic judge runs
> - `IsolatedAgenticJudgeEnv.run` now provisions an explicit runtime box for the solver and collects artifacts from it when the solver does not publish any to `solution.state.artifacts`.
> - `JudgeTask.from_trace` accepts an optional `artifacts` parameter; for `share_runtime=False`, it embeds the provided artifacts (or an empty dict) instead of reading from `solution.state.artifacts`.
> - Behavioral Change: isolated judge runs previously received no artifacts or stale artifacts from the solution state; they now receive artifacts collected directly from the solver's runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 60e3277.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->