### PR TITLE
feat(v1): run configs + align resume logic with prl

### DIFF
--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -184,7 +184,10 @@ def _eval_config(
             "reasoning_effort": reasoning_effort,
         },
         rich=False,
-        output_dir=output_dir,
+        # Tests treat the given directory as the run dir itself: split it into the
+        # grouping dir + run.dir so `output_path` resolves back to it exactly.
+        output_dir=output_dir.parent,
+        run={"dir": output_dir.name},
         **({"serve": {"pool": pool}} if pool else {}),
         model=CI_MODEL,
     )

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -184,8 +184,6 @@ def _eval_config(
             "reasoning_effort": reasoning_effort,
         },
         rich=False,
-        # Tests treat the given directory as the run dir itself: split it into the
-        # grouping dir + run.dir so `output_path` resolves back to it exactly.
         output_dir=output_dir.parent,
         run={"dir": output_dir.name},
         **({"serve": {"pool": pool}} if pool else {}),

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -665,7 +665,7 @@ async def test_replay_round_trip(run_v1, tmp_path):
     import tomllib
     from pathlib import Path
 
-    from verifiers.v1.cli.output import CONFIG_FILE
+    from verifiers.v1.cli.output import saved_config_path
     from verifiers.v1.cli.replay import run_replay
     from verifiers.v1.configs.cli.replay import ReplayConfig
 
@@ -683,7 +683,7 @@ async def test_replay_round_trip(run_v1, tmp_path):
     async def replay(source_dir: Path, out: Path):
         # The CLI's layering, minus the argv plumbing: the saved run's config is the base
         # (`ReplayConfig` ignores its eval-only keys), the source's output_dir is dropped.
-        data = tomllib.loads((source_dir / CONFIG_FILE).read_text())
+        data = tomllib.loads(saved_config_path(source_dir).read_text())
         data.pop("output_dir", None)
         config = ReplayConfig(**{**data, "rich": False})
         (trace,) = await run_replay(config, source_dir, out)

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -662,7 +662,6 @@ async def test_replay_round_trip(run_v1, tmp_path):
     typed rebuild fails and the trace-only `@reward` silently stops running (the
     wire-narrowing regression). Trace-only rewards are deterministic given the transcript,
     so all three generations must agree."""
-    import tomllib
     from pathlib import Path
 
     from verifiers.v1.cli.output import saved_config_path
@@ -683,7 +682,9 @@ async def test_replay_round_trip(run_v1, tmp_path):
     async def replay(source_dir: Path, out: Path):
         # The CLI's layering, minus the argv plumbing: the saved run's config is the base
         # (`ReplayConfig` ignores its eval-only keys), the source's output_dir is dropped.
-        data = tomllib.loads(saved_config_path(source_dir).read_text())
+        import json
+
+        data = json.loads(saved_config_path(source_dir).read_text())
         data.pop("output_dir", None)
         config = ReplayConfig(**{**data, "rich": False})
         (trace,) = await run_replay(config, source_dir, out)

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -69,7 +69,6 @@ from verifiers.v1.runtimes import (
     RuntimeInfo,
     RuntimeProcess,
     SubprocessConfig,
-    set_base_sandbox_labels,
 )
 from verifiers.v1.state import State, StateT
 from verifiers.v1.task import Task, TaskData, TaskResources, TaskTimeout, WireTaskData
@@ -275,7 +274,6 @@ __all__ = [  # noqa: RUF022 - grouped by public API area
     "SubprocessConfig",
     "DockerConfig",
     "PrimeConfig",
-    "set_base_sandbox_labels",
     "Env",
     "SingleAgentEnv",
     "EnvConfig",

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -69,6 +69,7 @@ from verifiers.v1.runtimes import (
     RuntimeInfo,
     RuntimeProcess,
     SubprocessConfig,
+    set_base_sandbox_labels,
 )
 from verifiers.v1.state import State, StateT
 from verifiers.v1.task import Task, TaskData, TaskResources, TaskTimeout, WireTaskData
@@ -274,6 +275,7 @@ __all__ = [  # noqa: RUF022 - grouped by public API area
     "SubprocessConfig",
     "DockerConfig",
     "PrimeConfig",
+    "set_base_sandbox_labels",
     "Env",
     "SingleAgentEnv",
     "EnvConfig",

--- a/verifiers/v1/cli/eval/main.py
+++ b/verifiers/v1/cli/eval/main.py
@@ -20,7 +20,6 @@ from verifiers.v1.cli.resolve import (
     references_config_file,
     with_positional_taskset,
 )
-from verifiers.v1.cli.resume import split_resume
 from verifiers.v1.configs.cli.eval import EvalConfig, RunConfig
 from verifiers.v1.utils.interrupt import install_interrupt
 from verifiers.v1.utils.logging import setup_logging
@@ -29,8 +28,7 @@ logger = logging.getLogger(__name__)
 
 USAGE = (
     "usage: uv run eval [<taskset-id>] [--env.id <id>] [options] [@ file.toml]\n"
-    "       uv run eval --resume <run-dir>   (re-run a previous run's missing/errored rollouts)\n"
-    "       uv run eval --resume --run.name <name> [-o <output-dir>]   (same, located by run name)"
+    "       uv run eval --resume --run.name <name> [-o <output-dir>]   (re-run a previous run's missing/errored rollouts)"
 )
 
 
@@ -68,24 +66,24 @@ def main(argv: list[str] | None = None) -> None:
                 narrow_config(EvalConfig, argv)
             )  # full option help, narrowed to the given ids
         return
-    resume_target, rest = split_resume(argv, "eval", allow_bare=True)
     # re-run a previous run's missing/errored rollouts, in place
-    if resume_target is not None:
-        if resume_target is True:  # bare --resume: locate the run dir by name
-            with plugin_errors():
-                sys.argv = [sys.argv[0], *rest]
-                args = cli(ResumeArgs)
-            leaf = args.run.dir or args.run.name
-            if leaf is None:
-                raise SystemExit(
-                    f"{USAGE}\n--resume needs a run dir, --run.name, or --run.dir"
-                )
-            resume_target = args.output_dir / leaf
-        elif rest:
+    if any(arg == "--resume" or arg.startswith("--resume=") for arg in argv):
+        if any(arg.startswith("--resume=") for arg in argv):
             raise SystemExit(
-                f"{USAGE}\n--resume <dir> re-runs a saved config verbatim and takes no other arguments"
+                f"{USAGE}\n--resume takes no value - the run is located by name"
             )
-        config = load_resume_config(resume_target)
+        rest = [arg for arg in argv if arg != "--resume"]
+        if rest and not rest[0].startswith("-"):
+            raise SystemExit(f"{USAGE}\n--resume locates the run by name, not by path")
+        with plugin_errors():
+            sys.argv = [sys.argv[0], *rest]
+            args = cli(ResumeArgs)
+        leaf = args.run.dir or args.run.name
+        if leaf is None:
+            raise SystemExit(
+                f"{USAGE}\n--resume needs --run.name <name> (or --run.dir <dir>)"
+            )
+        config = load_resume_config(args.output_dir / leaf)
     else:
         # An env-block flag (or a since-moved flat axis) skips the usage gate so the
         # typed parse renders its did-you-mean instead of a bare usage line.

--- a/verifiers/v1/cli/eval/main.py
+++ b/verifiers/v1/cli/eval/main.py
@@ -32,9 +32,11 @@ USAGE = (
 )
 
 
-def config_digest(config_dict: dict) -> str:
-    """Canonical hash of a resolved config, as saved to (or parsed from) config.toml."""
-    canonical = json.dumps(config_dict, sort_keys=True, separators=(",", ":"))
+def config_digest(config: EvalConfig) -> str:
+    """Canonical hash of a resolved config. Hashes the model dump (not the raw TOML), so
+    the saved config compares through the same schema the invocation resolved through."""
+    dump = config.model_dump(mode="json", exclude_none=True)
+    canonical = json.dumps(dump, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(canonical.encode()).hexdigest()
 
 
@@ -93,13 +95,15 @@ def main(argv: list[str] | None = None) -> None:
             raise SystemExit(
                 f"--resume: no {CONFIG_FILE} in {run_path} - not an eval run dir"
             )
-        saved = tomllib.loads(saved_path.read_text())
-        current = json.loads(config.model_dump_json(exclude_none=True))
-        if config_digest(saved) != config_digest(current):
+        with plugin_errors():
+            saved = config_type.model_validate(tomllib.loads(saved_path.read_text()))
+        if config_digest(saved) != config_digest(config):
+            saved_dump = saved.model_dump(mode="json", exclude_none=True)
+            current_dump = config.model_dump(mode="json", exclude_none=True)
             changed = sorted(
                 key
-                for key in set(saved) | set(current)
-                if saved.get(key) != current.get(key)
+                for key in set(saved_dump) | set(current_dump)
+                if saved_dump.get(key) != current_dump.get(key)
             )
             raise SystemExit(
                 f"--resume requires the exact config the run was started with - it differs "

--- a/verifiers/v1/cli/eval/main.py
+++ b/verifiers/v1/cli/eval/main.py
@@ -20,6 +20,7 @@ from verifiers.v1.cli.resolve import (
     references_config_file,
     with_positional_taskset,
 )
+from verifiers.v1.cli.resume import split_resume
 from verifiers.v1.configs.cli.eval import EvalConfig, RunConfig
 from verifiers.v1.utils.interrupt import install_interrupt
 from verifiers.v1.utils.logging import setup_logging
@@ -28,7 +29,8 @@ logger = logging.getLogger(__name__)
 
 USAGE = (
     "usage: uv run eval [<taskset-id>] [--env.id <id>] [options] [@ file.toml]\n"
-    "       uv run eval --resume --run.name <name> [-o <output-dir>]   (re-run a previous run's missing/errored rollouts)"
+    "       uv run eval --resume <run-dir>   (re-run a previous run's missing/errored rollouts)\n"
+    "       uv run eval --resume --run.name <name> [-o <output-dir>]   (same, located by run name)"
 )
 
 
@@ -66,20 +68,24 @@ def main(argv: list[str] | None = None) -> None:
                 narrow_config(EvalConfig, argv)
             )  # full option help, narrowed to the given ids
         return
+    resume_target, rest = split_resume(argv, "eval", allow_bare=True)
     # re-run a previous run's missing/errored rollouts, in place
-    if "--resume" in argv:
-        rest = [arg for arg in argv if arg != "--resume"]
-        if rest and not rest[0].startswith("-"):
-            raise SystemExit(f"{USAGE}\n--resume locates the run by name, not by path")
-        with plugin_errors():
-            sys.argv = [sys.argv[0], *rest]
-            args = cli(ResumeArgs)
-        leaf = args.run.dir or args.run.name
-        if leaf is None:
+    if resume_target is not None:
+        if resume_target is True:  # bare --resume: locate the run dir by name
+            with plugin_errors():
+                sys.argv = [sys.argv[0], *rest]
+                args = cli(ResumeArgs)
+            leaf = args.run.dir or args.run.name
+            if leaf is None:
+                raise SystemExit(
+                    f"{USAGE}\n--resume needs a run dir, --run.name, or --run.dir"
+                )
+            resume_target = args.output_dir / leaf
+        elif rest:
             raise SystemExit(
-                f"{USAGE}\n--resume needs --run.name <name> (or --run.dir <dir>)"
+                f"{USAGE}\n--resume <dir> re-runs a saved config verbatim and takes no other arguments"
             )
-        config = load_resume_config(args.output_dir / leaf)
+        config = load_resume_config(resume_target)
     else:
         # An env-block flag (or a since-moved flat axis) skips the usage gate so the
         # typed parse renders its did-you-mean instead of a bare usage line.
@@ -103,24 +109,24 @@ def main(argv: list[str] | None = None) -> None:
                 *argv,
             ]  # let prime-pydantic-config render help/errors
             config = cli(config_type)
+        # A named run directory is reused only by `--resume` or wiped by `--clean`: any
+        # other write into it — the dry-run config.toml included, which would clobber the
+        # config `--resume` reloads — would overwrite the previous run.
+        run_path = output_path(config)
+        if config.clean and run_path.exists():
+            if not run_path.resolve().is_relative_to(config.output_dir.resolve()):
+                raise SystemExit("--clean requires run.dir to remain under output_dir")
+            shutil.rmtree(run_path)
+        traces_file = run_path / TRACES_FILE
+        if traces_file.exists() and traces_file.stat().st_size > 0:
+            raise SystemExit(
+                f"run directory {run_path} already contains results - resume it with "
+                f"`{resume_command(config)}`, overwrite it with --clean, or pick another --run.name"
+            )
         if config.dry_run:  # resolved + validated; write it to the output dir and exit
             setup_logging("DEBUG" if config.verbose else "INFO")
             logger.info("wrote config to %s", write_config(config, output_path(config)))
             return
-    # A named run directory is reused only by `--resume` or wiped by `--clean`: a second
-    # run writing into it would overwrite its results.
-    if config.clean and config.resume is None and output_path(config).exists():
-        shutil.rmtree(output_path(config))
-    traces_file = output_path(config) / TRACES_FILE
-    if (
-        config.resume is None
-        and traces_file.exists()
-        and traces_file.stat().st_size > 0
-    ):
-        raise SystemExit(
-            f"run directory {output_path(config)} already contains results - resume it with "
-            f"`{resume_command(config)}`, overwrite it with --clean, or pick another --run.name"
-        )
     # Execution path: in-process by default; `--server` opts into the env-server worker pool
     # (the path prime-rl trains through). The `--rich` dashboard reads live in-process run
     # slots, so it's in-process only (`server + rich` is rejected at config validation).

--- a/verifiers/v1/cli/eval/main.py
+++ b/verifiers/v1/cli/eval/main.py
@@ -4,13 +4,10 @@ import asyncio
 import logging
 import shutil
 import sys
-from pathlib import Path
 
-from pydantic import AliasChoices, Field
-from pydantic_config import BaseConfig, cli
+from pydantic_config import cli
 
 import verifiers.v1 as vf
-from verifiers.v1.cli.eval.resume import load_resume_config
 from verifiers.v1.cli.eval.runner import run_eval
 from verifiers.v1.cli.output import TRACES_FILE, output_path, write_config
 from verifiers.v1.cli.resolve import (
@@ -20,7 +17,7 @@ from verifiers.v1.cli.resolve import (
     references_config_file,
     with_positional_taskset,
 )
-from verifiers.v1.configs.cli.eval import EvalConfig, RunConfig
+from verifiers.v1.configs.cli.eval import EvalConfig
 from verifiers.v1.utils.interrupt import install_interrupt
 from verifiers.v1.utils.logging import setup_logging
 
@@ -28,31 +25,8 @@ logger = logging.getLogger(__name__)
 
 USAGE = (
     "usage: uv run eval [<taskset-id>] [--env.id <id>] [options] [@ file.toml]\n"
-    "       uv run eval --resume --run.name <name> [-o <output-dir>]   (re-run a previous run's missing/errored rollouts)"
+    "       uv run eval @ <run-dir>/config.toml --resume   (re-run the run's missing/errored rollouts)"
 )
-
-
-class ResumeArgs(BaseConfig):
-    """The arguments `--resume` takes: the run to resume, located as
-    `output_dir / (run.dir or run.name)`. The run's saved config is then loaded
-    verbatim, so nothing else may be passed."""
-
-    run: RunConfig = Field(default_factory=RunConfig)
-    output_dir: Path = Field(
-        Path("outputs"), validation_alias=AliasChoices("output_dir", "o")
-    )
-
-
-def resume_command(config: EvalConfig) -> str:
-    """The `--resume` invocation that targets this config's run dir."""
-    parts = ["uv run eval --resume"]
-    if config.run.dir != config.run.name:
-        parts.append(f"--run.dir {config.run.dir}")
-    else:
-        parts.append(f"--run.name {config.run.name}")
-    if config.output_dir != Path("outputs"):
-        parts.append(f"-o {config.output_dir}")
-    return " ".join(parts)
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -66,65 +40,46 @@ def main(argv: list[str] | None = None) -> None:
                 narrow_config(EvalConfig, argv)
             )  # full option help, narrowed to the given ids
         return
-    # re-run a previous run's missing/errored rollouts, in place
-    if any(arg == "--resume" or arg.startswith("--resume=") for arg in argv):
-        if any(arg.startswith("--resume=") for arg in argv):
-            raise SystemExit(
-                f"{USAGE}\n--resume takes no value - the run is located by name"
-            )
-        rest = [arg for arg in argv if arg != "--resume"]
-        if rest and not rest[0].startswith("-"):
-            raise SystemExit(f"{USAGE}\n--resume locates the run by name, not by path")
-        with plugin_errors():
-            sys.argv = [sys.argv[0], *rest]
-            args = cli(ResumeArgs)
-        leaf = args.run.dir or args.run.name
-        if leaf is None:
-            raise SystemExit(
-                f"{USAGE}\n--resume needs --run.name <name> (or --run.dir <dir>)"
-            )
-        config = load_resume_config(args.output_dir / leaf)
-    else:
-        # An env-block flag (or a since-moved flat axis) skips the usage gate so the
-        # typed parse renders its did-you-mean instead of a bare usage line.
-        typed_axis = any(
-            a.startswith(("--env.", "--taskset.", "--harness.", "--serve."))
-            for a in argv
-        )
-        if (
-            not extract_id(argv, "env.taskset")
-            and not references_config_file(argv)
-            and not typed_axis
-        ):
-            raise SystemExit(
-                USAGE
-            )  # need a taskset (positional / --env.taskset.id) or a @ file.toml
+    # An env-block flag (or a since-moved flat axis) skips the usage gate so the
+    # typed parse renders its did-you-mean instead of a bare usage line.
+    typed_axis = any(
+        a.startswith(("--env.", "--taskset.", "--harness.", "--serve.")) for a in argv
+    )
+    if (
+        not extract_id(argv, "env.taskset")
+        and not references_config_file(argv)
+        and not typed_axis
+    ):
+        raise SystemExit(
+            USAGE
+        )  # need a taskset (positional / --env.taskset.id) or a @ file.toml
 
-        with plugin_errors():
-            config_type = narrow_config(EvalConfig, argv)
-            sys.argv = [
-                sys.argv[0],
-                *argv,
-            ]  # let prime-pydantic-config render help/errors
-            config = cli(config_type)
-        # A named run directory is reused only by `--resume` or wiped by `--clean`: any
-        # other write into it — the dry-run config.toml included, which would clobber the
-        # config `--resume` reloads — would overwrite the previous run.
-        run_path = output_path(config)
-        if config.clean and run_path.exists():
-            if not run_path.resolve().is_relative_to(config.output_dir.resolve()):
-                raise SystemExit("--clean requires run.dir to remain under output_dir")
-            shutil.rmtree(run_path)
-        traces_file = run_path / TRACES_FILE
-        if traces_file.exists() and traces_file.stat().st_size > 0:
-            raise SystemExit(
-                f"run directory {run_path} already contains results - resume it with "
-                f"`{resume_command(config)}`, overwrite it with --clean, or pick another --run.name"
-            )
-        if config.dry_run:  # resolved + validated; write it to the output dir and exit
-            setup_logging("DEBUG" if config.verbose else "INFO")
-            logger.info("wrote config to %s", write_config(config, output_path(config)))
-            return
+    with plugin_errors():
+        config_type = narrow_config(EvalConfig, argv)
+        sys.argv = [
+            sys.argv[0],
+            *argv,
+        ]  # let prime-pydantic-config render help/errors
+        config = cli(config_type)
+    # A named run directory is re-entered only by `--resume` or wiped by `--clean`: any
+    # other write into it — the dry-run config.toml included, which would clobber the
+    # config a resume typically re-runs — would overwrite the previous run.
+    run_path = output_path(config)
+    if config.clean and not config.resume and run_path.exists():
+        if not run_path.resolve().is_relative_to(config.output_dir.resolve()):
+            raise SystemExit("--clean requires run.dir to remain under output_dir")
+        shutil.rmtree(run_path)
+    traces_file = run_path / TRACES_FILE
+    if not config.resume and traces_file.exists() and traces_file.stat().st_size > 0:
+        raise SystemExit(
+            f"run directory {run_path} already contains results - append --resume to "
+            "re-run its missing/errored rollouts, overwrite it with --clean, or pick "
+            "another --run.name"
+        )
+    if config.dry_run:  # resolved + validated; write it to the output dir and exit
+        setup_logging("DEBUG" if config.verbose else "INFO")
+        logger.info("wrote config to %s", write_config(config, output_path(config)))
+        return
     # Execution path: in-process by default; `--server` opts into the env-server worker pool
     # (the path prime-rl trains through). The `--rich` dashboard reads live in-process run
     # slots, so it's in-process only (`server + rich` is rejected at config validation).

--- a/verifiers/v1/cli/eval/main.py
+++ b/verifiers/v1/cli/eval/main.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import sys
+from pathlib import Path
 
 from pydantic_config import cli
 
@@ -26,8 +27,39 @@ logger = logging.getLogger(__name__)
 
 USAGE = (
     "usage: uv run eval [<taskset-id>] [--env.id <id>] [options] [@ file.toml]\n"
-    "       uv run eval --resume <output-dir>   (re-run a previous run's missing/errored rollouts)"
+    "       uv run eval --resume <run-dir>   (re-run a previous run's missing/errored rollouts)\n"
+    "       uv run eval --resume --run.name <name> [-o <output-dir>]   (same, located by run name)"
 )
+
+
+def bare_resume_dir(rest: list[str]) -> Path:
+    """Resolve a bare ``--resume``: the run dir is ``output_dir / (run.dir or run.name)``."""
+    values: dict[str, str] = {}
+    output_dir = Path("outputs")
+    i = 0
+    while i < len(rest):
+        key, _, value = rest[i].partition("=")
+        if key not in ("--run.name", "--run.dir", "--output-dir", "-o"):
+            raise SystemExit(
+                f"{USAGE}\nbare --resume locates the run by name and takes only --run.name, "
+                f"--run.dir, and --output-dir, got {rest[i]!r}"
+            )
+        if not value:
+            if i + 1 >= len(rest):
+                raise SystemExit(f"{USAGE}\n{key} needs a value")
+            i += 1
+            value = rest[i]
+        if key in ("--output-dir", "-o"):
+            output_dir = Path(value)
+        else:
+            values[key] = value
+        i += 1
+    leaf = values.get("--run.dir") or values.get("--run.name")
+    if leaf is None:
+        raise SystemExit(
+            f"{USAGE}\nbare --resume needs --run.name <name> (or --run.dir <dir>)"
+        )
+    return output_dir / leaf
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -41,12 +73,14 @@ def main(argv: list[str] | None = None) -> None:
                 narrow_config(EvalConfig, argv)
             )  # full option help, narrowed to the given ids
         return
-    resume_dir, rest = split_resume(argv, "eval")
+    resume_dir, rest = split_resume(argv, "eval", allow_bare=True)
     # re-run a previous run's missing/errored rollouts, in place
     if resume_dir is not None:
-        if rest:
+        if resume_dir is True:  # bare --resume: locate the run dir by name
+            resume_dir = bare_resume_dir(rest)
+        elif rest:
             raise SystemExit(
-                f"{USAGE}\n--resume re-runs a saved config verbatim and takes no other arguments"
+                f"{USAGE}\n--resume <dir> re-runs a saved config verbatim and takes no other arguments"
             )
         config = load_resume_config(resume_dir)
     else:

--- a/verifiers/v1/cli/eval/main.py
+++ b/verifiers/v1/cli/eval/main.py
@@ -9,7 +9,7 @@ from pydantic_config import cli
 import verifiers.v1 as vf
 from verifiers.v1.cli.eval.resume import load_resume_config
 from verifiers.v1.cli.eval.runner import run_eval
-from verifiers.v1.cli.output import output_path, write_config
+from verifiers.v1.cli.output import TRACES_FILE, output_path, write_config
 from verifiers.v1.cli.resolve import (
     extract_id,
     narrow_config,
@@ -76,6 +76,18 @@ def main(argv: list[str] | None = None) -> None:
             setup_logging("DEBUG" if config.verbose else "INFO")
             logger.info("wrote config to %s", write_config(config, output_path(config)))
             return
+    # A named run directory is reused only by `--resume`: a second run writing into it
+    # would overwrite its results.
+    traces_file = output_path(config) / TRACES_FILE
+    if (
+        config.resume is None
+        and traces_file.exists()
+        and traces_file.stat().st_size > 0
+    ):
+        raise SystemExit(
+            f"run directory {output_path(config)} already contains results - resume it with "
+            f"`uv run eval --resume {output_path(config)}`, pick another --run.name, or delete it"
+        )
     # Execution path: in-process by default; `--server` opts into the env-server worker pool
     # (the path prime-rl trains through). The `--rich` dashboard reads live in-process run
     # slots, so it's in-process only (`server + rich` is rejected at config validation).

--- a/verifiers/v1/cli/eval/main.py
+++ b/verifiers/v1/cli/eval/main.py
@@ -1,10 +1,10 @@
 """Eval CLI entrypoint."""
 
 import asyncio
+import json
 import logging
 import shutil
 import sys
-import tomllib
 
 from pydantic_config import cli
 
@@ -14,7 +14,6 @@ from verifiers.v1.cli.output import (
     TRACES_FILE,
     config_digest,
     output_path,
-    saved_config_digest,
     saved_config_path,
     write_config,
 )
@@ -33,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 USAGE = (
     "usage: uv run eval [<taskset-id>] [--env.id <id>] [options] [@ file.toml]\n"
-    "       uv run eval @ <run-dir>/configs/eval.toml --resume   (re-run the run's missing/errored rollouts)"
+    "       uv run eval @ <run-dir>/configs/eval.json --resume   (re-run the run's missing/errored rollouts)"
 )
 
 
@@ -86,24 +85,16 @@ def main(argv: list[str] | None = None) -> None:
         )
     if config.resume:
         # A resumed eval is only trustworthy under the exact config that produced the
-        # existing rollouts — anything else silently mixes incomparable results. The
-        # saved config carries the digest of the in-memory resolved config, so the check
-        # also covers explicit-None settings TOML cannot represent.
+        # existing rollouts — anything else silently mixes incomparable results. Saved
+        # configs are full JSON dumps (nulls included), so the comparison is exact.
         saved_path = saved_config_path(run_path)
         if saved_path is None:
             raise SystemExit(
                 f"--resume: no saved config under {run_path} - not a run dir"
             )
-        saved_digest = saved_config_digest(saved_path)
-        if saved_digest is None:
-            raise SystemExit(
-                f"--resume: {saved_path} has no digest - not a resolved run config"
-            )
-        if saved_digest != config_digest(config):
-            with plugin_errors():
-                saved = config_type.model_validate(
-                    tomllib.loads(saved_path.read_text())
-                )
+        with plugin_errors():
+            saved = config_type.model_validate(json.loads(saved_path.read_text()))
+        if config_digest(saved) != config_digest(config):
             saved_dump = saved.model_dump(mode="json")
             current_dump = config.model_dump(mode="json")
             changed = sorted(
@@ -111,13 +102,11 @@ def main(argv: list[str] | None = None) -> None:
                 for key in set(saved_dump) | set(current_dump)
                 if saved_dump.get(key) != current_dump.get(key)
             )
-            if changed:
-                hint = f"it differs in [{', '.join(changed)}] - re-run with `uv run eval @ {saved_path} --resume`"
-            else:
-                hint = "explicitly-None settings differ (TOML cannot store them) - re-pass them, e.g. `-c None`"
             raise SystemExit(
-                f"--resume requires the exact config the run was started with - {hint}, "
-                "or start a fresh run (resumed rollouts would not be comparable)"
+                f"--resume requires the exact config the run was started with - it "
+                f"differs in [{', '.join(changed)}]. Resumed rollouts would not be "
+                f"comparable; re-run with `uv run eval @ {saved_path} --resume`, or "
+                "start a fresh run"
             )
     if config.dry_run:  # resolved + validated; write it to the output dir and exit
         setup_logging("DEBUG" if config.verbose else "INFO")

--- a/verifiers/v1/cli/eval/main.py
+++ b/verifiers/v1/cli/eval/main.py
@@ -2,10 +2,12 @@
 
 import asyncio
 import logging
+import shutil
 import sys
 from pathlib import Path
 
-from pydantic_config import cli
+from pydantic import AliasChoices, Field
+from pydantic_config import BaseConfig, cli
 
 import verifiers.v1 as vf
 from verifiers.v1.cli.eval.resume import load_resume_config
@@ -18,8 +20,7 @@ from verifiers.v1.cli.resolve import (
     references_config_file,
     with_positional_taskset,
 )
-from verifiers.v1.cli.resume import split_resume
-from verifiers.v1.configs.cli.eval import EvalConfig
+from verifiers.v1.configs.cli.eval import EvalConfig, RunConfig
 from verifiers.v1.utils.interrupt import install_interrupt
 from verifiers.v1.utils.logging import setup_logging
 
@@ -27,39 +28,31 @@ logger = logging.getLogger(__name__)
 
 USAGE = (
     "usage: uv run eval [<taskset-id>] [--env.id <id>] [options] [@ file.toml]\n"
-    "       uv run eval --resume <run-dir>   (re-run a previous run's missing/errored rollouts)\n"
-    "       uv run eval --resume --run.name <name> [-o <output-dir>]   (same, located by run name)"
+    "       uv run eval --resume --run.name <name> [-o <output-dir>]   (re-run a previous run's missing/errored rollouts)"
 )
 
 
-def bare_resume_dir(rest: list[str]) -> Path:
-    """Resolve a bare ``--resume``: the run dir is ``output_dir / (run.dir or run.name)``."""
-    values: dict[str, str] = {}
-    output_dir = Path("outputs")
-    i = 0
-    while i < len(rest):
-        key, _, value = rest[i].partition("=")
-        if key not in ("--run.name", "--run.dir", "--output-dir", "-o"):
-            raise SystemExit(
-                f"{USAGE}\nbare --resume locates the run by name and takes only --run.name, "
-                f"--run.dir, and --output-dir, got {rest[i]!r}"
-            )
-        if not value:
-            if i + 1 >= len(rest):
-                raise SystemExit(f"{USAGE}\n{key} needs a value")
-            i += 1
-            value = rest[i]
-        if key in ("--output-dir", "-o"):
-            output_dir = Path(value)
-        else:
-            values[key] = value
-        i += 1
-    leaf = values.get("--run.dir") or values.get("--run.name")
-    if leaf is None:
-        raise SystemExit(
-            f"{USAGE}\nbare --resume needs --run.name <name> (or --run.dir <dir>)"
-        )
-    return output_dir / leaf
+class ResumeArgs(BaseConfig):
+    """The arguments `--resume` takes: the run to resume, located as
+    `output_dir / (run.dir or run.name)`. The run's saved config is then loaded
+    verbatim, so nothing else may be passed."""
+
+    run: RunConfig = Field(default_factory=RunConfig)
+    output_dir: Path = Field(
+        Path("outputs"), validation_alias=AliasChoices("output_dir", "o")
+    )
+
+
+def resume_command(config: EvalConfig) -> str:
+    """The `--resume` invocation that targets this config's run dir."""
+    parts = ["uv run eval --resume"]
+    if config.run.dir != config.run.name:
+        parts.append(f"--run.dir {config.run.dir}")
+    else:
+        parts.append(f"--run.name {config.run.name}")
+    if config.output_dir != Path("outputs"):
+        parts.append(f"-o {config.output_dir}")
+    return " ".join(parts)
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -73,16 +66,20 @@ def main(argv: list[str] | None = None) -> None:
                 narrow_config(EvalConfig, argv)
             )  # full option help, narrowed to the given ids
         return
-    resume_dir, rest = split_resume(argv, "eval", allow_bare=True)
     # re-run a previous run's missing/errored rollouts, in place
-    if resume_dir is not None:
-        if resume_dir is True:  # bare --resume: locate the run dir by name
-            resume_dir = bare_resume_dir(rest)
-        elif rest:
+    if "--resume" in argv:
+        rest = [arg for arg in argv if arg != "--resume"]
+        if rest and not rest[0].startswith("-"):
+            raise SystemExit(f"{USAGE}\n--resume locates the run by name, not by path")
+        with plugin_errors():
+            sys.argv = [sys.argv[0], *rest]
+            args = cli(ResumeArgs)
+        leaf = args.run.dir or args.run.name
+        if leaf is None:
             raise SystemExit(
-                f"{USAGE}\n--resume <dir> re-runs a saved config verbatim and takes no other arguments"
+                f"{USAGE}\n--resume needs --run.name <name> (or --run.dir <dir>)"
             )
-        config = load_resume_config(resume_dir)
+        config = load_resume_config(args.output_dir / leaf)
     else:
         # An env-block flag (or a since-moved flat axis) skips the usage gate so the
         # typed parse renders its did-you-mean instead of a bare usage line.
@@ -110,8 +107,10 @@ def main(argv: list[str] | None = None) -> None:
             setup_logging("DEBUG" if config.verbose else "INFO")
             logger.info("wrote config to %s", write_config(config, output_path(config)))
             return
-    # A named run directory is reused only by `--resume`: a second run writing into it
-    # would overwrite its results.
+    # A named run directory is reused only by `--resume` or wiped by `--clean`: a second
+    # run writing into it would overwrite its results.
+    if config.clean and config.resume is None and output_path(config).exists():
+        shutil.rmtree(output_path(config))
     traces_file = output_path(config) / TRACES_FILE
     if (
         config.resume is None
@@ -120,7 +119,7 @@ def main(argv: list[str] | None = None) -> None:
     ):
         raise SystemExit(
             f"run directory {output_path(config)} already contains results - resume it with "
-            f"`uv run eval --resume {output_path(config)}`, pick another --run.name, or delete it"
+            f"`{resume_command(config)}`, overwrite it with --clean, or pick another --run.name"
         )
     # Execution path: in-process by default; `--server` opts into the env-server worker pool
     # (the path prime-rl trains through). The `--rich` dashboard reads live in-process run

--- a/verifiers/v1/cli/eval/main.py
+++ b/verifiers/v1/cli/eval/main.py
@@ -116,7 +116,7 @@ def main(argv: list[str] | None = None) -> None:
     # (the path prime-rl trains through). The `--rich` dashboard reads live in-process run
     # slots, so it's in-process only (`server + rich` is rejected at config validation).
     # Always tee the run's logs to a file under the output dir (in-process and server mode).
-    log_file = str(output_path(config) / "eval.log")
+    log_file = str(output_path(config) / "logs" / "eval.log")
     level = "DEBUG" if config.verbose else "INFO"
     if config.rich:
         setup_logging(level, log_file=log_file, console=False)

--- a/verifiers/v1/cli/eval/main.py
+++ b/verifiers/v1/cli/eval/main.py
@@ -1,8 +1,6 @@
 """Eval CLI entrypoint."""
 
 import asyncio
-import hashlib
-import json
 import logging
 import shutil
 import sys
@@ -12,7 +10,14 @@ from pydantic_config import cli
 
 import verifiers.v1 as vf
 from verifiers.v1.cli.eval.runner import run_eval
-from verifiers.v1.cli.output import CONFIG_FILE, TRACES_FILE, output_path, write_config
+from verifiers.v1.cli.output import (
+    TRACES_FILE,
+    config_digest,
+    output_path,
+    saved_config_digest,
+    saved_config_path,
+    write_config,
+)
 from verifiers.v1.cli.resolve import (
     extract_id,
     narrow_config,
@@ -28,16 +33,8 @@ logger = logging.getLogger(__name__)
 
 USAGE = (
     "usage: uv run eval [<taskset-id>] [--env.id <id>] [options] [@ file.toml]\n"
-    "       uv run eval @ <run-dir>/config.toml --resume   (re-run the run's missing/errored rollouts)"
+    "       uv run eval @ <run-dir>/configs/eval.toml --resume   (re-run the run's missing/errored rollouts)"
 )
-
-
-def config_digest(config: EvalConfig) -> str:
-    """Canonical hash of a resolved config. Hashes the model dump (not the raw TOML), so
-    the saved config compares through the same schema the invocation resolved through."""
-    dump = config.model_dump(mode="json", exclude_none=True)
-    canonical = json.dumps(dump, sort_keys=True, separators=(",", ":"))
-    return hashlib.sha256(canonical.encode()).hexdigest()
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -89,26 +86,38 @@ def main(argv: list[str] | None = None) -> None:
         )
     if config.resume:
         # A resumed eval is only trustworthy under the exact config that produced the
-        # existing rollouts — anything else silently mixes incomparable results.
-        saved_path = run_path / CONFIG_FILE
-        if not saved_path.exists():
+        # existing rollouts — anything else silently mixes incomparable results. The
+        # saved config carries the digest of the in-memory resolved config, so the check
+        # also covers explicit-None settings TOML cannot represent.
+        saved_path = saved_config_path(run_path)
+        if saved_path is None:
             raise SystemExit(
-                f"--resume: no {CONFIG_FILE} in {run_path} - not an eval run dir"
+                f"--resume: no saved config under {run_path} - not a run dir"
             )
-        with plugin_errors():
-            saved = config_type.model_validate(tomllib.loads(saved_path.read_text()))
-        if config_digest(saved) != config_digest(config):
-            saved_dump = saved.model_dump(mode="json", exclude_none=True)
-            current_dump = config.model_dump(mode="json", exclude_none=True)
+        saved_digest = saved_config_digest(saved_path)
+        if saved_digest is None:
+            raise SystemExit(
+                f"--resume: {saved_path} has no digest - not a resolved run config"
+            )
+        if saved_digest != config_digest(config):
+            with plugin_errors():
+                saved = config_type.model_validate(
+                    tomllib.loads(saved_path.read_text())
+                )
+            saved_dump = saved.model_dump(mode="json")
+            current_dump = config.model_dump(mode="json")
             changed = sorted(
                 key
                 for key in set(saved_dump) | set(current_dump)
                 if saved_dump.get(key) != current_dump.get(key)
             )
+            if changed:
+                hint = f"it differs in [{', '.join(changed)}] - re-run with `uv run eval @ {saved_path} --resume`"
+            else:
+                hint = "explicitly-None settings differ (TOML cannot store them) - re-pass them, e.g. `-c None`"
             raise SystemExit(
-                f"--resume requires the exact config the run was started with - it differs "
-                f"in [{', '.join(changed)}]. Resumed rollouts would not be comparable; "
-                f"re-run with `uv run eval @ {saved_path} --resume`, or start a fresh run"
+                f"--resume requires the exact config the run was started with - {hint}, "
+                "or start a fresh run (resumed rollouts would not be comparable)"
             )
     if config.dry_run:  # resolved + validated; write it to the output dir and exit
         setup_logging("DEBUG" if config.verbose else "INFO")

--- a/verifiers/v1/cli/eval/main.py
+++ b/verifiers/v1/cli/eval/main.py
@@ -1,15 +1,18 @@
 """Eval CLI entrypoint."""
 
 import asyncio
+import hashlib
+import json
 import logging
 import shutil
 import sys
+import tomllib
 
 from pydantic_config import cli
 
 import verifiers.v1 as vf
 from verifiers.v1.cli.eval.runner import run_eval
-from verifiers.v1.cli.output import TRACES_FILE, output_path, write_config
+from verifiers.v1.cli.output import CONFIG_FILE, TRACES_FILE, output_path, write_config
 from verifiers.v1.cli.resolve import (
     extract_id,
     narrow_config,
@@ -27,6 +30,12 @@ USAGE = (
     "usage: uv run eval [<taskset-id>] [--env.id <id>] [options] [@ file.toml]\n"
     "       uv run eval @ <run-dir>/config.toml --resume   (re-run the run's missing/errored rollouts)"
 )
+
+
+def config_digest(config_dict: dict) -> str:
+    """Canonical hash of a resolved config, as saved to (or parsed from) config.toml."""
+    canonical = json.dumps(config_dict, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -76,6 +85,27 @@ def main(argv: list[str] | None = None) -> None:
             "re-run its missing/errored rollouts, overwrite it with --clean, or pick "
             "another --run.name"
         )
+    if config.resume:
+        # A resumed eval is only trustworthy under the exact config that produced the
+        # existing rollouts — anything else silently mixes incomparable results.
+        saved_path = run_path / CONFIG_FILE
+        if not saved_path.exists():
+            raise SystemExit(
+                f"--resume: no {CONFIG_FILE} in {run_path} - not an eval run dir"
+            )
+        saved = tomllib.loads(saved_path.read_text())
+        current = json.loads(config.model_dump_json(exclude_none=True))
+        if config_digest(saved) != config_digest(current):
+            changed = sorted(
+                key
+                for key in set(saved) | set(current)
+                if saved.get(key) != current.get(key)
+            )
+            raise SystemExit(
+                f"--resume requires the exact config the run was started with - it differs "
+                f"in [{', '.join(changed)}]. Resumed rollouts would not be comparable; "
+                f"re-run with `uv run eval @ {saved_path} --resume`, or start a fresh run"
+            )
     if config.dry_run:  # resolved + validated; write it to the output dir and exit
         setup_logging("DEBUG" if config.verbose else "INFO")
         logger.info("wrote config to %s", write_config(config, output_path(config)))

--- a/verifiers/v1/cli/eval/resume.py
+++ b/verifiers/v1/cli/eval/resume.py
@@ -35,7 +35,8 @@ def load_resume_config(resume_dir: Path) -> EvalConfig:
         )
     config = EvalConfig.model_validate(tomllib.loads(config_path.read_text()))
     config.resume = resume_dir
-    config.output_dir = resume_dir
+    config.output_dir = resume_dir.parent
+    config.run.name = resume_dir.name
     return config
 
 

--- a/verifiers/v1/cli/eval/resume.py
+++ b/verifiers/v1/cli/eval/resume.py
@@ -1,9 +1,8 @@
 """Resume an interrupted eval: reload its finished rollouts and run only the rest.
 
-`--resume <dir>` reloads the run's saved config verbatim (so it takes no other
-flags) and writes back into the same dir. `load` keeps the good saved rollouts and
-re-runs what's owed: missing rollouts (never written) and errored ones (dropped and
-redone).
+`--resume` re-enters the run dir the resolved config points at and writes back into
+it. `load` keeps the good saved rollouts and re-runs what's owed: missing rollouts
+(never written) and errored ones (dropped and redone).
 
 A saved rollout is matched to a selected task by content: `task_key` hashes the
 task's wire data. Tasks with identical data are interchangeable, a task whose data
@@ -11,33 +10,16 @@ changed since the interrupted run re-runs, and nothing depends on `data.idx`.
 """
 
 import json
-import tomllib
 from collections import Counter, defaultdict
 from collections.abc import Callable
 from pathlib import Path
 
 from pydantic_core import from_json
 
-from verifiers.v1.cli.output import CONFIG_FILE, TRACES_FILE, sniff_episode
-from verifiers.v1.configs.cli.eval import EvalConfig
+from verifiers.v1.cli.output import TRACES_FILE, sniff_episode
 from verifiers.v1.episode import Episode, WireEpisode
 from verifiers.v1.task import task_key
 from verifiers.v1.trace import WireTrace
-
-
-def load_resume_config(resume_dir: Path) -> EvalConfig:
-    """Rebuild the run's `EvalConfig` from its saved `config.toml`, pointed back at its own
-    output dir so the resumed rollouts append to the same `traces.jsonl`."""
-    config_path = resume_dir / CONFIG_FILE
-    if not config_path.exists():
-        raise SystemExit(
-            f"--resume: no config.toml in {resume_dir} - not an eval output dir"
-        )
-    config = EvalConfig.model_validate(tomllib.loads(config_path.read_text()))
-    config.resume = True
-    config.output_dir = resume_dir.parent
-    config.run.dir = resume_dir.name
-    return config
 
 
 def load(

--- a/verifiers/v1/cli/eval/resume.py
+++ b/verifiers/v1/cli/eval/resume.py
@@ -36,7 +36,7 @@ def load_resume_config(resume_dir: Path) -> EvalConfig:
     config = EvalConfig.model_validate(tomllib.loads(config_path.read_text()))
     config.resume = resume_dir
     config.output_dir = resume_dir.parent
-    config.run.name = resume_dir.name
+    config.run.dir = resume_dir.name
     return config
 
 

--- a/verifiers/v1/cli/eval/resume.py
+++ b/verifiers/v1/cli/eval/resume.py
@@ -34,7 +34,7 @@ def load_resume_config(resume_dir: Path) -> EvalConfig:
             f"--resume: no config.toml in {resume_dir} - not an eval output dir"
         )
     config = EvalConfig.model_validate(tomllib.loads(config_path.read_text()))
-    config.resume = resume_dir
+    config.resume = True
     config.output_dir = resume_dir.parent
     config.run.dir = resume_dir.name
     return config

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -73,7 +73,7 @@ async def run_eval(env: Env, config: EvalConfig) -> list[Episode]:
 
     async def on_complete(episode: Episode) -> None:
         for trace in episode.traces:
-            trace.record_run(EvalRunInfo(id=config.uuid))
+            trace.record_run(EvalRunInfo(id=config.run.id, name=config.run.name))
         await append_episode(out, episode, write_lock)
 
     # Serving resources (shared tool servers, interception) come up once for the
@@ -206,7 +206,7 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
                     **payload,
                 )
             for trace in episode.traces:
-                trace.record_run(EvalRunInfo(id=config.uuid))
+                trace.record_run(EvalRunInfo(id=config.run.id, name=config.run.name))
             await append_episode(out, episode, write_lock)
             return [episode]
 

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -44,7 +44,7 @@ async def run_eval(env: Env, config: EvalConfig) -> list[Episode]:
     plan = [(task, config.num_rollouts) for task in tasks]
     # Kept on-disk rollouts rejoin the run as finished episodes; only owed ones re-run.
     finished: list[Episode] = []
-    if config.resume is not None:
+    if config.resume:
         keys = [task.hash for task in tasks]
         finished, owed = resume.load(out, keys, config.num_rollouts, env.complete)
         if not owed:  # already complete - report it and exit successfully
@@ -168,7 +168,7 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
         ]
         out = output_path(config)
         finished: list[Episode] = []
-        if config.resume is not None:
+        if config.resume:
             keys = [task.hash for task in tasks]
             finished, owed = resume.load(out, keys, config.num_rollouts)
             counts = distribute(keys, owed, config.num_rollouts)

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -136,7 +136,7 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
     # Spawned processes inherit no logging — hand them the main process's setup so
     # their rollout logs land in the output dir.
     level = "DEBUG" if config.verbose else "INFO"
-    log_file = str(output_path(config) / "eval.log")
+    log_file = str(output_path(config) / "logs" / "eval.log")
     mpctx = mp.get_context("spawn")
     address_queue: mp.Queue = mpctx.Queue()
     # Death pipe: serve_env self-terminates if this process dies abruptly — we keep

--- a/verifiers/v1/cli/gepa.py
+++ b/verifiers/v1/cli/gepa.py
@@ -69,20 +69,21 @@ def main(argv: list[str] | None = None) -> None:
             "gepa optimizes one agent's prompt against per-trace rewards and can't "
             "drive a multi-agent interaction — only eval runs those"
         )
-    if config.dry_run:  # resolved + validated; write it to the output dir and exit
-        logger.info(
-            "wrote config to %s", write_config(config, output_path(config), "gepa.json")
-        )
-        return
-
-    # A named run directory is never silently reused: a second run writing into it
-    # would overwrite its results.
+    # A named run directory is never silently reused: any write into it — the dry-run
+    # config included, which would destroy the existing traces' config provenance —
+    # would overwrite the previous run.
     traces_file = output_path(config) / TRACES_FILE
     if traces_file.exists() and traces_file.stat().st_size > 0:
         raise SystemExit(
             f"run directory {output_path(config)} already contains results - "
             "pick another --run.name or delete it"
         )
+
+    if config.dry_run:  # resolved + validated; write it to the output dir and exit
+        logger.info(
+            "wrote config to %s", write_config(config, output_path(config), "gepa.json")
+        )
+        return
 
     # First Ctrl-C / SIGTERM warns and raises KeyboardInterrupt so a killed/timed-out run still
     # runs the runner's `serving()` teardown (interception / tool-server runtimes); further

--- a/verifiers/v1/cli/gepa.py
+++ b/verifiers/v1/cli/gepa.py
@@ -14,7 +14,7 @@ import sys
 from pydantic_config import cli
 
 import verifiers.v1 as vf
-from verifiers.v1.cli.output import output_path, write_config
+from verifiers.v1.cli.output import TRACES_FILE, output_path, write_config
 from verifiers.v1.cli.resolve import (
     extract_id,
     narrow_config,
@@ -72,6 +72,15 @@ def main(argv: list[str] | None = None) -> None:
     if config.dry_run:  # resolved + validated; write it to the output dir and exit
         logger.info("wrote config to %s", write_config(config, output_path(config)))
         return
+
+    # A named run directory is never silently reused: a second run writing into it
+    # would overwrite its results.
+    traces_file = output_path(config) / TRACES_FILE
+    if traces_file.exists() and traces_file.stat().st_size > 0:
+        raise SystemExit(
+            f"run directory {output_path(config)} already contains results - "
+            "pick another --run.name or delete it"
+        )
 
     # First Ctrl-C / SIGTERM warns and raises KeyboardInterrupt so a killed/timed-out run still
     # runs the runner's `serving()` teardown (interception / tool-server runtimes); further

--- a/verifiers/v1/cli/gepa.py
+++ b/verifiers/v1/cli/gepa.py
@@ -71,7 +71,7 @@ def main(argv: list[str] | None = None) -> None:
         )
     if config.dry_run:  # resolved + validated; write it to the output dir and exit
         logger.info(
-            "wrote config to %s", write_config(config, output_path(config), "gepa.toml")
+            "wrote config to %s", write_config(config, output_path(config), "gepa.json")
         )
         return
 

--- a/verifiers/v1/cli/gepa.py
+++ b/verifiers/v1/cli/gepa.py
@@ -70,7 +70,9 @@ def main(argv: list[str] | None = None) -> None:
             "drive a multi-agent interaction — only eval runs those"
         )
     if config.dry_run:  # resolved + validated; write it to the output dir and exit
-        logger.info("wrote config to %s", write_config(config, output_path(config)))
+        logger.info(
+            "wrote config to %s", write_config(config, output_path(config), "gepa.toml")
+        )
         return
 
     # A named run directory is never silently reused: a second run writing into it

--- a/verifiers/v1/cli/output.py
+++ b/verifiers/v1/cli/output.py
@@ -16,7 +16,6 @@ import json
 from functools import cache
 from pathlib import Path
 
-import tomli_w
 from pydantic import BaseModel, TypeAdapter
 
 from verifiers.v1.configs.cli.eval import EvalConfig
@@ -28,13 +27,9 @@ TRACES_FILE = "traces.jsonl"
 """Filename a run's rollout episodes are written to (one JSON episode per line)."""
 
 CONFIG_DIR = "configs"
-"""Directory inside a run dir holding its resolved config (one `<cli>.toml`, re-runnable
-via `@ <run-dir>/configs/<cli>.toml`)."""
-
-DIGEST_PREFIX = "# digest: "
-"""Comment line prepended to a saved config: the digest of the in-memory resolved config.
-Comments are not config — this is provenance, letting `--resume` verify the invocation
-against what actually ran, including explicit-None settings TOML cannot represent."""
+"""Directory inside a run dir holding its resolved config (one `<cli>.json`, re-runnable
+via `@ <run-dir>/configs/<cli>.json`). Resolved configs are JSON, not TOML: JSON keeps
+nulls, so explicit None settings round-trip exactly on re-parse."""
 
 
 def config_digest(config: BaseModel) -> str:
@@ -45,21 +40,13 @@ def config_digest(config: BaseModel) -> str:
 
 
 def saved_config_path(run_dir: Path) -> Path | None:
-    """The run's saved resolved config (`configs/<cli>.toml`), None if absent."""
+    """The run's saved resolved config (`configs/<cli>.json`), None if absent."""
     candidates = (
-        sorted((run_dir / CONFIG_DIR).glob("*.toml"))
+        sorted((run_dir / CONFIG_DIR).glob("*.json"))
         if (run_dir / CONFIG_DIR).is_dir()
         else []
     )
     return candidates[0] if candidates else None
-
-
-def saved_config_digest(path: Path) -> str | None:
-    """The digest recorded when the config was saved, None for a file without one."""
-    first = path.read_text().split("\n", 1)[0]
-    return (
-        first.removeprefix(DIGEST_PREFIX) if first.startswith(DIGEST_PREFIX) else None
-    )
 
 
 # Compiling an adapter is the expensive part; run output reuses only a few model classes.
@@ -75,22 +62,20 @@ def output_path(config: EvalConfig) -> Path:
 
 
 def write_config(
-    config: BaseModel, results_dir: Path, filename: str = "eval.toml"
+    config: BaseModel, results_dir: Path, filename: str = "eval.json"
 ) -> Path:
     """Write the run's resolved config to `configs/<filename>` (re-readable via
-    `@ <path>`); return its path. mode="json" makes values TOML-friendly (Path -> str,
-    etc.); exclude_none drops the nulls TOML can't represent — the prepended digest
-    comment still covers them (see `DIGEST_PREFIX`)."""
+    `@ <path>`); return its path. The full model dump is written, nulls included, so the
+    file round-trips exactly."""
     config_dir = results_dir / CONFIG_DIR
     config_dir.mkdir(parents=True, exist_ok=True)
-    toml = tomli_w.dumps(config.model_dump(mode="json", exclude_none=True))
     config_path = config_dir / filename
-    config_path.write_text(f"{DIGEST_PREFIX}{config_digest(config)}\n{toml}")
+    config_path.write_text(json.dumps(config.model_dump(mode="json"), indent=2))
     return config_path
 
 
 def save_config(
-    config: BaseModel, results_dir: Path, filename: str = "eval.toml"
+    config: BaseModel, results_dir: Path, filename: str = "eval.json"
 ) -> None:
     """Set up the run's output dir: write the resolved config and start a fresh (empty)
     `traces.jsonl`. Call once up front, before episodes start landing."""

--- a/verifiers/v1/cli/output.py
+++ b/verifiers/v1/cli/output.py
@@ -34,10 +34,11 @@ type_adapter = cache(TypeAdapter)
 
 
 def output_path(config: EvalConfig) -> Path:
-    """Where this run writes: `output_dir / run.name` — the same grouping convention as
-    training. The run name is auto-generated (`<env>--<model>--<harness>`) unless set."""
-    assert config.run.name is not None
-    return config.output_dir / config.run.name
+    """Where this run writes: `output_dir / run.dir` — the same grouping convention as
+    training. The run directory defaults to the auto-generated run name
+    (`<env>--<model>--<harness>--<short-id>`)."""
+    assert config.run.dir is not None
+    return config.output_dir / config.run.dir
 
 
 def write_config(config: BaseModel, results_dir: Path) -> Path:

--- a/verifiers/v1/cli/output.py
+++ b/verifiers/v1/cli/output.py
@@ -22,7 +22,6 @@ from verifiers.v1.configs.cli.eval import EvalConfig
 from verifiers.v1.episode import Episode, WireEpisode
 from verifiers.v1.trace import Trace
 from verifiers.v1.utils.aio import run_shielded
-from verifiers.v1.utils.install import env_name
 
 TRACES_FILE = "traces.jsonl"
 """Filename a run's rollout episodes are written to (one JSON episode per line)."""
@@ -35,22 +34,10 @@ type_adapter = cache(TypeAdapter)
 
 
 def output_path(config: EvalConfig) -> Path:
-    """Where this run writes: `outputs/<env>--<model>--<harness>/<uuid>` (or the explicit
-    `--output-dir`). The per-run `uuid` leaf means runs never overwrite each other."""
-    if config.output_dir is not None:
-        return config.output_dir
-    taskset = config.env.taskset
-    env = taskset.name if taskset.id else "no-taskset"
-    if taskset.id and config.env.id:
-        # Same compounding as `EnvConfig.env_id`: a `best-of-n+gsm8k` run must
-        # not share a parent dir with a plain `gsm8k` one.
-        env = f"{env_name(config.env.id)}+{env}"
-    # Every seat's resolved harness, distinct, in role order.
-    harness = "+".join(
-        dict.fromkeys(h.name for h in config.env.agent_harnesses().values())
-    )
-    name = f"{env}--{config.model.replace('/', '--')}--{harness or 'default'}"
-    return Path("outputs") / name / config.uuid
+    """Where this run writes: `output_dir / run.name` — the same grouping convention as
+    training. The run name is auto-generated (`<env>--<model>--<harness>`) unless set."""
+    assert config.run.name is not None
+    return config.output_dir / config.run.name
 
 
 def write_config(config: BaseModel, results_dir: Path) -> Path:

--- a/verifiers/v1/cli/output.py
+++ b/verifiers/v1/cli/output.py
@@ -11,6 +11,7 @@ before the episode atom (one bare trace per line) are still readable:
 """
 
 import asyncio
+import hashlib
 import json
 from functools import cache
 from pathlib import Path
@@ -26,8 +27,40 @@ from verifiers.v1.utils.aio import run_shielded
 TRACES_FILE = "traces.jsonl"
 """Filename a run's rollout episodes are written to (one JSON episode per line)."""
 
-CONFIG_FILE = "config.toml"
-"""Filename a run's resolved config is written to (re-runnable via `@ config.toml`)."""
+CONFIG_DIR = "configs"
+"""Directory inside a run dir holding its resolved config (one `<cli>.toml`, re-runnable
+via `@ <run-dir>/configs/<cli>.toml`)."""
+
+DIGEST_PREFIX = "# digest: "
+"""Comment line prepended to a saved config: the digest of the in-memory resolved config.
+Comments are not config — this is provenance, letting `--resume` verify the invocation
+against what actually ran, including explicit-None settings TOML cannot represent."""
+
+
+def config_digest(config: BaseModel) -> str:
+    """Canonical hash of a resolved config's full model dump (nulls included)."""
+    dump = config.model_dump(mode="json")
+    canonical = json.dumps(dump, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def saved_config_path(run_dir: Path) -> Path | None:
+    """The run's saved resolved config (`configs/<cli>.toml`), None if absent."""
+    candidates = (
+        sorted((run_dir / CONFIG_DIR).glob("*.toml"))
+        if (run_dir / CONFIG_DIR).is_dir()
+        else []
+    )
+    return candidates[0] if candidates else None
+
+
+def saved_config_digest(path: Path) -> str | None:
+    """The digest recorded when the config was saved, None for a file without one."""
+    first = path.read_text().split("\n", 1)[0]
+    return (
+        first.removeprefix(DIGEST_PREFIX) if first.startswith(DIGEST_PREFIX) else None
+    )
+
 
 # Compiling an adapter is the expensive part; run output reuses only a few model classes.
 type_adapter = cache(TypeAdapter)
@@ -41,21 +74,27 @@ def output_path(config: EvalConfig) -> Path:
     return config.output_dir / config.run.dir
 
 
-def write_config(config: BaseModel, results_dir: Path) -> Path:
-    """Write the run's resolved `config.toml` (re-readable via `@ config.toml`); return its
-    path. mode="json" makes values TOML-friendly (Path -> str, etc.); exclude_none drops the
-    nulls TOML can't represent."""
-    results_dir.mkdir(parents=True, exist_ok=True)
+def write_config(
+    config: BaseModel, results_dir: Path, filename: str = "eval.toml"
+) -> Path:
+    """Write the run's resolved config to `configs/<filename>` (re-readable via
+    `@ <path>`); return its path. mode="json" makes values TOML-friendly (Path -> str,
+    etc.); exclude_none drops the nulls TOML can't represent — the prepended digest
+    comment still covers them (see `DIGEST_PREFIX`)."""
+    config_dir = results_dir / CONFIG_DIR
+    config_dir.mkdir(parents=True, exist_ok=True)
     toml = tomli_w.dumps(config.model_dump(mode="json", exclude_none=True))
-    config_path = results_dir / CONFIG_FILE
-    config_path.write_text(toml)
+    config_path = config_dir / filename
+    config_path.write_text(f"{DIGEST_PREFIX}{config_digest(config)}\n{toml}")
     return config_path
 
 
-def save_config(config: BaseModel, results_dir: Path) -> None:
-    """Set up the run's output dir: write `config.toml` and start a fresh (empty)
+def save_config(
+    config: BaseModel, results_dir: Path, filename: str = "eval.toml"
+) -> None:
+    """Set up the run's output dir: write the resolved config and start a fresh (empty)
     `traces.jsonl`. Call once up front, before episodes start landing."""
-    write_config(config, results_dir)
+    write_config(config, results_dir, filename)
     (results_dir / TRACES_FILE).write_text(
         ""
     )  # fresh; appended to as rollouts complete

--- a/verifiers/v1/cli/replay.py
+++ b/verifiers/v1/cli/replay.py
@@ -10,10 +10,10 @@ cross-trace `score()` can't run offline.
 
 import asyncio
 import contextlib
+import json
 import logging
 import sys
 import time
-import tomllib
 from pathlib import Path
 
 from pydantic_config import cli
@@ -47,7 +47,7 @@ USAGE = (
 def _narrow(config_path: Path) -> type[ReplayConfig]:
     """Narrow replay config to the saved taskset's config type. The source may be
     an eval run (taskset on the [env] block) or an earlier replay (root taskset)."""
-    data = tomllib.loads(config_path.read_text())
+    data = json.loads(config_path.read_text())
     taskset = data.get("taskset") or (data.get("env") or {}).get("taskset") or {}
     taskset_id = taskset.get("id")
     return narrow_taskset_config(ReplayConfig, taskset_id)
@@ -66,7 +66,7 @@ async def run_replay(config: ReplayConfig, source: Path, out: Path) -> list[Trac
     source_config = saved_config_path(source)
     if source_config is None:
         raise SystemExit(f"no saved config under {source} - not a run dir")
-    saved = tomllib.loads(source_config.read_text())
+    saved = json.loads(source_config.read_text())
     saved_env = saved.get("env") or {}
     saved_taskset = saved.get("taskset") or saved_env.get("taskset") or {}
     env_cls = vf.environment_class(
@@ -129,7 +129,7 @@ async def run_replay(config: ReplayConfig, source: Path, out: Path) -> list[Trac
         for _ in range(config.num_rescores)
     ]
 
-    save_config(config, out, "replay.toml")
+    save_config(config, out, "replay.json")
     logger.info(
         "replay: re-scoring %d trace(s) x%d from %s -> %s",
         len(traces),
@@ -212,7 +212,7 @@ def main(argv: list[str] | None = None) -> None:
     config_type = _narrow(config_path)
     sys.argv = [sys.argv[0], *layered]
     config = cli(config_type)
-    source_out = tomllib.loads(config_path.read_text()).get("output_dir")
+    source_out = json.loads(config_path.read_text()).get("output_dir")
     # Clear the source run's output_dir unless the user overrode it.
     if config.output_dir is None or str(config.output_dir) == str(source_out):
         config = config.model_copy(update={"output_dir": None})
@@ -225,7 +225,7 @@ def main(argv: list[str] | None = None) -> None:
     level = "DEBUG" if config.verbose else "INFO"
     if config.dry_run:
         setup_logging(level)
-        logger.info("wrote config to %s", write_config(config, out, "replay.toml"))
+        logger.info("wrote config to %s", write_config(config, out, "replay.json"))
         return
 
     log_file = str(out / "replay.log")

--- a/verifiers/v1/cli/replay.py
+++ b/verifiers/v1/cli/replay.py
@@ -21,10 +21,10 @@ from pydantic_config import cli
 import verifiers.v1 as vf
 from verifiers.v1.cli.dashboard.replay import ReplayProgress, replay_dashboard
 from verifiers.v1.cli.output import (
-    CONFIG_FILE,
     append_trace,
     read_episodes,
     save_config,
+    saved_config_path,
     write_config,
 )
 from verifiers.v1.cli.resolve import narrow_taskset_config
@@ -63,7 +63,10 @@ async def run_replay(config: ReplayConfig, source: Path, out: Path) -> list[Trac
     # Refuse multi-agent up front, from the SOURCE run's saved config — the replay
     # layer's taskset is overridable and must not decide what the run was.
     # Everything below may assume plain single-agent episodes.
-    saved = tomllib.loads((source / CONFIG_FILE).read_text())
+    source_config = saved_config_path(source)
+    if source_config is None:
+        raise SystemExit(f"no saved config under {source} - not a run dir")
+    saved = tomllib.loads(source_config.read_text())
     saved_env = saved.get("env") or {}
     saved_taskset = saved.get("taskset") or saved_env.get("taskset") or {}
     env_cls = vf.environment_class(
@@ -126,7 +129,7 @@ async def run_replay(config: ReplayConfig, source: Path, out: Path) -> list[Trac
         for _ in range(config.num_rescores)
     ]
 
-    save_config(config, out)
+    save_config(config, out, "replay.toml")
     logger.info(
         "replay: re-scoring %d trace(s) x%d from %s -> %s",
         len(traces),
@@ -201,9 +204,9 @@ def main(argv: list[str] | None = None) -> None:
         cli(ReplayConfig)  # full, typed pydantic-config option help
         return
     source = Path(argv.pop(0))
-    config_path = source / CONFIG_FILE
-    if not config_path.exists():
-        raise SystemExit(f"{USAGE}\nno config.toml in {source}")
+    config_path = saved_config_path(source)
+    if config_path is None:
+        raise SystemExit(f"{USAGE}\nno saved config under {source} - not a run dir")
 
     layered = ["@", str(config_path), *argv]
     config_type = _narrow(config_path)
@@ -222,7 +225,7 @@ def main(argv: list[str] | None = None) -> None:
     level = "DEBUG" if config.verbose else "INFO"
     if config.dry_run:
         setup_logging(level)
-        logger.info("wrote config to %s", write_config(config, out))
+        logger.info("wrote config to %s", write_config(config, out, "replay.toml"))
         return
 
     log_file = str(out / "replay.log")

--- a/verifiers/v1/cli/replay.py
+++ b/verifiers/v1/cli/replay.py
@@ -228,7 +228,7 @@ def main(argv: list[str] | None = None) -> None:
         logger.info("wrote config to %s", write_config(config, out, "replay.json"))
         return
 
-    log_file = str(out / "replay.log")
+    log_file = str(out / "logs" / "replay.log")
     if config.rich:
         setup_logging(level, log_file=log_file, console=False)
         logging.lastResort = None

--- a/verifiers/v1/cli/resume.py
+++ b/verifiers/v1/cli/resume.py
@@ -1,7 +1,5 @@
 """Resume primitives shared by eval-like CLIs."""
 
-from pathlib import Path
-
 
 def distribute(
     selected_keys: list[str], owed: dict[str, int], num_results: int
@@ -15,17 +13,3 @@ def distribute(
             remaining[key] -= take
         counts.append(take)
     return counts
-
-
-def split_resume(argv: list[str], command: str) -> tuple[Path | None, list[str]]:
-    """Pull ``--resume <dir>`` from argv, returning the dir and other arguments."""
-    for i, arg in enumerate(argv):
-        if arg == "--resume":
-            if i + 1 >= len(argv):
-                raise SystemExit(
-                    f"--resume needs an output dir: uv run {command} --resume <dir>"
-                )
-            return Path(argv[i + 1]), argv[:i] + argv[i + 2 :]
-        if arg.startswith("--resume="):
-            return Path(arg.split("=", 1)[1]), argv[:i] + argv[i + 1 :]
-    return None, argv

--- a/verifiers/v1/cli/resume.py
+++ b/verifiers/v1/cli/resume.py
@@ -17,18 +17,11 @@ def distribute(
     return counts
 
 
-def split_resume(
-    argv: list[str], command: str, *, allow_bare: bool = False
-) -> tuple[Path | bool | None, list[str]]:
-    """Pull ``--resume [<dir>]`` from argv, returning the dir and other arguments.
-
-    With ``allow_bare``, a ``--resume`` without a value returns ``True`` — the caller
-    resolves the run dir from the remaining arguments (e.g. ``--run.name``)."""
+def split_resume(argv: list[str], command: str) -> tuple[Path | None, list[str]]:
+    """Pull ``--resume <dir>`` from argv, returning the dir and other arguments."""
     for i, arg in enumerate(argv):
         if arg == "--resume":
-            if i + 1 >= len(argv) or argv[i + 1].startswith("-"):
-                if allow_bare:
-                    return True, argv[:i] + argv[i + 1 :]
+            if i + 1 >= len(argv):
                 raise SystemExit(
                     f"--resume needs an output dir: uv run {command} --resume <dir>"
                 )

--- a/verifiers/v1/cli/resume.py
+++ b/verifiers/v1/cli/resume.py
@@ -17,11 +17,18 @@ def distribute(
     return counts
 
 
-def split_resume(argv: list[str], command: str) -> tuple[Path | None, list[str]]:
-    """Pull ``--resume <dir>`` from argv, returning the dir and other arguments."""
+def split_resume(
+    argv: list[str], command: str, *, allow_bare: bool = False
+) -> tuple[Path | bool | None, list[str]]:
+    """Pull ``--resume [<dir>]`` from argv, returning the dir and other arguments.
+
+    With ``allow_bare``, a ``--resume`` without a value returns ``True`` — the caller
+    resolves the run dir from the remaining arguments (e.g. ``--run.name``)."""
     for i, arg in enumerate(argv):
         if arg == "--resume":
-            if i + 1 >= len(argv):
+            if i + 1 >= len(argv) or argv[i + 1].startswith("-"):
+                if allow_bare:
+                    return True, argv[:i] + argv[i + 1 :]
                 raise SystemExit(
                     f"--resume needs an output dir: uv run {command} --resume <dir>"
                 )

--- a/verifiers/v1/cli/validate.py
+++ b/verifiers/v1/cli/validate.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 
 RESULTS_FILE = "results.jsonl"
 SUMMARY_FILE = "summary.json"
-LOG_FILE = "validate.log"
+LOG_FILE = "logs/validate.log"
 FINAL_REASONS = frozenset({"valid", "invalid"})
 REASONS = ("valid", "invalid", "error", "timeout")
 

--- a/verifiers/v1/cli/validate.py
+++ b/verifiers/v1/cli/validate.py
@@ -4,9 +4,9 @@ import asyncio
 import contextlib
 import json
 import logging
+import shutil
 import sys
 import time
-import tomllib
 from collections import Counter, defaultdict
 from collections.abc import Mapping, Sequence
 from pathlib import Path
@@ -18,7 +18,7 @@ from pydantic_core import from_json
 
 import verifiers.v1 as vf
 from verifiers.v1.cli.dashboard import TaskProgress, validate_dashboard
-from verifiers.v1.cli.output import CONFIG_FILE, write_config
+from verifiers.v1.cli.output import write_config
 from verifiers.v1.cli.resolve import (
     extract_id,
     narrow_taskset_config,
@@ -26,7 +26,7 @@ from verifiers.v1.cli.resolve import (
     references_config_file,
     with_positional_taskset,
 )
-from verifiers.v1.cli.resume import distribute, split_resume
+from verifiers.v1.cli.resume import distribute
 from verifiers.v1.configs.cli.validate import ValidateConfig
 from verifiers.v1.runtimes import make_runtime
 from verifiers.v1.state import state_cls
@@ -51,7 +51,7 @@ ResultRow = dict[str, Any]
 USAGE = (
     "usage: uv run validate [<taskset-id>] [--only-setup | --only-gold] "
     "[-o <output-dir>] [--runtime.type subprocess] [options] [@ file.toml]\n"
-    "       uv run validate --resume <output-dir>\n"
+    "       uv run validate @ <run-dir>/config.toml --resume   (re-run missing/errored/timed-out tasks)\n"
     "       runs persisted gold and setup-only checks per task (no model)"
 )
 
@@ -72,9 +72,10 @@ def validation_mode(config: ValidateConfig) -> str:
 
 
 def output_path(config: ValidateConfig) -> Path:
-    if config.output_dir is not None:
-        return config.output_dir
-    return Path("outputs") / f"{config.name}--validate" / config.uuid
+    """Where this run writes: `output_dir / run.dir` — the same grouping convention as
+    eval and training."""
+    assert config.run.dir is not None
+    return config.output_dir / config.run.dir
 
 
 def _write_rows(path: Path, rows: Sequence[ResultRow]) -> None:
@@ -194,18 +195,6 @@ def save_run(config: ValidateConfig, results_dir: Path, total: int) -> None:
     write_config(config, results_dir)
     (results_dir / RESULTS_FILE).write_text("")
     write_summary(results_dir, summarize([], total, validation_mode(config)))
-
-
-def load_resume_config(resume_dir: Path) -> ValidateConfig:
-    path = resume_dir / CONFIG_FILE
-    if not path.exists():
-        raise SystemExit(
-            f"--resume: no config.toml in {resume_dir} - not a validate output dir"
-        )
-    config = ValidateConfig.model_validate(tomllib.loads(path.read_text()))
-    config.resume = resume_dir
-    config.output_dir = resume_dir
-    return config
 
 
 def _classify(valid: bool, exc: BaseException | None) -> str:
@@ -385,7 +374,7 @@ async def run_validate(config: ValidateConfig) -> list[dict]:
     checks = "gold+setup" if mode == "all" else mode
     out = output_path(config)
     selected_keys = [task.hash for task in tasks]
-    if config.resume is None:
+    if not config.resume:
         save_run(config, out, len(tasks))
         rows: list[ResultRow] = []
         counts = [1] * len(tasks)
@@ -400,7 +389,7 @@ async def run_validate(config: ValidateConfig) -> list[dict]:
     ]
     logger.info(
         "%s %d/%d task(s) from %s on the %s runtime (%s)",
-        "resuming" if config.resume is not None else "validating",
+        "resuming" if config.resume else "validating",
         len(plan),
         len(tasks),
         config.name,
@@ -480,28 +469,31 @@ def main(argv: list[str] | None = None) -> None:
         with plugin_errors():
             cli(_narrow(argv))  # full option help, narrowed to the given taskset
         return
-    resume_dir, rest = split_resume(argv, "validate")
-    if resume_dir is not None:
-        if rest:
-            raise SystemExit(
-                f"{USAGE}\n--resume replays the saved config and takes no other arguments"
-            )
-        with plugin_errors():
-            config = load_resume_config(resume_dir)
-    else:
-        if not extract_id(argv, "taskset") and not references_config_file(argv):
-            raise SystemExit(
-                USAGE
-            )  # need a taskset (positional / --taskset.id) or a @ file.toml
+    if not extract_id(argv, "taskset") and not references_config_file(argv):
+        raise SystemExit(
+            USAGE
+        )  # need a taskset (positional / --taskset.id) or a @ file.toml
 
-        with plugin_errors():
-            config_type = _narrow(argv)
-            sys.argv = [
-                sys.argv[0],
-                *argv,
-            ]  # let prime-pydantic-config render help/errors
-            config = cli(config_type)
+    with plugin_errors():
+        config_type = _narrow(argv)
+        sys.argv = [
+            sys.argv[0],
+            *argv,
+        ]  # let prime-pydantic-config render help/errors
+        config = cli(config_type)
     out = output_path(config)
+    # A named run directory is re-entered only by `--resume` or wiped by `--clean`: any
+    # other write into it would overwrite the previous run's results.
+    if config.clean and not config.resume and out.exists():
+        if not out.resolve().is_relative_to(config.output_dir.resolve()):
+            raise SystemExit("--clean requires run.dir to remain under output_dir")
+        shutil.rmtree(out)
+    results_file = out / RESULTS_FILE
+    if not config.resume and results_file.exists() and results_file.stat().st_size > 0:
+        raise SystemExit(
+            f"run directory {out} already contains results - append --resume to re-run "
+            "its missing/errored tasks, overwrite it with --clean, or pick another --run.name"
+        )
     setup_logging(
         "DEBUG" if config.verbose else "INFO",
         log_file=str(out / LOG_FILE),

--- a/verifiers/v1/cli/validate.py
+++ b/verifiers/v1/cli/validate.py
@@ -192,7 +192,7 @@ def write_summary(results_dir: Path, summary: Mapping[str, Any]) -> None:
 
 
 def save_run(config: ValidateConfig, results_dir: Path, total: int) -> None:
-    write_config(config, results_dir)
+    write_config(config, results_dir, "validate.toml")
     (results_dir / RESULTS_FILE).write_text("")
     write_summary(results_dir, summarize([], total, validation_mode(config)))
 

--- a/verifiers/v1/cli/validate.py
+++ b/verifiers/v1/cli/validate.py
@@ -192,7 +192,7 @@ def write_summary(results_dir: Path, summary: Mapping[str, Any]) -> None:
 
 
 def save_run(config: ValidateConfig, results_dir: Path, total: int) -> None:
-    write_config(config, results_dir, "validate.toml")
+    write_config(config, results_dir, "validate.json")
     (results_dir / RESULTS_FILE).write_text("")
     write_summary(results_dir, summarize([], total, validation_mode(config)))
 

--- a/verifiers/v1/configs/cli/eval.py
+++ b/verifiers/v1/configs/cli/eval.py
@@ -27,9 +27,10 @@ def default_run_name(env: EnvConfig, model: str) -> str:
         name = f"{env_name(env.id)}+{name}"
     # Every seat's resolved harness, distinct, in role order.
     harness = "+".join(dict.fromkeys(h.name for h in env.agent_harnesses().values()))
-    return (
+    slug = (
         f"{name}--{model.replace('/', '--')}--{harness or 'default'}--{uuid4().hex[:8]}"
     )
+    return slug.lower()
 
 
 class RunConfig(BaseConfig):
@@ -40,9 +41,7 @@ class RunConfig(BaseConfig):
     """Run directory name — the run writes to `output_dir / dir`. Defaults to `run.name`;
     set it only when the directory should differ from the display name."""
 
-    # Not config: the id is minted per process (never user-set) and stamped on traces
-    # and the platform upload. TODO: fetch it from the Prime SDK once runs are
-    # registered there.
+    # TODO: fetch the id from the Prime SDK once runs are registered there.
     _id: str = PrivateAttr(default_factory=lambda: str(uuid4()))
 
     @property
@@ -94,6 +93,9 @@ class EvalConfig(BaseConfig):
     dry_run: bool = Field(False, exclude=True)
     """Resolve + validate the config and dump it, then exit. Excluded from the saved
     config so re-running `@ config.toml` (or resuming/replaying the dir) actually runs."""
+    clean: bool = Field(False, exclude=True)
+    """Delete the run directory (`output_dir / run.dir`) before running, overwriting a
+    previous run's results. Excluded from the saved config."""
     rich: bool = True
     """Show a live dashboard instead of per-rollout logs (in-process only; an unset
     `rich` defaults off under `--server`)."""

--- a/verifiers/v1/configs/cli/eval.py
+++ b/verifiers/v1/configs/cli/eval.py
@@ -16,8 +16,9 @@ from verifiers.v1.utils.install import env_name
 
 
 def default_run_name(env: EnvConfig, model: str) -> str:
-    """The auto-generated run name: `<env>--<model>--<harness>`, a descriptive leaf
-    for the run directory `output_dir / run.name`."""
+    """The auto-generated run name: `<env>--<model>--<harness>--<short-id>`, a
+    descriptive leaf for the run directory `output_dir / run.name`. The short-id
+    suffix keeps repeated invocations from colliding."""
     taskset = env.taskset
     name = taskset.name if taskset.id else "no-taskset"
     if taskset.id and env.id:
@@ -26,13 +27,18 @@ def default_run_name(env: EnvConfig, model: str) -> str:
         name = f"{env_name(env.id)}+{name}"
     # Every seat's resolved harness, distinct, in role order.
     harness = "+".join(dict.fromkeys(h.name for h in env.agent_harnesses().values()))
-    return f"{name}--{model.replace('/', '--')}--{harness or 'default'}"
+    return (
+        f"{name}--{model.replace('/', '--')}--{harness or 'default'}--{uuid4().hex[:8]}"
+    )
 
 
 class RunConfig(BaseConfig):
     name: str | None = None
-    """Run name — the run writes to `output_dir / name`. Auto-generated as
-    `<env>--<model>--<harness>` when unset."""
+    """Run name. Auto-generated as `<env>--<model>--<harness>--<short-id>` when unset."""
+
+    dir: str | None = None
+    """Run directory name — the run writes to `output_dir / dir`. Defaults to `run.name`;
+    set it only when the directory should differ from the display name."""
 
     # Not config: the id is minted per process (never user-set) and stamped on traces
     # and the platform upload. TODO: fetch it from the Prime SDK once runs are
@@ -145,4 +151,6 @@ class EvalConfig(BaseConfig):
     def auto_setup_run_name(self):
         if self.run.name is None:
             self.run.name = default_run_name(self.env, self.model)
+        if self.run.dir is None:
+            self.run.dir = self.run.name
         return self

--- a/verifiers/v1/configs/cli/eval.py
+++ b/verifiers/v1/configs/cli/eval.py
@@ -111,10 +111,11 @@ class EvalConfig(BaseConfig):
     )
     """Directory that groups related runs. The run itself (config.toml + traces.jsonl)
     writes to `output_dir / run.name`."""
-    resume: Path | None = Field(None, exclude=True)
-    """Set by `--resume <dir>`: re-run missing or errored rollouts, appending to that
-    run's own results. The run's saved config is loaded verbatim, so `--resume` takes
-    no other arguments. Excluded from the saved config."""
+    resume: bool = Field(False, exclude=True)
+    """Re-run the run's missing/errored rollouts in place instead of starting fresh. The
+    run dir comes from the resolved config (`output_dir / run.dir`), so resume with the
+    run's own config — e.g. `uv run eval @ <run-dir>/config.toml --resume`. Excluded
+    from the saved config."""
 
     @model_validator(mode="after")
     def reject_rich_with_server(self):

--- a/verifiers/v1/configs/cli/eval.py
+++ b/verifiers/v1/configs/cli/eval.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from uuid import uuid4
 
-from pydantic import AliasChoices, Field, SerializeAsAny, model_validator
+from pydantic import AliasChoices, Field, PrivateAttr, SerializeAsAny, model_validator
 from pydantic_config import BaseConfig
 
 from verifiers.v1.clients import ClientConfig, EvalClientConfig
@@ -12,6 +12,36 @@ from verifiers.v1.configs.env import EnvConfig
 from verifiers.v1.configs.serve import ServeConfig
 from verifiers.v1.envs.single_agent import SingleAgentEnvConfig
 from verifiers.v1.types import SamplingConfig
+from verifiers.v1.utils.install import env_name
+
+
+def default_run_name(env: EnvConfig, model: str) -> str:
+    """The auto-generated run name: `<env>--<model>--<harness>`, a descriptive leaf
+    for the run directory `output_dir / run.name`."""
+    taskset = env.taskset
+    name = taskset.name if taskset.id else "no-taskset"
+    if taskset.id and env.id:
+        # Same compounding as `EnvConfig.env_id`: a `best-of-n+gsm8k` run must
+        # not share a name with a plain `gsm8k` one.
+        name = f"{env_name(env.id)}+{name}"
+    # Every seat's resolved harness, distinct, in role order.
+    harness = "+".join(dict.fromkeys(h.name for h in env.agent_harnesses().values()))
+    return f"{name}--{model.replace('/', '--')}--{harness or 'default'}"
+
+
+class RunConfig(BaseConfig):
+    name: str | None = None
+    """Run name — the run writes to `output_dir / name`. Auto-generated as
+    `<env>--<model>--<harness>` when unset."""
+
+    # Not config: the id is minted per process (never user-set) and stamped on traces
+    # and the platform upload. TODO: fetch it from the Prime SDK once runs are
+    # registered there.
+    _id: str = PrivateAttr(default_factory=lambda: str(uuid4()))
+
+    @property
+    def id(self) -> str:
+        return self._id
 
 
 class EvalConfig(BaseConfig):
@@ -21,9 +51,9 @@ class EvalConfig(BaseConfig):
     serve: ServeConfig = ServeConfig()
     """How the env is hosted under `--server`: the worker pool, each worker's episode
     bound. Ignored by an in-process run."""
-    uuid: str = Field(default_factory=lambda: str(uuid4()), exclude=True)
-    """Auto-generated run id — the leaf of the output dir, so runs never overwrite.
-    Excluded from the saved config so re-running `@ config.toml` lands in a fresh dir."""
+    run: RunConfig = Field(default_factory=RunConfig)
+    """Run identity: `run.name` names the run directory under `output_dir`, `run.id` is
+    stamped on traces."""
     model: str = Field(
         "deepseek/deepseek-v4-flash", validation_alias=AliasChoices("model", "m")
     )
@@ -68,11 +98,11 @@ class EvalConfig(BaseConfig):
     """Upload the finished run to the Prime Intellect platform (the private Evaluations
     tab) at the end of the eval. On by default; disable with `--no-push`. Needs
     `$PRIME_API_KEY` or `prime login`."""
-    output_dir: Path | None = Field(
-        None, validation_alias=AliasChoices("output_dir", "o")
+    output_dir: Path = Field(
+        Path("outputs"), validation_alias=AliasChoices("output_dir", "o")
     )
-    """Where to write the run (config.toml + traces.jsonl). None = a fresh per-run dir
-    under `outputs/<env>--<model>--<harness>/<uuid>` (so runs never overwrite each other)."""
+    """Directory that groups related runs. The run itself (config.toml + traces.jsonl)
+    writes to `output_dir / run.name`."""
     resume: Path | None = Field(None, exclude=True)
     """Set by `--resume <dir>`: re-run missing or errored rollouts, appending to that
     run's own results. The run's saved config is loaded verbatim, so `--resume` takes
@@ -110,3 +140,9 @@ class EvalConfig(BaseConfig):
     @classmethod
     def _resolve_env(cls, data):
         return resolve_env_field(data, narrowed_env_annotation(cls))
+
+    @model_validator(mode="after")
+    def auto_setup_run_name(self):
+        if self.run.name is None:
+            self.run.name = default_run_name(self.env, self.model)
+        return self

--- a/verifiers/v1/configs/cli/validate.py
+++ b/verifiers/v1/configs/cli/validate.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 from pydantic import AliasChoices, Field, SerializeAsAny, model_validator
 from pydantic_config import BaseConfig
 
+from verifiers.v1.configs.cli.eval import RunConfig
 from verifiers.v1.configs.taskset import TasksetConfig
 from verifiers.v1.runtimes import PrimeConfig, RuntimeConfig
 
@@ -19,9 +20,9 @@ class CheckTimeoutConfig(BaseConfig):
 
 
 class ValidateConfig(BaseConfig):
-    uuid: str = Field(default_factory=lambda: str(uuid4()), exclude=True)
-    """Auto-generated run id — the default output directory leaf. Excluded from the
-    saved config so re-running it starts a fresh run."""
+    run: RunConfig = Field(default_factory=RunConfig)
+    """Run identity: `run.name` auto-generates as `<taskset>--validate--<short-id>` and
+    names the run directory under `output_dir`."""
     taskset: SerializeAsAny[TasksetConfig] = TasksetConfig()
     runtime: RuntimeConfig = PrimeConfig()
     """Where each task's validation hooks run."""
@@ -46,18 +47,31 @@ class ValidateConfig(BaseConfig):
     """Log at debug level instead of the default info."""
     rich: bool = True
     """Show a live dashboard (one row per task) instead of per-task log lines."""
-    output_dir: Path | None = Field(
-        None, validation_alias=AliasChoices("output_dir", "o")
+    output_dir: Path = Field(
+        Path("outputs"), validation_alias=AliasChoices("output_dir", "o")
     )
-    """Where to write config.toml, results.jsonl, summary.json, and validate.log. None
-    creates a fresh run under outputs/<taskset>--validate/<uuid>."""
-    resume: Path | None = Field(None, exclude=True)
-    """Set by --resume: re-run missing, errored, and timed-out tasks in this directory.
-    The saved config is replayed verbatim, so resume takes no other arguments."""
+    """Directory that groups related runs. The run (config.toml, results.jsonl,
+    summary.json, validate.log) writes to `output_dir / run.dir`."""
+    resume: bool = Field(False, exclude=True)
+    """Re-run the run's missing, errored, and timed-out tasks in place. The run dir comes
+    from the resolved config (`output_dir / run.dir`), so resume with the run's own
+    config — e.g. `uv run validate @ <run-dir>/config.toml --resume`. Excluded from the
+    saved config."""
+    clean: bool = Field(False, exclude=True)
+    """Delete the run directory (`output_dir / run.dir`) before running, overwriting a
+    previous run's results. Excluded from the saved config."""
 
     @property
     def name(self) -> str:
         return self.taskset.name
+
+    @model_validator(mode="after")
+    def auto_setup_run_name(self):
+        if self.run.name is None:
+            self.run.name = f"{self.name}--validate--{uuid4().hex[:8]}".lower()
+        if self.run.dir is None:
+            self.run.dir = self.run.name
+        return self
 
     @model_validator(mode="after")
     def _validate_only(self):

--- a/verifiers/v1/gepa/config.py
+++ b/verifiers/v1/gepa/config.py
@@ -9,13 +9,13 @@ always runs in-process, since its adapter protocol is itself synchronous (see
 `GEPAAdapter`)."""
 
 from pathlib import Path
-from uuid import uuid4
 
 from pydantic import AliasChoices, Field, SerializeAsAny, model_validator
 from pydantic_config import BaseConfig
 
 from verifiers.v1.clients import EvalClientConfig
 from verifiers.v1.configs.cli.env import narrowed_env_annotation, resolve_env_field
+from verifiers.v1.configs.cli.eval import RunConfig, default_run_name
 from verifiers.v1.configs.env import EnvConfig
 from verifiers.v1.envs.single_agent import SingleAgentEnvConfig
 from verifiers.v1.types import SamplingConfig
@@ -35,9 +35,9 @@ class GEPAConfig(BaseConfig):
     def _resolve_env(cls, data):
         return resolve_env_field(data, narrowed_env_annotation(cls))
 
-    uuid: str = Field(default_factory=lambda: str(uuid4()), exclude=True)
-    """Auto-generated run id — the leaf of the output dir, so runs never overwrite.
-    Excluded from the saved config so re-running `@ config.toml` lands in a fresh dir."""
+    run: RunConfig = Field(default_factory=RunConfig)
+    """Run identity: `run.name` names the run directory under `output_dir`; auto-generated
+    like an eval's when unset."""
     model: str = Field(
         "deepseek/deepseek-v4-flash", validation_alias=AliasChoices("model", "m")
     )
@@ -75,14 +75,19 @@ class GEPAConfig(BaseConfig):
         128, validation_alias=AliasChoices("max_concurrent", "c")
     )
     """Max rollouts in flight at once, across the whole run."""
-    output_dir: Path | None = Field(
-        None, validation_alias=AliasChoices("output_dir", "o")
+    output_dir: Path = Field(
+        Path("outputs"), validation_alias=AliasChoices("output_dir", "o")
     )
-    """Where to write results (config.toml + the streamed traces.jsonl, alongside GEPA's own
-    candidates.json / run_log.json). None = a fresh per-run dir under
-    `outputs/<env>--<model>--<harness>/<uuid>` (via `output_path`)."""
+    """Directory that groups related runs. The run (config.toml + the streamed traces.jsonl,
+    alongside GEPA's own candidates.json / run_log.json) writes to `output_dir / run.name`."""
     save_results: bool = True
     verbose: bool = Field(False, validation_alias=AliasChoices("verbose", "v"))
     dry_run: bool = Field(False, exclude=True)
     """Resolve + validate the config and dump it, then exit. Excluded from the
     saved config so re-running `@ config.toml` runs for real."""
+
+    @model_validator(mode="after")
+    def auto_setup_run_name(self):
+        if self.run.name is None:
+            self.run.name = default_run_name(self.env, self.model)
+        return self

--- a/verifiers/v1/gepa/config.py
+++ b/verifiers/v1/gepa/config.py
@@ -90,4 +90,6 @@ class GEPAConfig(BaseConfig):
     def auto_setup_run_name(self):
         if self.run.name is None:
             self.run.name = default_run_name(self.env, self.model)
+        if self.run.dir is None:
+            self.run.dir = self.run.name
         return self

--- a/verifiers/v1/gepa/runner.py
+++ b/verifiers/v1/gepa/runner.py
@@ -51,8 +51,8 @@ def run_gepa(env: Env, config: GEPAConfig) -> GEPAResult:
     run_dir = output_path(config) if config.save_results else None
     if run_dir is not None:
         save_config(
-            config, run_dir
-        )  # config.toml + a fresh traces.jsonl (like run_eval)
+            config, run_dir, "gepa.toml"
+        )  # resolved config + a fresh traces.jsonl (like run_eval)
         logger.info("results: %s", run_dir)
 
     # optimize() is synchronous and blocking, so it drives the run from this (main) thread. We

--- a/verifiers/v1/gepa/runner.py
+++ b/verifiers/v1/gepa/runner.py
@@ -51,7 +51,7 @@ def run_gepa(env: Env, config: GEPAConfig) -> GEPAResult:
     run_dir = output_path(config) if config.save_results else None
     if run_dir is not None:
         save_config(
-            config, run_dir, "gepa.toml"
+            config, run_dir, "gepa.json"
         )  # resolved config + a fresh traces.jsonl (like run_eval)
         logger.info("results: %s", run_dir)
 

--- a/verifiers/v1/runtimes/__init__.py
+++ b/verifiers/v1/runtimes/__init__.py
@@ -14,7 +14,12 @@ from verifiers.v1.runtimes.base import (
 )
 from verifiers.v1.runtimes.docker import DockerConfig, DockerRuntime, DockerRuntimeInfo
 from verifiers.v1.runtimes.modal import ModalConfig, ModalRuntime, ModalRuntimeInfo
-from verifiers.v1.runtimes.prime import PrimeConfig, PrimeRuntime, PrimeRuntimeInfo
+from verifiers.v1.runtimes.prime import (
+    PrimeConfig,
+    PrimeRuntime,
+    PrimeRuntimeInfo,
+    set_base_sandbox_labels,
+)
 from verifiers.v1.runtimes.subprocess import (
     SubprocessConfig,
     SubprocessRuntime,
@@ -82,6 +87,7 @@ __all__ = [
     "PrimeConfig",
     "PrimeRuntime",
     "PrimeRuntimeInfo",
+    "set_base_sandbox_labels",
     "ProgramResult",
     "Runtime",
     "RuntimeConfig",

--- a/verifiers/v1/runtimes/__init__.py
+++ b/verifiers/v1/runtimes/__init__.py
@@ -87,7 +87,6 @@ __all__ = [
     "PrimeConfig",
     "PrimeRuntime",
     "PrimeRuntimeInfo",
-    "set_base_sandbox_labels",
     "ProgramResult",
     "Runtime",
     "RuntimeConfig",
@@ -99,4 +98,5 @@ __all__ = [
     "make_runtime",
     "provision_runtime",
     "runtime_is_local",
+    "set_base_sandbox_labels",
 ]

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -10,6 +10,7 @@ import asyncio
 import contextlib
 import logging
 import math
+import os
 import shlex
 import tempfile
 from collections.abc import AsyncIterator
@@ -39,6 +40,14 @@ MAX_LIFETIME = 24 * 60 * 60
 """Prime's fixed cap (seconds) on any sandbox's total lifetime."""
 
 
+def base_labels() -> list[str]:
+    """Sandbox labels injected by the launching process via comma-separated
+    ``VF_SANDBOX_LABELS`` (e.g. a trainer stamps its run name so every sandbox of a
+    run is findable on the platform). Config labels extend these."""
+    raw = os.environ.get("VF_SANDBOX_LABELS", "")
+    return [label for label in (part.strip() for part in raw.split(",")) if label]
+
+
 class PrimeConfig(NetworkPolicyConfig):
     type: Literal["prime"] = "prime"
     image: str = "python:3.11-slim"
@@ -54,7 +63,7 @@ class PrimeConfig(NetworkPolicyConfig):
     region: str | None = None
     """Region to provision in (None = provider-chosen)."""
     labels: list[str] = Field(default_factory=list)
-    """Labels attached to the sandbox."""
+    """Labels attached to the sandbox, extending any base labels from ``VF_SANDBOX_LABELS``."""
     # TaskData.resources uses these units; non-default runtime config values take precedence.
     cpu: float = 1.0
     """CPU cores."""
@@ -175,7 +184,9 @@ class PrimeRuntime(Runtime):
                 sandbox = await self._client.create(
                     CreateSandboxRequest(
                         name=self.name,
-                        labels=self.config.labels,
+                        labels=list(
+                            dict.fromkeys([*base_labels(), *self.config.labels])
+                        ),
                         docker_image=self.config.image,
                         vm=self.config.vm,
                         guaranteed=self.config.guaranteed,

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -10,7 +10,6 @@ import asyncio
 import contextlib
 import logging
 import math
-import os
 import shlex
 import tempfile
 from collections.abc import AsyncIterator
@@ -40,12 +39,16 @@ MAX_LIFETIME = 24 * 60 * 60
 """Prime's fixed cap (seconds) on any sandbox's total lifetime."""
 
 
-def base_labels() -> list[str]:
-    """Sandbox labels injected by the launching process via comma-separated
-    ``VF_SANDBOX_LABELS`` (e.g. a trainer stamps its run name so every sandbox of a
-    run is findable on the platform). Config labels extend these."""
-    raw = os.environ.get("VF_SANDBOX_LABELS", "")
-    return [label for label in (part.strip() for part in raw.split(",")) if label]
+_base_labels: list[str] = []
+
+
+def set_base_sandbox_labels(labels: list[str]) -> None:
+    """Set process-wide base labels attached to every Prime sandbox, extended by each
+    runtime's ``PrimeConfig.labels``. Call it in the process that creates the sandboxes
+    (env-server workers set it via their setup hook) — e.g. a trainer stamps its run
+    name so every sandbox of a run is findable on the platform."""
+    global _base_labels
+    _base_labels = list(labels)
 
 
 class PrimeConfig(NetworkPolicyConfig):
@@ -63,7 +66,7 @@ class PrimeConfig(NetworkPolicyConfig):
     region: str | None = None
     """Region to provision in (None = provider-chosen)."""
     labels: list[str] = Field(default_factory=list)
-    """Labels attached to the sandbox, extending any base labels from ``VF_SANDBOX_LABELS``."""
+    """Labels attached to the sandbox, extending any process-wide base labels (see ``set_base_sandbox_labels``)."""
     # TaskData.resources uses these units; non-default runtime config values take precedence.
     cpu: float = 1.0
     """CPU cores."""
@@ -185,7 +188,7 @@ class PrimeRuntime(Runtime):
                     CreateSandboxRequest(
                         name=self.name,
                         labels=list(
-                            dict.fromkeys([*base_labels(), *self.config.labels])
+                            dict.fromkeys([*_base_labels, *self.config.labels])
                         ),
                         docker_image=self.config.image,
                         vm=self.config.vm,

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -39,7 +39,7 @@ MAX_LIFETIME = 24 * 60 * 60
 """Prime's fixed cap (seconds) on any sandbox's total lifetime."""
 
 
-_base_labels: list[str] = []
+BASE_LABELS: list[str] = []
 
 
 def set_base_sandbox_labels(labels: list[str]) -> None:
@@ -47,8 +47,8 @@ def set_base_sandbox_labels(labels: list[str]) -> None:
     runtime's ``PrimeConfig.labels``. Call it in the process that creates the sandboxes
     (env-server workers set it via their setup hook) — e.g. a trainer stamps its run
     name so every sandbox of a run is findable on the platform."""
-    global _base_labels
-    _base_labels = list(labels)
+    global BASE_LABELS
+    BASE_LABELS = list(labels)
 
 
 class PrimeConfig(NetworkPolicyConfig):
@@ -187,9 +187,7 @@ class PrimeRuntime(Runtime):
                 sandbox = await self._client.create(
                     CreateSandboxRequest(
                         name=self.name,
-                        labels=list(
-                            dict.fromkeys([*_base_labels, *self.config.labels])
-                        ),
+                        labels=list(dict.fromkeys([*BASE_LABELS, *self.config.labels])),
                         docker_image=self.config.image,
                         vm=self.config.vm,
                         guaranteed=self.config.guaranteed,

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -146,7 +146,7 @@ class EvalRunInfo(BaseModel):
 
     id: str
     name: str | None = None
-    """Human-readable run name, consumer-stamped (e.g. the trainer's run directory name)."""
+    """Human-readable run name, consumer-stamped."""
     step: int | None = None
 
 
@@ -155,7 +155,7 @@ class TrainRunInfo(BaseModel):
 
     id: str
     name: str | None = None
-    """Human-readable run name, consumer-stamped (e.g. the trainer's run directory name)."""
+    """Human-readable run name, consumer-stamped."""
     step: int | None = None
 
 

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -145,6 +145,8 @@ class EvalRunInfo(BaseModel):
     type: Literal["eval"] = "eval"
 
     id: str
+    name: str | None = None
+    """Human-readable run name, consumer-stamped (e.g. the trainer's run directory name)."""
     step: int | None = None
 
 
@@ -152,6 +154,8 @@ class TrainRunInfo(BaseModel):
     type: Literal["train"] = "train"
 
     id: str
+    name: str | None = None
+    """Human-readable run name, consumer-stamped (e.g. the trainer's run directory name)."""
     step: int | None = None
 
 

--- a/verifiers/v1/utils/platform.py
+++ b/verifiers/v1/utils/platform.py
@@ -234,7 +234,7 @@ def push_traces(
     num_examples = len({t.task.data.idx for t in traces})
     metadata = {
         "framework": "verifiers",
-        "run_id": config.uuid,
+        "run_id": config.run.id,
         "model": config.model,
         "num_examples": num_examples,
         "rollouts_per_example": config.num_rollouts,
@@ -284,7 +284,7 @@ def push_traces(
             eval_id = post(
                 "/evaluations/",
                 {
-                    "name": f"{env_name}--{config.model}--{config.uuid[:8]}",
+                    "name": config.run.name,
                     "environments": [{"id": env_id}],
                     "model_name": config.model,
                     "dataset": env_name,


### PR DESCRIPTION
## Summary

- **Traces retain the run name**: `EvalRunInfo`/`TrainRunInfo` gain an optional `name` next to the id (additive, no version bump); consumers like the prime-rl orchestrator stamp it (companion PrimeIntellect-ai/prime-rl#3268).
- **Run-dir convention everywhere**: eval, GEPA, and validate write to `output_dir / run.dir` with auto-generated, collision-free names (`<env>--<model>--<harness>--<short-id>`, validate: `<taskset>--validate--<short-id>`); `run.dir` defaults to `run.name`. The run id is minted per process, never a config field.
- **Resolved configs live at `configs/<cli>.json`** inside the run dir (prime-rl's layout). JSON keeps nulls, so the artifact round-trips exactly — explicit-None settings included.
- **One resume model**: `--resume` is a plain flag on the resolved config — resume by re-running the run's own command, typically `uv run eval @ <run-dir>/configs/eval.json --resume`. Eval resume compares digests of the full resolved dumps, which is exact now that the artifact is JSON.
- **Overwrite protection**: a run dir with results refuses a fresh run; `--clean` deletes it first (containment-checked); the guard and `--clean` run before `--dry-run` writes the config.
- **Base sandbox labels**: `set_base_sandbox_labels()` (in `verifiers.v1.runtimes`) sets process-wide labels every Prime sandbox gets, extended by `PrimeConfig.labels`; prime-rl stamps the training run name so a run's sandboxes are findable on the platform.

### Example

```bash
uv run eval gsm8k                     # -> outputs/gsm8k--deepseek--deepseek-v4-flash--rlm--5f820406/
uv run eval gsm8k --run.name my-eval  # -> outputs/my-eval/ (a used run dir blocks)
uv run eval @ outputs/my-eval/configs/eval.json --resume   # re-run missing/errored rollouts
uv run eval gsm8k --run.name my-eval --clean               # overwrite the run dir
```

```jsonc
// outputs/my-eval/configs/eval.json — written by the run, re-runnable via `@ <path>`
// (full resolved dump, nulls included, so it round-trips exactly)
{
  "model": "deepseek/deepseek-v4-flash",
  "num_tasks": 2,
  "max_concurrent": null,
  "env": {"taskset": {"id": "gsm8k"}},
  "run": {"name": "my-eval", "dir": "my-eval"}
}
```

## Breaking

- **Output layout**: eval/GEPA `outputs/<slug>/<uuid>` and validate `outputs/<taskset>--validate/<uuid>` → `<output_dir>/<run_dir>`, with the resolved config at `configs/<cli>.json` instead of `config.toml`; `--output-dir` is now the grouping dir.
- **`--resume <dir>` removed** (eval + validate): `resume` is a bool on the resolved config; eval additionally rejects a changed config by digest.
- **`uuid` config fields removed** (`EvalConfig`, `GEPAConfig`, `ValidateConfig`) — use `run.name` / process-minted `run.id`.

## Verification

Live 2-task reverse-text runs:

- **eval**: completes into `outputs/<run_dir>/` with `configs/eval.json` and `logs/eval.log`; same-name rerun blocks; `@ configs/eval.json --resume` → "nothing to resume"; after deleting one episode line, `--resume` re-runs exactly the 1 owed rollout; `--clean` reruns fresh.
- **digest check**: resume with `-n 3` rejected naming `num_tasks`; a run started with explicit `-c None` stores `"max_concurrent": null` and resumes via the documented command with nothing re-passed.
- **validate** (subprocess runtime): completes with `valid_rate 1.0`; same-name rerun blocks; `@ configs/validate.json --resume` resumes 0/2 owed.
- V1 e2e fixtures updated; ruff green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking output paths, config format, and resume CLI; wrong migration can clobber runs or mix incomparable resumed rollouts if digest checks are bypassed.
> 
> **Overview**
> **Run layout and identity** — Eval, validate, and GEPA now write to `output_dir / run.dir` (auto names like `<env>--<model>--<harness>--<short-id>`) via new **`RunConfig`** (`name`, `dir`, process-minted `id`). Top-level **`uuid`** fields are removed; traces and platform uploads use **`run.id`** and optional **`run.name`**.
> 
> **Saved configs** — Resolved runs persist as full JSON under **`configs/<cli>.json`** (replacing root **`config.toml`**), with nulls kept for exact round-trip. Replay and e2e tests load via **`saved_config_path`**.
> 
> **Resume and safety** — **`--resume <dir>`** is gone: resume is a flag on the saved config (e.g. `uv run eval @ …/configs/eval.json --resume`). Eval compares **`config_digest`** and rejects mismatches. Non-empty run dirs block fresh writes unless **`--resume`** or **`--clean`** (containment-checked); GEPA gets a similar traces guard.
> 
> **Other** — Logs move under **`logs/`**. **`set_base_sandbox_labels`** merges process-wide labels into Prime sandbox creation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca5a0175b798fd78fe09afc056d69a1faf2370fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add run configs with name/dir/id and align resume logic across eval, validate, and replay CLIs
> - Introduces `RunConfig` (name, dir, id) into `EvalConfig`, `ValidateConfig`, and `GEPAConfig`; run name is auto-generated as a slug and the run directory defaults to `outputs/<run.dir>`.
> - Replaces TOML config persistence with JSON under `configs/<name>.json` inside the run directory, enabling exact round-trips and `@`-file usage.
> - Eval, validate, and replay CLIs now enforce non-destructive run directory reuse: `--clean` wipes an existing run dir, `--resume` requires a matching saved config digest, and overwriting an existing results/traces file without either flag is an error.
> - Resume validation compares canonical SHA-256 digests of the resolved config JSON and lists differing top-level keys when they mismatch.
> - Trace metadata (`EvalRunInfo`, `TrainRunInfo`) and platform uploads now include both run `id` and human-readable `name`.
> - Adds `set_base_sandbox_labels` to `PrimeRuntime` so process-wide labels are merged with per-config labels on sandbox creation.
> - Behavioral Change: `output_path` no longer generates a UUID-leafed path; all output now goes under `output_dir / run.dir` derived from the resolved config.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca5a017.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->














