### PR TITLE
Remove ACP transcript rendering

### DIFF
--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -47,8 +47,6 @@ class ACPConfig:
 class ACPHarness(Harness[ConfigT]):
     """Harness backed by one live ACP process and native session per rollout."""
 
-    SUPPORTS_RESUME = True
-
     async def setup(self, runtime: Runtime) -> None:
         await runtime.prepare_uv_script(
             ACP_SOURCE, {**self.config.resolved_env, "UV_FROZEN": "false"}
@@ -168,8 +166,6 @@ class ACPHarnessSession(HarnessSession):
     ) -> None:
         super().__init__(harness, ctx, trace, runtime, endpoint, secret, mcp_urls, data)
         self.config = config
-        self.prompt = config.prompt
-        self.system_prompt = config.system_prompt
         self._process: RuntimeProcess | None = None
         self._reader: _PacketReader | None = None
         self._stderr_tail = bytearray()
@@ -198,25 +194,26 @@ class ACPHarnessSession(HarnessSession):
         return self._stderr_tail.decode(errors="replace").strip()
 
     async def _run(self, messages: Messages | None) -> ProgramResult:
-        prompt = self.prompt if messages is None else messages
+        prompt = self.config.prompt if messages is None else messages
         if prompt is None:
             raise ValueError("ACP requires a prompt")
         if not isinstance(prompt, str) and (
             not prompt or any(message.role != "user" for message in prompt)
         ):
             raise ValueError("an ACP turn must contain user messages only")
-        wire_messages = (
-            [{"role": "user", "content": prompt}]
+        user_contents = (
+            [prompt]
             if isinstance(prompt, str)
             else [
-                message.model_dump(mode="json", exclude_none=True) for message in prompt
+                message.model_dump(mode="json", include={"content"})["content"]
+                for message in prompt
             ]
         )
         config = {
             "command": self.config.command,
-            "messages": wire_messages,
+            "user_contents": user_contents,
             "mcp_urls": self.mcp_urls,
-            "system_prompt": self.system_prompt or "",
+            "system_prompt": self.config.system_prompt or "",
             "session_meta": self.config.session_meta or {},
             "allow_empty_tool_reply": self.config.allow_empty_tool_reply,
         }

--- a/verifiers/v1/acp/runner.py
+++ b/verifiers/v1/acp/runner.py
@@ -88,21 +88,13 @@ class VerifiersACPClient(Client):
         return RequestPermissionResponse(outcome=outcome)
 
 
-def content_blocks(messages: list[dict], supports_images: bool) -> list:
-    """Render ordered VF messages as one ACP user prompt.
-
-    ACP prompt blocks have no message roles, so a multi-message user turn keeps its
-    order and roles as visible labels.
-    """
+def user_content_blocks(contents: list, supports_images: bool) -> list:
+    """Render one user turn's ordered VF contents as ACP prompt blocks."""
     blocks = []
-    transcript = len(messages) != 1 or messages[0].get("role") != "user"
-    for message in messages:
-        if transcript:
-            separator = "\n\n" if blocks else ""
-            role = message.get("role", "message")
-            label = "(system)" if role == "system" else f"[{role}]"
-            blocks.append(text_block(f"{separator}{label}\n"))
-        content = message.get("content") or ""
+    for index, content in enumerate(contents):
+        if index:
+            blocks.append(text_block("\n\n"))
+        content = content or ""
         parts = (
             [{"type": "text", "text": content}] if isinstance(content, str) else content
         )
@@ -122,13 +114,6 @@ def content_blocks(messages: list[dict], supports_images: bool) -> list:
             ):
                 raise ValueError("ACP image prompts require base64 data:image URLs")
             blocks.append(image_block(data, media_type))
-        metadata = {
-            key: value
-            for key, value in message.items()
-            if key not in ("role", "content") and value
-        }
-        if metadata:
-            blocks.append(text_block("\n" + json.dumps(metadata, ensure_ascii=False)))
     return blocks
 
 
@@ -150,13 +135,10 @@ async def prompt(
 ) -> str:
     prompt_capabilities = capabilities and capabilities.prompt_capabilities
     supports_images = bool(prompt_capabilities and prompt_capabilities.image)
-    messages = config["messages"]
+    blocks = []
     if is_new and config["system_prompt"]:
-        messages = [
-            {"role": "system", "content": config["system_prompt"]},
-            *messages,
-        ]
-    blocks = content_blocks(messages, supports_images)
+        blocks.append(text_block(f"(system)\n{config['system_prompt']}\n\n[user]\n"))
+    blocks.extend(user_content_blocks(config["user_contents"], supports_images))
     if not blocks:
         raise ValueError("ACP prompt has no content")
     client.reset()

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -332,16 +332,20 @@ class Agent:
         return None
 
     def _check_resume_support(self) -> None:
-        # Multi-turn capability is a derived fact, not a flag: an exchange advances
-        # by resuming the harness onto the conversation, so the harness needs either
-        # the default relaunch (a Messages prompt) or its own native continuation.
+        # Multi-turn capability is derived: a harness needs transcript replay, a
+        # native resume implementation, or a rollout-scoped session implementation.
         harness = self.harness
-        if type(harness).resume is Harness.resume and not harness.SUPPORTS_RESUME:
+        if (
+            type(harness).session is Harness.session
+            and type(harness).resume is Harness.resume
+            and not harness.SUPPORTS_RESUME
+        ):
             raise ValueError(
                 f"Harness {harness.config.id!r} cannot host a user: resuming an "
                 "exchange takes transcript-backed resume (SUPPORTS_RESUME) for the "
-                "default relaunch-on-the-conversation, or a native resume() "
-                "override. Use a harness that has one (e.g. bash or null)."
+                "default relaunch-on-the-conversation, a native resume() override, "
+                "or a rollout-scoped session() override. Use a harness that has "
+                "one (e.g. bash or null)."
             )
 
     async def run(

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -212,8 +212,8 @@ class Harness(ABC, Generic[ConfigT]):
         trace's current branch plus `messages`) as a Messages prompt: correct for any
         stateless chat program, including the very first segment of an exchange the
         user opens (an empty branch). A harness with its own session state overrides
-        this with a native continuation (codex: `codex exec resume`) instead of
-        replaying a conversation it already owns."""
+        this or returns a specialized session handle with a native continuation
+        instead of replaying a conversation it already owns."""
         if not self.SUPPORTS_RESUME:
             raise HarnessError(
                 f"harness {self.config.id!r} cannot continue an exchange: it neither "

--- a/verifiers/v1/harnesses/openclaw/harness.py
+++ b/verifiers/v1/harnesses/openclaw/harness.py
@@ -149,7 +149,7 @@ class OpenClawHarness(ACPHarness[OpenClawHarnessConfig]):
         config_path = f"{state_dir}/openclaw.json"
         skills_dir = f"{state_dir}/skills"
         config = {
-            # Provider replay state must remain byte-exact in this isolated rollout transcript.
+            # Provider state must remain byte-exact within this isolated rollout.
             "logging": {"redactSensitive": "off"},
             "gateway": {
                 "mode": "local",


### PR DESCRIPTION
## What changed

- Send only ordered user contents across the private ACP runner boundary.
- Render the first-turn system prompt explicitly instead of constructing a synthetic roleful transcript.
- Remove generic role labels and message-metadata replay from the ACP content-block renderer.
- Let the interaction gate recognize a rollout-scoped native `session()` implementation directly, so `ACPHarness` no longer claims transcript-backed `SUPPORTS_RESUME`.
- Remove stale native-continuation and OpenClaw transcript wording.

## Why

ACP continuation is now exclusively one live process and one native ACP session per rollout. After roleful initial prompts were rejected, the old transcript renderer could only receive typed `UserMessage`s plus the runner's synthetic first-turn system message. Its arbitrary role labels and metadata path were therefore dead remnants of transcript seeding, while `SUPPORTS_RESUME = True` described replay behavior ACP no longer uses.

User-only multimodal and multi-message turns remain supported. Their contents retain order and are separated without role emulation. The system prefix preserves the existing single-turn wire text exactly and is emitted only for the first native ACP prompt.

## Validation

- `uv run ruff check ...`
- `uv run ruff format --check ...`
- `uv run ty check verifiers`
- `uv run pytest tests/v1 -m 'not e2e' -q` (70 passed)
- Focused ACP wire-format probe covering first and subsequent prompts.
- Live Prime VM ACP continuation E2Es for Pool and RLM (2 passed), including MCP continuation and the single-branch assertions.
- Parsed all 45 repository TOML files.
- Focused pre-commit hooks passed. Repository-wide pre-commit reached the same Ruff success but still reports the pre-existing inline-HTML markdownlint failures in the untouched legacy SWE README.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove ACP transcript rendering from prompt construction
> - Replaces `messages`-based prompt construction with a `user_contents` list in [runner.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2353/files#diff-d5f52739b5575f4d9a3006836e988d6527ccfd28d82a299aa1554eb0878b95ca), dropping transcript role labels and per-message metadata from ACP prompt blocks.
> - Renames `content_blocks` to `user_content_blocks` in the runner, which now renders only user turn content with blank-line separators; system prompt is injected as a prefixed text block only at session start.
> - Sets `SUPPORTS_RESUME` to `False` on `ACPHarness` (removing the explicit `True` override) and relaxes `Agent._check_resume_support` to accept harnesses that provide a rollout-scoped `session()` override.
> - Behavioral Change: ACP processes now receive `user_contents` and `system_prompt` fields instead of `messages`; any ACP runner expecting the old wire format will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 41ff848.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the ACP runner wire contract (`messages` → `user_contents`) and multi-turn gating logic; behavior is covered by tests but any external consumer of the old format would break.
> 
> **Overview**
> **ACP prompt construction** no longer builds roleful message transcripts for the private runner. The harness session sends **`user_contents`** (ordered user turn bodies only) plus a separate **`system_prompt`**, instead of a **`messages`** list with roles and metadata.
> 
> In **`runner.py`**, **`content_blocks`** becomes **`user_content_blocks`**, which joins multimulti-part user content with blank lines and drops role labels and JSON metadata replay. On the first native prompt only, the system text is prefixed as **`(system)\n…\n\n[user]\n`** so first-turn wire text stays compatible without synthesizing a full transcript.
> 
> **`ACPHarness`** drops **`SUPPORTS_RESUME = True`** because continuation is one live process/session per rollout, not transcript replay. **`Agent._check_resume_support`** now allows harnesses that override rollout-scoped **`session()`** even when they do not claim **`SUPPORTS_RESUME`**. Docstrings in **`harness.py`** and OpenClaw are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41ff8484a23515508c6f8201f09c40a6499e65b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->