### PR TITLE
Support isolated networking across Docker and rootless Podman

### DIFF
--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -268,7 +268,7 @@ async def serve_in_runtime(
         # Keep provider temp files in the runtime workdir so cleanup removes them.
         assert runtime.info.id is not None
         env["TMPDIR"] = runtime.info.id
-    if runtime.published_port is not None:
+    if exposed and runtime.published_port is not None:
         env["MCP_HOST"] = "0.0.0.0"
     fixed = runtime.published_port if exposed else None
     port_file = None

--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -317,12 +317,23 @@ async def reachable_url(
     runtime; `consumer_is_local` = the consumer can use a host-local URL without a tunnel.
 
     - `colocated` -> localhost (same runtime, in-sandbox or host loopback);
-    - the server runs in a remote sandbox -> its own published URL (`expose`), reachable anywhere;
-    - else it's host-local -> localhost to a local consumer, a host tunnel to a remote one."""
+    - a non-colocated sandbox service -> its published URL (`expose`), when it has one;
+    - a host-local URL -> direct for a local consumer, through a host tunnel for a remote one."""
     if colocated:
         yield f"http://127.0.0.1:{port}"
-    elif not service.is_local:  # in a remote sandbox → it publishes its own port
-        yield await service.expose(port)
+    elif published := await service.expose(port):
+        if consumer_is_local or not service.is_local:
+            yield published
+        else:
+            published_port = urlsplit(published).port
+            if published_port is None:
+                raise ToolsetError(
+                    f"{service.type} runtime exposed an invalid URL: {published}"
+                )
+            async with PrimeTunnel().expose(published_port) as url:
+                yield url
+    elif not service.is_local:
+        raise ToolsetError(f"{service.type} runtime did not expose service port {port}")
     elif consumer_is_local:  # local consumer → localhost, no public tunnel
         yield f"http://127.0.0.1:{port}"
     else:  # remote consumer → a host tunnel publishes the port outward
@@ -365,8 +376,9 @@ async def _serve(
             runtime = harness_runtime
         else:
             runtime = make_runtime(cfg.runtime)
-            await runtime.start()
+            runtime.configure_exposure()
             stack.push_async_callback(runtime.stop)
+            await runtime.start()
         # Only consumers outside the server runtime need its fixed published port. Colocated tools
         # use independent OS-assigned ports, avoiding clashes on the runtime's service port.
         exposed = runtime is not harness_runtime

--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -376,7 +376,6 @@ async def _serve(
             runtime = harness_runtime
         else:
             runtime = make_runtime(cfg.runtime)
-            runtime.configure_exposure()
             stack.push_async_callback(runtime.stop)
             await runtime.start()
         # Only consumers outside the server runtime need its fixed published port. Colocated tools

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -42,9 +42,8 @@ _ENSURE_UV = (
     f"|| {{ {_INSTALL_CURL}; {_DOWNLOAD_UV}; }}"
 )
 
-# The single port a self-publishing runtime (modal/prime) forwards to a public URL for a server
-# hosted in its sandbox. A server placed in such a runtime binds this (on 0.0.0.0) and is reached
-# at the runtime's public URL.
+# The single port a publishing runtime forwards for a server hosted in its sandbox. A server
+# placed in such a runtime binds this (on 0.0.0.0) and is reached at the runtime's exposed URL.
 SERVICE_PORT = 8000
 
 
@@ -365,13 +364,19 @@ class Runtime(ABC):
         """A fixed port this runtime exposes to the outside at startup, declared up front to the
         provider (Modal forwards only ports named at `Sandbox.create`). When set, a server placed
         here binds it instead of a host-chosen free port, and `expose` returns its public URL.
-        `None` for local runtimes (subprocess/docker), which pick a free port."""
+        `None` when this runtime has no port reserved for an exposed service."""
         return None
+
+    def configure_exposure(self) -> None:
+        """Declare before `start` that this runtime will host a non-colocated server.
+
+        Providers that always reserve a service port need no action. A runtime whose
+        forwarding must be selected at container creation can override this hook.
+        """
 
     async def expose(self, port: int) -> str | None:
         """Publish a port running *inside this runtime* to a URL reachable from the host/outside,
-        or None when local. A remote runtime overrides this with the provider's native port
-        exposure (modal `tunnels()`, prime `client.expose`), torn down with the sandbox in
-        `stop()`. The reverse of a host `Tunnel` (interception.tunnel, which reaches a host
-        port from inside a runtime)."""
+        or None when no forwarding is needed. Sandboxes override this with local port mapping
+        or their provider's native exposure, torn down with the runtime in `stop()`. The reverse
+        of a host `Tunnel` (interception.tunnel, which reaches a host port from inside a runtime)."""
         return None

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -42,8 +42,9 @@ _ENSURE_UV = (
     f"|| {{ {_INSTALL_CURL}; {_DOWNLOAD_UV}; }}"
 )
 
-# The single port a publishing runtime forwards for a server hosted in its sandbox. A server
-# placed in such a runtime binds this (on 0.0.0.0) and is reached at the runtime's exposed URL.
+# The single port a self-publishing runtime (modal/prime) forwards to a public URL for a server
+# hosted in its sandbox. A server placed in such a runtime binds this (on 0.0.0.0) and is reached
+# at the runtime's public URL.
 SERVICE_PORT = 8000
 
 
@@ -364,19 +365,12 @@ class Runtime(ABC):
         """A fixed port this runtime exposes to the outside at startup, declared up front to the
         provider (Modal forwards only ports named at `Sandbox.create`). When set, a server placed
         here binds it instead of a host-chosen free port, and `expose` returns its public URL.
-        `None` when this runtime has no port reserved for an exposed service."""
+        `None` for runtimes without a reserved service port."""
         return None
-
-    def configure_exposure(self) -> None:
-        """Declare before `start` that this runtime will host a non-colocated server.
-
-        Providers that always reserve a service port need no action. A runtime whose
-        forwarding must be selected at container creation can override this hook.
-        """
 
     async def expose(self, port: int) -> str | None:
         """Publish a port running *inside this runtime* to a URL reachable from the host/outside,
-        or None when no forwarding is needed. Sandboxes override this with local port mapping
-        or their provider's native exposure, torn down with the runtime in `stop()`. The reverse
-        of a host `Tunnel` (interception.tunnel, which reaches a host port from inside a runtime)."""
+        or None when unavailable. A runtime overrides this with the provider's native port
+        exposure or a local port mapping, torn down with the sandbox in `stop()`. The reverse of
+        a host `Tunnel` (interception.tunnel, which reaches a host port from inside a runtime)."""
         return None

--- a/verifiers/v1/runtimes/docker/__init__.py
+++ b/verifiers/v1/runtimes/docker/__init__.py
@@ -383,9 +383,7 @@ class DockerRuntime(Runtime):
         return f"http://127.0.0.1:{host_port}"
 
     async def prepare_execution(self, routes: list[str] | None) -> None:
-        """Allow the declared framework routes, then leave the proxy as the only route."""
-        if not self.network_restricted:
-            return
+        """Install framework routes, then cut direct egress for restricted runs."""
         assert self._proxy is not None
         if routes is None:
             self._proxy.policy = NetworkPolicy(
@@ -400,8 +398,9 @@ class DockerRuntime(Runtime):
             self.config.allow,
             self.config.block,
             framework,
+            allow_non_global=not self.network_restricted,
         )
-        if self._cut:
+        if not self.network_restricted or self._cut:
             return
         script = r"""
 set -eu

--- a/verifiers/v1/runtimes/docker/__init__.py
+++ b/verifiers/v1/runtimes/docker/__init__.py
@@ -245,7 +245,7 @@ class DockerRuntime(Runtime):
             *options,
             *limits,
             "--workdir",
-            self.config.workdir,
+            "/",
             "--entrypoint",
             "sleep",
             "--name",
@@ -259,6 +259,19 @@ class DockerRuntime(Runtime):
         self.info.id = run.stdout.strip()[
             :12
         ]  # `docker run -d` prints the container id
+        workdir = await docker(
+            "exec",
+            "--user",
+            "0",
+            self._container,
+            "mkdir",
+            "-p",
+            self.config.workdir,
+        )
+        if workdir.exit_code != 0:
+            raise SandboxError(
+                f"could not create container workdir: {workdir.stderr.strip()}"
+            )
 
         # Docker or Podman isolates the container's network. This proxy lets the
         # container reach Verifiers callbacks and enforces restricted egress. It starts

--- a/verifiers/v1/runtimes/docker/__init__.py
+++ b/verifiers/v1/runtimes/docker/__init__.py
@@ -239,9 +239,8 @@ class DockerRuntime(Runtime):
                 "." not in registry and ":" not in registry and registry != "localhost"
             ):
                 image = f"docker.io/{image}"
-        run = await docker(
-            "run",
-            "--detach",
+        create = await docker(
+            "create",
             *options,
             *limits,
             "--workdir",
@@ -253,12 +252,23 @@ class DockerRuntime(Runtime):
             image,
             "infinity",
         )
-        if run.exit_code != 0:
-            raise SandboxError(f"docker run failed: {run.stderr.strip()}")
+        if create.exit_code != 0:
+            raise SandboxError(f"docker create failed: {create.stderr.strip()}")
         self._container = self.name
-        self.info.id = run.stdout.strip()[
-            :12
-        ]  # `docker run -d` prints the container id
+        self.info.id = create.stdout.strip()[:12]
+        network = await docker(
+            "inspect", "--format", "{{.HostConfig.NetworkMode}}", self._container
+        )
+        if network.exit_code != 0:
+            raise SandboxError(f"docker inspect failed: {network.stderr.strip()}")
+        if network.stdout.strip() == "host":
+            raise SandboxError(
+                "docker runtime requires an isolated network namespace, but the "
+                "container engine selected host networking"
+            )
+        start = await docker("start", self._container)
+        if start.exit_code != 0:
+            raise SandboxError(f"docker start failed: {start.stderr.strip()}")
         workdir = await docker(
             "exec",
             "--user",
@@ -319,8 +329,8 @@ class DockerRuntime(Runtime):
                     "DAC_OVERRIDE",
                     "--security-opt",
                     "no-new-privileges",
-                    "--mount",
-                    f"type=bind,source={directory},target=/run/vf",
+                    "--volume",
+                    f"{directory}:/run/vf:Z",
                     "docker.io/library/python:3.11-alpine",
                     "python3",
                     "-c",
@@ -422,18 +432,28 @@ class DockerRuntime(Runtime):
             raise SandboxError(f"docker network cut failed: {cut.stderr.strip()}")
         self._cut = True
 
-    def _proxy_env(self) -> dict[str, str]:
+    def _proxy_env(self, env: dict[str, str]) -> dict[str, str]:
         if self._proxy is None:
             return {}
         host = "127.0.0.1" if sys.platform == "linux" else _PROXY_HOST
         proxy = f"http://verifiers:{self._proxy.token}@{host}:{self._proxy.port}"
+        no_proxy = ",".join(
+            filter(
+                None,
+                (
+                    env.get("NO_PROXY"),
+                    env.get("no_proxy"),
+                    "localhost,127.0.0.1,::1,[::1]",
+                ),
+            )
+        )
         return {
             "HTTP_PROXY": proxy,
             "HTTPS_PROXY": proxy,
             "http_proxy": proxy,
             "https_proxy": proxy,
-            "NO_PROXY": "localhost,127.0.0.1",
-            "no_proxy": "localhost,127.0.0.1",
+            "NO_PROXY": no_proxy,
+            "no_proxy": no_proxy,
         }
 
     async def teardown(self) -> None:
@@ -442,7 +462,7 @@ class DockerRuntime(Runtime):
         await super().teardown()
 
     async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
-        env = {**env, **self._proxy_env()}
+        env = {**env, **self._proxy_env(env)}
         env_args = [arg for k, v in env.items() for arg in ("--env", f"{k}={v}")]
         return await docker(
             "exec", *env_args, "--workdir", self.config.workdir, self._container, *argv
@@ -452,7 +472,7 @@ class DockerRuntime(Runtime):
         self, argv: list[str], env: dict[str, str]
     ) -> RuntimeProcess:
         assert self._container is not None
-        env = {**env, **self._proxy_env()}
+        env = {**env, **self._proxy_env(env)}
         env_args = [
             arg for key, value in env.items() for arg in ("--env", f"{key}={value}")
         ]
@@ -512,7 +532,7 @@ class DockerRuntime(Runtime):
     async def run_background(
         self, argv: list[str], env: dict[str, str], log: str
     ) -> None:
-        env = {**env, **self._proxy_env()}
+        env = {**env, **self._proxy_env(env)}
         env_args = [arg for k, v in env.items() for arg in ("--env", f"{k}={v}")]
         inner = f"{' '.join(shlex.quote(a) for a in argv)} > {shlex.quote(log)} 2>&1"
         run = await docker(

--- a/verifiers/v1/runtimes/docker/__init__.py
+++ b/verifiers/v1/runtimes/docker/__init__.py
@@ -1,4 +1,4 @@
-"""Local Docker runtime with optional execution-time URL filtering."""
+"""Local Docker-compatible runtime with optional execution-time URL filtering."""
 
 import array
 import asyncio
@@ -18,6 +18,7 @@ from urllib.parse import urlsplit
 from verifiers.v1.configs.runtime import NetworkPolicyConfig
 from verifiers.v1.errors import SandboxError
 from verifiers.v1.runtimes.base import (
+    SERVICE_PORT,
     BaseRuntimeInfo,
     ProgramResult,
     Runtime,
@@ -183,8 +184,16 @@ class DockerRuntime(Runtime):
         self._container: str | None = None  # our `--name` (used for exec/rm)
         self._proxy: EgressProxy | None = None
         self._proxy_host_ip: str | None = None
+        self._published_port: int | None = None
         self._stopped = False
         self._cut = False
+
+    @property
+    def published_port(self) -> int | None:
+        return self._published_port
+
+    def configure_exposure(self) -> None:
+        self._published_port = SERVICE_PORT
 
     async def start(self) -> None:
         try:
@@ -198,14 +207,13 @@ class DockerRuntime(Runtime):
             hint = ""
             if "permission denied" in detail.lower():
                 hint = (
-                    "\nYour user isn't in the `docker` group. Either run the command "
-                    'under `sg docker -c "..."`, or add yourself with '
-                    "`sudo usermod -aG docker $USER` and start a new login shell."
+                    "\nThe current user cannot access the configured container engine; "
+                    "check its Docker socket permissions."
                 )
             raise RuntimeError(
-                f"docker runtime selected but the Docker daemon is not reachable: {detail}{hint}"
+                "docker runtime selected but the Docker-compatible engine is not "
+                f"reachable: {detail}{hint}"
             )
-        self._container = self.name
         limits: list[str] = []
         if self.config.cpu is not None:
             limits += ["--cpus", str(self.config.cpu)]
@@ -214,65 +222,98 @@ class DockerRuntime(Runtime):
         _, gpu_count = parse_gpu(self.config.gpu)
         if gpu_count:
             limits += ["--gpus", str(gpu_count)]
-        restricted = self.network_restricted
-        if restricted:
-            network = [
-                "--network",
-                "bridge",
+        options: list[str] = []
+        if self.published_port is not None:
+            options += ["--publish", f"127.0.0.1::{self.published_port}"]
+        if self.network_restricted:
+            options += [
                 "--cap-drop",
                 "NET_ADMIN",
                 "--cap-drop",
                 "NET_RAW",
                 "--security-opt",
                 "no-new-privileges",
-                "--sysctl",
-                "net.ipv6.conf.all.disable_ipv6=1",
             ]
-            if sys.platform != "linux":
-                network += ["--add-host", f"{_PROXY_HOST}:host-gateway"]
-        else:
-            network = ["--network", "host"]
+        if sys.platform != "linux":
+            options += ["--add-host", f"{_PROXY_HOST}:host-gateway"]
+        image = self.config.image
+        if (await docker("image", "inspect", image)).exit_code != 0:
+            registry, separator, _ = image.partition("/")
+            if not separator:
+                image = f"docker.io/library/{image}"
+            elif (
+                "." not in registry and ":" not in registry and registry != "localhost"
+            ):
+                image = f"docker.io/{image}"
         run = await docker(
             "run",
             "--detach",
-            *network,
+            *options,
             *limits,
             "--workdir",
-            self.config.workdir,
+            "/",
             "--entrypoint",
             "sleep",
             "--name",
-            self._container,
-            self.config.image,
+            self.name,
+            image,
             "infinity",
         )
         if run.exit_code != 0:
             raise SandboxError(f"docker run failed: {run.stderr.strip()}")
+        self._container = self.name
         self.info.id = run.stdout.strip()[
             :12
         ]  # `docker run -d` prints the container id
-        if restricted:
-            # Setup is trusted; colocated servers fetch their task from host interception
-            # before the final framework routes are known.
-            self._proxy = EgressProxy(
-                NetworkPolicy(["*"], [], [HOST_ALIAS], allow_non_global=True)
+        workdir = await docker(
+            "exec",
+            "--user",
+            "0",
+            self._container,
+            "mkdir",
+            "-p",
+            self.config.workdir,
+        )
+        if workdir.exit_code != 0:
+            raise SandboxError(
+                f"could not create container workdir: {workdir.stderr.strip()}"
             )
-            if sys.platform == "linux":
-                await self._proxy.start(listener=await self._container_listener())
-            else:
-                host = await docker(
-                    "exec",
-                    self._container,
-                    "sh",
-                    "-c",
-                    f"awk '$2 == \"{_PROXY_HOST}\" {{ print $1; exit }}' /etc/hosts",
+        network = await docker(
+            "inspect", "--format", "{{.HostConfig.NetworkMode}}", self._container
+        )
+        if network.exit_code != 0:
+            raise SandboxError(
+                f"could not inspect container network: {network.stderr.strip()}"
+            )
+        if network.stdout.strip() == "host":
+            await self.stop()
+            raise SandboxError(
+                "container engine selected host networking by default; configure an "
+                "isolated default network (for rootless Podman, install or enable pasta)"
+            )
+
+        # Docker or Podman isolates the container's network. This proxy lets the
+        # container reach Verifiers callbacks and enforces restricted egress. It starts
+        # open during setup, then prepare_execution() applies the final network policy.
+        self._proxy = EgressProxy(
+            NetworkPolicy(["*"], [], [HOST_ALIAS], allow_non_global=True)
+        )
+        if sys.platform == "linux":
+            await self._proxy.start(listener=await self._container_listener())
+        else:
+            host = await docker(
+                "exec",
+                self._container,
+                "sh",
+                "-c",
+                f"awk '$2 == \"{_PROXY_HOST}\" {{ print $1; exit }}' /etc/hosts",
+            )
+            self._proxy_host_ip = host.stdout.strip()
+            if host.exit_code != 0 or not self._proxy_host_ip:
+                raise SandboxError(
+                    f"could not resolve {_PROXY_HOST} in container: {host.stderr.strip()}"
                 )
-                self._proxy_host_ip = host.stdout.strip()
-                if host.exit_code != 0 or not self._proxy_host_ip:
-                    raise SandboxError(
-                        f"could not resolve {_PROXY_HOST} in Docker: {host.stderr.strip()}"
-                    )
-                await self._proxy.start("127.0.0.1")
+            await self._proxy.start("127.0.0.1")
         logger.info(
             "docker: started container %s (image=%s)",
             self._container,
@@ -299,7 +340,7 @@ class DockerRuntime(Runtime):
                     "no-new-privileges",
                     "--mount",
                     f"type=bind,source={directory},target=/run/vf",
-                    "python:3.11-alpine",
+                    "docker.io/library/python:3.11-alpine",
                     "python3",
                     "-c",
                     _PASS_LISTENER,
@@ -320,18 +361,26 @@ class DockerRuntime(Runtime):
         return listener
 
     def host_url(self, url: str) -> str:
-        host = urlsplit(url).hostname
-        # Keep numeric loopback container-local; the proxy maps this reserved name to
+        parts = urlsplit(url)
+        host = parts.hostname
+        # Keep numeric loopback container-local. The proxy maps this reserved name to
         # the Verifiers process's loopback for interception and host-local MCP routes.
-        if self.network_restricted and host in ("127.0.0.1", "localhost"):
-            return url.replace(host, HOST_ALIAS, 1)
-        if (
-            not self.network_restricted
-            and sys.platform != "linux"
-            and host in ("127.0.0.1", "localhost")
-        ):
-            return url.replace(host, "host.docker.internal", 1)
+        if host in ("127.0.0.1", "localhost"):
+            userinfo, separator, authority = parts.netloc.rpartition("@")
+            netloc = f"{userinfo}{separator}{HOST_ALIAS}{authority[len(host) :]}"
+            return parts._replace(netloc=netloc).geturl()
         return url
+
+    async def expose(self, port: int) -> str:
+        assert self._container is not None
+        published = await docker("port", self._container, f"{port}/tcp")
+        lines = published.stdout.strip().splitlines()
+        host_port = lines[0].rsplit(":", 1)[-1] if lines else ""
+        if published.exit_code != 0 or not host_port.isdigit():
+            raise SandboxError(
+                f"docker service port {port} was not published: {published.stderr.strip()}"
+            )
+        return f"http://127.0.0.1:{host_port}"
 
     async def prepare_execution(self, routes: list[str] | None) -> None:
         """Allow the declared framework routes, then leave the proxy as the only route."""
@@ -354,25 +403,32 @@ class DockerRuntime(Runtime):
         )
         if self._cut:
             return
-        script = (
-            "set -eu; HOST=$1; "
-            "PORT=$2; "
-            'if [ -n "$HOST" ]; then apk add --no-cache iptables >/dev/null; fi; '
-            "GW=$(ip route show default | awk '/^default via/{print $3; exit}'); "
-            "SUBNET=$(ip route show | awk '/scope link/{print $1; exit}'); "
-            'if [ -n "$HOST" ]; then '
-            'if [ "$HOST" = "$GW" ]; then ip route add "$HOST/32" dev eth0; '
-            'else ip route add "$HOST/32" via "$GW"; '
-            'ip route add "$GW/32" dev eth0; fi; '
-            "fi; "
-            "ip route del default; "
-            'ip route del "$SUBNET" dev eth0; '
-            "ip route add blackhole 127.0.0.11/32 table local; "
-            'if [ -n "$HOST" ]; then iptables -F OUTPUT; '
-            "iptables -A OUTPUT -o lo -j ACCEPT; "
-            'iptables -A OUTPUT -d "$HOST" -p tcp --dport "$PORT" -j ACCEPT; '
-            "iptables -A OUTPUT -j REJECT; fi"
-        )
+        script = r"""
+set -eu
+HOST=$1
+PORT=$2
+if [ -n "$HOST" ]; then
+    apk add --no-cache iptables >/dev/null
+    ROUTE=$(ip -4 route get "$HOST")
+    DEV=$(printf '%s\n' "$ROUTE" | awk '{ for (i = 1; i <= NF; i++) if ($i == "dev") { print $(i + 1); exit } }')
+    GW=$(printf '%s\n' "$ROUTE" | awk '{ for (i = 1; i <= NF; i++) if ($i == "via") { print $(i + 1); exit } }')
+fi
+ip -4 route flush table main
+ip -6 route flush table main || true
+ip route add blackhole 127.0.0.11/32 table local
+if [ -n "$HOST" ]; then
+    if [ -n "$GW" ]; then
+        ip -4 route add "$GW/32" dev "$DEV"
+        ip -4 route add "$HOST/32" via "$GW" dev "$DEV"
+    else
+        ip -4 route add "$HOST/32" dev "$DEV"
+    fi
+    iptables -F OUTPUT
+    iptables -A OUTPUT -o lo -j ACCEPT
+    iptables -A OUTPUT -d "$HOST" -p tcp --dport "$PORT" -j ACCEPT
+    iptables -A OUTPUT -j REJECT
+fi
+"""
         cut = await docker(
             "run",
             "--rm",
@@ -382,7 +438,7 @@ class DockerRuntime(Runtime):
             "ALL",
             "--cap-add",
             "NET_ADMIN",
-            "alpine:3.22",
+            "docker.io/library/alpine:3.22",
             "sh",
             "-c",
             script,
@@ -394,16 +450,21 @@ class DockerRuntime(Runtime):
             raise SandboxError(f"docker network cut failed: {cut.stderr.strip()}")
         self._cut = True
 
-    def _proxy_env(self) -> dict[str, str]:
+    def _proxy_env(self, env: dict[str, str]) -> dict[str, str]:
         if self._proxy is None:
             return {}
         host = "127.0.0.1" if sys.platform == "linux" else _PROXY_HOST
-        proxy = f"http://verifiers:{self._proxy.token}@{host}:{self._proxy.port}"
+        all_proxy = env.get("all_proxy", env.get("ALL_PROXY"))
+        http = env.get("http_proxy", env.get("HTTP_PROXY", all_proxy))
+        https = env.get("https_proxy", env.get("HTTPS_PROXY", all_proxy))
+        no_proxy = env.get("no_proxy", env.get("NO_PROXY"))
+        http_proxy = f"http://verifiers:{self._proxy.token_for(http, no_proxy)}@{host}:{self._proxy.port}"
+        https_proxy = f"http://verifiers:{self._proxy.token_for(https, no_proxy)}@{host}:{self._proxy.port}"
         return {
-            "HTTP_PROXY": proxy,
-            "HTTPS_PROXY": proxy,
-            "http_proxy": proxy,
-            "https_proxy": proxy,
+            "HTTP_PROXY": http_proxy,
+            "HTTPS_PROXY": https_proxy,
+            "http_proxy": http_proxy,
+            "https_proxy": https_proxy,
             "NO_PROXY": "localhost,127.0.0.1",
             "no_proxy": "localhost,127.0.0.1",
         }
@@ -414,7 +475,7 @@ class DockerRuntime(Runtime):
         await super().teardown()
 
     async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
-        env = {**env, **(self._proxy_env() if self._cut else {})}
+        env = {**env, **self._proxy_env(env)}
         env_args = [arg for k, v in env.items() for arg in ("--env", f"{k}={v}")]
         return await docker(
             "exec", *env_args, "--workdir", self.config.workdir, self._container, *argv
@@ -424,7 +485,7 @@ class DockerRuntime(Runtime):
         self, argv: list[str], env: dict[str, str]
     ) -> RuntimeProcess:
         assert self._container is not None
-        env = {**env, **(self._proxy_env() if self._cut else {})}
+        env = {**env, **self._proxy_env(env)}
         env_args = [
             arg for key, value in env.items() for arg in ("--env", f"{key}={value}")
         ]
@@ -484,8 +545,7 @@ class DockerRuntime(Runtime):
     async def run_background(
         self, argv: list[str], env: dict[str, str], log: str
     ) -> None:
-        # Detached servers survive the cut, so they need the initially permissive proxy.
-        env = {**env, **self._proxy_env()}
+        env = {**env, **self._proxy_env(env)}
         env_args = [arg for k, v in env.items() for arg in ("--env", f"{k}={v}")]
         inner = f"{' '.join(shlex.quote(a) for a in argv)} > {shlex.quote(log)} 2>&1"
         run = await docker(

--- a/verifiers/v1/runtimes/docker/__init__.py
+++ b/verifiers/v1/runtimes/docker/__init__.py
@@ -1,4 +1,4 @@
-"""Local Docker-compatible runtime with optional execution-time URL filtering."""
+"""Local Docker runtime with optional execution-time URL filtering."""
 
 import array
 import asyncio
@@ -184,16 +184,12 @@ class DockerRuntime(Runtime):
         self._container: str | None = None  # our `--name` (used for exec/rm)
         self._proxy: EgressProxy | None = None
         self._proxy_host_ip: str | None = None
-        self._published_port: int | None = None
         self._stopped = False
         self._cut = False
 
     @property
     def published_port(self) -> int | None:
-        return self._published_port
-
-    def configure_exposure(self) -> None:
-        self._published_port = SERVICE_PORT
+        return SERVICE_PORT
 
     async def start(self) -> None:
         try:
@@ -207,12 +203,12 @@ class DockerRuntime(Runtime):
             hint = ""
             if "permission denied" in detail.lower():
                 hint = (
-                    "\nThe current user cannot access the configured container engine; "
-                    "check its Docker socket permissions."
+                    "\nYour user isn't in the `docker` group. Either run the command "
+                    'under `sg docker -c "..."`, or add yourself with '
+                    "`sudo usermod -aG docker $USER` and start a new login shell."
                 )
             raise RuntimeError(
-                "docker runtime selected but the Docker-compatible engine is not "
-                f"reachable: {detail}{hint}"
+                f"docker runtime selected but the Docker daemon is not reachable: {detail}{hint}"
             )
         limits: list[str] = []
         if self.config.cpu is not None:
@@ -222,9 +218,7 @@ class DockerRuntime(Runtime):
         _, gpu_count = parse_gpu(self.config.gpu)
         if gpu_count:
             limits += ["--gpus", str(gpu_count)]
-        options: list[str] = []
-        if self.published_port is not None:
-            options += ["--publish", f"127.0.0.1::{self.published_port}"]
+        options = ["--publish", f"127.0.0.1::{SERVICE_PORT}"]
         if self.network_restricted:
             options += [
                 "--cap-drop",
@@ -251,7 +245,7 @@ class DockerRuntime(Runtime):
             *options,
             *limits,
             "--workdir",
-            "/",
+            self.config.workdir,
             "--entrypoint",
             "sleep",
             "--name",
@@ -265,32 +259,6 @@ class DockerRuntime(Runtime):
         self.info.id = run.stdout.strip()[
             :12
         ]  # `docker run -d` prints the container id
-        workdir = await docker(
-            "exec",
-            "--user",
-            "0",
-            self._container,
-            "mkdir",
-            "-p",
-            self.config.workdir,
-        )
-        if workdir.exit_code != 0:
-            raise SandboxError(
-                f"could not create container workdir: {workdir.stderr.strip()}"
-            )
-        network = await docker(
-            "inspect", "--format", "{{.HostConfig.NetworkMode}}", self._container
-        )
-        if network.exit_code != 0:
-            raise SandboxError(
-                f"could not inspect container network: {network.stderr.strip()}"
-            )
-        if network.stdout.strip() == "host":
-            await self.stop()
-            raise SandboxError(
-                "container engine selected host networking by default; configure an "
-                "isolated default network (for rootless Podman, install or enable pasta)"
-            )
 
         # Docker or Podman isolates the container's network. This proxy lets the
         # container reach Verifiers callbacks and enforces restricted egress. It starts
@@ -402,32 +370,24 @@ class DockerRuntime(Runtime):
         )
         if not self.network_restricted or self._cut:
             return
-        script = r"""
-set -eu
-HOST=$1
-PORT=$2
-if [ -n "$HOST" ]; then
-    apk add --no-cache iptables >/dev/null
-    ROUTE=$(ip -4 route get "$HOST")
-    DEV=$(printf '%s\n' "$ROUTE" | awk '{ for (i = 1; i <= NF; i++) if ($i == "dev") { print $(i + 1); exit } }')
-    GW=$(printf '%s\n' "$ROUTE" | awk '{ for (i = 1; i <= NF; i++) if ($i == "via") { print $(i + 1); exit } }')
-fi
-ip -4 route flush table main
-ip -6 route flush table main || true
-ip route add blackhole 127.0.0.11/32 table local
-if [ -n "$HOST" ]; then
-    if [ -n "$GW" ]; then
-        ip -4 route add "$GW/32" dev "$DEV"
-        ip -4 route add "$HOST/32" via "$GW" dev "$DEV"
-    else
-        ip -4 route add "$HOST/32" dev "$DEV"
-    fi
-    iptables -F OUTPUT
-    iptables -A OUTPUT -o lo -j ACCEPT
-    iptables -A OUTPUT -d "$HOST" -p tcp --dport "$PORT" -j ACCEPT
-    iptables -A OUTPUT -j REJECT
-fi
-"""
+        script = (
+            "set -eu; HOST=$1; PORT=$2; "
+            'if [ -n "$HOST" ]; then apk add --no-cache iptables >/dev/null; '
+            'ROUTE=$(ip -4 route get "$HOST"); '
+            "DEV=$(printf '%s\\n' \"$ROUTE\" | awk '{ for (i = 1; i <= NF; i++) "
+            'if ($i == "dev") { print $(i + 1); exit } }\'); '
+            "GW=$(printf '%s\\n' \"$ROUTE\" | awk '{ for (i = 1; i <= NF; i++) "
+            'if ($i == "via") { print $(i + 1); exit } }\'); fi; '
+            "ip -4 route flush table main; ip -6 route flush table main || true; "
+            "ip route add blackhole 127.0.0.11/32 table local; "
+            'if [ -n "$HOST" ]; then if [ -n "$GW" ]; then '
+            'ip -4 route add "$GW/32" dev "$DEV"; '
+            'ip -4 route add "$HOST/32" via "$GW" dev "$DEV"; '
+            'else ip -4 route add "$HOST/32" dev "$DEV"; fi; '
+            "iptables -F OUTPUT; iptables -A OUTPUT -o lo -j ACCEPT; "
+            'iptables -A OUTPUT -d "$HOST" -p tcp --dport "$PORT" -j ACCEPT; '
+            "iptables -A OUTPUT -j REJECT; fi"
+        )
         cut = await docker(
             "run",
             "--rm",
@@ -449,21 +409,16 @@ fi
             raise SandboxError(f"docker network cut failed: {cut.stderr.strip()}")
         self._cut = True
 
-    def _proxy_env(self, env: dict[str, str]) -> dict[str, str]:
+    def _proxy_env(self) -> dict[str, str]:
         if self._proxy is None:
             return {}
         host = "127.0.0.1" if sys.platform == "linux" else _PROXY_HOST
-        all_proxy = env.get("all_proxy", env.get("ALL_PROXY"))
-        http = env.get("http_proxy", env.get("HTTP_PROXY", all_proxy))
-        https = env.get("https_proxy", env.get("HTTPS_PROXY", all_proxy))
-        no_proxy = env.get("no_proxy", env.get("NO_PROXY"))
-        http_proxy = f"http://verifiers:{self._proxy.token_for(http, no_proxy)}@{host}:{self._proxy.port}"
-        https_proxy = f"http://verifiers:{self._proxy.token_for(https, no_proxy)}@{host}:{self._proxy.port}"
+        proxy = f"http://verifiers:{self._proxy.token}@{host}:{self._proxy.port}"
         return {
-            "HTTP_PROXY": http_proxy,
-            "HTTPS_PROXY": https_proxy,
-            "http_proxy": http_proxy,
-            "https_proxy": https_proxy,
+            "HTTP_PROXY": proxy,
+            "HTTPS_PROXY": proxy,
+            "http_proxy": proxy,
+            "https_proxy": proxy,
             "NO_PROXY": "localhost,127.0.0.1",
             "no_proxy": "localhost,127.0.0.1",
         }
@@ -474,7 +429,7 @@ fi
         await super().teardown()
 
     async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
-        env = {**env, **self._proxy_env(env)}
+        env = {**env, **self._proxy_env()}
         env_args = [arg for k, v in env.items() for arg in ("--env", f"{k}={v}")]
         return await docker(
             "exec", *env_args, "--workdir", self.config.workdir, self._container, *argv
@@ -484,7 +439,7 @@ fi
         self, argv: list[str], env: dict[str, str]
     ) -> RuntimeProcess:
         assert self._container is not None
-        env = {**env, **self._proxy_env(env)}
+        env = {**env, **self._proxy_env()}
         env_args = [
             arg for key, value in env.items() for arg in ("--env", f"{key}={value}")
         ]
@@ -544,7 +499,7 @@ fi
     async def run_background(
         self, argv: list[str], env: dict[str, str], log: str
     ) -> None:
-        env = {**env, **self._proxy_env(env)}
+        env = {**env, **self._proxy_env()}
         env_args = [arg for k, v in env.items() for arg in ("--env", f"{k}={v}")]
         inner = f"{' '.join(shlex.quote(a) for a in argv)} > {shlex.quote(log)} 2>&1"
         run = await docker(

--- a/verifiers/v1/runtimes/docker/egress.py
+++ b/verifiers/v1/runtimes/docker/egress.py
@@ -331,6 +331,7 @@ class EgressProxy:
                 writer.write(
                     b"HTTP/1.1 407 Proxy Authentication Required\r\n"
                     b'Proxy-Authenticate: Basic realm="verifiers"\r\n'
+                    b"Connection: close\r\n"
                     b"Content-Length: 0\r\n\r\n"
                 )
                 await _drain(writer)

--- a/verifiers/v1/runtimes/docker/egress.py
+++ b/verifiers/v1/runtimes/docker/egress.py
@@ -380,8 +380,8 @@ class EgressProxy:
                 dial_host = "127.0.0.1" if host.lower() == HOST_ALIAS else host
                 if (
                     upstream_proxy is None
-                    or not self.policy.allow_non_global
                     or not upstream_proxy.remote_dns
+                    or (not self.policy.allow_non_global and not framework)
                 ):
                     target_addresses = await asyncio.wait_for(
                         asyncio.get_running_loop().getaddrinfo(

--- a/verifiers/v1/runtimes/docker/egress.py
+++ b/verifiers/v1/runtimes/docker/egress.py
@@ -1,4 +1,4 @@
-"""In-process HTTP(S) policy proxy for network-filtered Docker runtimes."""
+"""Authenticated host bridge and HTTP(S) policy proxy for container runtimes."""
 
 import asyncio
 import base64
@@ -7,9 +7,11 @@ import hmac
 import secrets
 import socket
 import ssl
+import struct
 from dataclasses import dataclass
-from ipaddress import ip_address
-from urllib.parse import urlsplit, urlunsplit
+from ipaddress import ip_address, ip_network
+from urllib.parse import unquote, urlsplit, urlunsplit
+from urllib.request import proxy_bypass_environment
 
 import h11
 
@@ -72,6 +74,147 @@ class NetworkPolicy:
         )
 
 
+@dataclass(frozen=True)
+class _UpstreamProxy:
+    host: str
+    port: int
+    scheme: str
+    authorization: bytes | None
+    username: str | None
+    password: str | None
+
+    @property
+    def remote_dns(self) -> bool:
+        return self.scheme in ("http", "https", "socks4a", "socks5h")
+
+    @classmethod
+    def parse(cls, url: str) -> "_UpstreamProxy":
+        parsed = urlsplit(url if "://" in url else f"http://{url}")
+        schemes = {"http", "https", "socks4", "socks4a", "socks5", "socks5h"}
+        if parsed.scheme not in schemes or parsed.hostname is None:
+            raise ValueError(f"unsupported upstream proxy URL: {url!r}")
+        username = unquote(parsed.username) if parsed.username is not None else None
+        password = unquote(parsed.password or "") if username is not None else None
+        authorization = None
+        if username is not None and parsed.scheme in ("http", "https"):
+            credentials = f"{username}:{password}"
+            authorization = b"Basic " + base64.b64encode(credentials.encode())
+        return cls(
+            parsed.hostname,
+            parsed.port or {"http": 80, "https": 443}.get(parsed.scheme, 1080),
+            parsed.scheme,
+            authorization,
+            username,
+            password,
+        )
+
+
+@dataclass(frozen=True)
+class _ProxyRoute:
+    upstream: _UpstreamProxy | None = None
+    no_proxy: str | None = None
+
+
+def _proxy_bypass(host: str, no_proxy: str) -> bool:
+    if proxy_bypass_environment(host, {"no": no_proxy}):
+        return True
+    hostname = urlsplit(f"//{host}").hostname
+    if hostname is None:
+        return False
+    try:
+        address = ip_address(hostname)
+    except ValueError:
+        return False
+    for entry in no_proxy.split(","):
+        with contextlib.suppress(ValueError):
+            if address in ip_network(entry.strip(), strict=False):
+                return True
+    return False
+
+
+async def _connect_socks(
+    proxy: _UpstreamProxy,
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    host: str,
+    port: int,
+) -> None:
+    username = (proxy.username or "").encode()
+    if proxy.scheme in ("socks5", "socks5h"):
+        methods = b"\x00\x02" if proxy.username is not None else b"\x00"
+        writer.write(bytes((5, len(methods))) + methods)
+        await _drain(writer)
+        version, method = await asyncio.wait_for(reader.readexactly(2), _HEADER_TIMEOUT)
+        if version != 5 or method == 0xFF:
+            raise ConnectionError("SOCKS5 proxy rejected authentication methods")
+        if method == 2:
+            password = (proxy.password or "").encode()
+            if len(username) > 255 or len(password) > 255:
+                raise ValueError("SOCKS5 proxy credentials are too long")
+            writer.write(
+                bytes((1, len(username)))
+                + username
+                + bytes((len(password),))
+                + password
+            )
+            await _drain(writer)
+            if (
+                await asyncio.wait_for(reader.readexactly(2), _HEADER_TIMEOUT)
+                != b"\x01\x00"
+            ):
+                raise ConnectionError("SOCKS5 proxy rejected credentials")
+        elif method != 0:
+            raise ConnectionError(
+                f"SOCKS5 proxy selected unsupported method ({method})"
+            )
+        try:
+            address = ip_address(host)
+            encoded_host = bytes((1 if address.version == 4 else 4,)) + address.packed
+        except ValueError:
+            encoded = host.encode("idna")
+            if len(encoded) > 255:
+                raise ValueError("SOCKS5 target hostname is too long")
+            encoded_host = bytes((3, len(encoded))) + encoded
+        writer.write(b"\x05\x01\x00" + encoded_host + struct.pack("!H", port))
+        await _drain(writer)
+        version, status, _, address_type = await asyncio.wait_for(
+            reader.readexactly(4), _HEADER_TIMEOUT
+        )
+        if version != 5 or status != 0:
+            raise ConnectionError(f"SOCKS5 proxy rejected connection ({status})")
+        length = {1: 4, 4: 16}.get(address_type)
+        if address_type == 3:
+            length = (await asyncio.wait_for(reader.readexactly(1), _HEADER_TIMEOUT))[0]
+        if length is None:
+            raise ConnectionError("SOCKS5 proxy returned an invalid address")
+        await asyncio.wait_for(reader.readexactly(length + 2), _HEADER_TIMEOUT)
+        return
+
+    suffix = b""
+    try:
+        address = ip_address(host)
+        if address.version != 4:
+            raise ValueError
+        encoded_host = address.packed
+    except ValueError:
+        if proxy.scheme != "socks4a":
+            raise ConnectionError("SOCKS4 requires an IPv4 target")
+        encoded_host = b"\x00\x00\x00\x01"
+        suffix = host.encode("idna") + b"\x00"
+    writer.write(
+        b"\x04\x01"
+        + struct.pack("!H", port)
+        + encoded_host
+        + username
+        + b"\x00"
+        + suffix
+    )
+    await _drain(writer)
+    response = await asyncio.wait_for(reader.readexactly(8), _HEADER_TIMEOUT)
+    if response[1] != 90:
+        raise ConnectionError(f"SOCKS4 proxy rejected connection ({response[1]})")
+
+
 async def _read_client_hello(
     reader: asyncio.StreamReader,
 ) -> tuple[bytes, str | None]:
@@ -117,8 +260,26 @@ class EgressProxy:
         self._authorization = b"Basic " + base64.b64encode(
             f"verifiers:{self.token}".encode()
         )
+        self._routes = {self._authorization: _ProxyRoute()}
+        self._route_tokens: dict[tuple[str, str], str] = {}
         self.server: asyncio.Server | None = None
         self.port = 0
+
+    def token_for(self, upstream: str | None, no_proxy: str | None = None) -> str:
+        if not upstream:
+            return self.token
+        key = (upstream, no_proxy or "")
+        if token := self._route_tokens.get(key):
+            return token
+        token = secrets.token_urlsafe(32)
+        authorization = b"Basic " + base64.b64encode(f"verifiers:{token}".encode())
+        try:
+            parsed = _UpstreamProxy.parse(upstream)
+        except ValueError:
+            parsed = None
+        self._routes[authorization] = _ProxyRoute(parsed, no_proxy)
+        self._route_tokens[key] = token
+        return token
 
     async def start(
         self, bind_host: str | None = None, *, listener: socket.socket | None = None
@@ -159,7 +320,13 @@ class EgressProxy:
                 ),
                 b"",
             )
-            if not hmac.compare_digest(authorization, self._authorization):
+            selected = object()
+            route: _ProxyRoute | object = selected
+            for expected, candidate in self._routes.items():
+                if hmac.compare_digest(authorization, expected):
+                    route = candidate
+                    break
+            if route is selected:
                 response_started = True
                 writer.write(
                     b"HTTP/1.1 407 Proxy Authentication Required\r\n"
@@ -168,6 +335,8 @@ class EgressProxy:
                 )
                 await _drain(writer)
                 return
+            assert isinstance(route, _ProxyRoute)
+            upstream_proxy = route.upstream
             method = request.method.decode("ascii")
             target = request.target.decode("ascii")
             connect = method == "CONNECT"
@@ -194,39 +363,95 @@ class EgressProxy:
             permitted = (connect or scheme == "http") and self.policy.permits(
                 scheme, host, port, connect=connect
             )
-            addresses = []
+            framework = any(
+                network_rule_matches(route, scheme, host, port)
+                for route in self.policy.routes
+            )
+            authority = f"[{host}]:{port}" if ":" in host else f"{host}:{port}"
+            if (framework and host.lower() == HOST_ALIAS) or (
+                upstream_proxy is not None
+                and route.no_proxy is not None
+                and _proxy_bypass(authority, route.no_proxy)
+            ):
+                upstream_proxy = None
+            target_addresses = []
+            proxy_target = None
             if permitted:
                 dial_host = "127.0.0.1" if host.lower() == HOST_ALIAS else host
-                addresses = await asyncio.wait_for(
-                    asyncio.get_running_loop().getaddrinfo(
-                        dial_host, port, type=socket.SOCK_STREAM
-                    ),
-                    _IO_TIMEOUT,
-                )
-                framework = any(
-                    network_rule_matches(route, scheme, host, port)
-                    for route in self.policy.routes
-                )
+                if (
+                    upstream_proxy is None
+                    or not self.policy.allow_non_global
+                    or not upstream_proxy.remote_dns
+                ):
+                    target_addresses = await asyncio.wait_for(
+                        asyncio.get_running_loop().getaddrinfo(
+                            dial_host, port, type=socket.SOCK_STREAM
+                        ),
+                        _IO_TIMEOUT,
+                    )
                 if not framework and not self.policy.allow_non_global:
-                    for *_, address in addresses:
+                    for *_, address in target_addresses:
                         resolved = ip_address(address[0])
                         mapped = getattr(resolved, "ipv4_mapped", None)
                         if not (mapped or resolved).is_global:
                             permitted = False
                             break
+                if permitted and upstream_proxy is not None and target_addresses:
+                    # Keep an upstream proxy from resolving an allowed name to a private address.
+                    candidates = [address[4][0] for address in target_addresses]
+                    if upstream_proxy.scheme in ("socks4", "socks4a"):
+                        candidates = [
+                            address
+                            for address in candidates
+                            if ip_address(address).version == 4
+                        ]
+                    if (
+                        not upstream_proxy.remote_dns
+                        or not self.policy.allow_non_global
+                    ):
+                        if not candidates:
+                            permitted = False
+                        else:
+                            proxy_target = candidates[0]
             if not permitted:
                 response_started = True
                 writer.write(b"HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n")
                 await _drain(writer)
                 return
+            assert upstream_proxy is None or isinstance(upstream_proxy, _UpstreamProxy)
+            connect_host = (
+                upstream_proxy.host if upstream_proxy is not None else dial_host
+            )
+            connect_port = upstream_proxy.port if upstream_proxy is not None else port
+            addresses = (
+                await asyncio.wait_for(
+                    asyncio.get_running_loop().getaddrinfo(
+                        connect_host, connect_port, type=socket.SOCK_STREAM
+                    ),
+                    _IO_TIMEOUT,
+                )
+                if upstream_proxy is not None
+                else target_addresses
+            )
             for family, _, _, _, address in addresses:
                 try:
+                    tls = (
+                        ssl.create_default_context()
+                        if upstream_proxy and upstream_proxy.scheme == "https"
+                        else None
+                    )
                     upstream_reader, upstream_writer = await asyncio.wait_for(
                         asyncio.open_connection(
                             address[0],
                             address[1],
                             family=family,
                             flags=socket.AI_NUMERICHOST,
+                            ssl=tls,
+                            server_hostname=(
+                                upstream_proxy.host
+                                if upstream_proxy is not None and tls
+                                else None
+                            ),
                         ),
                         _HEADER_TIMEOUT,
                     )
@@ -235,7 +460,47 @@ class EgressProxy:
                     continue
             if upstream_reader is None or upstream_writer is None:
                 raise ConnectionError(f"could not connect to {host}:{port}")
+            socks = upstream_proxy is not None and upstream_proxy.scheme.startswith(
+                "socks"
+            )
+            if socks:
+                await _connect_socks(
+                    upstream_proxy,
+                    upstream_reader,
+                    upstream_writer,
+                    proxy_target or host,
+                    port,
+                )
             if connect:
+                if upstream_proxy is not None and not socks:
+                    if proxy_target is None:
+                        authority = request.target
+                    else:
+                        target_host = (
+                            f"[{proxy_target}]" if ":" in proxy_target else proxy_target
+                        )
+                        authority = f"{target_host}:{port}".encode("ascii")
+                    headers = [
+                        b"CONNECT " + authority + b" HTTP/1.1",
+                        b"Host: " + authority,
+                    ]
+                    if upstream_proxy.authorization is not None:
+                        headers.append(
+                            b"Proxy-Authorization: " + upstream_proxy.authorization
+                        )
+                    upstream_writer.write(b"\r\n".join(headers) + b"\r\n\r\n")
+                    await _drain(upstream_writer)
+                    response_head = await asyncio.wait_for(
+                        upstream_reader.readuntil(b"\r\n\r\n"), _HEADER_TIMEOUT
+                    )
+                    response = h11.Connection(h11.CLIENT)
+                    response.receive_data(response_head)
+                    status = response.next_event()
+                    if (
+                        not isinstance(status, h11.Response)
+                        or not 200 <= status.status_code < 300
+                    ):
+                        raise ConnectionError("upstream proxy rejected CONNECT")
                 response_started = True
                 writer.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
                 await _drain(writer)
@@ -253,7 +518,19 @@ class EgressProxy:
                     await _drain(upstream_writer)
                 await _relay(reader, writer, upstream_reader, upstream_writer)
             else:
-                path = urlunsplit(("", "", parsed.path or "/", parsed.query, ""))
+                if upstream_proxy is None or socks:
+                    path = urlunsplit(("", "", parsed.path or "/", parsed.query, ""))
+                elif proxy_target is None:
+                    path = request.target
+                else:
+                    target_host = (
+                        f"[{proxy_target}]" if ":" in proxy_target else proxy_target
+                    )
+                    if port != (443 if scheme == "https" else 80):
+                        target_host = f"{target_host}:{port}"
+                    path = urlunsplit(
+                        (scheme, target_host, parsed.path or "/", parsed.query, "")
+                    )
                 authority = f"[{host}]" if ":" in host else host
                 if port != (443 if scheme == "https" else 80):
                     authority = f"{authority}:{port}"
@@ -281,6 +558,14 @@ class EgressProxy:
                     for name, value in request.headers
                     if name.lower() not in excluded
                 ]
+                if (
+                    upstream_proxy is not None
+                    and not socks
+                    and upstream_proxy.authorization is not None
+                ):
+                    headers.append(
+                        (b"Proxy-Authorization", upstream_proxy.authorization)
+                    )
                 upstream = h11.Connection(h11.CLIENT)
                 upstream_writer.write(
                     upstream.send(

--- a/verifiers/v1/runtimes/docker/egress.py
+++ b/verifiers/v1/runtimes/docker/egress.py
@@ -1,4 +1,4 @@
-"""Authenticated host bridge and HTTP(S) policy proxy for container runtimes."""
+"""In-process HTTP(S) policy proxy for network-filtered Docker runtimes."""
 
 import asyncio
 import base64
@@ -7,11 +7,9 @@ import hmac
 import secrets
 import socket
 import ssl
-import struct
 from dataclasses import dataclass
-from ipaddress import ip_address, ip_network
-from urllib.parse import unquote, urlsplit, urlunsplit
-from urllib.request import proxy_bypass_environment
+from ipaddress import ip_address
+from urllib.parse import urlsplit, urlunsplit
 
 import h11
 
@@ -74,147 +72,6 @@ class NetworkPolicy:
         )
 
 
-@dataclass(frozen=True)
-class _UpstreamProxy:
-    host: str
-    port: int
-    scheme: str
-    authorization: bytes | None
-    username: str | None
-    password: str | None
-
-    @property
-    def remote_dns(self) -> bool:
-        return self.scheme in ("http", "https", "socks4a", "socks5h")
-
-    @classmethod
-    def parse(cls, url: str) -> "_UpstreamProxy":
-        parsed = urlsplit(url if "://" in url else f"http://{url}")
-        schemes = {"http", "https", "socks4", "socks4a", "socks5", "socks5h"}
-        if parsed.scheme not in schemes or parsed.hostname is None:
-            raise ValueError(f"unsupported upstream proxy URL: {url!r}")
-        username = unquote(parsed.username) if parsed.username is not None else None
-        password = unquote(parsed.password or "") if username is not None else None
-        authorization = None
-        if username is not None and parsed.scheme in ("http", "https"):
-            credentials = f"{username}:{password}"
-            authorization = b"Basic " + base64.b64encode(credentials.encode())
-        return cls(
-            parsed.hostname,
-            parsed.port or {"http": 80, "https": 443}.get(parsed.scheme, 1080),
-            parsed.scheme,
-            authorization,
-            username,
-            password,
-        )
-
-
-@dataclass(frozen=True)
-class _ProxyRoute:
-    upstream: _UpstreamProxy | None = None
-    no_proxy: str | None = None
-
-
-def _proxy_bypass(host: str, no_proxy: str) -> bool:
-    if proxy_bypass_environment(host, {"no": no_proxy}):
-        return True
-    hostname = urlsplit(f"//{host}").hostname
-    if hostname is None:
-        return False
-    try:
-        address = ip_address(hostname)
-    except ValueError:
-        return False
-    for entry in no_proxy.split(","):
-        with contextlib.suppress(ValueError):
-            if address in ip_network(entry.strip(), strict=False):
-                return True
-    return False
-
-
-async def _connect_socks(
-    proxy: _UpstreamProxy,
-    reader: asyncio.StreamReader,
-    writer: asyncio.StreamWriter,
-    host: str,
-    port: int,
-) -> None:
-    username = (proxy.username or "").encode()
-    if proxy.scheme in ("socks5", "socks5h"):
-        methods = b"\x00\x02" if proxy.username is not None else b"\x00"
-        writer.write(bytes((5, len(methods))) + methods)
-        await _drain(writer)
-        version, method = await asyncio.wait_for(reader.readexactly(2), _HEADER_TIMEOUT)
-        if version != 5 or method == 0xFF:
-            raise ConnectionError("SOCKS5 proxy rejected authentication methods")
-        if method == 2:
-            password = (proxy.password or "").encode()
-            if len(username) > 255 or len(password) > 255:
-                raise ValueError("SOCKS5 proxy credentials are too long")
-            writer.write(
-                bytes((1, len(username)))
-                + username
-                + bytes((len(password),))
-                + password
-            )
-            await _drain(writer)
-            if (
-                await asyncio.wait_for(reader.readexactly(2), _HEADER_TIMEOUT)
-                != b"\x01\x00"
-            ):
-                raise ConnectionError("SOCKS5 proxy rejected credentials")
-        elif method != 0:
-            raise ConnectionError(
-                f"SOCKS5 proxy selected unsupported method ({method})"
-            )
-        try:
-            address = ip_address(host)
-            encoded_host = bytes((1 if address.version == 4 else 4,)) + address.packed
-        except ValueError:
-            encoded = host.encode("idna")
-            if len(encoded) > 255:
-                raise ValueError("SOCKS5 target hostname is too long")
-            encoded_host = bytes((3, len(encoded))) + encoded
-        writer.write(b"\x05\x01\x00" + encoded_host + struct.pack("!H", port))
-        await _drain(writer)
-        version, status, _, address_type = await asyncio.wait_for(
-            reader.readexactly(4), _HEADER_TIMEOUT
-        )
-        if version != 5 or status != 0:
-            raise ConnectionError(f"SOCKS5 proxy rejected connection ({status})")
-        length = {1: 4, 4: 16}.get(address_type)
-        if address_type == 3:
-            length = (await asyncio.wait_for(reader.readexactly(1), _HEADER_TIMEOUT))[0]
-        if length is None:
-            raise ConnectionError("SOCKS5 proxy returned an invalid address")
-        await asyncio.wait_for(reader.readexactly(length + 2), _HEADER_TIMEOUT)
-        return
-
-    suffix = b""
-    try:
-        address = ip_address(host)
-        if address.version != 4:
-            raise ValueError
-        encoded_host = address.packed
-    except ValueError:
-        if proxy.scheme != "socks4a":
-            raise ConnectionError("SOCKS4 requires an IPv4 target")
-        encoded_host = b"\x00\x00\x00\x01"
-        suffix = host.encode("idna") + b"\x00"
-    writer.write(
-        b"\x04\x01"
-        + struct.pack("!H", port)
-        + encoded_host
-        + username
-        + b"\x00"
-        + suffix
-    )
-    await _drain(writer)
-    response = await asyncio.wait_for(reader.readexactly(8), _HEADER_TIMEOUT)
-    if response[1] != 90:
-        raise ConnectionError(f"SOCKS4 proxy rejected connection ({response[1]})")
-
-
 async def _read_client_hello(
     reader: asyncio.StreamReader,
 ) -> tuple[bytes, str | None]:
@@ -260,26 +117,8 @@ class EgressProxy:
         self._authorization = b"Basic " + base64.b64encode(
             f"verifiers:{self.token}".encode()
         )
-        self._routes = {self._authorization: _ProxyRoute()}
-        self._route_tokens: dict[tuple[str, str], str] = {}
         self.server: asyncio.Server | None = None
         self.port = 0
-
-    def token_for(self, upstream: str | None, no_proxy: str | None = None) -> str:
-        if not upstream:
-            return self.token
-        key = (upstream, no_proxy or "")
-        if token := self._route_tokens.get(key):
-            return token
-        token = secrets.token_urlsafe(32)
-        authorization = b"Basic " + base64.b64encode(f"verifiers:{token}".encode())
-        try:
-            parsed = _UpstreamProxy.parse(upstream)
-        except ValueError:
-            parsed = None
-        self._routes[authorization] = _ProxyRoute(parsed, no_proxy)
-        self._route_tokens[key] = token
-        return token
 
     async def start(
         self, bind_host: str | None = None, *, listener: socket.socket | None = None
@@ -320,13 +159,7 @@ class EgressProxy:
                 ),
                 b"",
             )
-            selected = object()
-            route: _ProxyRoute | object = selected
-            for expected, candidate in self._routes.items():
-                if hmac.compare_digest(authorization, expected):
-                    route = candidate
-                    break
-            if route is selected:
+            if not hmac.compare_digest(authorization, self._authorization):
                 response_started = True
                 writer.write(
                     b"HTTP/1.1 407 Proxy Authentication Required\r\n"
@@ -336,8 +169,6 @@ class EgressProxy:
                 )
                 await _drain(writer)
                 return
-            assert isinstance(route, _ProxyRoute)
-            upstream_proxy = route.upstream
             method = request.method.decode("ascii")
             target = request.target.decode("ascii")
             connect = method == "CONNECT"
@@ -364,95 +195,39 @@ class EgressProxy:
             permitted = (connect or scheme == "http") and self.policy.permits(
                 scheme, host, port, connect=connect
             )
-            framework = any(
-                network_rule_matches(route, scheme, host, port)
-                for route in self.policy.routes
-            )
-            authority = f"[{host}]:{port}" if ":" in host else f"{host}:{port}"
-            if (framework and host.lower() == HOST_ALIAS) or (
-                upstream_proxy is not None
-                and route.no_proxy is not None
-                and _proxy_bypass(authority, route.no_proxy)
-            ):
-                upstream_proxy = None
-            target_addresses = []
-            proxy_target = None
+            addresses = []
             if permitted:
                 dial_host = "127.0.0.1" if host.lower() == HOST_ALIAS else host
-                if (
-                    upstream_proxy is None
-                    or not upstream_proxy.remote_dns
-                    or (not self.policy.allow_non_global and not framework)
-                ):
-                    target_addresses = await asyncio.wait_for(
-                        asyncio.get_running_loop().getaddrinfo(
-                            dial_host, port, type=socket.SOCK_STREAM
-                        ),
-                        _IO_TIMEOUT,
-                    )
+                addresses = await asyncio.wait_for(
+                    asyncio.get_running_loop().getaddrinfo(
+                        dial_host, port, type=socket.SOCK_STREAM
+                    ),
+                    _IO_TIMEOUT,
+                )
+                framework = any(
+                    network_rule_matches(route, scheme, host, port)
+                    for route in self.policy.routes
+                )
                 if not framework and not self.policy.allow_non_global:
-                    for *_, address in target_addresses:
+                    for *_, address in addresses:
                         resolved = ip_address(address[0])
                         mapped = getattr(resolved, "ipv4_mapped", None)
                         if not (mapped or resolved).is_global:
                             permitted = False
                             break
-                if permitted and upstream_proxy is not None and target_addresses:
-                    # Keep an upstream proxy from resolving an allowed name to a private address.
-                    candidates = [address[4][0] for address in target_addresses]
-                    if upstream_proxy.scheme in ("socks4", "socks4a"):
-                        candidates = [
-                            address
-                            for address in candidates
-                            if ip_address(address).version == 4
-                        ]
-                    if (
-                        not upstream_proxy.remote_dns
-                        or not self.policy.allow_non_global
-                    ):
-                        if not candidates:
-                            permitted = False
-                        else:
-                            proxy_target = candidates[0]
             if not permitted:
                 response_started = True
                 writer.write(b"HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n")
                 await _drain(writer)
                 return
-            assert upstream_proxy is None or isinstance(upstream_proxy, _UpstreamProxy)
-            connect_host = (
-                upstream_proxy.host if upstream_proxy is not None else dial_host
-            )
-            connect_port = upstream_proxy.port if upstream_proxy is not None else port
-            addresses = (
-                await asyncio.wait_for(
-                    asyncio.get_running_loop().getaddrinfo(
-                        connect_host, connect_port, type=socket.SOCK_STREAM
-                    ),
-                    _IO_TIMEOUT,
-                )
-                if upstream_proxy is not None
-                else target_addresses
-            )
             for family, _, _, _, address in addresses:
                 try:
-                    tls = (
-                        ssl.create_default_context()
-                        if upstream_proxy and upstream_proxy.scheme == "https"
-                        else None
-                    )
                     upstream_reader, upstream_writer = await asyncio.wait_for(
                         asyncio.open_connection(
                             address[0],
                             address[1],
                             family=family,
                             flags=socket.AI_NUMERICHOST,
-                            ssl=tls,
-                            server_hostname=(
-                                upstream_proxy.host
-                                if upstream_proxy is not None and tls
-                                else None
-                            ),
                         ),
                         _HEADER_TIMEOUT,
                     )
@@ -461,47 +236,7 @@ class EgressProxy:
                     continue
             if upstream_reader is None or upstream_writer is None:
                 raise ConnectionError(f"could not connect to {host}:{port}")
-            socks = upstream_proxy is not None and upstream_proxy.scheme.startswith(
-                "socks"
-            )
-            if socks:
-                await _connect_socks(
-                    upstream_proxy,
-                    upstream_reader,
-                    upstream_writer,
-                    proxy_target or host,
-                    port,
-                )
             if connect:
-                if upstream_proxy is not None and not socks:
-                    if proxy_target is None:
-                        authority = request.target
-                    else:
-                        target_host = (
-                            f"[{proxy_target}]" if ":" in proxy_target else proxy_target
-                        )
-                        authority = f"{target_host}:{port}".encode("ascii")
-                    headers = [
-                        b"CONNECT " + authority + b" HTTP/1.1",
-                        b"Host: " + authority,
-                    ]
-                    if upstream_proxy.authorization is not None:
-                        headers.append(
-                            b"Proxy-Authorization: " + upstream_proxy.authorization
-                        )
-                    upstream_writer.write(b"\r\n".join(headers) + b"\r\n\r\n")
-                    await _drain(upstream_writer)
-                    response_head = await asyncio.wait_for(
-                        upstream_reader.readuntil(b"\r\n\r\n"), _HEADER_TIMEOUT
-                    )
-                    response = h11.Connection(h11.CLIENT)
-                    response.receive_data(response_head)
-                    status = response.next_event()
-                    if (
-                        not isinstance(status, h11.Response)
-                        or not 200 <= status.status_code < 300
-                    ):
-                        raise ConnectionError("upstream proxy rejected CONNECT")
                 response_started = True
                 writer.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
                 await _drain(writer)
@@ -519,19 +254,7 @@ class EgressProxy:
                     await _drain(upstream_writer)
                 await _relay(reader, writer, upstream_reader, upstream_writer)
             else:
-                if upstream_proxy is None or socks:
-                    path = urlunsplit(("", "", parsed.path or "/", parsed.query, ""))
-                elif proxy_target is None:
-                    path = request.target
-                else:
-                    target_host = (
-                        f"[{proxy_target}]" if ":" in proxy_target else proxy_target
-                    )
-                    if port != (443 if scheme == "https" else 80):
-                        target_host = f"{target_host}:{port}"
-                    path = urlunsplit(
-                        (scheme, target_host, parsed.path or "/", parsed.query, "")
-                    )
+                path = urlunsplit(("", "", parsed.path or "/", parsed.query, ""))
                 authority = f"[{host}]" if ":" in host else host
                 if port != (443 if scheme == "https" else 80):
                     authority = f"{authority}:{port}"
@@ -559,14 +282,6 @@ class EgressProxy:
                     for name, value in request.headers
                     if name.lower() not in excluded
                 ]
-                if (
-                    upstream_proxy is not None
-                    and not socks
-                    and upstream_proxy.authorization is not None
-                ):
-                    headers.append(
-                        (b"Proxy-Authorization", upstream_proxy.authorization)
-                    )
                 upstream = h11.Connection(h11.CLIENT)
                 upstream_writer.write(
                     upstream.send(


### PR DESCRIPTION
## Overview

Make local container runtimes use the container engine's isolated default network for every task while keeping host callbacks and restricted egress in Verifiers. This prevents unrestricted tasks from sharing host ports and supports Docker-compatible rootless Podman without requiring Docker's bridge network.

## Details

- stop forcing host networking for unrestricted tasks and bridge networking for restricted tasks
- route framework callbacks through the existing authenticated proxy in both network modes
- preserve restricted egress by removing direct routes while retaining only the proxy path
- publish the fixed tool-service port to an ephemeral host-loopback port
- qualify Docker Hub image names where Podman requires unambiguous registry resolution

## Impact

Tasks can bind fixed ports without colliding with the host or concurrent evaluations. Native Docker uses its isolated default bridge, while rootless Podman can use its configured rootless network backend.

Closes #2319.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default container networking and how MCP URLs are reached; workloads that depended on host networking or implicit localhost reachability may need port publishing or updated consumer paths.
> 
> **Overview**
> **Docker runtime** no longer uses host networking for unrestricted tasks or a separate bridge-only path for restricted ones. Every container runs on the engine’s default isolated network, always publishes `SERVICE_PORT` to an ephemeral **127.0.0.1** host port, and always runs traffic through the **egress proxy** (policy tightened in `prepare_execution`; route/iptables “cut” only when restricted).
> 
> **`DockerRuntime.expose`** resolves the published mapping via `docker port` and returns a host-loopback URL. **`reachable_url`** in MCP launch now prefers `Runtime.expose` for non-colocated sandboxes, tunnels through **PrimeTunnel** when a local Docker service must be reached from a remote consumer, and errors if a remote runtime cannot expose the port. **`MCP_HOST=0.0.0.0`** is set only when the server is **exposed** and the runtime has a **`published_port`**.
> 
> Supporting tweaks: **`host_url`** rewrites loopback to the proxy host alias for all Docker runs; proxy env is applied for all execs (with merged **NO_PROXY**); container lifecycle uses **create/start** with host-network rejection; Podman-friendly **docker.io** image names; egress proxy adds **Connection: close** on 407 responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33bc530aa6135abcf5f2fe075e6db65a2e3d7f06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support isolated networking across Docker and rootless Podman runtimes
> - Docker containers are now created with an isolated network namespace and a published service port using `docker create --publish :SERVICE_PORT` instead of `docker run` with host/bridge networking.
> - The egress proxy is started for all Docker runs (not just network-restricted ones), and proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`) are injected into all `run`, `open_process`, and `run_background` calls.
> - `DockerRuntime.expose()` is added to return a reachable `http://127.0.0.1:HOST_PORT` URL for a container's published port, and `Runtime.expose()` is introduced as a base class method.
> - `reachable_url` in [launch.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2361/files#diff-989d87123d40d48511f9e1df74594d2e30776e9a99c11eca49d9cc20bf9e2230) now routes non-colocated sandbox services through their published port via a provider tunnel, and raises `ToolsetError` for remote runtimes that don't expose the requested port.
> - Risk: all Docker containers now run with an isolated network by default; previously unrestricted containers had direct host network access.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 33bc530.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->