### PR TITLE
Isolate OpenClaw skills per rollout

### DIFF
--- a/verifiers/v1/harnesses/openclaw/harness.py
+++ b/verifiers/v1/harnesses/openclaw/harness.py
@@ -147,6 +147,7 @@ class OpenClawHarness(ACPHarness[OpenClawHarnessConfig]):
         provider, _, _ = ctx.model.partition("/")
         state_dir = f".vf-openclaw/{trace.id}"
         config_path = f"{state_dir}/openclaw.json"
+        skills_dir = f"{state_dir}/skills"
         config = {
             # Provider replay state must remain byte-exact in this isolated rollout transcript.
             "logging": {"redactSensitive": "off"},
@@ -195,11 +196,19 @@ class OpenClawHarness(ACPHarness[OpenClawHarnessConfig]):
             },
         }
         if self.config.skills:
-            config["skills"] = {"load": {"extraDirs": [self._staged_skills_dir]}}
+            config["skills"] = {"load": {"extraDirs": [skills_dir]}}
         if not self.config.use_bundled_skill:
             # OpenClaw treats an empty allowlist as all; a no-match key disables the catalog.
             config.setdefault("skills", {})["allowBundled"] = ["__none__"]
         await runtime.write(config_path, json.dumps(config).encode())
+        if self.config.skills:
+            copied = await runtime.run(
+                ["cp", "-R", self._staged_skills_dir, skills_dir], {}
+            )
+            if copied.exit_code != 0:
+                raise RuntimeError(
+                    f"failed to isolate OpenClaw skills: {copied.stderr.strip()[-500:]}"
+                )
 
         env = {
             **self.config.resolved_env,


### PR DESCRIPTION
## What changed

- Keep the uploaded OpenClaw skill tree as a staging cache.
- Copy it into `.vf-openclaw/<trace>/skills` for each rollout.
- Point `skills.load.extraDirs` at that rollout-local copy and fail explicitly if isolation cannot be established.

## Why

The staged skill directory is writable. Referencing it directly from every rollout lets one OpenClaw session mutate skill inputs observed by later sessions on a borrowed/shared runtime. The per-trace OpenClaw state was already cleaned up, so making the skill tree part of that state restores rollout isolation without changing the upload path.

## Validation

- Parsed all repository TOML files.
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check verifiers`
- `uv run pytest tests/v1 -m 'not e2e' -q` (70 passed)
- Prime VM isolation probe mutated rollout A's copy and confirmed the staged source and rollout B remained unchanged.
- Prime VM live OpenClaw ACP-resume E2E passed with a configured temporary skill, two live segments, MCP recall, reward, and one branch.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Isolate OpenClaw skills per trace in `OpenClawHarness`
> Previously, all traces shared a single staged skills directory, risking cross-trace contamination. Now, each trace gets its own skills directory at `.vf-openclaw/{trace.id}/skills`, populated by copying the staged skills directory at run setup time. If the copy fails, setup aborts with a `RuntimeError` including the command's stderr output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f1ad597.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches rollout setup and skill loading paths where incorrect copy or path handling could break skill-enabled evals, but scope is limited to OpenClaw harness isolation with explicit failure on copy errors.
> 
> **Overview**
> **OpenClaw harness skills are no longer shared across rollouts on the same runtime.**
> 
> When skills are enabled, `prepare_acp` now sets `skills.load.extraDirs` to `.vf-openclaw/<trace.id>/skills` instead of the shared staged upload directory. Before starting the agent, it **copies** the staged skill tree into that trace-local path; setup **fails with a clear `RuntimeError`** if the copy does not succeed.
> 
> The staged directory remains an immutable upload cache from `setup`; only each rollout’s copy is writable, so one session cannot mutate skill inputs seen by later sessions. Trace-local skill state is removed with the existing `.vf-openclaw/<trace.id>` cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1ad597f9075bcc6ede8dbbd0af19accbcbfef86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->