### PR TITLE
Add native ACP session import

### DIFF
--- a/tests/v1/fixtures/echo_acp_resume_v1.py
+++ b/tests/v1/fixtures/echo_acp_resume_v1.py
@@ -4,6 +4,8 @@ import verifiers.v1 as vf
 
 CODEWORD = "violet-cascade-731"
 TOOL_STAMP = "resume-ok-9d2"
+SEEDED_CALL_ID = "seed_recall"
+SEEDED_REPLY = "imported-assistant-4f8"
 
 
 def _key(text: str) -> str:
@@ -21,6 +23,7 @@ class ResumeToolset(vf.Toolset[vf.ToolsetConfig]):
 
 class ACPResumeTaskConfig(vf.TaskConfig):
     tools: vf.ToolsetConfig = vf.ToolsetConfig(colocated=True)
+    seeded: bool = False
 
 
 class ACPResumeConfig(vf.TasksetConfig):
@@ -38,9 +41,10 @@ class ACPResumeTask(vf.Task[vf.TaskData, vf.State, ACPResumeTaskConfig]):
         if len(segments) != 2:
             return 0.0
         first, second = segments
+        expected_first = SEEDED_REPLY if trace.info["acp_seeded"] else "READY"
         resumed_tool_output = "\n".join(second["tool_outputs"])
         return float(
-            bool(first["last_reply"].strip())
+            _key(first["last_reply"]) == _key(expected_first)
             and _key(CODEWORD) in _key(second["last_reply"])
             and _key(TOOL_STAMP) in _key(second["last_reply"])
             and _key(CODEWORD) in _key(resumed_tool_output)
@@ -53,14 +57,16 @@ class ACPResumeEnv(vf.SingleAgentEnv):
     async def run(self, task, agents):
         async with agents.agent.interaction(task) as interaction:
             first = await interaction.turn(
-                f"Remember the codeword {CODEWORD}. Reply with exactly READY."
+                None
+                if task.config.seeded
+                else f"Remember the codeword {CODEWORD}. Reply with exactly READY."
             )
             segments = [first]
             if not first.terminated:
                 segments.append(
                     await interaction.turn(
-                        "Call `resume_recall` with the codeword from my previous "
-                        "message, then reply with exactly the tool result."
+                        "Call `resume_recall` with the codeword from our conversation "
+                        "history, then reply with exactly the tool result."
                     )
                 )
             interaction.trace.info["acp_segments"] = [
@@ -76,16 +82,42 @@ class ACPResumeEnv(vf.SingleAgentEnv):
                 }
                 for segment in segments
             ]
+            interaction.trace.info["acp_seeded"] = task.config.seeded
 
 
 class ACPResumeTaskset(vf.Taskset[ACPResumeTask, ACPResumeConfig]):
     def load(self) -> list[ACPResumeTask]:
+        prompt = None
+        if self.config.task.seeded:
+            prompt = [
+                vf.UserMessage(content=f"Remember the codeword {CODEWORD}."),
+                vf.AssistantMessage(
+                    tool_calls=[
+                        vf.ToolCall(
+                            id=SEEDED_CALL_ID,
+                            name="resume_recall",
+                            arguments=f'{{"codeword":"{CODEWORD}"}}',
+                        )
+                    ]
+                ),
+                vf.ToolMessage(
+                    content=f"{CODEWORD} [{TOOL_STAMP}]",
+                    tool_call_id=SEEDED_CALL_ID,
+                    name="resume_recall",
+                ),
+                vf.AssistantMessage(content=SEEDED_REPLY),
+                vf.UserMessage(
+                    content="Reply with exactly the previous assistant reply."
+                ),
+            ]
         return [
             ACPResumeTask(
                 vf.TaskData(
                     idx=0,
-                    prompt=None,
-                    system_prompt=(
+                    prompt=prompt,
+                    system_prompt=None
+                    if self.config.task.seeded
+                    else (
                         "Follow each user instruction exactly. Preserve conversational "
                         "context between turns and use requested tools."
                     ),

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -10,9 +10,9 @@ import pytest
 mark = pytest.mark
 
 
-def pair(a: str, b: str, id: str, *extra_marks):
+def pair(a: str, b: str, id: str, *values):
     marks = [getattr(mark, a.replace("-", "_")), getattr(mark, b.replace("-", "_"))]
-    return pytest.param(a, b, marks=[*marks, *extra_marks], id=id)
+    return pytest.param(a, b, *values, marks=marks, id=id)
 
 
 # harness x harness runtime: every harness once, both local runtimes hit (subprocess
@@ -64,28 +64,50 @@ USER_RUNTIMES = [
 # ACP-backed harnesses: each must preserve an exchange across interaction segments and
 # retain MCP access after resuming. Cover every harness in the local container runtime,
 # plus remote placements for the sandbox/tunnel and native-process boundaries.
-ACP_RESUME_PLACEMENTS = [
-    pair("codex", "docker", "codex-acp-in-docker"),
-    pair("claude-code", "docker", "claude-code-acp-in-docker"),
-    pair("hermes-agent", "docker", "hermes-agent-acp-in-docker"),
-    pair("rlm", "docker", "rlm-acp-in-docker"),
+ACP_PLACEMENTS = [
+    pair("codex", "docker", "codex-acp-in-docker", False),
+    pair("claude-code", "docker", "claude-code-acp-in-docker", False),
+    pair("hermes-agent", "docker", "hermes-agent-acp-in-docker", False),
+    pair("rlm", "docker", "rlm-acp-in-docker", False),
     pytest.param(
         {"id": "kimi-code", "transport": "responses"},
         "docker",
+        False,
         marks=[mark.kimi_code, mark.docker],
         id="kimi-code-responses-acp-in-docker",
     ),
     pytest.param(
         {"id": "pi", "transport": "responses"},
         "docker",
+        False,
         marks=[mark.pi, mark.docker],
         id="pi-responses-acp-in-docker",
     ),
-    pair("pool", "docker", "pool-acp-in-docker"),
-    pair("openclaw", "docker", "openclaw-acp-in-docker"),
-    pair("pool", "prime", "pool-acp-in-prime"),
-    pair("rlm", "prime", "rlm-acp-in-prime-vm"),
+    pair("pool", "docker", "pool-acp-in-docker", False),
+    pair("openclaw", "docker", "openclaw-acp-in-docker", False),
+    pair("pool", "prime", "pool-acp-in-prime", False),
+    pair("rlm", "prime", "rlm-acp-in-prime-vm", False),
+    pair("codex", "docker", "codex-import-in-docker", True),
+    pair("claude-code", "docker", "claude-code-import-in-docker", True),
+    pair("hermes-agent", "docker", "hermes-agent-import-in-docker", True),
+    pair("rlm", "docker", "rlm-import-in-docker", True),
+    pytest.param(
+        {"id": "kimi-code", "transport": "responses"},
+        "docker",
+        True,
+        marks=[mark.kimi_code, mark.docker],
+        id="kimi-code-responses-import-in-docker",
+    ),
+    pytest.param(
+        {"id": "pi", "transport": "responses"},
+        "docker",
+        True,
+        marks=[mark.pi, mark.docker],
+        id="pi-responses-import-in-docker",
+    ),
+    pair("openclaw", "docker", "openclaw-import-in-docker", True),
 ]
+# Pool 1.0.15 has no exact history-import extension, so only its live rows are present.
 
 # harness runtime x tool placement: every axis value once plus the two-container case
 # (harness and tool in separate docker boxes) and a prime-colocated row (a tool in its
@@ -232,10 +254,12 @@ async def test_interaction(live_ctx):
 
 @pytest.mark.e2e
 @pytest.mark.parametrize(
-    "harness,harness_runtime", ACP_RESUME_PLACEMENTS, indirect=True
+    "harness,harness_runtime,seeded",
+    ACP_PLACEMENTS,
+    indirect=["harness", "harness_runtime"],
 )
-async def test_acp_resume_with_tool(run_v1, harness, harness_runtime, tmp_path):
-    """Each ACP harness preserves context and MCP access across two segments."""
+async def test_acp_resume_with_tool(run_v1, harness, harness_runtime, seeded, tmp_path):
+    """ACP keeps one session and imports supplied history before the first turn."""
     (trace,) = await run_v1(
         "echo-acp-resume-v1",
         harness=harness,
@@ -247,6 +271,7 @@ async def test_acp_resume_with_tool(run_v1, harness, harness_runtime, tmp_path):
         max_turns=8,
         max_tokens=8192,
         rollout_timeout=600,
+        taskset_overrides={"task": {"seeded": seeded}},
     )
     assert trace.ok, trace.errors
     assert trace.stop_condition == "user_closed"

--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -16,11 +16,12 @@ from verifiers.v1.harness import Harness, HarnessSession
 from verifiers.v1.runtimes import ProgramResult, Runtime, RuntimeProcess
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
-from verifiers.v1.types import Messages
+from verifiers.v1.types import Messages, SystemMessage
 from verifiers.v1.utils.aio import run_shielded
 
 ACP_SOURCE = (Path(__file__).resolve().parent / "runner.py").read_text()
 MAX_PACKET_BYTES = 128 * 1024 * 1024
+SESSION_IMPORT = "verifiers.dev/sessionImport"
 
 __all__ = ["ACPConfig", "ACPHarness"]
 
@@ -166,6 +167,23 @@ class ACPHarnessSession(HarnessSession):
     ) -> None:
         super().__init__(harness, ctx, trace, runtime, endpoint, secret, mcp_urls, data)
         self.config = config
+        history: Messages = []
+        if isinstance(config.prompt, list):
+            if not config.prompt or config.prompt[-1].role != "user":
+                raise ValueError(
+                    "an imported ACP conversation must end with a user turn"
+                )
+            history, config.prompt = config.prompt[:-1], config.prompt[-1:]
+        if history and config.system_prompt:
+            # ACP prompts have no system role. Import it before history so adapters
+            # can preserve the task instruction natively or reject it explicitly.
+            history.insert(0, SystemMessage(content=config.system_prompt))
+            config.system_prompt = None
+        self.session_import = [
+            message.model_dump(mode="json", exclude_none=True) for message in history
+        ]
+        if config.session_meta and SESSION_IMPORT in config.session_meta:
+            raise ValueError(f"{SESSION_IMPORT} is reserved by ACP")
         self._process: RuntimeProcess | None = None
         self._reader: _PacketReader | None = None
         self._stderr_tail = bytearray()
@@ -222,6 +240,9 @@ class ACPHarnessSession(HarnessSession):
                 raise HarnessError(
                     f"harness {self.harness.config.id!r} session is already closed"
                 )
+            config["session_import"] = (
+                self.session_import if self._process is None else []
+            )
             if self._process is None:
                 await self._start()
             assert self._process is not None

--- a/verifiers/v1/acp/runner.py
+++ b/verifiers/v1/acp/runner.py
@@ -36,6 +36,7 @@ from acp.schema import (
 
 MAX_PACKET_BYTES = 128 * 1024 * 1024
 LATE_UPDATE_GRACE_SECONDS = 1.0
+SESSION_IMPORT = "verifiers.dev/sessionImport"
 
 
 class VerifiersACPClient(Client):
@@ -213,10 +214,29 @@ class ACPSession:
                 client_capabilities=ClientCapabilities(),
             )
             self.capabilities = initialized.agent_capabilities
+            session_import = config["session_import"]
+            if SESSION_IMPORT in config["session_meta"]:
+                raise RuntimeError(f"{SESSION_IMPORT} is reserved by ACP")
+            if session_import:
+                metadata = self.capabilities.field_meta if self.capabilities else None
+                extension = (metadata or {}).get(SESSION_IMPORT)
+                version = (
+                    extension.get("version") if isinstance(extension, dict) else None
+                )
+                if type(version) is not int or version != 1:
+                    raise RuntimeError(
+                        "ACP agent does not support exact VF session import"
+                    )
+            session_meta = dict(config["session_meta"])
+            if session_import:
+                session_meta[SESSION_IMPORT] = {
+                    "version": 1,
+                    "messages": session_import,
+                }
             session = await self.connection.new_session(
                 cwd=os.getcwd(),
                 mcp_servers=mcp_servers(config),
-                **config["session_meta"],
+                **session_meta,
             )
         except BaseException:
             with suppress(BaseException):
@@ -229,6 +249,8 @@ class ACPSession:
     async def run(self, config: dict) -> str:
         if self.connection is None:
             await self.start(config)
+        elif config["session_import"]:
+            raise RuntimeError("ACP session history can only be imported at creation")
         assert self.session_id is not None
         reply = await prompt(
             self.client,

--- a/verifiers/v1/harnesses/claude_code/harness.py
+++ b/verifiers/v1/harnesses/claude_code/harness.py
@@ -1,13 +1,19 @@
 """Run Claude Code through the Claude Agent SDK ACP adapter."""
 
 import shlex
+from pathlib import Path
 
 from pydantic import Field
 
 from verifiers.v1.acp import ACPConfig, ACPHarness
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
-from verifiers.v1.harnesses.node import NODE_BIN_DIR, ensure_node
+from verifiers.v1.harnesses.node import (
+    NODE_BIN_DIR,
+    ensure_node,
+    node_patch_id,
+    prepare_node_patch,
+)
 from verifiers.v1.runtimes import Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
@@ -19,14 +25,18 @@ CLAUDE_BIN = f"{PACKAGES_DIR}/node_modules/.bin/claude"
 ACP_BIN = f"{PACKAGES_DIR}/node_modules/.bin/claude-agent-acp"
 CLAUDE_CONFIG_ROOT = ".vf-claude"
 SKILLS_DIR = ".claude/skills"
+SESSION_IMPORT_PATCH = Path(__file__).with_name("session_import.patch").read_bytes()
+SESSION_IMPORT_PATCH_ID = node_patch_id(SESSION_IMPORT_PATCH)
 ACP_INSTALL = r"""
 set -e
 export PATH="/var/tmp/vf-node/bin:$PATH"
 rm -f {ready}
+rm -rf {packages}/node_modules/@agentclientprotocol/claude-agent-acp
 npm install --prefix {packages} --no-audit --no-fund \
     --omit=dev \
     "@anthropic-ai/claude-code@$VF_CLAUDE_CODE_VERSION" \
     "@agentclientprotocol/claude-agent-acp@$VF_CLAUDE_ACP_VERSION" >/dev/null
+{patch}
 touch {ready}
 """
 
@@ -49,8 +59,18 @@ class ClaudeCodeHarness(ACPHarness[ClaudeCodeHarnessConfig]):
         packages = PACKAGES_DIR.format(**versions)
         claude_bin = CLAUDE_BIN.format(**versions)
         acp_bin = ACP_BIN.format(**versions)
-        ready = f"{directory}/.ready"
-        script = ACP_INSTALL.replace("{packages}", packages).replace("{ready}", ready)
+        ready = f"{directory}/.ready-{SESSION_IMPORT_PATCH_ID}"
+        patch = await prepare_node_patch(
+            runtime,
+            directory,
+            f"{packages}/node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.js",
+            SESSION_IMPORT_PATCH,
+        )
+        script = (
+            ACP_INSTALL.replace("{packages}", packages)
+            .replace("{patch}", patch)
+            .replace("{ready}", ready)
+        )
         ensure = shlex.quote(
             f"[ -f {ready} ] && [ -x {claude_bin} ] && [ -x {acp_bin} ] || ({script})"
         )

--- a/verifiers/v1/harnesses/claude_code/session_import.patch
+++ b/verifiers/v1/harnesses/claude_code/session_import.patch
@@ -1,0 +1,194 @@
+--- node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.js
++++ node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.js
+@@ -55,4 +55,123 @@
+- *  `InitializeResponse._meta.steering.supported`. */
++ *  `InitializeResponse._meta.steering.supported`. */
+-const STEER_METHOD = "_session/steering";
++const STEER_METHOD = "_session/steering";
++const SESSION_IMPORT_KEY = "verifiers.dev/sessionImport";
++const SESSION_IMPORT_VERSION = 1;
++function contentBlocks(content) {
++    if (typeof content === "string")
++        return [{ type: "text", text: content }];
++    return content.map((part) => part.type === "text"
++        ? { type: "text", text: part.text }
++        : { type: "image", source: { type: "url", url: part.image_url.url } });
++}
++function textContent(content) {
++    if (typeof content === "string")
++        return content;
++    if (content.some((part) => part.type !== "text")) {
++        throw RequestError.invalidParams(undefined, "system session history cannot contain images");
++    }
++    return content.map((part) => part.text).join("\n");
++}
++function parseSessionImport(meta, sessionId, cwd) {
++    if (!meta || typeof meta !== "object" || !(SESSION_IMPORT_KEY in meta))
++        return null;
++    const value = meta[SESSION_IMPORT_KEY];
++    const { version, messages } = value;
++    if (version !== SESSION_IMPORT_VERSION || !Array.isArray(messages)) {
++        throw RequestError.invalidParams(undefined, `${SESSION_IMPORT_KEY} requires version 1 and messages`);
++    }
++    const entries = [];
++    const system = [];
++    let parentUuid = null;
++    const add = (type, message) => {
++        const uuid = randomUUID();
++        entries.push({
++            type,
++            uuid,
++            parentUuid,
++            isSidechain: false,
++            userType: "external",
++            cwd,
++            sessionId,
++            timestamp: new Date().toISOString(),
++            message,
++        });
++        parentUuid = uuid;
++    };
++    for (const raw of messages) {
++        if (raw.role === "system") {
++            if (entries.length) {
++                throw RequestError.invalidParams(undefined, "system session history must precede conversation messages");
++            }
++            system.push(textContent(raw.content));
++        }
++        else if (raw.role === "user") {
++            add("user", { role: "user", content: contentBlocks(raw.content) });
++        }
++        else if (raw.role === "tool") {
++            add("user", {
++                role: "user",
++                content: [{
++                        type: "tool_result",
++                        tool_use_id: raw.tool_call_id,
++                        content: contentBlocks(raw.content),
++                    }],
++            });
++        }
++        else if (raw.role === "assistant") {
++            const blocks = [];
++            if (raw.provider_state?.length) {
++                if (raw.provider_state.some((block) => !["thinking", "redacted_thinking"].includes(String(block["type"])))) {
++                    throw RequestError.invalidParams(undefined, "assistant provider_state is not Anthropic history");
++                }
++                const reasoning = raw.provider_state.filter((block) => block.type === "thinking").map((block) => block.thinking ?? "").join("");
++                if ((raw.reasoning_content ?? "") !== reasoning) {
++                    throw RequestError.invalidParams(undefined, "assistant provider_state does not match its typed message");
++                }
++                blocks.push(...raw.provider_state);
++            }
++            else if (raw.reasoning_content != null) {
++                throw RequestError.invalidParams(undefined, "Anthropic reasoning history requires signed provider_state");
++            }
++            blocks.push(...contentBlocks(raw.content));
++            for (const call of raw.tool_calls ?? []) {
++                let input;
++                try {
++                    input = JSON.parse(call.arguments);
++                }
++                catch {
++                    throw RequestError.invalidParams(undefined, `tool call ${call.id} has invalid JSON arguments`);
++                }
++                blocks.push({ type: "tool_use", id: call.id, name: call.name, input });
++            }
++            if (!blocks.length) {
++                throw RequestError.invalidParams(undefined, "assistant session history cannot be empty");
++            }
++            add("assistant", {
++                id: `msg_${randomUUID().replaceAll("-", "")}`,
++                type: "message",
++                role: "assistant",
++                model: process.env.ANTHROPIC_MODEL ?? "unknown",
++                content: blocks,
++                stop_reason: raw.tool_calls?.length ? "tool_use" : "end_turn",
++                stop_sequence: null,
++                usage: { input_tokens: 0, output_tokens: 0 },
++            });
++        }
++        else {
++            throw RequestError.invalidParams(undefined, `unsupported session history role: ${String(raw.role)}`);
++        }
++    }
++    const store = {
++        async append() { },
++        async load(key) {
++            return key.sessionId === sessionId ? entries : null;
++        },
++    };
++    return {
++        entries,
++        store,
++        ...(system.length ? { systemPrompt: system.join("\n\n") } : {}),
++    };
++}
+-/** How urgently the SDK delivers a steered message relative to the running
++/** How urgently the SDK delivers a steered message relative to the running
+- *  turn — an internal Claude implementation detail, not part of the wire
++ *  turn — an internal Claude implementation detail, not part of the wire
+@@ -695,4 +814,5 @@
+-                        promptQueueing: true,
++                        promptQueueing: true,
+-                    },
++                    },
++                    [SESSION_IMPORT_KEY]: { version: SESSION_IMPORT_VERSION },
+-                },
++                },
+-                promptCapabilities: {
++                promptCapabilities: {
+@@ -4216,4 +4336,5 @@
+-            sessionId = randomUUID();
++            sessionId = randomUUID();
+-        }
++        }
++        const sessionImport = parseSessionImport(params._meta, sessionId, params.cwd);
+-        const input = new Pushable();
++        const input = new Pushable();
+-        const settingsManager = new SettingsManager(params.cwd, {
++        const settingsManager = new SettingsManager(params.cwd, {
+@@ -4265,4 +4386,18 @@
+-            }
++            }
+-        }
++        }
++        if (sessionImport?.systemPrompt) {
++            if (typeof systemPrompt === "string") {
++                systemPrompt += `\n\n${sessionImport.systemPrompt}`;
++            }
++            else if (Array.isArray(systemPrompt)) {
++                systemPrompt = [...systemPrompt, sessionImport.systemPrompt];
++            }
++            else if (systemPrompt) {
++                systemPrompt = {
++                    ...systemPrompt,
++                    append: [systemPrompt.append, sessionImport.systemPrompt].filter(Boolean).join("\n\n"),
++                };
++            }
++        }
+-        const permissionMode = resolvePermissionMode(settingsManager.getSettings().permissions?.defaultMode, this.logger);
++        const permissionMode = resolvePermissionMode(settingsManager.getSettings().permissions?.defaultMode, this.logger);
+-        // Extract options from _meta if provided
++        // Extract options from _meta if provided
+@@ -4433,4 +4568,5 @@
+-            },
++            },
+-            ...creationOpts,
++            ...creationOpts,
++            ...(sessionImport && { resume: sessionId, sessionStore: sessionImport.store }),
+-            abortController,
++            abortController,
+-        };
++        };
+@@ -4444,5 +4580,5 @@
+-            ...acpAdditionalDirectories,
++            ...acpAdditionalDirectories,
+-        ];
++        ];
+-        if (creationOpts?.resume === undefined || creationOpts?.forkSession) {
++        if ((!creationOpts?.resume && !sessionImport) || creationOpts?.forkSession) {
+-            // Set our own session id if not resuming an existing session.
++            // Set our own session id if not resuming an existing session.
+-            options.sessionId = sessionId;
++            options.sessionId = sessionId;

--- a/verifiers/v1/harnesses/codex/harness.py
+++ b/verifiers/v1/harnesses/codex/harness.py
@@ -6,13 +6,19 @@ import logging
 import re
 import shlex
 from collections import Counter
+from pathlib import Path
 
 from pydantic import Field
 
 from verifiers.v1.acp import ACPConfig, ACPHarness
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
-from verifiers.v1.harnesses.node import NODE_BIN_DIR, ensure_node
+from verifiers.v1.harnesses.node import (
+    NODE_BIN_DIR,
+    ensure_node,
+    node_patch_id,
+    prepare_node_patch,
+)
 from verifiers.v1.runtimes import Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
@@ -25,14 +31,18 @@ ACP_VERSION = "1.1.10"
 CODEX_BIN = f"{PACKAGES_DIR}/node_modules/.bin/codex"
 ACP_BIN = f"{PACKAGES_DIR}/node_modules/.bin/codex-acp"
 SKILLS_DIR = ".agents/skills"
+SESSION_IMPORT_PATCH = Path(__file__).with_name("session_import.patch").read_bytes()
+SESSION_IMPORT_PATCH_ID = node_patch_id(SESSION_IMPORT_PATCH)
 INSTALL = r"""
 set -e
 export PATH="/var/tmp/vf-node/bin:$PATH"
 rm -f {ready}
+rm -rf {packages}/node_modules/@agentclientprotocol/codex-acp
 npm install --prefix {packages} --ignore-scripts --no-audit --no-fund \
     --omit=dev \
     "@agentclientprotocol/codex-acp@$VF_CODEX_ACP_VERSION" \
     "@openai/codex@$VF_CODEX_VERSION" >/dev/null
+{patch}
 touch {ready}
 """
 
@@ -62,8 +72,18 @@ class CodexHarness(ACPHarness[CodexHarnessConfig]):
         packages = PACKAGES_DIR.format(**versions)
         codex_bin = CODEX_BIN.format(**versions)
         acp_bin = ACP_BIN.format(**versions)
-        ready = f"{directory}/.ready"
-        script = INSTALL.replace("{packages}", packages).replace("{ready}", ready)
+        ready = f"{directory}/.ready-{SESSION_IMPORT_PATCH_ID}"
+        patch = await prepare_node_patch(
+            runtime,
+            directory,
+            f"{packages}/node_modules/@agentclientprotocol/codex-acp/dist/index.js",
+            SESSION_IMPORT_PATCH,
+        )
+        script = (
+            INSTALL.replace("{packages}", packages)
+            .replace("{patch}", patch)
+            .replace("{ready}", ready)
+        )
         ensure = shlex.quote(
             f"[ -f {ready} ] && [ -x {codex_bin} ] && [ -x {acp_bin} ] || ({script})"
         )

--- a/verifiers/v1/harnesses/codex/session_import.patch
+++ b/verifiers/v1/harnesses/codex/session_import.patch
@@ -1,0 +1,153 @@
+--- node_modules/@agentclientprotocol/codex-acp/dist/index.js
++++ node_modules/@agentclientprotocol/codex-acp/dist/index.js
+@@ -26268,2 +26268,82 @@
+-// src/CodexAcpClient.ts
++// src/CodexAcpClient.ts
++var SESSION_IMPORT_KEY = "verifiers.dev/sessionImport";
++var SESSION_IMPORT_VERSION = 1;
++function contentItems(content, output) {
++  if (typeof content === "string") {
++    return [{ type: output ? "output_text" : "input_text", text: content }];
++  }
++  return (content ?? []).map((part) => {
++    if (part.type === "text") {
++      return { type: output ? "output_text" : "input_text", text: part.text };
++    }
++    if (output) {
++      throw RequestError.invalidParams(void 0, "assistant session history cannot contain images");
++    }
++    return { type: "input_image", image_url: part.image_url.url };
++  });
++}
++function sessionImportItems(meta3) {
++  if (!meta3 || typeof meta3 !== "object" || !(SESSION_IMPORT_KEY in meta3)) {
++    return [];
++  }
++  const value = meta3[SESSION_IMPORT_KEY];
++  const { version: version2, messages } = value;
++  if (version2 !== SESSION_IMPORT_VERSION || !Array.isArray(messages)) {
++    throw RequestError.invalidParams(void 0, `${SESSION_IMPORT_KEY} requires version 1 and messages`);
++  }
++  const items = [];
++  for (const message of messages) {
++    if (message.role === "system" || message.role === "user") {
++      items.push({ type: "message", role: message.role, content: contentItems(message.content, false) });
++    } else if (message.role === "tool") {
++      if (typeof message.tool_call_id !== "string") {
++        throw RequestError.invalidParams(void 0, "tool session history requires tool_call_id");
++      }
++      items.push({
++        type: "function_call_output",
++        call_id: message.tool_call_id,
++        output: typeof message.content === "string" ? message.content : contentItems(message.content, false)
++      });
++    } else if (message.role === "assistant") {
++      if (message.provider_state?.length) {
++        if (message.provider_state.some((item) => item.type === "message" && item.role !== "assistant")) {
++          throw RequestError.invalidParams(void 0, "assistant provider_state is not Responses history");
++        }
++        const content = message.provider_state.filter((item) => item.type === "message").map((item) => typeof item.content === "string" ? item.content : (item.content ?? []).filter((part) => ["input_text", "output_text"].includes(part.type)).map((part) => part.text ?? "").join("")).join("");
++        const reasoning = message.provider_state.filter((item) => item.type === "reasoning").flatMap((item) => [...item.summary ?? [], ...item.content ?? []]).map((part) => part.text ?? "").filter(Boolean).join("\n");
++        const calls = message.provider_state.filter((item) => ["function_call", "custom_tool_call"].includes(item.type)).map((item) => ({ id: item.call_id, name: item.name, arguments: item.arguments ?? item.input ?? "" }));
++        const typedCalls = message.tool_calls ?? [];
++        if ((message.content ?? "") !== content || (message.reasoning_content ?? "") !== reasoning || calls.length !== typedCalls.length || calls.some((call, index) => call.id !== typedCalls[index]?.id || call.name !== typedCalls[index]?.name || call.arguments !== typedCalls[index]?.arguments)) {
++          throw RequestError.invalidParams(void 0, "assistant provider_state does not match its typed message");
++        }
++        items.push(...message.provider_state);
++        continue;
++      }
++      if (message.reasoning_content != null) {
++        throw RequestError.invalidParams(
++          void 0,
++          "exact Responses reasoning history requires provider_state"
++        );
++      }
++      const itemCount = items.length;
++      if (message.content != null) {
++        items.push({ type: "message", role: "assistant", content: contentItems(message.content, true) });
++      }
++      for (const call of message.tool_calls ?? []) {
++        items.push({
++          type: "function_call",
++          call_id: call.id,
++          name: call.name,
++          arguments: call.arguments
++        });
++      }
++      if (items.length === itemCount) {
++        throw RequestError.invalidParams(void 0, "assistant session history cannot be empty");
++      }
++    } else {
++      throw RequestError.invalidParams(void 0, `unsupported session history role: ${String(message.role)}`);
++    }
++  }
++  return items;
++}
+-var CUSTOM_GATEWAY_PROVIDER_ID = "custom-gateway";
++var CUSTOM_GATEWAY_PROVIDER_ID = "custom-gateway";
+@@ -26580,2 +26660,3 @@
+-  async newSession(request) {
++  async newSession(request) {
++    const importedItems = sessionImportItems(request._meta);
+-    const additionalDirectories = readAdditionalDirectories(request.cwd, request.additionalDirectories, request._meta);
++    const additionalDirectories = readAdditionalDirectories(request.cwd, request.additionalDirectories, request._meta);
+@@ -26587,16 +26668,27 @@
+-    });
++    });
+-    const codexModels = await this.fetchAvailableModels();
+-    if (codexModels.length === 0) {
+-      throw new Error("Codex did not return any models");
++    try {
++      if (importedItems.length) {
++        await this.codexClient.threadInjectItems({ threadId: response.thread.id, items: importedItems });
++      }
++      const codexModels = await this.fetchAvailableModels();
++      if (codexModels.length === 0) {
++        throw new Error("Codex did not return any models");
++      }
++      const currentModelId = this.createModelId(codexModels, response.model, response.reasoningEffort).toString();
++      return {
++        sessionId: response.thread.id,
++        currentModelId,
++        models: codexModels,
++        collaborationMode: this.getCollaborationMode(response.thread.id),
++        modelProvider: response.modelProvider,
++        currentServiceTier: response.serviceTier ?? null,
++        additionalDirectories
++      };
++    } catch (error51) {
++      if (importedItems.length) {
++        await this.codexClient.threadArchive({ threadId: response.thread.id }).catch(() => {
++        });
++      }
++      throw error51;
+-    }
++    }
+-    const currentModelId = this.createModelId(codexModels, response.model, response.reasoningEffort).toString();
+-    return {
+-      sessionId: response.thread.id,
+-      currentModelId,
+-      models: codexModels,
+-      collaborationMode: this.getCollaborationMode(response.thread.id),
+-      modelProvider: response.modelProvider,
+-      currentServiceTier: response.serviceTier ?? null,
+-      additionalDirectories
+-    };
+-  }
++  }
+@@ -28773,2 +28865,5 @@
+-      agentCapabilities: {
++      agentCapabilities: {
++        _meta: {
++          "verifiers.dev/sessionImport": { version: 1 }
++        },
+-        auth: {
++        auth: {
+@@ -30967,2 +31062,5 @@
+-  }
++  }
++  async threadInjectItems(params) {
++    return await this.sendRequest({ method: "thread/inject_items", params });
++  }
+-  getThreadSettings(threadId) {
++  getThreadSettings(threadId) {

--- a/verifiers/v1/harnesses/hermes_agent/program.py
+++ b/verifiers/v1/harnesses/hermes_agent/program.py
@@ -5,13 +5,168 @@
 """Start Hermes Agent's native ACP server."""
 
 import os
+from copy import deepcopy
+from typing import Any
 
 from hermes_cli.models import detect_provider_for_model
 from hermes_cli.providers import determine_api_mode
 
+SESSION_IMPORT = "verifiers.dev/sessionImport"
+
+
+def native_messages(
+    messages: list[dict[str, Any]], api_mode: str
+) -> list[dict[str, Any]]:
+    """Convert typed VF messages into Hermes' persisted conversation shape."""
+    native = []
+    for message in messages:
+        role = message["role"]
+        imported = {"role": role, "content": deepcopy(message.get("content"))}
+        if role == "tool":
+            imported["tool_call_id"] = message["tool_call_id"]
+            if name := message.get("name"):
+                imported["tool_name"] = name
+        elif role == "assistant":
+            calls = message.get("tool_calls") or []
+            imported["tool_calls"] = [
+                {
+                    "id": call["id"],
+                    "type": "function",
+                    "function": {
+                        "name": call["name"],
+                        "arguments": call["arguments"],
+                    },
+                }
+                for call in calls
+            ]
+            reasoning = message.get("reasoning_content")
+            if reasoning is not None:
+                imported["reasoning_content"] = reasoning
+            state = deepcopy(message.get("provider_state") or [])
+            if api_mode == "codex_responses" and reasoning is not None and not state:
+                raise ValueError(
+                    "exact Responses reasoning history requires provider_state"
+                )
+            if state and api_mode == "codex_responses":
+                if any(
+                    item.get("type") not in {"reasoning", "message", "function_call"}
+                    for item in state
+                ):
+                    raise ValueError(
+                        "Hermes cannot exactly import this Responses provider state"
+                    )
+                reasoning_items = [
+                    item for item in state if item.get("type") == "reasoning"
+                ]
+                message_items = [
+                    item for item in state if item.get("type") == "message"
+                ]
+                function_items = [
+                    item for item in state if item.get("type") == "function_call"
+                ]
+                try:
+                    invalid_messages = any(
+                        item.get("role") != "assistant"
+                        or any(
+                            part.get("type") != "output_text"
+                            for part in item.get("content") or []
+                        )
+                        or any(
+                            item.get(key) is not None
+                            for key in ("encrypted_content", "signature", "data")
+                        )
+                        for item in message_items
+                    )
+                    state_content = "".join(
+                        part.get("text", "")
+                        for item in message_items
+                        for part in item.get("content") or []
+                    )
+                    state_reasoning = "\n".join(
+                        part.get("text", "")
+                        for item in reasoning_items
+                        for part in [
+                            *(item.get("summary") or []),
+                            *(item.get("content") or []),
+                        ]
+                        if part.get("text")
+                    )
+                except (AttributeError, TypeError):
+                    invalid_messages = True
+                    state_content = state_reasoning = ""
+                replayed_calls = [
+                    {
+                        "type": "function_call",
+                        "call_id": call["id"],
+                        "name": call["name"],
+                        "arguments": call["arguments"],
+                    }
+                    for call in calls
+                ]
+                if (
+                    invalid_messages
+                    or state_content != (message.get("content") or "")
+                    or state_reasoning != (reasoning or "")
+                    or function_items != replayed_calls
+                ):
+                    raise ValueError(
+                        "Hermes cannot exactly import this Responses provider state"
+                    )
+                if reasoning_items:
+                    imported["codex_reasoning_items"] = reasoning_items
+                if message_items:
+                    imported["codex_message_items"] = message_items
+            elif state:
+                imported["reasoning_details"] = state
+        native.append(imported)
+    return native
+
+
 model = os.environ["HERMES_INFERENCE_MODEL"].rsplit("/", 1)[-1]
 provider, _ = detect_provider_for_model(model, "auto") or ("auto", model)
 os.environ.setdefault("HERMES_INTERCEPT_TRANSPORT", determine_api_mode(provider))
+
+import acp_adapter.server
+from acp_adapter.server import HermesACPAgent
+
+
+class VerifiersHermesACPAgent(HermesACPAgent):
+    async def initialize(self, *args: Any, **kwargs: Any):
+        response = await super().initialize(*args, **kwargs)
+        capabilities = response.agent_capabilities
+        capabilities.field_meta = {
+            **(capabilities.field_meta or {}),
+            SESSION_IMPORT: {"version": 1},
+        }
+        return response
+
+    async def new_session(self, *args: Any, **kwargs: Any):
+        session_import = kwargs.get(SESSION_IMPORT)
+        if session_import is None:
+            return await super().new_session(*args, **kwargs)
+        if not isinstance(session_import, dict) or session_import.get("version") != 1:
+            raise ValueError("unsupported verifiers.dev/sessionImport version")
+        messages = session_import.get("messages")
+        if not isinstance(messages, list):
+            raise TypeError("verifiers.dev/sessionImport.messages must be a list")
+        imported = native_messages(messages, os.environ["HERMES_INTERCEPT_TRANSPORT"])
+        response = await super().new_session(*args, **kwargs)
+        state = self.session_manager.get_session(response.session_id)
+        if state is None:
+            raise RuntimeError("Hermes did not retain its newly created session")
+        try:
+            db = self.session_manager._get_db()
+            if db is None:
+                raise RuntimeError("Hermes session persistence is unavailable")
+            db.replace_messages(state.session_id, imported)
+            state.history = imported
+        except Exception:
+            self.session_manager.remove_session(response.session_id)
+            raise
+        return response
+
+
+acp_adapter.server.HermesACPAgent = VerifiersHermesACPAgent
 
 from acp_adapter.entry import main
 

--- a/verifiers/v1/harnesses/kimi_code/harness.py
+++ b/verifiers/v1/harnesses/kimi_code/harness.py
@@ -2,6 +2,7 @@
 
 import logging
 import shlex
+from pathlib import Path
 from typing import Literal
 
 import tomli_w
@@ -18,8 +19,8 @@ logger = logging.getLogger(__name__)
 
 BINARY = "/tmp/vf-kimi-code/bin/kimi"
 KIMI_HOME = ".vf-kimi-code"
-ACP_COMMAND = [BINARY, "acp"]
 SKILLS_DIR = f"{KIMI_HOME}/skills"
+PROGRAM_SOURCE = (Path(__file__).resolve().parent / "program.py").read_text()
 
 INSTALL = r"""
 set -e
@@ -124,8 +125,12 @@ class KimiCodeHarness(ACPHarness[KimiCodeHarnessConfig]):
                 "KIMI_MODEL_PROVIDER_TYPE": provider_type,
                 "KIMI_DISABLE_TELEMETRY": "1",
                 "KIMI_CODE_NO_AUTO_UPDATE": "1",
+                "KIMI_ACP_BINARY": BINARY,
             },
-            command=ACP_COMMAND,
+            command=await runtime.prepare_uv_script(
+                PROGRAM_SOURCE,
+                {**self.config.resolved_env, "KIMI_ACP_BINARY": BINARY},
+            ),
             prompt=prompt,
             system_prompt=system_prompt,
         )

--- a/verifiers/v1/harnesses/kimi_code/program.py
+++ b/verifiers/v1/harnesses/kimi_code/program.py
@@ -1,0 +1,285 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Add exact VF session import to Kimi Code's native ACP server."""
+
+import asyncio
+import json
+import os
+import shutil
+import sys
+from contextlib import suppress
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+SESSION_IMPORT = "verifiers.dev/sessionImport"
+
+
+class SessionImportError(ValueError):
+    pass
+
+
+def content_parts(content: Any) -> list[dict[str, Any]]:
+    if isinstance(content, str):
+        return [{"type": "text", "text": content}]
+    return [
+        {"type": "text", "text": part["text"]}
+        if part["type"] == "text"
+        else {
+            "type": "image_url",
+            "imageUrl": {"url": part["image_url"]["url"]},
+        }
+        for part in content
+    ]
+
+
+def native_messages(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, dict) or value.get("version") != 1:
+        raise SessionImportError("unsupported verifiers.dev/sessionImport version")
+    messages = value.get("messages")
+    if not isinstance(messages, list):
+        raise SessionImportError("verifiers.dev/sessionImport.messages must be a list")
+
+    native = []
+    for message in messages:
+        role = message["role"]
+        if message.get("provider_state") not in (None, []):
+            raise SessionImportError(
+                "Kimi cannot exactly import opaque provider state with its native context"
+            )
+
+        content = []
+        reasoning = message.get("reasoning_content")
+        if reasoning is not None:
+            content.append({"type": "think", "think": reasoning})
+        if message.get("content") is not None:
+            content.extend(content_parts(message["content"]))
+        imported = {"role": role, "content": content}
+        if role == "assistant":
+            calls = message.get("tool_calls") or []
+            imported["toolCalls"] = [
+                {
+                    "type": "function",
+                    "id": call["id"],
+                    "name": call["name"],
+                    "arguments": call["arguments"],
+                }
+                for call in calls
+            ]
+        elif role == "user":
+            imported["origin"] = {"kind": "user"}
+        elif role == "tool":
+            imported["toolCallId"] = message["tool_call_id"]
+            if name := message.get("name"):
+                imported["name"] = name
+        native.append(imported)
+    return native
+
+
+class KimiACPProxy:
+    def __init__(self) -> None:
+        self.binary = os.environ["KIMI_ACP_BINARY"]
+        self.child: asyncio.subprocess.Process | None = None
+        self.reader: asyncio.Task[None] | None = None
+        self.waiting_id: Any = None
+        self.response: asyncio.Future[dict[str, Any]] | None = None
+        self.initialize_params: dict[str, Any] | None = None
+
+    def output(self, message: dict[str, Any]) -> None:
+        line = json.dumps(message, ensure_ascii=False, separators=(",", ":")).encode()
+        sys.stdout.buffer.write(line + b"\n")
+        sys.stdout.buffer.flush()
+
+    async def start(self) -> None:
+        env = os.environ.copy()
+        env.pop("KIMI_ACP_BINARY", None)
+        self.child = await asyncio.create_subprocess_exec(
+            self.binary,
+            "acp",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        self.reader = asyncio.create_task(self.relay(self.child))
+
+    async def relay(self, child: asyncio.subprocess.Process) -> None:
+        assert child.stdout is not None
+        while line := await child.stdout.readline():
+            message = json.loads(line)
+            if (
+                "method" not in message
+                and "id" in message
+                and message["id"] == self.waiting_id
+                and self.response is not None
+            ):
+                self.response.set_result(message)
+            else:
+                self.output(message)
+        if self.response is not None and not self.response.done():
+            self.response.set_exception(
+                RuntimeError("Kimi ACP server exited before replying")
+            )
+
+    async def send(self, message: dict[str, Any]) -> None:
+        if self.child is None or self.child.stdin is None:
+            raise RuntimeError("Kimi ACP server is not running")
+        self.child.stdin.write(
+            json.dumps(message, ensure_ascii=False, separators=(",", ":")).encode()
+            + b"\n"
+        )
+        await self.child.stdin.drain()
+
+    async def request(self, message: dict[str, Any]) -> dict[str, Any]:
+        self.waiting_id = message["id"]
+        self.response = asyncio.get_running_loop().create_future()
+        try:
+            await self.send(message)
+            return await self.response
+        finally:
+            self.waiting_id = None
+            self.response = None
+
+    async def internal_request(self, method: str, params: dict[str, Any]) -> None:
+        response = await self.request(
+            {
+                "jsonrpc": "2.0",
+                "id": f"vf-session-import-{method}",
+                "method": method,
+                "params": params,
+            }
+        )
+        if error := response.get("error"):
+            raise RuntimeError(f"Kimi {method} failed after session import: {error}")
+
+    async def stop(self) -> None:
+        child, self.child = self.child, None
+        reader, self.reader = self.reader, None
+        if child is None:
+            return
+        with suppress(ProcessLookupError):
+            child.terminate()
+        try:
+            await asyncio.wait_for(child.wait(), 10)
+        except TimeoutError:
+            child.kill()
+            await child.wait()
+        if reader is not None:
+            await reader
+
+    @staticmethod
+    def import_wire(session: Path, messages: list[dict[str, Any]]) -> None:
+        wire = session / "agents/main/wire.jsonl"
+        records = b"".join(
+            json.dumps(
+                {"type": "context.append_message", "message": message},
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ).encode()
+            + b"\n"
+            for message in messages
+        )
+        target = wire.with_name("wire.jsonl.vf-import")
+        target.write_bytes(wire.read_bytes() + records)
+        target.replace(wire)
+
+    async def initialize(self, message: dict[str, Any]) -> None:
+        response = await self.request(message)
+        if result := response.get("result"):
+            capabilities = result.setdefault("agentCapabilities", {})
+            capabilities.setdefault("_meta", {})[SESSION_IMPORT] = {"version": 1}
+            self.initialize_params = deepcopy(message.get("params") or {})
+        self.output(response)
+
+    async def new_session(self, message: dict[str, Any], value: Any) -> None:
+        imported = native_messages(value)
+        request = deepcopy(message)
+        params = request["params"]
+        metadata = params.get("_meta") or {}
+        metadata.pop(SESSION_IMPORT)
+        if not metadata:
+            params.pop("_meta", None)
+        response = await self.request(request)
+        result = response.get("result")
+        if not isinstance(result, dict):
+            self.output(response)
+            return
+        if self.initialize_params is None:
+            raise RuntimeError("Kimi session/new arrived before initialize")
+        session_id = result["sessionId"]
+        sessions = Path(os.environ["KIMI_CODE_HOME"]).resolve() / "sessions"
+        matches = list(sessions.glob(f"*/{session_id}"))
+        session = matches[0] if len(matches) == 1 else None
+        try:
+            if session is None:
+                raise RuntimeError(
+                    f"expected one Kimi session for {session_id}, found {len(matches)}"
+                )
+            await self.stop()
+            self.import_wire(session, imported)
+            await self.start()
+            await self.internal_request("initialize", self.initialize_params)
+            await self.internal_request(
+                "session/resume",
+                {
+                    "cwd": params["cwd"],
+                    "sessionId": session_id,
+                    "mcpServers": params.get("mcpServers") or [],
+                },
+            )
+        except Exception as error:
+            if session is not None:
+                shutil.rmtree(session, ignore_errors=True)
+            if self.child is None:
+                try:
+                    await self.start()
+                except (OSError, RuntimeError) as restart_error:
+                    raise RuntimeError(
+                        f"{error}; Kimi restart failed: {restart_error}"
+                    ) from error
+            raise RuntimeError(str(error)) from error
+        self.output(response)
+
+    async def run(self) -> None:
+        await self.start()
+        while line := await asyncio.to_thread(sys.stdin.buffer.readline):
+            message = json.loads(line)
+            try:
+                if message.get("method") == "initialize":
+                    await self.initialize(message)
+                elif (
+                    message.get("method") == "session/new"
+                    and (
+                        metadata := (message.get("params") or {}).get("_meta") or {}
+                    ).get(SESSION_IMPORT)
+                    is not None
+                ):
+                    await self.new_session(message, metadata[SESSION_IMPORT])
+                else:
+                    await self.send(message)
+            except Exception as error:  # noqa: BLE001 - return child failures over JSON-RPC
+                self.output(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": message["id"],
+                        "error": {
+                            "code": -32602
+                            if isinstance(error, SessionImportError)
+                            else -32603,
+                            "message": str(error),
+                        },
+                    }
+                )
+
+
+async def main() -> None:
+    proxy = KimiACPProxy()
+    try:
+        await proxy.run()
+    finally:
+        await proxy.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/verifiers/v1/harnesses/node.py
+++ b/verifiers/v1/harnesses/node.py
@@ -1,10 +1,25 @@
+import json
 import shlex
+from hashlib import sha256
 
 from verifiers.v1.runtimes import Runtime
 
 NODE_DIR = "/var/tmp/vf-node"
 NODE_BIN_DIR = f"{NODE_DIR}/bin"
 NODE_VERSION = "22.19.0"
+PATCH_SOURCE = r"""
+const fs = require("fs");
+const [target] = process.argv.slice(2);
+let source = fs.readFileSync(target, "utf8");
+for (const [before, after] of __REPLACEMENTS__) {
+    const start = source.indexOf(before);
+    if (start < 0 || source.indexOf(before, start + 1) >= 0) {
+        throw new Error(`patch source mismatch: ${target}`);
+    }
+    source = source.slice(0, start) + after + source.slice(start + before.length);
+}
+fs.writeFileSync(target, source);
+"""
 
 INSTALL = r"""
 set -e
@@ -52,3 +67,45 @@ async def ensure_node(runtime: Runtime) -> None:
     result = await runtime.run(["sh", "-c", guarded], {"VF_NODE_VERSION": NODE_VERSION})
     if result.exit_code != 0:
         raise RuntimeError(f"Node.js install failed: {result.stderr.strip()[-500:]}")
+
+
+def node_patch_id(patch: bytes) -> str:
+    return sha256(patch).hexdigest()[:12]
+
+
+def _patch_replacements(patch: bytes) -> list[tuple[str, str]]:
+    replacements = []
+    before: list[str] | None = None
+    after: list[str] | None = None
+    for line in patch.decode().splitlines(keepends=True):
+        if line.startswith("@@"):
+            if before is not None and after is not None:
+                replacements.append(("".join(before), "".join(after)))
+            before, after = [], []
+        elif before is not None and after is not None:
+            if line.startswith("\\"):
+                continue
+            if line[:1] in (" ", "-"):
+                before.append(line[1:])
+            if line[:1] in (" ", "+"):
+                after.append(line[1:])
+    if before is not None and after is not None:
+        replacements.append(("".join(before), "".join(after)))
+    if not replacements:
+        raise ValueError("Node package patch contains no hunks")
+    return replacements
+
+
+async def prepare_node_patch(
+    runtime: Runtime, directory: str, target: str, patch: bytes
+) -> str:
+    """Upload a source-checked Node patch command and return its shell prefix."""
+    revision = sha256(patch).hexdigest()
+    script = f"{directory}/apply-patch-{revision}.js"
+    await runtime.write(
+        script,
+        PATCH_SOURCE.replace(
+            "__REPLACEMENTS__", json.dumps(_patch_replacements(patch))
+        ).encode(),
+    )
+    return " ".join(map(shlex.quote, (f"{NODE_BIN_DIR}/node", script, target)))

--- a/verifiers/v1/harnesses/openclaw/harness.py
+++ b/verifiers/v1/harnesses/openclaw/harness.py
@@ -5,12 +5,12 @@ import json
 import logging
 import secrets
 import shlex
-
-from pydantic import Field
+from pathlib import Path
 
 from verifiers.v1.acp import ACPConfig, ACPHarness
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
+from verifiers.v1.harnesses.node import ensure_node, node_patch_id, prepare_node_patch
 from verifiers.v1.runtimes import Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
@@ -18,12 +18,21 @@ from verifiers.v1.trace import Trace
 logger = logging.getLogger(__name__)
 
 # OpenClaw and its bundled Node runtime exceed the small /tmp tmpfs in some VMs.
-OPENCLAW_DIR = "/var/tmp/vf-openclaw-{version}"
+OPENCLAW_VERSION = "2026.7.1-2"
+OPENCLAW_DIR = f"/var/tmp/vf-openclaw-{OPENCLAW_VERSION}"
 OPENCLAW_BIN = f"{OPENCLAW_DIR}/bin/openclaw"
+OPENCLAW_ACP = (
+    f"{OPENCLAW_DIR}/tools/node/lib/node_modules/openclaw/dist/acp-cli-BXc5GttU.js"
+)
+SESSION_IMPORT_PATCH = Path(__file__).with_name("session_import.patch").read_bytes()
+SESSION_IMPORT_PATCH_ID = node_patch_id(SESSION_IMPORT_PATCH)
 INSTALL = r"""
 set -e
+rm -rf {dir}
 command -v curl >/dev/null || (apt-get update -qq && apt-get install -y -qq curl ca-certificates >/dev/null)
 curl -fsSL --proto '=https' --tlsv1.2 https://openclaw.ai/install-cli.sh | bash -s -- --prefix {dir} --version {version} --no-onboard
+{patch}
+touch {ready}
 """
 
 OPENCLAW_COMMAND = [
@@ -82,8 +91,6 @@ wait "$acp_pid"
 
 
 class OpenClawHarnessConfig(HarnessConfig):
-    version: str = Field(default="2026.7.1-2", pattern=r"^[A-Za-z0-9._+-]+$")
-    """OpenClaw release to install, pinned for reproducibility."""
     use_bundled_skill: bool = True
     """Enable OpenClaw's bundled skill catalog in addition to uploaded harness skills."""
 
@@ -94,6 +101,7 @@ class OpenClawHarness(ACPHarness[OpenClawHarnessConfig]):
     SUPPORTS_SKILLS = True
 
     async def setup(self, runtime: Runtime) -> None:
+        await ensure_node(runtime)
         if not hasattr(self, "_staged_skills_dir"):
             self._staged_skills_dir = (
                 f".vf-openclaw/staged-skills-{secrets.token_hex(8)}"
@@ -115,18 +123,26 @@ class OpenClawHarness(ACPHarness[OpenClawHarnessConfig]):
                         )
                     await self.install_skills(runtime, self._staged_skills_dir)
                     await runtime.write(ready_path, b"")
-        directory = OPENCLAW_DIR.format(version=self.config.version)
-        binary = OPENCLAW_BIN.format(version=self.config.version)
-        script = INSTALL.replace("{version}", self.config.version).replace(
-            "{dir}", directory
+        ready = f"{OPENCLAW_DIR}/.ready-{SESSION_IMPORT_PATCH_ID}"
+        patch_dir = f"{OPENCLAW_DIR}-patch-{SESSION_IMPORT_PATCH_ID}"
+        patch = await prepare_node_patch(
+            runtime,
+            patch_dir,
+            OPENCLAW_ACP,
+            SESSION_IMPORT_PATCH,
         )
-        ensure = shlex.quote(f"[ -x {binary} ] || ({script})")
+        script = (
+            INSTALL.replace("{version}", OPENCLAW_VERSION)
+            .replace("{dir}", OPENCLAW_DIR)
+            .replace("{patch}", patch)
+            .replace("{ready}", ready)
+        )
+        ensure = shlex.quote(f"[ -f {ready} ] && [ -x {OPENCLAW_BIN} ] || ({script})")
         guarded = (
-            f"mkdir -p {directory} && "
-            f'"$(command -v flock || command -v lockf)" {directory}/install.lock '
+            f'"$(command -v flock || command -v lockf)" {OPENCLAW_DIR}.install.lock '
             f"bash -o pipefail -c {ensure}"
         )
-        logger.info("openclaw: ensuring OpenClaw %s is installed", self.config.version)
+        logger.info("openclaw: ensuring OpenClaw %s is installed", OPENCLAW_VERSION)
         result = await runtime.run(["sh", "-c", guarded], self.config.resolved_env)
         if result.exit_code != 0:
             detail = (result.stderr or result.stdout).strip()[-500:]
@@ -219,7 +235,7 @@ class OpenClawHarness(ACPHarness[OpenClawHarnessConfig]):
             "OPENCLAW_HIDE_BANNER": "1",
             "OPENCLAW_SUPPRESS_NOTES": "1",
             "NO_COLOR": "1",
-            "VF_OPENCLAW_BIN": OPENCLAW_BIN.format(version=self.config.version),
+            "VF_OPENCLAW_BIN": OPENCLAW_BIN,
         }
         # OpenClaw rejects ACP per-session MCP declarations; the isolated Gateway
         # config owns the equivalent task-scoped server definitions.

--- a/verifiers/v1/harnesses/openclaw/session_import.patch
+++ b/verifiers/v1/harnesses/openclaw/session_import.patch
@@ -1,0 +1,203 @@
+--- tools/node/lib/node_modules/openclaw/dist/acp-cli-BXc5GttU.js
++++ tools/node/lib/node_modules/openclaw/dist/acp-cli-BXc5GttU.js
+@@ -22,2 +22,6 @@
+-import { i as getRuntimeConfig } from "./io-By0s-a_s.js";
++import { i as getRuntimeConfig } from "./io-By0s-a_s.js";
++import { t as resolveModel } from "./model-wpoKGSDF.js";
++import { p as deleteSessionEntryLifecycle } from "./session-accessor-D7yi6P1i.js";
++import { resolveStorePath, upsertSessionEntry } from "./plugin-sdk/session-store-runtime.js";
++import { resolveSessionTranscriptLegacyFileTarget, withSessionTranscriptWriteLock } from "./plugin-sdk/session-transcript-runtime.js";
+-import { i as omitEnvKeysCaseInsensitive, n as listKnownProviderAuthEnvVarNames } from "./provider-env-vars-BDpb07cq.js";
++import { i as omitEnvKeysCaseInsensitive, n as listKnownProviderAuthEnvVarNames } from "./provider-env-vars-BDpb07cq.js";
+@@ -1851,2 +1855,164 @@
+-const ACP_GATEWAY_DISCONNECT_GRACE_MS = 5e3;
++const ACP_GATEWAY_DISCONNECT_GRACE_MS = 5e3;
++const SESSION_IMPORT_KEY = "verifiers.dev/sessionImport";
++const SESSION_IMPORT_VERSION = 1;
++function importTextContent(content) {
++	if (typeof content === "string") return content;
++	if (content.some((part) => part.type !== "text")) throw new Error("OpenClaw session import supports text content only.");
++	return content.map((part) => ({
++		type: "text",
++		text: part.text
++	}));
++}
++function prepareSessionImport(meta) {
++	if (!meta || typeof meta !== "object" || !(SESSION_IMPORT_KEY in meta)) return null;
++	const extension = meta[SESSION_IMPORT_KEY];
++	if (!extension || typeof extension !== "object" || extension.version !== SESSION_IMPORT_VERSION || !Array.isArray(extension.messages)) throw new Error(`${SESSION_IMPORT_KEY} requires version 1 and messages.`);
++	const config = getRuntimeConfig();
++	const primary = config.agents?.defaults?.model?.primary;
++	if (typeof primary !== "string" || !primary.includes("/")) throw new Error("OpenClaw session import requires a configured primary model.");
++	const separator = primary.indexOf("/");
++	const resolved = resolveModel(primary.slice(0, separator), primary.slice(separator + 1), void 0, config);
++	if (!resolved.model) throw new Error(resolved.error ?? `Unknown model: ${primary}`);
++	const model = resolved.model;
++	const timestamp = Date.now();
++	const messages = [];
++	const pendingTools = /* @__PURE__ */ new Map();
++	let expectedRole = "user";
++	for (const [index, raw] of extension.messages.entries()) {
++		if (raw.role !== expectedRole) throw new Error(`OpenClaw session import expected ${expectedRole} at message ${index}.`);
++		if (raw.role === "user") {
++			messages.push({
++				role: "user",
++				content: importTextContent(raw.content),
++				timestamp: timestamp + index
++			});
++			expectedRole = "assistant";
++			continue;
++		}
++		if (raw.role === "tool") {
++			const tool = pendingTools.get(raw.tool_call_id);
++			if (!tool || raw.name != null && raw.name !== tool.name) throw new Error(`OpenClaw session import has no matching tool call for ${String(raw.tool_call_id)}.`);
++			const content = importTextContent(raw.content);
++			messages.push({
++				role: "toolResult",
++				toolCallId: raw.tool_call_id,
++				toolName: tool.name,
++				content: typeof content === "string" ? [{
++					type: "text",
++					text: content
++				}] : content,
++				isError: false,
++				timestamp: timestamp + index
++			});
++			pendingTools.delete(raw.tool_call_id);
++			if (pendingTools.size === 0) expectedRole = "assistant";
++			continue;
++		}
++		if (raw.reasoning_content != null || raw.provider_state?.length) throw new Error("OpenClaw session import does not yet support assistant reasoning state.");
++		const blocks = [];
++		if (raw.content != null) blocks.push({
++			type: "text",
++			text: raw.content
++		});
++		for (const call of raw.tool_calls ?? []) {
++			if (pendingTools.has(call.id)) throw new Error(`OpenClaw session import has duplicate tool call ${call.id}.`);
++			if (!/^[a-zA-Z0-9_-]{1,64}$/.test(call.id)) throw new Error(`OpenClaw session import cannot preserve tool call ID ${call.id}.`);
++			let args;
++			try {
++				args = JSON.parse(call.arguments);
++			} catch {
++				throw new Error(`OpenClaw session import tool call ${call.id} has invalid JSON arguments.`);
++			}
++			if (!args || typeof args !== "object" || Array.isArray(args)) throw new Error(`OpenClaw session import tool call ${call.id} arguments must be an object.`);
++			if (model.api !== "anthropic-messages" && JSON.stringify(args) !== call.arguments) throw new Error(`OpenClaw session import tool call ${call.id} requires canonical JSON arguments.`);
++			blocks.push({
++				type: "toolCall",
++				id: call.id,
++				name: call.name,
++				arguments: args
++			});
++			pendingTools.set(call.id, call);
++		}
++		if (blocks.length === 0) throw new Error("OpenClaw session import assistant messages cannot be empty.");
++		messages.push({
++			role: "assistant",
++			content: blocks,
++			api: model.api,
++			provider: model.provider,
++			model: model.id,
++			usage: {
++				input: 0,
++				output: 0,
++				cacheRead: 0,
++				cacheWrite: 0,
++				totalTokens: 0,
++				cost: {
++					input: 0,
++					output: 0,
++					cacheRead: 0,
++					cacheWrite: 0,
++					total: 0
++				}
++			},
++			stopReason: pendingTools.size ? "toolUse" : "stop",
++			timestamp: timestamp + index
++		});
++		expectedRole = pendingTools.size ? "tool" : "user";
++	}
++	if (pendingTools.size) throw new Error("OpenClaw session import ends with pending tool calls.");
++	return { config, messages, model };
++}
++async function writeSessionImport(sessionImport, session) {
++	const now = Date.now();
++	const agentId = "main";
++	const storePath = resolveStorePath(void 0, { agentId });
++	let sessionFile;
++	try {
++		await upsertSessionEntry({
++			agentId,
++			sessionKey: session.sessionKey,
++			storePath,
++			entry: {
++				sessionId: session.sessionId,
++				updatedAt: now,
++				sessionStartedAt: now,
++				modelProvider: sessionImport.model.provider,
++				model: sessionImport.model.id
++			}
++		});
++		sessionFile = (await resolveSessionTranscriptLegacyFileTarget({
++			agentId,
++			sessionId: session.sessionId,
++			sessionKey: session.sessionKey,
++			storePath
++		})).sessionFile;
++		await withSessionTranscriptWriteLock({
++			config: sessionImport.config,
++			sessionFile,
++			sessionId: session.sessionId,
++			sessionKey: session.sessionKey,
++			storePath
++		}, async ({ appendMessage }) => {
++			for (const message of sessionImport.messages) await appendMessage({
++				message,
++				cwd: session.cwd
++			});
++		});
++	} catch (error) {
++		const cleanup = deleteSessionEntryLifecycle({
++			agentId,
++			archiveTranscript: false,
++			expectedSessionId: session.sessionId,
++			storePath,
++			target: {
++				canonicalKey: session.sessionKey,
++				storeKeys: [session.sessionKey]
++			}
++		});
++		const transcriptCleanup = sessionFile ? fs$1.rm(sessionFile, { force: true }) : Promise.resolve();
++		const cleanupFailures = (await Promise.allSettled([cleanup, transcriptCleanup])).filter((result) => result.status === "rejected").map((result) => result.reason);
++		if (cleanupFailures.length) throw new AggregateError([error, ...cleanupFailures], "OpenClaw session import failed and cleanup was incomplete.");
++		throw error;
++	}
++}
+-function normalizedChatSendAckStatus(status) {
++function normalizedChatSendAckStatus(status) {
+@@ -1995,2 +2161,5 @@
+-			agentCapabilities: {
++			agentCapabilities: {
++				_meta: {
++					[SESSION_IMPORT_KEY]: { version: SESSION_IMPORT_VERSION }
++				},
+-				loadSession: true,
++				loadSession: true,
+@@ -2017,2 +2186,3 @@
+-		this.assertSupportedSessionSetup(params.mcpServers);
++		this.assertSupportedSessionSetup(params.mcpServers);
++		const sessionImport = prepareSessionImport(params["_meta"]);
+-		this.enforceSessionCreateRateLimit("newSession");
++		this.enforceSessionCreateRateLimit("newSession");
+@@ -2033,2 +2203,8 @@
+-		});
++		});
++		try {
++			if (sessionImport) await writeSessionImport(sessionImport, session);
++		} catch (error) {
++			this.sessionStore.deleteSession(sessionId);
++			throw error;
++		}
+-		this.log(`newSession: ${session.sessionId} -> ${session.sessionKey}`);
++		this.log(`newSession: ${session.sessionId} -> ${session.sessionKey}`);

--- a/verifiers/v1/harnesses/pi/harness.py
+++ b/verifiers/v1/harnesses/pi/harness.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import shlex
+from pathlib import Path
 from typing import Literal
 
 from pydantic import Field
@@ -10,7 +11,12 @@ from pydantic import Field
 from verifiers.v1.acp import ACPConfig, ACPHarness
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
-from verifiers.v1.harnesses.node import NODE_BIN_DIR, ensure_node
+from verifiers.v1.harnesses.node import (
+    NODE_BIN_DIR,
+    ensure_node,
+    node_patch_id,
+    prepare_node_patch,
+)
 from verifiers.v1.runtimes import Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
@@ -28,20 +34,20 @@ ACP_VERSION = "0.0.33"
 MCP_ADAPTER = f"{PACKAGES_DIR}/node_modules/pi-mcp-adapter/index.ts"
 ACP_BIN = f"{PACKAGES_DIR}/node_modules/.bin/pi-acp"
 ACP_COMMAND = [f"{NODE_BIN_DIR}/node", ACP_BIN]
+SESSION_IMPORT_PATCH = Path(__file__).with_name("session_import.patch").read_bytes()
+SESSION_IMPORT_PATCH_ID = node_patch_id(SESSION_IMPORT_PATCH)
 
 INSTALL = r"""
 set -e
 packages=/var/tmp/vf-pi/mcp
 export PATH="/var/tmp/vf-node/bin:$PATH"
 
-versions="$VF_PI_VERSION:$VF_PI_MCP_VERSION:$VF_PI_ACP_VERSION"
-if [ "$(cat "$packages/.versions" 2>/dev/null)" != "$versions" ]; then
-    npm install --prefix "$packages" --ignore-scripts --no-audit --no-fund --omit=dev \
-        "@earendil-works/pi-coding-agent@$VF_PI_VERSION" \
-        "pi-mcp-adapter@$VF_PI_MCP_VERSION" \
-        "pi-acp@$VF_PI_ACP_VERSION" >/dev/null
-    printf %s "$versions" > "$packages/.versions"
-fi
+rm -rf "$packages/node_modules/pi-acp"
+npm install --prefix "$packages" --ignore-scripts --no-audit --no-fund --omit=dev \
+    "@earendil-works/pi-coding-agent@$VF_PI_VERSION" \
+    "pi-mcp-adapter@$VF_PI_MCP_VERSION" \
+    "pi-acp@$VF_PI_ACP_VERSION" >/dev/null
+$VF_PI_ACP_PATCH
 """
 
 
@@ -69,6 +75,16 @@ class PiHarness(ACPHarness[PiHarnessConfig]):
             self.config.version,
             ACP_VERSION,
         )
+        ready = (
+            f"{PI_DIR}/.ready-{self.config.version}-{MCP_VERSION}-{ACP_VERSION}-"
+            f"{SESSION_IMPORT_PATCH_ID}"
+        )
+        patch = await prepare_node_patch(
+            runtime,
+            PI_DIR,
+            f"{PACKAGES_DIR}/node_modules/pi-acp/dist/index.js",
+            SESSION_IMPORT_PATCH,
+        )
         lock = f"{PI_DIR}/install.lock"
         guarded = (
             f"mkdir -p {PI_DIR} && "
@@ -78,7 +94,7 @@ class PiHarness(ACPHarness[PiHarnessConfig]):
             f'[ "$(readlink {lock})" != "$owner" ] || rm -f {lock}; fi; '
             f"sleep 0.1; done; "
             f'trap \'[ "$(readlink {lock})" != "$$" ] || rm -f {lock}\' EXIT; '
-            f"sh -c {shlex.quote(INSTALL)}"
+            f"[ -f {ready} ] || (sh -c {shlex.quote(INSTALL)} && touch {ready})"
         )
         install = await runtime.run(
             ["sh", "-c", guarded],
@@ -86,6 +102,7 @@ class PiHarness(ACPHarness[PiHarnessConfig]):
                 "VF_PI_VERSION": self.config.version,
                 "VF_PI_MCP_VERSION": MCP_VERSION,
                 "VF_PI_ACP_VERSION": ACP_VERSION,
+                "VF_PI_ACP_PATCH": patch,
             },
         )
         if install.exit_code != 0:
@@ -166,6 +183,7 @@ class PiHarness(ACPHarness[PiHarnessConfig]):
             "PI_CODING_AGENT_DIR": agent_dir,
             "PI_OFFLINE": "1",
             "PI_TELEMETRY": "0",
+            "PI_ACP_CODING_AGENT_MODULE": f"{PACKAGES_DIR}/node_modules/@earendil-works/pi-coding-agent/dist/index.js",
         }
         skill_args = [
             arg

--- a/verifiers/v1/harnesses/pi/session_import.patch
+++ b/verifiers/v1/harnesses/pi/session_import.patch
@@ -1,0 +1,227 @@
+--- dist/index.js
++++ dist/index.js
+@@ -1780,4 +1780,152 @@
+-var MODEL_CONFIG_ID = "model";
++var MODEL_CONFIG_ID = "model";
+-var THOUGHT_LEVEL_CONFIG_ID = "thought_level";
++var THOUGHT_LEVEL_CONFIG_ID = "thought_level";
++var SESSION_IMPORT = "verifiers.dev/sessionImport";
++function importContent(content, allowString) {
++  if (typeof content === "string") {
++    return allowString ? content : [{ type: "text", text: content }];
++  }
++  return content.map((part) => {
++    const item = part;
++    if (item.type === "text") {
++      return { type: "text", text: item.text };
++    }
++    const image = item.image_url;
++    const match = item.type === "image_url" && typeof image?.url === "string" ? /^data:([^;,]+);base64,(.*)$/s.exec(image.url) : null;
++    if (!match) {
++      throw RequestError3.invalidParams("Pi can import inline base64 images only");
++    }
++    return { type: "image", mimeType: match[1], data: match[2] };
++  });
++}
++function sessionImport(params) {
++  const metadata = params?._meta;
++  if (!metadata || typeof metadata !== "object" || !(SESSION_IMPORT in metadata)) return null;
++  const value = metadata[SESSION_IMPORT];
++  if (!value || typeof value !== "object" || value.version !== 1 || !Array.isArray(value.messages)) {
++    throw RequestError3.invalidParams(`${SESSION_IMPORT} requires version 1 and messages`);
++  }
++  const imported = [];
++  const pendingTools = /* @__PURE__ */ new Map();
++  const toolIds = /* @__PURE__ */ new Set();
++  for (const raw of value.messages) {
++    if (raw.role === "system") {
++      throw RequestError3.invalidParams("Pi cannot import historical system messages");
++    }
++    if (raw.role === "user") {
++      if (pendingTools.size) {
++        throw RequestError3.invalidParams("imported user message interrupts pending tool calls");
++      }
++      imported.push({ role: "user", content: importContent(raw.content, true) });
++      continue;
++    }
++    if (raw.role === "assistant") {
++      if (pendingTools.size) {
++        throw RequestError3.invalidParams("imported assistant message interrupts pending tool calls");
++      }
++      if (raw.provider_state?.length) {
++        throw RequestError3.invalidParams("Pi cannot exactly import opaque VF provider state");
++      }
++      if (raw.reasoning_content != null) {
++        throw RequestError3.invalidParams("Pi cannot exactly import VF reasoning without provider state");
++      }
++      const content = [];
++      if (raw.content !== null && raw.content !== void 0) {
++        content.push({ type: "text", text: raw.content });
++      }
++      for (const call of raw.tool_calls ?? []) {
++        let args;
++        try {
++          args = JSON.parse(call.arguments);
++        } catch {
++          throw RequestError3.invalidParams(`tool call ${call.id} has invalid JSON arguments`);
++        }
++        if (!args || typeof args !== "object" || Array.isArray(args)) {
++          throw RequestError3.invalidParams(`tool call ${call.id} arguments must be an object`);
++        }
++        if (toolIds.has(call.id)) {
++          throw RequestError3.invalidParams(`duplicate imported tool call id: ${call.id}`);
++        }
++        content.push({ type: "toolCall", id: call.id, name: call.name, arguments: args });
++        pendingTools.set(call.id, call.name);
++        toolIds.add(call.id);
++      }
++      if (content.length === 0) {
++        throw RequestError3.invalidParams("imported assistant messages cannot be empty");
++      }
++      imported.push({ role: "assistant", content });
++      continue;
++    }
++    if (raw.role === "tool") {
++      const expectedName = pendingTools.get(raw.tool_call_id);
++      if (!expectedName) {
++        throw RequestError3.invalidParams(`imported tool result ${raw.tool_call_id} has no pending call`);
++      }
++      if (raw.name !== void 0 && raw.name !== expectedName) {
++        throw RequestError3.invalidParams(`imported tool result ${raw.tool_call_id} has the wrong name`);
++      }
++      imported.push({
++        role: "toolResult",
++        toolCallId: raw.tool_call_id,
++        toolName: expectedName,
++        content: importContent(raw.content, false),
++        isError: false
++      });
++      pendingTools.delete(raw.tool_call_id);
++      continue;
++    }
++    throw RequestError3.invalidParams(`unsupported imported message role: ${String(raw.role)}`);
++  }
++  if (pendingTools.size) {
++    throw RequestError3.invalidParams("session import ends with pending tool calls");
++  }
++  return imported;
++}
++async function writeSessionImport(session, cwd, state, messages) {
++  const sessionFile = typeof state?.sessionFile === "string" ? state.sessionFile : null;
++  const model = state?.model;
++  if (!sessionFile || !model || typeof model.api !== "string" || typeof model.provider !== "string" || typeof model.id !== "string") {
++    throw new Error("Pi did not expose a persistent session and active model");
++  }
++  const codingAgent = process.env.PI_ACP_CODING_AGENT_MODULE;
++  if (!codingAgent) throw new Error("PI_ACP_CODING_AGENT_MODULE is required for session import");
++  const { SessionManager: PiSessionManager } = await import(codingAgent);
++  const importedSession = PiSessionManager.create(cwd, void 0, { id: session.sessionId });
++  const importedFile = importedSession.getSessionFile();
++  if (!importedFile || existsSync4(importedFile)) {
++    throw new Error("Pi did not provide a fresh session file for import");
++  }
++  try {
++    for (const imported of messages) {
++      const message = imported.role === "assistant" ? {
++        ...imported,
++        api: model.api,
++        provider: model.provider,
++        model: model.id,
++        usage: {
++          input: 0,
++          output: 0,
++          cacheRead: 0,
++          cacheWrite: 0,
++          totalTokens: 0,
++          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }
++        },
++        stopReason: imported.content.some((block) => block.type === "toolCall") ? "toolUse" : "stop",
++        timestamp: Date.now()
++      } : { ...imported, timestamp: Date.now() };
++      importedSession.appendMessage(message);
++    }
++    if (!existsSync4(importedFile)) throw new Error("Pi did not persist the imported session");
++    await session.proc.switchSession(importedFile);
++    return importedFile;
++  } catch (e) {
++    if (existsSync4(importedFile)) {
++      try {
++        unlinkSync(importedFile);
++      } catch {
++      }
++    }
++    throw e;
++  }
++}
+-function builtinAvailableCommands() {
++function builtinAvailableCommands() {
+-  return [
++  return [
+@@ -1934,4 +2082,5 @@
+-      agentCapabilities: {
++      agentCapabilities: {
+-        loadSession: true,
++        loadSession: true,
++        _meta: { [SESSION_IMPORT]: { version: 1 } },
+-        mcpCapabilities: { http: false, sse: false },
++        mcpCapabilities: { http: false, sse: false },
+-        promptCapabilities: {
++        promptCapabilities: {
+@@ -1953,4 +2102,5 @@
+-      throw RequestError3.invalidParams(`cwd must be an absolute path: ${params.cwd}`);
++      throw RequestError3.invalidParams(`cwd must be an absolute path: ${params.cwd}`);
+-    }
++    }
++    const imported = sessionImport(params);
+-    this.lastSessionCwd = params.cwd;
++    this.lastSessionCwd = params.cwd;
+-    const fileCommands = loadSlashCommands(params.cwd);
++    const fileCommands = loadSlashCommands(params.cwd);
+@@ -2004,4 +2154,31 @@
+-        "Configure an API key or log in with an OAuth provider."
++        "Configure an API key or log in with an OAuth provider."
+-      );
++      );
++    }
++    if (imported) {
++      const originalSessionFile = typeof state?.sessionFile === "string" && state.sessionFile.trim() ? state.sessionFile : null;
++      const originalSessionFileExisted = originalSessionFile ? existsSync4(originalSessionFile) : false;
++      let importedFile = null;
++      try {
++        importedFile = await writeSessionImport(session, params.cwd, state, imported);
++        state.sessionFile = importedFile;
++        this.store.upsert({
++          sessionId: session.sessionId,
++          cwd: params.cwd,
++          sessionFile: state.sessionFile
++        });
++      } catch (e) {
++        this.sessions.close(session.sessionId);
++        this.store.delete(session.sessionId);
++        for (const sessionFile of /* @__PURE__ */ new Set([originalSessionFileExisted ? null : originalSessionFile, importedFile])) {
++          if (sessionFile && existsSync4(sessionFile)) {
++            try {
++              unlinkSync(sessionFile);
++            } catch {
++            }
++          }
++        }
++        if (e instanceof RequestError3) throw e;
++        throw RequestError3.internalError({}, String(e?.message ?? e));
++      }
+-    }
++    }
+-    const { configOptions, models, modes } = await getSessionConfiguration(session.proc, {
++    const { configOptions, models, modes } = await getSessionConfiguration(session.proc, {
+@@ -2016,6 +2193,5 @@
+-      updateNotice
++      updateNotice
+-    });
++    });
+-    if (preludeText)
+-      session.setStartupInfo(preludeText);
++    if (preludeText) session.setStartupInfo(preludeText);
+-    this.sessions.closeAllExcept?.(session.sessionId);
++    this.sessions.closeAllExcept?.(session.sessionId);
+-    const response = {
++    const response = {

--- a/verifiers/v1/harnesses/rlm/acp.py
+++ b/verifiers/v1/harnesses/rlm/acp.py
@@ -1,0 +1,118 @@
+"""RLM ACP entrypoint with exact VF conversation import."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from acp import RequestError, run_agent
+from rlm.acp import RLMACPAgent
+
+SESSION_IMPORT = "verifiers.dev/sessionImport"
+
+
+def _chat_messages(messages: object) -> list[dict[str, Any]]:
+    if not isinstance(messages, list):
+        raise TypeError("messages must be a list")
+
+    converted: list[dict[str, Any]] = []
+    for message in messages:
+        role = message.get("role")
+        content = message.get("content")
+        if role == "user":
+            converted.append({"role": role, "content": content})
+        elif role == "assistant":
+            wire: dict[str, Any] = {"role": role, "content": content or ""}
+            provider_state = message.get("provider_state")
+            reasoning = message.get("reasoning_content")
+            if provider_state:
+                if not all(
+                    str(item.get("type", "")).startswith("reasoning.")
+                    for item in provider_state
+                ):
+                    raise ValueError(
+                        "RLM can import Chat reasoning_details provider state only"
+                    )
+                wire["reasoning_details"] = provider_state
+            if reasoning is not None:
+                wire["reasoning_content"] = reasoning
+
+            if tool_calls := message.get("tool_calls"):
+                wire["tool_calls"] = [
+                    {
+                        "id": call["id"],
+                        "type": "function",
+                        "function": {
+                            "name": call["name"],
+                            "arguments": call["arguments"],
+                        },
+                    }
+                    for call in tool_calls
+                ]
+            converted.append(wire)
+        elif role == "tool":
+            wire = {
+                "role": role,
+                "tool_call_id": message["tool_call_id"],
+                "content": content,
+            }
+            if name := message.get("name"):
+                wire["name"] = name
+            converted.append(wire)
+        else:
+            raise ValueError(f"RLM cannot import {role!r} messages")
+    if not converted or converted[0]["role"] != "user":
+        raise ValueError("RLM session history must start with a user message")
+    return converted
+
+
+class ImportingRLMACPAgent(RLMACPAgent):
+    async def initialize(self, *args: Any, **kwargs: Any):
+        response = await super().initialize(*args, **kwargs)
+        metadata = response.agent_capabilities.field_meta or {}
+        response.agent_capabilities.field_meta = {
+            **metadata,
+            SESSION_IMPORT: {"version": 1},
+        }
+        return response
+
+    async def new_session(self, *args: Any, **kwargs: Any):
+        extension = kwargs.pop(SESSION_IMPORT, None)
+        if extension is None:
+            return await super().new_session(*args, **kwargs)
+        try:
+            if not isinstance(extension, dict) or extension.get("version") != 1:
+                raise ValueError("unsupported session import version")
+            messages = _chat_messages(extension.get("messages"))
+        except (TypeError, ValueError) as error:
+            raise RequestError.invalid_params({"reason": str(error)}) from error
+
+        response = await super().new_session(*args, **kwargs)
+        state = self._sessions[response.session_id]
+        try:
+            # RLM builds its system prompt and persistent IPython kernel here; no
+            # model call occurs until Engine.prompt() continues into its run loop.
+            await state.engine._start(messages[0]["content"])
+            assert state.engine._messages is not None
+            state.engine._messages[1:] = messages
+            state.engine._turn = sum(
+                message["role"] == "assistant" for message in messages
+            )
+            state.engine._branch_start_turn = state.engine._turn
+        except BaseException:
+            state.engine.close()
+            self._sessions.pop(response.session_id, None)
+            raise
+        return response
+
+
+async def main() -> None:
+    agent = ImportingRLMACPAgent()
+    try:
+        await run_agent(agent, use_unstable_protocol=True)
+    finally:
+        await agent.shutdown()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -4,6 +4,7 @@ import json
 import logging
 import random
 import shlex
+from pathlib import Path
 from typing import Literal
 
 from pydantic import Field, PositiveInt, model_validator
@@ -25,6 +26,7 @@ RLM_DIR = "/tmp/vf-rlm"
 RLM_BIN = f"{RLM_DIR}/bin/rlm"
 SKILLS_DIR = "/task/rlm-skills"
 RLM_STATE_DIR = ".vf-rlm"
+ACP_SOURCE = (Path(__file__).resolve().parent / "acp.py").read_text()
 
 
 class RLMHarnessConfig(HarnessConfig):
@@ -136,9 +138,18 @@ class RLMHarness(ACPHarness[RLMHarnessConfig]):
         data: TaskData,
     ) -> ACPConfig:
         system_prompt, prompt = self.resolve_prompt(data)
+        acp_path = f"{RLM_STATE_DIR}/{trace.id}/acp.py"
+        await runtime.write(acp_path, ACP_SOURCE.encode())
         return ACPConfig(
             env=self._env(ctx, trace, endpoint, secret, data, system_prompt),
-            command=[RLM_BIN, "--acp"],
+            command=[
+                "sh",
+                "-c",
+                'read -r interpreter < "$1"; exec "${interpreter#\\#!}" "$2"',
+                "vf-rlm-acp",
+                RLM_BIN,
+                acp_path,
+            ],
             prompt=prompt,
         )
 


### PR DESCRIPTION
Stacked on #2291.

## Summary

- add the versioned `verifiers.dev/sessionImport` extension to seed a native ACP session before its first prompt without making a model call
- import typed VF history through each adapter's native store for Codex, Claude Code, Hermes, Kimi Code, Pi, RLM, and OpenClaw
- capability-negotiate the extension and reject history an adapter cannot represent exactly
- keep Pool on #2291's persistent live-session path because Pool 1.0.15 exposes no exact history-import API
- cover ordinary continuation and seeded history import through one parametrized ACP E2E flow

## Why

ACP prompts can only represent a new user turn; they cannot inject prior assistant or tool messages. Replaying those turns through the model is expensive and inexact. The import extension initializes each adapter's own persistent history, preserving tool-call identity and provider continuation state where its native format supports it.

## Validation

- 70 non-E2E v1 tests
- Ruff check and format
- `ty` pre-push parity check
- focused shared ACP, Kimi, Pi, and RLM import probes
- exact-source application plus Node syntax validation for the Codex, Claude Code, Pi, and OpenClaw adapter patches
- `git diff --check`

Kimi Code's existing upstream Responses `phase` replay loss remains documented in the branch-count assertion.
