### PR TITLE
Prevent --clean from deleting output roots

### DIFF
--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -62,35 +62,6 @@ USER_RUNTIMES = [
 ]
 
 
-@pytest.mark.parametrize("command", ["eval", "validate"])
-def test_clean_refuses_output_root(command, tmp_path, monkeypatch):
-    """Cleaning one run must never delete the directory grouping every run."""
-    if command == "eval":
-        from verifiers.v1.cli.eval.main import main
-    else:
-        from verifiers.v1.cli.validate import main
-
-    output_dir = tmp_path / "outputs"
-    sentinel = output_dir / "another-run" / "traces.jsonl"
-    sentinel.parent.mkdir(parents=True)
-    sentinel.write_text("keep")
-    monkeypatch.setattr("sys.argv", [command])
-
-    with pytest.raises(SystemExit, match="run.dir to name a child of output_dir"):
-        main(
-            [
-                "echo-v1",
-                "--output-dir",
-                str(output_dir),
-                "--run.dir",
-                ".",
-                "--clean",
-            ]
-        )
-
-    assert sentinel.read_text() == "keep"
-
-
 # ACP-backed harnesses: each must preserve an exchange across interaction segments and
 # retain MCP access after resuming. Cover every harness in the local container runtime,
 # plus remote placements for the sandbox/tunnel and native-process boundaries.

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -61,6 +61,36 @@ USER_RUNTIMES = [
     pytest.param("modal", marks=[mark.modal], id="harness-in-modal"),
 ]
 
+
+@pytest.mark.parametrize("command", ["eval", "validate"])
+def test_clean_refuses_output_root(command, tmp_path, monkeypatch):
+    """Cleaning one run must never delete the directory grouping every run."""
+    if command == "eval":
+        from verifiers.v1.cli.eval.main import main
+    else:
+        from verifiers.v1.cli.validate import main
+
+    output_dir = tmp_path / "outputs"
+    sentinel = output_dir / "another-run" / "traces.jsonl"
+    sentinel.parent.mkdir(parents=True)
+    sentinel.write_text("keep")
+    monkeypatch.setattr("sys.argv", [command])
+
+    with pytest.raises(SystemExit, match="run.dir to name a child of output_dir"):
+        main(
+            [
+                "echo-v1",
+                "--output-dir",
+                str(output_dir),
+                "--run.dir",
+                ".",
+                "--clean",
+            ]
+        )
+
+    assert sentinel.read_text() == "keep"
+
+
 # ACP-backed harnesses: each must preserve an exchange across interaction segments and
 # retain MCP access after resuming. Cover every harness in the local container runtime,
 # plus remote placements for the sandbox/tunnel and native-process boundaries.

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -61,7 +61,6 @@ USER_RUNTIMES = [
     pytest.param("modal", marks=[mark.modal], id="harness-in-modal"),
 ]
 
-
 # ACP-backed harnesses: each must preserve an exchange across interaction segments and
 # retain MCP access after resuming. Cover every harness in the local container runtime,
 # plus remote placements for the sandbox/tunnel and native-process boundaries.

--- a/verifiers/v1/cli/eval/main.py
+++ b/verifiers/v1/cli/eval/main.py
@@ -73,8 +73,12 @@ def main(argv: list[str] | None = None) -> None:
     # config a resume typically re-runs — would overwrite the previous run.
     run_path = output_path(config)
     if config.clean and not config.resume and run_path.exists():
-        if not run_path.resolve().is_relative_to(config.output_dir.resolve()):
-            raise SystemExit("--clean requires run.dir to remain under output_dir")
+        output_dir = config.output_dir.resolve()
+        resolved_run_path = run_path.resolve()
+        if resolved_run_path == output_dir or not resolved_run_path.is_relative_to(
+            output_dir
+        ):
+            raise SystemExit("--clean requires run.dir to name a child of output_dir")
         shutil.rmtree(run_path)
     traces_file = run_path / TRACES_FILE
     if not config.resume and traces_file.exists() and traces_file.stat().st_size > 0:

--- a/verifiers/v1/cli/validate.py
+++ b/verifiers/v1/cli/validate.py
@@ -485,8 +485,10 @@ def main(argv: list[str] | None = None) -> None:
     # A named run directory is re-entered only by `--resume` or wiped by `--clean`: any
     # other write into it would overwrite the previous run's results.
     if config.clean and not config.resume and out.exists():
-        if not out.resolve().is_relative_to(config.output_dir.resolve()):
-            raise SystemExit("--clean requires run.dir to remain under output_dir")
+        output_dir = config.output_dir.resolve()
+        resolved_out = out.resolve()
+        if resolved_out == output_dir or not resolved_out.is_relative_to(output_dir):
+            raise SystemExit("--clean requires run.dir to name a child of output_dir")
         shutil.rmtree(out)
     results_file = out / RESULTS_FILE
     if not config.resume and results_file.exists() and results_file.stat().st_size > 0:


### PR DESCRIPTION
## Overview

Prevent eval and validate cleanup from treating the shared output directory as an individual run directory.

## Details

Both CLIs now require the resolved run path to be a strict child of `output_dir` before recursively deleting it. Paths that resolve to the output root, including `run.dir = "."`, exit with a clear error while preserving sibling runs.

The behavior remains unchanged for valid child run directories and for paths that already escape the configured output directory.