### PR TITLE
chore: bump prime-sandboxes to 0.2.36

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "openai>=2.9.0",
     "openai-agents>=0.8.2",
     "prime-tunnel>=0.1.8",
-    "prime-sandboxes>=0.2.35",
+    "prime-sandboxes>=0.2.36",
     "pydantic>=2.12.3",
     "requests",
     "rich>=11.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3299,19 +3299,21 @@ toml = [
 
 [[package]]
 name = "prime-sandboxes"
-version = "0.2.35"
+version = "0.2.36"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
+    { name = "certifi" },
     { name = "connect-python" },
     { name = "httpx" },
     { name = "protobuf" },
     { name = "pydantic" },
+    { name = "pyqwest" },
     { name = "tenacity" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/cc/287c0db192ddbe003bd5882d1aab5461cdb3912d0c92db7b39734a9e828e/prime_sandboxes-0.2.35.tar.gz", hash = "sha256:e716bfccdcb51aefd5e2d48fdfc3a79bea8c6825bce1871f49f095ced03efc94", size = 86226, upload-time = "2026-08-05T14:29:53.33Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/c8/ca5261ff5d5c2e944e198866ead91b09bc88eb0390a905925bb6d7f9cd28/prime_sandboxes-0.2.36.tar.gz", hash = "sha256:3a5c8a7912b1ea0fb775674650835f7f86aac1a05aa8566c2db129b9a622fe55", size = 88415, upload-time = "2026-08-12T23:30:15.214Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/07/c186395925f780b1a18b350f562ebc4e8a64a182c37bd1e3db3948f297e2/prime_sandboxes-0.2.35-py3-none-any.whl", hash = "sha256:29d7057532b21545be5938d3aee822ae3a54085a45934d5c3ac55190e06c5bbb", size = 47189, upload-time = "2026-08-05T14:29:52.142Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/26/081296fc8e6d8ce962f2aee0e47ac843982094dedb34a1fad22d10086f37/prime_sandboxes-0.2.36-py3-none-any.whl", hash = "sha256:a5db92d927cf4a3dd37ce230027a9d83dbf21804d4f6ed2255d276c1962fa8f2", size = 49316, upload-time = "2026-08-12T23:30:14.047Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bump the `prime-sandboxes` floor from `0.2.35` to `0.2.36` and re-lock.
- 0.2.36 ships the per-process transport fix for live ACP processes ([prime#831](https://github.com/PrimeIntellect-ai/prime/pull/831)).

## Verification

Before: rlm harness on prime VM sandboxes at high rollout concurrency (>100 held process streams) failed with `process stdin RPC failed (deadline_exceeded)` — all live-process RPCs multiplexed over one HTTP/2 connection capped at 100 streams by the gateway. At 128 concurrency, 107/128 rollouts failed.

After (patched SDK, same eval — gsm8k + rlm + prime-vm): 127/127 rollouts ok at 128 concurrency; 996/1000 ok at 1000 concurrency with zero `deadline_exceeded`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `prime-sandboxes` minimum version to 0.2.36
> Updates the minimum version constraint for `prime-sandboxes` in [pyproject.toml](https://github.com/PrimeIntellect-ai/verifiers/pull/2344/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) from `>=0.2.35` to `>=0.2.36`, and updates the lockfile accordingly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6e3a30c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dependency upgrade with no local code changes; risk is limited to SDK/runtime behavior for Prime VM sandboxes and live-process evals.
> 
> **Overview**
> **Dependency bump only:** the `prime-sandboxes` floor in `pyproject.toml` moves from `>=0.2.35` to `>=0.2.36`, with `uv.lock` updated to pin **0.2.36** (including new transitive deps `certifi` and `pyqwest` on that package).
> 
> This pulls in **0.2.36’s per-process transport fix** for live ACP process RPCs (avoids multiplexing many process streams on a single HTTP/2 connection and hitting gateway stream limits / `deadline_exceeded` under high rollout concurrency). No application code in this repo changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e3a30cce480e4298419b69d04909b7358b9c3d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->