### PR TITLE
Support Harbor runtime environment and health checks

### DIFF
--- a/docs/v1/harbor.md
+++ b/docs/v1/harbor.md
@@ -126,6 +126,7 @@ Under any other env, a separate-verifier task refuses to grade in the agent's bo
 
 verifiers does not have parity with Harbor yet, so some features are missing and currently being worked on. The most notable missing features right now are:
 
+- Image `ENTRYPOINT`s are replaced with a keepalive, so `[environment.healthcheck]` cannot depend on entrypoint-based setup or services
 - Switching to a different verifier-phase network policy for a *shared* verifier ([Harbor Docs](https://www.harborframework.com/docs/tasks/network-policy)); a separate verifier's own policy is applied
 - Building a verifier image from `tests/Dockerfile`, which Harbor does when a declared `[verifier.environment]` names no `docker_image`. A separate verifier image itself is supported — it just has to be pre-built and pullable (see above), because verifiers never builds images
 - Sidecar services, and the sidecar artifacts and collect hooks that go with them ([Harbor Docs](https://www.harborframework.com/docs/tasks#sidecar-artifacts-and-collect-hooks))

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -547,9 +547,9 @@ class Agent:
             if task is not None
             else self.runtime_config
         )
-        async with provision_runtime(
-            config, env=task.runtime_env() if task is not None else None
-        ) as runtime:
+        async with provision_runtime(config) as runtime:
+            # Keep sandbox startup task-neutral: this box may later host another task.
+            runtime.env = dict(task.runtime_env()) if task is not None else {}
             yield runtime
 
 

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -547,7 +547,9 @@ class Agent:
             if task is not None
             else self.runtime_config
         )
-        async with provision_runtime(config) as runtime:
+        async with provision_runtime(
+            config, env=task.runtime_env() if task is not None else None
+        ) as runtime:
             yield runtime
 
 

--- a/verifiers/v1/cli/debug.py
+++ b/verifiers/v1/cli/debug.py
@@ -216,6 +216,7 @@ async def debug_task(task: Task, config: DebugConfig) -> tuple[Trace, bool]:
     runtime = make_runtime(
         resolve_runtime_config(config.runtime, task),
         name=f"debug-{task.data.idx}-{uuid4().hex[:8]}",
+        env=task.runtime_env(),
     )
     trace.agent.runtime = runtime.info
     setup_timeout = (

--- a/verifiers/v1/cli/debug.py
+++ b/verifiers/v1/cli/debug.py
@@ -216,7 +216,6 @@ async def debug_task(task: Task, config: DebugConfig) -> tuple[Trace, bool]:
     runtime = make_runtime(
         resolve_runtime_config(config.runtime, task),
         name=f"debug-{task.data.idx}-{uuid4().hex[:8]}",
-        env=task.runtime_env(),
     )
     trace.agent.runtime = runtime.info
     setup_timeout = (
@@ -225,6 +224,7 @@ async def debug_task(task: Task, config: DebugConfig) -> tuple[Trace, bool]:
         else task.data.timeout.setup
     )
     try:
+        runtime.env = dict(task.runtime_env())
         trace.timing.boot.start = time.time()
         await runtime.start()
         now = time.time()

--- a/verifiers/v1/cli/validate.py
+++ b/verifiers/v1/cli/validate.py
@@ -227,7 +227,6 @@ async def _run_gold(task: Task, config: ValidateConfig) -> ResultRow:
     runtime = make_runtime(
         resolve_runtime_config(config.runtime, task),
         name=f"validate-gold-{task.data.idx}-{uuid4().hex[:8]}",
-        env=task.runtime_env(),
     )
     setup_timeout = (
         config.timeout.setup
@@ -236,6 +235,7 @@ async def _run_gold(task: Task, config: ValidateConfig) -> ResultRow:
     )
     valid, exc = False, None
     try:
+        runtime.env = dict(task.runtime_env())
         trace = Trace(
             task=TraceTask(
                 type=type(task).__name__, data=task.data, key=task.key, hash=task.hash
@@ -271,7 +271,6 @@ async def _run_setup(task: Task, config: ValidateConfig) -> ResultRow:
     runtime = make_runtime(
         resolve_runtime_config(config.runtime, task),
         name=f"validate-setup-{task.data.idx}-{uuid4().hex[:8]}",
-        env=task.runtime_env(),
     )
     setup_timeout = (
         config.timeout.setup
@@ -280,6 +279,7 @@ async def _run_setup(task: Task, config: ValidateConfig) -> ResultRow:
     )
     valid, exc = False, None
     try:
+        runtime.env = dict(task.runtime_env())
         trace = Trace(
             task=TraceTask(
                 type=type(task).__name__, data=task.data, key=task.key, hash=task.hash

--- a/verifiers/v1/cli/validate.py
+++ b/verifiers/v1/cli/validate.py
@@ -227,6 +227,7 @@ async def _run_gold(task: Task, config: ValidateConfig) -> ResultRow:
     runtime = make_runtime(
         resolve_runtime_config(config.runtime, task),
         name=f"validate-gold-{task.data.idx}-{uuid4().hex[:8]}",
+        env=task.runtime_env(),
     )
     setup_timeout = (
         config.timeout.setup
@@ -270,6 +271,7 @@ async def _run_setup(task: Task, config: ValidateConfig) -> ResultRow:
     runtime = make_runtime(
         resolve_runtime_config(config.runtime, task),
         name=f"validate-setup-{task.data.idx}-{uuid4().hex[:8]}",
+        env=task.runtime_env(),
     )
     setup_timeout = (
         config.timeout.setup

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -81,6 +81,7 @@ class Rollout:
         self._interception = interception
         self.runtime = runtime
         self._owns_runtime = runtime is None
+        self._previous_runtime_env: dict[str, str] | None = None
         self.trace: Trace = Trace(
             task=TraceTask(
                 type=type(task).__name__,
@@ -172,6 +173,11 @@ class Rollout:
         self._failure = error
         self.trace.record_error(error)
 
+    def _restore_runtime_env(self) -> None:
+        if self._previous_runtime_env is not None and self.runtime is not None:
+            self.runtime.env = self._previous_runtime_env
+            self._previous_runtime_env = None
+
     async def open(self) -> bool:
         """Boot the rollout's world up to the point where segments can run: start
         (or borrow) the runtime, run task + harness setup, bring up the
@@ -179,8 +185,11 @@ class Rollout:
         proceed; a setup failure is captured onto the trace."""
         self._opened = True
         self.trace.timing.boot.start = time.time()
+        runtime_env = self.task.runtime_env()
         if self._owns_runtime:
-            self.runtime = make_runtime(self.runtime_config, name=self.trace.id)
+            self.runtime = make_runtime(
+                self.runtime_config, name=self.trace.id, env=runtime_env
+            )
         elif self.runtime.stopped:
             # A lifetime bug in the borrowing program: raise to the caller instead
             # of capturing onto the trace.
@@ -189,6 +198,9 @@ class Rollout:
                 "down by its owner; keep the provisioning context open for every run "
                 "placed into the box"
             )
+        else:
+            self._previous_runtime_env = dict(self.runtime.env)
+            self.runtime.env = {**self.runtime.env, **runtime_env}
         runtime = self.runtime
         assert self.trace.agent is not None  # minted with the trace
         self.trace.agent.runtime = runtime.info
@@ -421,6 +433,7 @@ class Rollout:
         if self.runtime is not None:
             with contextlib.suppress(Exception):
                 await self.harness.cleanup(self.trace, self.runtime)
+        self._restore_runtime_env()
         if self._owns_runtime and self.runtime is not None:
             with contextlib.suppress(Exception):
                 await self.runtime.stop()
@@ -502,6 +515,7 @@ class Rollout:
                     logger.warning(
                         "harness cleanup failed (rollout %s)", trace.id, exc_info=True
                     )
+            self._restore_runtime_env()
             # Tear down here — the env's `score()` (later) needs only the traces,
             # not a live runtime. A borrowed runtime is its creator's to tear down,
             # not this rollout's.

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -173,10 +173,11 @@ class Rollout:
         self._failure = error
         self.trace.record_error(error)
 
-    def _restore_runtime_env(self) -> None:
+    def _release_borrowed_runtime(self) -> None:
         if self._previous_runtime_env is not None and self.runtime is not None:
             self.runtime.env = self._previous_runtime_env
             self._previous_runtime_env = None
+            self.runtime.borrow_lock.release()
 
     async def open(self) -> bool:
         """Boot the rollout's world up to the point where segments can run: start
@@ -185,11 +186,8 @@ class Rollout:
         proceed; a setup failure is captured onto the trace."""
         self._opened = True
         self.trace.timing.boot.start = time.time()
-        runtime_env = self.task.runtime_env()
         if self._owns_runtime:
-            self.runtime = make_runtime(
-                self.runtime_config, name=self.trace.id, env=runtime_env
-            )
+            self.runtime = make_runtime(self.runtime_config, name=self.trace.id)
         elif self.runtime.stopped:
             # A lifetime bug in the borrowing program: raise to the caller instead
             # of capturing onto the trace.
@@ -198,9 +196,6 @@ class Rollout:
                 "down by its owner; keep the provisioning context open for every run "
                 "placed into the box"
             )
-        else:
-            self._previous_runtime_env = dict(self.runtime.env)
-            self.runtime.env = {**self.runtime.env, **runtime_env}
         runtime = self.runtime
         assert self.trace.agent is not None  # minted with the trace
         self.trace.agent.runtime = runtime.info
@@ -212,6 +207,15 @@ class Rollout:
             self.runtime_config.type,
         )
         try:
+            runtime_env = dict(self.task.runtime_env())
+            if self._owns_runtime:
+                runtime.env = runtime_env
+            else:
+                await runtime.borrow_lock.acquire()
+                self._previous_runtime_env = runtime.env
+                # The owner's defaults return after the borrow; they do not belong to
+                # this task and must not flow into its processes.
+                runtime.env = runtime_env
             if self.task.data.prompt is None and not self._has_user:
                 raise TaskError(
                     "task has no prompt and no user to open the conversation; set "
@@ -433,7 +437,7 @@ class Rollout:
         if self.runtime is not None:
             with contextlib.suppress(Exception):
                 await self.harness.cleanup(self.trace, self.runtime)
-        self._restore_runtime_env()
+        self._release_borrowed_runtime()
         if self._owns_runtime and self.runtime is not None:
             with contextlib.suppress(Exception):
                 await self.runtime.stop()
@@ -515,7 +519,7 @@ class Rollout:
                     logger.warning(
                         "harness cleanup failed (rollout %s)", trace.id, exc_info=True
                     )
-            self._restore_runtime_env()
+            self._release_borrowed_runtime()
             # Tear down here — the env's `score()` (later) needs only the traces,
             # not a live runtime. A borrowed runtime is its creator's to tear down,
             # not this rollout's.

--- a/verifiers/v1/runtimes/__init__.py
+++ b/verifiers/v1/runtimes/__init__.py
@@ -47,21 +47,28 @@ def _runtime_cls(config: RuntimeConfig) -> type[Runtime]:
     return SubprocessRuntime
 
 
-def make_runtime(config: RuntimeConfig, name: str | None = None) -> Runtime:
+def make_runtime(
+    config: RuntimeConfig,
+    name: str | None = None,
+    env: dict[str, str] | None = None,
+) -> Runtime:
     runtime = _runtime_cls(config)(config, name)
+    runtime.env = dict(env or {})
     register(runtime)
     return runtime
 
 
 @asynccontextmanager
 async def provision_runtime(
-    config: RuntimeConfig, name: str | None = None
+    config: RuntimeConfig,
+    name: str | None = None,
+    env: dict[str, str] | None = None,
 ) -> AsyncIterator[Runtime]:
     """Provision a box from `config` and tear it down on exit.
 
     `start()` sits inside the `try`: a failed start may already hold a paid sandbox, so
     it has to reach `stop()` (which is safe on a partially-started runtime)."""
-    runtime = make_runtime(config, name)
+    runtime = make_runtime(config, name, env)
     try:
         await runtime.start()
         yield runtime

--- a/verifiers/v1/runtimes/__init__.py
+++ b/verifiers/v1/runtimes/__init__.py
@@ -57,12 +57,14 @@ def make_runtime(config: RuntimeConfig, name: str | None = None) -> Runtime:
 async def provision_runtime(
     config: RuntimeConfig,
     name: str | None = None,
+    env: dict[str, str] | None = None,
 ) -> AsyncIterator[Runtime]:
     """Provision a box from `config` and tear it down on exit.
 
     `start()` sits inside the `try`: a failed start may already hold a paid sandbox, so
     it has to reach `stop()` (which is safe on a partially-started runtime)."""
     runtime = make_runtime(config, name)
+    runtime.env = dict(env or {})
     try:
         await runtime.start()
         yield runtime

--- a/verifiers/v1/runtimes/__init__.py
+++ b/verifiers/v1/runtimes/__init__.py
@@ -47,13 +47,8 @@ def _runtime_cls(config: RuntimeConfig) -> type[Runtime]:
     return SubprocessRuntime
 
 
-def make_runtime(
-    config: RuntimeConfig,
-    name: str | None = None,
-    env: dict[str, str] | None = None,
-) -> Runtime:
+def make_runtime(config: RuntimeConfig, name: str | None = None) -> Runtime:
     runtime = _runtime_cls(config)(config, name)
-    runtime.env = dict(env or {})
     register(runtime)
     return runtime
 
@@ -62,13 +57,12 @@ def make_runtime(
 async def provision_runtime(
     config: RuntimeConfig,
     name: str | None = None,
-    env: dict[str, str] | None = None,
 ) -> AsyncIterator[Runtime]:
     """Provision a box from `config` and tear it down on exit.
 
     `start()` sits inside the `try`: a failed start may already hold a paid sandbox, so
     it has to reach `stop()` (which is safe on a partially-started runtime)."""
-    runtime = make_runtime(config, name, env)
+    runtime = make_runtime(config, name)
     try:
         await runtime.start()
         yield runtime

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -147,6 +147,9 @@ class Runtime(ABC):
 
     def __init__(self, name: str | None = None) -> None:
         self.name = name or f"vf-{uuid.uuid4().hex[:12]}"
+        # Per-run task values live on the runtime rather than its serializable config/info.
+        # Explicit process values (model credentials, proxy settings, etc.) override these.
+        self.env: dict[str, str] = {}
         self._uv_interpreters: dict[str, str] = {}
         self._uv_script_locks: dict[str, asyncio.Lock] = {}
         self._setup_claimed = False
@@ -188,6 +191,10 @@ class Runtime(ABC):
     @abstractmethod
     async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
         pass
+
+    def process_env(self, env: dict[str, str]) -> dict[str, str]:
+        """Combine the task's runtime-wide environment with one process's values."""
+        return {**self.env, **env}
 
     async def alive(self) -> bool:
         """Whether the box still executes anything. Not every runtime raises when

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -150,6 +150,8 @@ class Runtime(ABC):
         # Per-run task values live on the runtime rather than its serializable config/info.
         # Explicit process values (model credentials, proxy settings, etc.) override these.
         self.env: dict[str, str] = {}
+        # A borrowed box is one mutable world, so its rollouts must own it one at a time.
+        self.borrow_lock = asyncio.Lock()
         self._uv_interpreters: dict[str, str] = {}
         self._uv_script_locks: dict[str, asyncio.Lock] = {}
         self._setup_claimed = False

--- a/verifiers/v1/runtimes/docker/__init__.py
+++ b/verifiers/v1/runtimes/docker/__init__.py
@@ -232,11 +232,17 @@ class DockerRuntime(Runtime):
                 network += ["--add-host", f"{_PROXY_HOST}:host-gateway"]
         else:
             network = ["--network", "host"]
+        env_args = [
+            arg
+            for key, value in self.env.items()
+            for arg in ("--env", f"{key}={value}")
+        ]
         run = await docker(
             "run",
             "--detach",
             *network,
             *limits,
+            *env_args,
             "--workdir",
             self.config.workdir,
             "--entrypoint",
@@ -414,7 +420,7 @@ class DockerRuntime(Runtime):
         await super().teardown()
 
     async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
-        env = {**env, **(self._proxy_env() if self._cut else {})}
+        env = {**self.process_env(env), **(self._proxy_env() if self._cut else {})}
         env_args = [arg for k, v in env.items() for arg in ("--env", f"{k}={v}")]
         return await docker(
             "exec", *env_args, "--workdir", self.config.workdir, self._container, *argv
@@ -424,7 +430,7 @@ class DockerRuntime(Runtime):
         self, argv: list[str], env: dict[str, str]
     ) -> RuntimeProcess:
         assert self._container is not None
-        env = {**env, **(self._proxy_env() if self._cut else {})}
+        env = {**self.process_env(env), **(self._proxy_env() if self._cut else {})}
         env_args = [
             arg for key, value in env.items() for arg in ("--env", f"{key}={value}")
         ]
@@ -485,7 +491,7 @@ class DockerRuntime(Runtime):
         self, argv: list[str], env: dict[str, str], log: str
     ) -> None:
         # Detached servers survive the cut, so they need the initially permissive proxy.
-        env = {**env, **self._proxy_env()}
+        env = {**self.process_env(env), **self._proxy_env()}
         env_args = [arg for k, v in env.items() for arg in ("--env", f"{k}={v}")]
         inner = f"{' '.join(shlex.quote(a) for a in argv)} > {shlex.quote(log)} 2>&1"
         run = await docker(

--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -138,6 +138,7 @@ class ModalRuntime(Runtime):
                     # (e.g. SWE task images) never starts the keep-alive and the sandbox dies.
                     image=modal.Image.from_registry(self.config.image).entrypoint([]),
                     workdir=self.config.workdir,
+                    env=self.env,
                     cpu=self.config.cpu,
                     memory=int(self.config.memory * 1024),  # Modal memory is MB
                     gpu=self.config.gpu,
@@ -172,7 +173,7 @@ class ModalRuntime(Runtime):
     async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
         try:
             proc = await self._sandbox.exec.aio(
-                *argv, workdir=self.config.workdir, env=env
+                *argv, workdir=self.config.workdir, env=self.process_env(env)
             )
             # Drain both pipes concurrently so a large stderr can't deadlock stdout.
             stdout, stderr = await asyncio.gather(
@@ -203,7 +204,7 @@ class ModalRuntime(Runtime):
                 pidfile,
                 *argv,
                 workdir=self.config.workdir,
-                env=env,
+                env=self.process_env(env),
                 text=False,
             )
             loop = asyncio.get_running_loop()

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -191,6 +191,7 @@ class PrimeRuntime(Runtime):
                         docker_image=self.config.image,
                         vm=self.config.vm,
                         guaranteed=self.config.guaranteed,
+                        environment_vars=self.env,
                         **{k: v for k, v in options.items() if v is not None},
                     )
                 )
@@ -270,7 +271,7 @@ class PrimeRuntime(Runtime):
                 shlex.join(argv),
                 timeout=MAX_LIFETIME,
                 working_dir=self.config.workdir,
-                env=env,
+                env=self.process_env(env),
                 poll_interval=1,
             )
         except (
@@ -296,7 +297,7 @@ class PrimeRuntime(Runtime):
                 self.info.id,
                 shlex.join(argv),
                 working_dir=self.config.workdir,
-                env=env,
+                env=self.process_env(env),
             )
         except Exception as e:
             raise SandboxError(f"prime live process failed to start: {e}") from e
@@ -328,7 +329,7 @@ class PrimeRuntime(Runtime):
                 self.info.id,
                 command,
                 working_dir=self.config.workdir,
-                env=env,
+                env=self.process_env(env),
             )
         except Exception as e:
             raise SandboxError(f"prime background launch failed: {e}") from e

--- a/verifiers/v1/runtimes/subprocess.py
+++ b/verifiers/v1/runtimes/subprocess.py
@@ -97,7 +97,7 @@ class SubprocessRuntime(Runtime):
 
     async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
         full_env = {k: v for k, v in os.environ.items() if "API_KEY" not in k.upper()}
-        full_env.update(env)
+        full_env.update(self.process_env(env))
         proc = await asyncio.create_subprocess_exec(
             *argv,
             env=full_env,
@@ -127,7 +127,7 @@ class SubprocessRuntime(Runtime):
         self, argv: list[str], env: dict[str, str]
     ) -> RuntimeProcess:
         full_env = {k: v for k, v in os.environ.items() if "API_KEY" not in k.upper()}
-        full_env.update(env)
+        full_env.update(self.process_env(env))
         proc = await asyncio.create_subprocess_exec(
             *argv,
             env=full_env,
@@ -144,7 +144,7 @@ class SubprocessRuntime(Runtime):
         self, argv: list[str], env: dict[str, str], log: str
     ) -> None:
         full_env = {k: v for k, v in os.environ.items() if "API_KEY" not in k.upper()}
-        full_env.update(env)
+        full_env.update(self.process_env(env))
         logfile = self.workdir / log
         with logfile.open(
             "wb"

--- a/verifiers/v1/task.py
+++ b/verifiers/v1/task.py
@@ -163,6 +163,10 @@ class Task(Generic[DataT, StateT, ConfigT]):
         clone.data = self.data.model_copy(update={"system_prompt": system_prompt})
         return clone
 
+    def runtime_env(self) -> dict[str, str]:
+        """Live-only process environment; unlike TaskData, it is not traced."""
+        return {}
+
     async def setup(self, trace: Trace, runtime: Runtime) -> None:
         return None
 

--- a/verifiers/v1/tasksets/harbor/env.py
+++ b/verifiers/v1/tasksets/harbor/env.py
@@ -108,8 +108,11 @@ class HarborEnv(vf.Env[HarborEnvConfig]):
                 # because the teardown ran out the clock.
                 async with AsyncExitStack() as boxes:
                     async with asyncio.timeout(grader.data.timeout.scoring):
-                        box = await boxes.enter_async_context(provision_runtime(config))
+                        box = await boxes.enter_async_context(
+                            provision_runtime(config, env=grader.runtime_env())
+                        )
                         await box.prepare_setup()
+                        await grader.setup(box)
                         # Artifacts first, tests second: an artifact entry pointing
                         # into /tests must not survive staging, which wipes and
                         # rebuilds that directory.

--- a/verifiers/v1/tasksets/harbor/env.py
+++ b/verifiers/v1/tasksets/harbor/env.py
@@ -108,8 +108,9 @@ class HarborEnv(vf.Env[HarborEnvConfig]):
                 # because the teardown ran out the clock.
                 async with AsyncExitStack() as boxes:
                     async with asyncio.timeout(grader.data.timeout.scoring):
-                        box = await boxes.enter_async_context(provision_runtime(config))
-                        box.env = dict(grader.runtime_env())
+                        box = await boxes.enter_async_context(
+                            provision_runtime(config, env=grader.runtime_env())
+                        )
                         await box.prepare_setup()
                         await grader.setup(box)
                         # Artifacts first, tests second: an artifact entry pointing

--- a/verifiers/v1/tasksets/harbor/env.py
+++ b/verifiers/v1/tasksets/harbor/env.py
@@ -108,9 +108,8 @@ class HarborEnv(vf.Env[HarborEnvConfig]):
                 # because the teardown ran out the clock.
                 async with AsyncExitStack() as boxes:
                     async with asyncio.timeout(grader.data.timeout.scoring):
-                        box = await boxes.enter_async_context(
-                            provision_runtime(config, env=grader.runtime_env())
-                        )
+                        box = await boxes.enter_async_context(provision_runtime(config))
+                        box.env = dict(grader.runtime_env())
                         await box.prepare_setup()
                         await grader.setup(box)
                         # Artifacts first, tests second: an artifact entry pointing

--- a/verifiers/v1/tasksets/harbor/taskset.py
+++ b/verifiers/v1/tasksets/harbor/taskset.py
@@ -25,6 +25,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+import time
 from collections.abc import Iterator
 from functools import lru_cache
 from pathlib import Path
@@ -116,6 +117,8 @@ class VerifierConfig(BaseModel):
     own image, which is what Harbor's fresh copy of `[environment]` resolves to."""
     resources: TaskResources = TaskResources()
     workdir: str | None = None
+    env: dict[str, str] = Field(default_factory=dict)
+    healthcheck: dict | None = None
     fresh_copy: bool = False
     """Whether this came from Harbor's fresh copy of `[environment]` rather than a
     declared `[verifier.environment]`. A fresh copy inherits the agent box's resolved
@@ -142,6 +145,9 @@ class HarborData(TaskData):
     """Host path to the task dir; used to stage tests/ to verify."""
     upload_environment: bool = False
     """Whether to stage environment/ into the workdir."""
+    env: dict[str, str] = Field(default_factory=dict)
+    """Raw `[environment.env]` templates, resolved only when the runtime starts."""
+    healthcheck: dict | None = None
     verifier_env: dict[str, str] = Field(default_factory=dict)
     """Raw [verifier.env] entries (literals or `${VAR}`/`${VAR:-default}` templates).
     Resolved against the host environment at scoring time, like `harbor run` — so a
@@ -157,25 +163,60 @@ class HarborData(TaskData):
 class HarborTask(Task[HarborData]):
     """Stage and run Harbor's verifier inside the task's live runtime."""
 
+    def runtime_env(self) -> dict[str, str]:
+        return resolve_env(self.data.env)
+
     async def setup(self, runtime: Runtime) -> None:
-        if not self.data.upload_environment:
-            return
-        await runtime.write(
-            "/tmp/environment.tgz",
-            make_tar(Path(self.data.task_dir) / "environment"),
-        )
-        result = await runtime.run(
-            [
-                "sh",
-                "-c",
-                "tar --no-same-owner -xzf /tmp/environment.tgz && rm /tmp/environment.tgz",
-            ],
-            {},
-        )
-        if result.exit_code:
-            raise RuntimeError(
-                f"environment setup failed (exit {result.exit_code}): "
-                f"{(result.stderr or result.stdout).strip()[-500:]}"
+        if self.data.upload_environment:
+            await runtime.write(
+                "/tmp/environment.tgz",
+                make_tar(Path(self.data.task_dir) / "environment"),
+            )
+            result = await runtime.run(
+                [
+                    "sh",
+                    "-c",
+                    "tar --no-same-owner -xzf /tmp/environment.tgz && rm /tmp/environment.tgz",
+                ],
+                {},
+            )
+            if result.exit_code:
+                raise RuntimeError(
+                    f"environment setup failed (exit {result.exit_code}): "
+                    f"{(result.stderr or result.stdout).strip()[-500:]}"
+                )
+        if self.data.healthcheck is not None:
+            await self._wait_for_health(runtime, self.data.healthcheck)
+
+    async def _wait_for_health(self, runtime: Runtime, healthcheck: dict) -> None:
+        from harbor.environments.base import HealthcheckError
+        from harbor.models.task.config import HealthcheckConfig
+
+        healthcheck = HealthcheckConfig.model_validate(healthcheck)
+        start_period_end = time.monotonic() + healthcheck.start_period_sec
+        failures = 0
+        while True:
+            in_start_period = time.monotonic() < start_period_end
+            try:
+                async with asyncio.timeout(healthcheck.timeout_sec):
+                    if (
+                        await runtime.run(["sh", "-c", healthcheck.command], {})
+                    ).exit_code == 0:
+                        return
+            except TimeoutError:
+                pass
+
+            if not in_start_period:
+                failures += 1
+                if failures >= healthcheck.retries:
+                    raise HealthcheckError(
+                        f"Healthcheck failed after {healthcheck.retries} consecutive "
+                        f"retries: {healthcheck.command}"
+                    )
+            await asyncio.sleep(
+                healthcheck.start_interval_sec
+                if in_start_period
+                else healthcheck.interval_sec
             )
 
     async def finalize(self, trace: Trace, runtime: Runtime) -> None:
@@ -259,7 +300,9 @@ class HarborTask(Task[HarborData]):
     async def _graded(self, runtime: Runtime, trace: Trace) -> float | dict[str, float]:
         # By absolute path, in the runtime's configured workdir: Harbor execs the
         # script the same way, and scripts do grade the agent's work at `$PWD`.
-        await runtime.run(["bash", "/tests/test.sh"], verifier_env(self.data))
+        await runtime.run(
+            ["bash", "/tests/test.sh"], resolve_env(self.data.verifier_env)
+        )
         scores = await self._reward_json(runtime)
         if scores is not None:
             if isinstance(scores, dict) and "reward" in scores:
@@ -314,6 +357,9 @@ def verifier_box_data(data: HarborData) -> HarborData:
             "image": verifier.image if verifier.image is not None else data.image,
             "workdir": data.workdir if fresh else verifier.workdir,
             "resources": data.resources if fresh else verifier.resources,
+            "upload_environment": data.upload_environment if fresh else False,
+            "env": dict(verifier.env),
+            "healthcheck": verifier.healthcheck,
             "network_allow": list(verifier.network_allow),
             "network_block": [],
         }
@@ -529,6 +575,7 @@ def parse_task(task_dir: Path, idx: int, harbor_config: HarborConfig) -> HarborD
         tags=meta.get("tags", []),
         task_dir=str(task_dir),
         upload_environment=upload_environment,
+        **environment.model_dump(include={"env", "healthcheck"}, mode="json"),
         verifier_env=parsed.verifier.env,
         artifacts=artifacts,
         collect=hooks,
@@ -645,7 +692,7 @@ def parse_verifier_environment(
         )
     unsupported = [
         field
-        for field in ("healthcheck", "mcp_servers", "skills_dir", "gpu_types", "tpu")
+        for field in ("mcp_servers", "skills_dir", "gpu_types", "tpu")
         if getattr(environment, field, None)
     ]
     if environment.os != TaskOS.LINUX or unsupported:
@@ -667,6 +714,7 @@ def parse_verifier_environment(
             else TaskResources()
         ),
         workdir=environment.workdir if declared else None,
+        **environment.model_dump(include={"env", "healthcheck"}, mode="json"),
         fresh_copy=not declared,
         network_allow=(
             ["*"]
@@ -676,16 +724,16 @@ def parse_verifier_environment(
     )
 
 
-def verifier_env(task: HarborData) -> dict[str, str]:
-    """Resolve templates at scoring time so host secrets are never serialized."""
-    if not task.verifier_env:
+def resolve_env(values: dict[str, str]) -> dict[str, str]:
+    """Resolve templates at execution time so host secrets are never serialized."""
+    if not values:
         return {}
 
     # Harbor is an optional dependency, so importing this module must still work
     # for users who do not install the Harbor extra.
     from harbor.utils.env import resolve_env_vars
 
-    return resolve_env_vars(task.verifier_env)
+    return resolve_env_vars(values)
 
 
 # Downloaded task directories are immutable. Cache the current task's environment


### PR DESCRIPTION
## Overview

Adds Harbor environment variables and health checks to V1 runtimes.

## Details

- exposes live-only task runtime environment values across subprocess, Docker, Modal, and Prime
- resolves Harbor environment templates at rollout time while keeping resolved values out of traces
- runs Harbor-compatible health checks after environment staging and before harness setup
- applies the same behavior to separate verifier runtimes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches every runtime exec path and changes concurrency for borrowed sandboxes; env resolution affects secrets and process behavior but follows existing Harbor template semantics.
> 
> **Overview**
> Harbor-style **environment variables** and **healthchecks** now flow into live sandboxes without landing in traces. Tasks expose a `runtime_env()` hook (default empty); Harbor resolves `[environment.env]` templates at execution time and applies them on every backend.
> 
> **Runtime behavior:** each box carries mutable `runtime.env`, merged with per-command env via `process_env()` (process values win). Docker/Modal/Prime pass env at container/sandbox creation and on exec; subprocess merges into the host-filtered environment. `provision_runtime` accepts an optional `env` dict before `start()`.
> 
> **Rollouts:** owned runtimes set `runtime.env` from the task at open; borrowed boxes take `borrow_lock`, swap in the borrower's env, and restore the owner's env on release/abort so shared sandboxes stay task-isolated.
> 
> **Harbor tasks:** `HarborData` / verifier configs gain `env` and `healthcheck`; setup can poll a healthcheck command after staging `environment/`; separate verifier boxes get their own env/healthcheck and skip agent environment upload when not a fresh copy. Verifier env templating is generalized as `resolve_env()`.
> 
> **Tooling:** debug, validate, and agent `provision()` set `runtime.env` consistently (empty when provisioning without a task).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6b4d09ea70c19fc3d83d77183cb0fd801f14204. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-task runtime environment variables and healthcheck support to Harbor tasks
> - Introduces `Task.runtime_env()` in [task.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2362/files#diff-a1b4a5d6915beae41831864087ea497ed41f0b67b9091ad1ee614834cbfd9399) as an overridable method returning per-task environment variables; `HarborTask` overrides this to resolve env templates from task data.
> - Propagates `runtime.env` through all runtime backends (Docker, Modal, Prime, Subprocess) so environment variables are injected at container/sandbox start and merged with per-process envs for all exec calls.
> - Adds `healthcheck` support to Harbor tasks: after environment staging, `HarborTask.setup` polls a shell command with configurable start period, interval, timeout, and retries via the new `_wait_for_health` helper.
> - In borrowed runtimes (`Rollout`), the previous env is saved and restored after the borrow, with serialization via `borrow_lock`.
> - Risk: healthcheck failures raise `HealthcheckError` and block task setup; misconfigured healthchecks or slow services may cause timeouts in validation and rollout flows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e4d654a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->