### PR TITLE
Keep ACP prompts user-only

### DIFF
--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -201,10 +201,8 @@ class ACPHarnessSession(HarnessSession):
         prompt = self.prompt if messages is None else messages
         if prompt is None:
             raise ValueError("ACP requires a prompt")
-        if (
-            messages is not None
-            and not isinstance(prompt, str)
-            and (not prompt or any(message.role != "user" for message in prompt))
+        if not isinstance(prompt, str) and (
+            not prompt or any(message.role != "user" for message in prompt)
         ):
             raise ValueError("an ACP turn must contain user messages only")
         wire_messages = (


### PR DESCRIPTION
## What changed

- Require every ACP `Messages` prompt, including the opening prompt, to be non-empty and user-only.
- Keep plain string prompts unchanged.

## Why

ACP 0.11 has prompt content blocks, but no roleful transcript-import or transcript-seeding operation. Accepting assistant/system messages for the opening prompt flattened them into a synthetic user prompt, which silently approximated a capability the protocol does not define.

We decided to punt transcript seeding rather than make it part of the ACP-linearity fix. This restores the pre-relaxation validation without changing continuation through the live rollout-scoped ACP session.

## Validation

- Parsed all repository TOML files.
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check verifiers`
- `uv run pytest tests/v1 -m 'not e2e' -q` (70 passed)
- Prime VM ACP resume E2E for Pool and RLM (2 passed), including the expected single branch and MCP continuation.
- Behavior probe confirmed empty and assistant-led initial `Messages` prompts fail before process startup.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ACPHarnessSession._run` to enforce user-only messages when using `self.prompt`
> Previously, the user-only role validation in `_run` only triggered when `messages` was explicitly passed. If the prompt came from `self.prompt` (i.e. `messages` is `None`), non-user roles could slip through unchecked. The guard condition in [__init__.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2351/files#diff-4a98e09e3584605f8da12349ce8fa454922c607127e29c836edfae5094b41ccf) is updated to apply the validation regardless of how the prompt was provided.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d587014.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small validation fix in ACP harness startup with no auth or data-path changes; failures surface earlier as explicit errors.
> 
> **Overview**
> **Tightens ACP prompt validation** in `ACPHarnessSession._run` so non-empty, user-only `Messages` lists are required whenever the prompt is not a plain string—not only when `messages` is passed explicitly for a continuation turn.
> 
> Previously the guard required `messages is not None`, so an opening prompt taken from `self.prompt` could bypass the check and allow empty or assistant/system-led message lists. Those cases are rejected again with `ValueError` before the ACP process is started, avoiding silent flattening into a synthetic user prompt for capabilities ACP does not define.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d58701412af71b73e69d3018a6b1eb3643d3a6a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->