### PR TITLE
Fix concurrent graph prefix commits

### DIFF
--- a/tests/v1/test_graph.py
+++ b/tests/v1/test_graph.py
@@ -232,6 +232,65 @@ def test_renderer_level_break_forks_by_token_id():
     ]
 
 
+def test_parallel_turns_rebase_shared_prefix_at_commit():
+    def response(content, prompt_ids, completion_id, message_spans):
+        return vf.Response(
+            id=content,
+            created=0,
+            model="test",
+            message=vf.AssistantMessage(content=content),
+            finish_reason="stop",
+            tokens=TurnTokens(
+                prompt_ids=prompt_ids,
+                completion_ids=[completion_id],
+                message_spans=message_spans,
+            ),
+        )
+
+    trace = vf.Trace(
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
+        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="x")),
+    )
+    system = vf.SystemMessage(content="shared worker system")
+    worker_a = vf.UserMessage(content="worker A")
+    worker_b = vf.UserMessage(content="worker B")
+
+    # Both requests resolve before either response commits, as they do during parallel
+    # inference. The second commit must discover the root created by the first.
+    turn_a = graph.prepare_turn(trace, [system, worker_a])
+    turn_b = graph.prepare_turn(trace, [system, worker_b])
+    turn_a.commit(response("A1", [1, 2, 3, 4], 5, [(0, 2), (2, 3)]))
+    turn_b.commit(response("B1", [1, 2, 6, 7], 8, [(0, 2), (2, 3)]))
+
+    roots = [node for node in trace.nodes if node.parent is None]
+    assert len(roots) == 1
+    assert trace.num_branches == 2
+
+    graph.prepare_turn(
+        trace,
+        [
+            system,
+            worker_a,
+            vf.AssistantMessage(content="A1"),
+            vf.UserMessage(content="continue A"),
+        ],
+    ).commit(
+        response(
+            "A2",
+            [1, 2, 3, 4, 5, 9, 10],
+            11,
+            [(0, 2), (2, 3), (3, 5), (5, 6)],
+        )
+    )
+
+    assert len([node for node in trace.nodes if node.parent is None]) == 1
+    assert trace.num_branches == 2
+    assert sorted(branch.token_ids for branch in trace.branches) == [
+        [1, 2, 3, 4, 5, 9, 10, 11],
+        [1, 2, 6, 7, 8],
+    ]
+
+
 def test_prompt_supplied_assistant_messages_are_not_sampled_turns():
     task = vf.TaskData(idx=0, prompt="few-shot")
     trace = vf.Trace(

--- a/tests/v1/test_graph.py
+++ b/tests/v1/test_graph.py
@@ -232,65 +232,6 @@ def test_renderer_level_break_forks_by_token_id():
     ]
 
 
-def test_parallel_turns_rebase_shared_prefix_at_commit():
-    def response(content, prompt_ids, completion_id, message_spans):
-        return vf.Response(
-            id=content,
-            created=0,
-            model="test",
-            message=vf.AssistantMessage(content=content),
-            finish_reason="stop",
-            tokens=TurnTokens(
-                prompt_ids=prompt_ids,
-                completion_ids=[completion_id],
-                message_spans=message_spans,
-            ),
-        )
-
-    trace = vf.Trace(
-        agent=vf.AgentInfo(config=vf.AgentConfig()),
-        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="x")),
-    )
-    system = vf.SystemMessage(content="shared worker system")
-    worker_a = vf.UserMessage(content="worker A")
-    worker_b = vf.UserMessage(content="worker B")
-
-    # Both requests resolve before either response commits, as they do during parallel
-    # inference. The second commit must discover the root created by the first.
-    turn_a = graph.prepare_turn(trace, [system, worker_a])
-    turn_b = graph.prepare_turn(trace, [system, worker_b])
-    turn_a.commit(response("A1", [1, 2, 3, 4], 5, [(0, 2), (2, 3)]))
-    turn_b.commit(response("B1", [1, 2, 6, 7], 8, [(0, 2), (2, 3)]))
-
-    roots = [node for node in trace.nodes if node.parent is None]
-    assert len(roots) == 1
-    assert trace.num_branches == 2
-
-    graph.prepare_turn(
-        trace,
-        [
-            system,
-            worker_a,
-            vf.AssistantMessage(content="A1"),
-            vf.UserMessage(content="continue A"),
-        ],
-    ).commit(
-        response(
-            "A2",
-            [1, 2, 3, 4, 5, 9, 10],
-            11,
-            [(0, 2), (2, 3), (3, 5), (5, 6)],
-        )
-    )
-
-    assert len([node for node in trace.nodes if node.parent is None]) == 1
-    assert trace.num_branches == 2
-    assert sorted(branch.token_ids for branch in trace.branches) == [
-        [1, 2, 3, 4, 5, 9, 10, 11],
-        [1, 2, 6, 7, 8],
-    ]
-
-
 def test_prompt_supplied_assistant_messages_are_not_sampled_turns():
     task = vf.TaskData(idx=0, prompt="few-shot")
     trace = vf.Trace(

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -563,11 +563,13 @@ def _commit_turn(
     # ids and keeps the message-hash prefix.
     prefix = turn.prefix_node_ids
     path_len = turn.path_len  # cumulative stored token length of the reused prefix
-    if tokens is not None:
-        # The original path produced this inference, so prefer it on a tie. A commit-time
-        # re-resolution wins only when a concurrent turn added a longer token-identical prefix.
-        best = -1
-        for candidate in (original, turn) if original is not None else (turn,):
+    # The original path produced this inference, so prefer it on a tie. A commit-time
+    # re-resolution wins only when a concurrent turn added a longer matching prefix.
+    best = -1
+    for candidate in (original, turn) if original is not None else (turn,):
+        keep = len(candidate.prefix_node_ids)
+        off = candidate.path_len
+        if tokens is not None:
             # Compare node by node against the prompt_ids slice at the running offset (C-level
             # list ==, short-circuits at the first divergent node) — no full concatenation.
             keep = 0
@@ -578,10 +580,10 @@ def _commit_turn(
                     break
                 off += len(node_tokens)
                 keep += 1
-            if keep > best:
-                prefix = candidate.prefix_node_ids[:keep]
-                path_len = off
-                best = keep
+        if keep > best:
+            prefix = candidate.prefix_node_ids[:keep]
+            path_len = off
+            best = keep
     num_reused = len(prefix)
     parent = prefix[-1] if prefix else None
     # cursor: in prompt_ids, the end of the previous *new* message's tokens

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -315,6 +315,7 @@ class PendingTurn:
     prompt: list[Message]
     prefix_node_ids: list[int]
     path_len: int
+    node_count: int
 
     @property
     def tail_start(self) -> int:
@@ -370,7 +371,15 @@ class PendingTurn:
 
     def commit(self, response: Response, tools: list[Tool] | None = None) -> int:
         """Add this turn to the graph; returns the committed assistant node's id."""
-        assistant_id = _commit_turn(self, response)
+        # Parallel requests can share a prefix that another request commits while this one
+        # is in flight. Resolve again so the later response joins that prefix instead of
+        # materializing a duplicate root from its stale pre-inference snapshot.
+        turn = (
+            self
+            if len(self.trace.nodes) == self.node_count
+            else prepare_turn(self.trace, self.prompt)
+        )
+        assistant_id = _commit_turn(turn, response)
         if tools:
             self.trace.tools = tools
         return assistant_id
@@ -422,6 +431,7 @@ def prepare_turn(trace: Trace, prompt: list[Message]) -> PendingTurn:
         prompt=prompt,
         prefix_node_ids=prefix_node_ids,
         path_len=path_len,
+        node_count=len(trace.nodes),
     )
 
 

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -379,7 +379,9 @@ class PendingTurn:
             if len(self.trace.nodes) == self.node_count
             else prepare_turn(self.trace, self.prompt)
         )
-        assistant_id = _commit_turn(turn, response)
+        assistant_id = _commit_turn(
+            turn, response, original=self if turn is not self else None
+        )
         if tools:
             self.trace.tools = tools
         return assistant_id
@@ -535,7 +537,9 @@ def _attribute_kept_tokens(
     node.kept_tokens = KeptTokens(ids=ids.copy(), counts=counts.copy())
 
 
-def _commit_turn(turn: PendingTurn, response: Response) -> int:
+def _commit_turn(
+    turn: PendingTurn, response: Response, original: PendingTurn | None = None
+) -> int:
     trace = turn.trace
     prompt = turn.prompt
     tokens = response.tokens
@@ -559,19 +563,25 @@ def _commit_turn(turn: PendingTurn, response: Response) -> int:
     # ids and keeps the message-hash prefix.
     prefix = turn.prefix_node_ids
     path_len = turn.path_len  # cumulative stored token length of the reused prefix
-    if tokens is not None and prefix:
-        # Compare node by node against the prompt_ids slice at the running offset (C-level list
-        # ==, short-circuits at the first divergent node) — no full concatenation materialized.
-        keep = 0
-        off = 0
-        for nid in prefix:
-            node_tokens = trace.nodes[nid].token_ids
-            if prompt_ids[off : off + len(node_tokens)] != node_tokens:
-                break
-            off += len(node_tokens)
-            keep += 1
-        prefix = prefix[:keep]
-        path_len = off
+    if tokens is not None:
+        # The original path produced this inference, so prefer it on a tie. A commit-time
+        # re-resolution wins only when a concurrent turn added a longer token-identical prefix.
+        best = -1
+        for candidate in (original, turn) if original is not None else (turn,):
+            # Compare node by node against the prompt_ids slice at the running offset (C-level
+            # list ==, short-circuits at the first divergent node) — no full concatenation.
+            keep = 0
+            off = 0
+            for nid in candidate.prefix_node_ids:
+                node_tokens = trace.nodes[nid].token_ids
+                if prompt_ids[off : off + len(node_tokens)] != node_tokens:
+                    break
+                off += len(node_tokens)
+                keep += 1
+            if keep > best:
+                prefix = candidate.prefix_node_ids[:keep]
+                path_len = off
+                best = keep
     num_reused = len(prefix)
     parent = prefix[-1] if prefix else None
     # cursor: in prompt_ids, the end of the previous *new* message's tokens


### PR DESCRIPTION
## Overview

Keep concurrent message-graph commits attached to shared prefixes that become available while inference is in flight.

## Details

Parallel model requests can resolve against the same graph snapshot before either response commits. A later response would continue using that stale snapshot, materialize an already-committed prefix again, and leave the earlier partial path as an extra graph leaf.

`PendingTurn` now records the graph size it resolved against. If another request changes the graph before the response commits, the turn resolves its prompt again and then uses the existing token-identity checks before reusing any prefix. Sequential turns retain the existing direct commit path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes graph node reuse and branching under concurrent commits and tokenized responses; correctness-critical for training trajectories but limited to the v1 message-graph commit path.
> 
> **Overview**
> Fixes a race where parallel rollouts could **duplicate already-committed prefix nodes** because each `PendingTurn` kept the graph snapshot from before inference.
> 
> `PendingTurn` now stores **`node_count`** when `prepare_turn` runs. On **`commit`**, if the trace has grown, the turn **re-resolves** the prompt and `_commit_turn` chooses the **longest token-identical prefix** between the fresh resolution and the original turn, **preferring the original on ties** so inference still attaches to the path that produced the response unless a concurrent commit extended a better shared prefix.
> 
> Sequential commits are unchanged when `len(trace.nodes) == node_count`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2892f2913b836d9e1b5128c8b4df8ee15498972. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix concurrent graph prefix commits by re-resolving stale prefix paths at commit time
> - Adds a `node_count` snapshot to `PendingTurn` to detect graph growth between `prepare_turn` and `commit`.
> - If the graph has grown since preparation, `commit` re-runs `prepare_turn` against the latest graph before calling `_commit_turn`.
> - `_commit_turn` now compares the original and re-resolved prefix candidates and picks the one with the longest common token prefix, preferring the original on ties.
> - Behavioral Change: committed assistant nodes may now attach to a longer prefix path than before when concurrent graph updates occurred.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c2892f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->