### PR TITLE
Fix runtime script and IPC paths

### DIFF
--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -20,13 +20,8 @@ from pydantic_config import BaseConfig
 
 from verifiers.v1.errors import SandboxError
 from verifiers.v1.utils.aio import run_shielded
-from verifiers.v1.utils.paths import CACHE_DIR
 
 logger = logging.getLogger(__name__)
-
-# Digest-keyed cache of prepared PEP 723 scripts. Every runtime's `write` creates parent
-# directories, so the path also works inside containers and sandboxes.
-SCRIPTS_DIR = str(CACHE_DIR / "runtimes" / "scripts")
 
 # Ensure the latest `uv` is available for our PEP 723 scripts: prefer pip on Python images,
 # then fall back to the standalone installer (curl/wget), installing curl + CA certs when a
@@ -181,6 +176,10 @@ class Runtime(ABC):
     subprocess and Docker (directly or through Docker's policy proxy); remote runtimes
     override to False and use a host `Tunnel` inward plus `expose` outward."""
 
+    scripts_dir: ClassVar[str] = "/tmp/vf-scripts"
+    """Digest-keyed PEP 723 scripts inside the runtime. Sandboxes own their `/tmp`;
+    the host subprocess runtime overrides this with its per-user cache."""
+
     info: BaseRuntimeInfo
 
     @property
@@ -282,7 +281,7 @@ class Runtime(ABC):
         """
         data = script.encode() if isinstance(script, str) else script
         digest = hashlib.sha256(data).hexdigest()
-        path = f"{SCRIPTS_DIR}/{digest}.py"
+        path = f"{self.scripts_dir}/{digest}.py"
         if digest not in self._uv_interpreters:
             async with self._uv_script_locks.setdefault(digest, asyncio.Lock()):
                 if digest not in self._uv_interpreters:

--- a/verifiers/v1/runtimes/subprocess.py
+++ b/verifiers/v1/runtimes/subprocess.py
@@ -77,6 +77,7 @@ class SubprocessProcess(RuntimeProcess):
 
 class SubprocessRuntime(Runtime):
     # Share prepared script environments across the worker's per-rollout runtimes.
+    scripts_dir: ClassVar[str] = str(CACHE_DIR / "runtimes" / "scripts")
     _interpreters: ClassVar[dict[str, str]] = {}
     _locks: ClassVar[dict[str, asyncio.Lock]] = {}
 

--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -90,7 +90,7 @@ class EnvServerPool:
         self.multiplex = multiplex
         self.elastic = elastic
         self.log_setup = log_setup
-        self._ipc_dir = tempfile.mkdtemp(prefix="vf-pool-")
+        self._ipc_dir = tempfile.mkdtemp(prefix="vf-pool-", dir="/tmp")
         self.workers: list[dict] = []
         self._mpctx = mp.get_context("spawn")
         self._poller: zmq.asyncio.Poller | None = None


### PR DESCRIPTION
## Summary

- keep prepared PEP 723 scripts under the runtime-owned `/tmp/vf-scripts` by default
- retain the per-user cache only for the host `SubprocessRuntime`
- create env-pool IPC directories directly under `/tmp` so Unix socket paths stay short

## Root cause

#2331 moved prepared scripts to a path derived from the host user's cache for every runtime. Guest runtimes interpreted that host path inside their own filesystem, where a non-root user may not be able to create it.

The same change used `tempfile.mkdtemp()` for pool IPC sockets without fixing its parent directory. A long configured `TMPDIR` could therefore exceed ZeroMQ's Unix socket path limit.

## Impact

Non-root container and sandbox images can prepare harness scripts again, while subprocess runtimes still avoid cross-user host collisions. Env-pool workers can bind their IPC sockets even when the process has a long `TMPDIR`.

## Validation

- focused runtime probe confirmed guest scripts use `/tmp/vf-scripts`, subprocess scripts use the user cache, and a long-`TMPDIR` IPC socket binds at a 23-byte path
- disposable `python:3.12-slim` container confirmed `/tmp/vf-scripts` is writable as UID 65534
- `uv run --frozen ruff check --fix .`
- `PYTHON_DOTENV_DISABLED=1 FASTMCP_ENV_FILE=/dev/null uv run --frozen pytest tests/ -q --disable-warnings`
- `uv run --frozen --python 3.13 ty check verifiers`
- touched-file pre-commit hooks and commit/push hooks

The repository-wide pre-commit command additionally reaches an existing markdownlint failure in the untouched legacy SWE README (inline HTML); its Ruff hooks pass.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix runtime script and IPC paths to use `/tmp` in sandboxed contexts
> - Moves the `scripts_dir` for script storage from a module-level `CACHE_DIR` constant to a per-class attribute on `Runtime`, defaulting to `/tmp/vf-scripts` so sandboxed runtimes write scripts inside their own `/tmp`
> - `SubprocessRuntime` overrides `scripts_dir` back to the `CACHE_DIR`-backed path, preserving the previous host behavior
> - IPC directories created by `EnvServerPool` are now explicitly placed under `/tmp` via `dir='/tmp'` in `tempfile.mkdtemp`
> - Behavioral Change: sandboxed runtimes that previously inherited the host cache path will now write scripts to `/tmp/vf-scripts` instead
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a97af7c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a97af7c7bc626477a9a8fd979ad88588c03f733e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->