### PR TITLE
Add Grok Build harness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -294,6 +294,7 @@ markers = [
     "pi: v1 e2e cases on the pi harness",
     "pool: v1 e2e cases on the pool harness",
     "codex: v1 e2e cases on the codex harness",
+    "grok_build: v1 e2e cases on the grok-build harness",
     "unit: marks tests as unit tests",
     "asyncio: marks tests as async tests",
     "parsers: marks tests for parser components",

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -25,7 +25,7 @@ Every combination carries its axes' pytest marks, so subsets select with `-m`:
 
 Marks: runtimes `subprocess` / `docker` / `prime` / `modal`, placement `colocated`,
 harnesses `null` / `bash` / `rlm` / `kimi_code` / `pi` / `pool` / `openclaw` / `codex` /
-`claude_code` / `hermes_agent`.
+`claude_code` / `grok_build` / `hermes_agent`.
 A mark is applied per axis, so it selects every case touching that value on ANY axis; for one exact
 combination use `-k` on the test id (e.g. `-k "harness-in-docker-with-tool-in-subprocess"`).
 prime/modal provision real remote sandboxes (slow, infra-flaky, need setup), so they're local-only.
@@ -71,7 +71,7 @@ def tool_runtime(request) -> dict:
 
 
 # Built-in harnesses are bundled in the `harnesses` package; the agent CLIs (`rlm` /
-# `kimi-code` / `openclaw` / `codex` / `claude-code` / `hermes-agent`) install their
+# `kimi-code` / `openclaw` / `codex` / `claude-code` / `grok-build` / `hermes-agent`) install their
 # dependencies at rollout.
 # `compact` (an example harness) and `terminus-2` (drives the host tmux) are excluded from e2e.
 @pytest.fixture

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -47,6 +47,7 @@ AGENTIC_PLACEMENTS = [
     ),
     pair("codex", "docker", "codex-harness-in-docker"),
     pair("claude-code", "docker", "claude-code-harness-in-docker"),
+    pair("grok-build", "docker", "grok-build-harness-in-docker"),
     pair("hermes-agent", "docker", "hermes-agent-harness-in-docker"),
     pair("bash", "prime", "bash-harness-in-prime"),
     pair("bash", "modal", "bash-harness-in-modal"),
@@ -67,6 +68,7 @@ USER_RUNTIMES = [
 ACP_RESUME_PLACEMENTS = [
     pair("codex", "docker", "codex-acp-in-docker"),
     pair("claude-code", "docker", "claude-code-acp-in-docker"),
+    pair("grok-build", "docker", "grok-build-acp-in-docker"),
     pair("hermes-agent", "docker", "hermes-agent-acp-in-docker"),
     pair("rlm", "docker", "rlm-acp-in-docker"),
     pytest.param(
@@ -257,9 +259,10 @@ async def test_acp_resume_with_tool(run_v1, harness, harness_runtime, tmp_path):
     assert len(segments) == 2
     assert segments[0]["terminated"] is False
     assert segments[1]["terminated"] is False
-    # Kimi Code is broken upstream: its Responses adapter drops message `phase` on replay.
+    # Kimi Code drops Responses `phase` on replay. Grok Build rewrites the first
+    # output message into a plain input item, producing one deterministic dead leaf.
     if harness.id != "kimi-code":
-        assert trace.num_branches == 1
+        assert trace.num_branches == (2 if harness.id == "grok-build" else 1)
     # Native MCP tools need not appear in the intercepted model request that
     # populates trace.tools; the ACP transcript is the source of truth for use.
     assert "tool" in segments[1]["roles"]

--- a/verifiers/v1/harnesses/__init__.py
+++ b/verifiers/v1/harnesses/__init__.py
@@ -8,6 +8,10 @@ from verifiers.v1.harnesses.claude_code import (
     ClaudeCodeHarnessConfig,
 )
 from verifiers.v1.harnesses.codex import CodexHarness, CodexHarnessConfig
+from verifiers.v1.harnesses.grok_build import (
+    GrokBuildHarness,
+    GrokBuildHarnessConfig,
+)
 from verifiers.v1.harnesses.hermes_agent import (
     HermesAgentHarness,
     HermesAgentHarnessConfig,
@@ -33,6 +37,8 @@ __all__ = [
     "ClaudeCodeHarnessConfig",
     "CodexHarness",
     "CodexHarnessConfig",
+    "GrokBuildHarness",
+    "GrokBuildHarnessConfig",
     "HermesAgentHarness",
     "HermesAgentHarnessConfig",
     "KimiCodeHarness",

--- a/verifiers/v1/harnesses/grok_build/__init__.py
+++ b/verifiers/v1/harnesses/grok_build/__init__.py
@@ -1,0 +1,6 @@
+from verifiers.v1.harnesses.grok_build.harness import (
+    GrokBuildHarness,
+    GrokBuildHarnessConfig,
+)
+
+__all__ = ["GrokBuildHarness", "GrokBuildHarnessConfig"]

--- a/verifiers/v1/harnesses/grok_build/harness.py
+++ b/verifiers/v1/harnesses/grok_build/harness.py
@@ -1,0 +1,227 @@
+"""Run Grok Build's native ACP server against interception."""
+
+import json
+import logging
+import shlex
+
+import tomli_w
+from pydantic import Field
+
+from verifiers.v1.acp import ACPConfig, ACPHarness
+from verifiers.v1.clients import ModelContext
+from verifiers.v1.configs.harness import HarnessConfig
+from verifiers.v1.runtimes import Runtime
+from verifiers.v1.task import TaskData
+from verifiers.v1.trace import Trace
+
+logger = logging.getLogger(__name__)
+
+GROK_DIR = "/var/tmp/vf-grok-build"
+BINARY = f"{GROK_DIR}/bin/grok"
+KEY_VAR = "VF_GROK_INTERCEPT_KEY"
+MODEL_ALIAS = "verifiers"
+SUMMARY_MODEL_ALIAS = "verifiers-session-summary"
+# Grok's Responses watchdog intentionally ignores lifecycle and empty-delta events. Verifiers
+# owns the rollout deadline and remote sandboxes live at most 24 hours, so keep Grok's independent
+# content watchdog just beyond that bound instead of fabricating model tokens to satisfy it.
+INFERENCE_IDLE_TIMEOUT_SECONDS = 25 * 60 * 60
+
+INSTALL = r"""
+set -e
+root=/var/tmp/vf-grok-build
+bin="$root/bin/grok"
+version_file="$root/.version"
+if [ -x "$bin" ] && [ "$(cat "$version_file" 2>/dev/null)" = "$VF_GROK_BUILD_VERSION" ]; then
+    exit 0
+fi
+if ! command -v bash >/dev/null || ! command -v curl >/dev/null; then
+    if command -v apk >/dev/null; then
+        apk add --no-cache bash curl ca-certificates >/dev/null
+    elif command -v apt-get >/dev/null; then
+        apt-get update -qq
+        apt-get install -y -qq bash curl ca-certificates >/dev/null
+    else
+        echo "Grok Build installation requires bash and curl" >&2
+        exit 1
+    fi
+fi
+installer="$root/install.sh"
+curl -fsSL https://x.ai/cli/install.sh -o "$installer"
+mkdir -p "$root/install-home"
+env \
+    HOME="$root/install-home" \
+    GROK_BIN_DIR="$root/bin" \
+    GROK_DISABLE_AUTOUPDATER=1 \
+    SHELL= \
+    bash "$installer" "$VF_GROK_BUILD_VERSION"
+test -x "$bin"
+printf %s "$VF_GROK_BUILD_VERSION" > "$version_file"
+"""
+
+
+class GrokBuildHarnessConfig(HarnessConfig):
+    version: str = Field(
+        default="1.0.3",
+        pattern=r"^[0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9._]+)?$",
+    )
+    """Grok Build release to install, pinned for reproducibility."""
+
+
+class GrokBuildHarness(ACPHarness[GrokBuildHarnessConfig]):
+    APPENDS_SYSTEM_PROMPT = True
+    SUPPORTS_MCP = True
+    SUPPORTS_SKILLS = True
+
+    async def setup(self, runtime: Runtime) -> None:
+        logger.info(
+            "grok-build: ensuring Grok Build %s is installed", self.config.version
+        )
+        lock = f"{GROK_DIR}/install.lock"
+        guarded = (
+            f"mkdir -p {GROK_DIR} && "
+            f'until ln -s "$$" {lock} 2>/dev/null; do '
+            f"owner=$(readlink {lock}); "
+            f'if ! kill -0 "$owner" 2>/dev/null; then '
+            f'[ "$(readlink {lock})" != "$owner" ] || rm -f {lock}; fi; '
+            f"sleep 0.1; done; "
+            f'trap \'[ "$(readlink {lock})" != "$$" ] || rm -f {lock}\' EXIT; '
+            f"sh -c {shlex.quote(INSTALL)}"
+        )
+        install = await runtime.run(
+            ["sh", "-c", guarded],
+            {"VF_GROK_BUILD_VERSION": self.config.version},
+        )
+        if install.exit_code != 0:
+            detail = (install.stderr or install.stdout).strip()[-500:]
+            raise RuntimeError(f"Grok Build install failed: {detail}")
+        await super().setup(runtime)
+
+    async def prepare_acp(
+        self,
+        ctx: ModelContext,
+        trace: Trace,
+        runtime: Runtime,
+        endpoint: str,
+        secret: str,
+        mcp_urls: dict[str, str],
+        data: TaskData,
+    ) -> ACPConfig:
+        grok_home = self.grok_home(trace)
+        await self.install_skills(runtime, f"{grok_home}/skills")
+
+        model = {
+            "model": ctx.model,
+            "base_url": endpoint,
+            "name": ctx.model,
+            "env_key": KEY_VAR,
+            "api_backend": "responses",
+            "inference_idle_timeout_secs": INFERENCE_IDLE_TIMEOUT_SECONDS,
+            "supports_backend_search": False,
+        }
+        if ctx.sampling.temperature is not None:
+            model["temperature"] = ctx.sampling.temperature
+        if ctx.sampling.top_p is not None:
+            model["top_p"] = ctx.sampling.top_p
+        if ctx.sampling.max_tokens is not None:
+            model["max_completion_tokens"] = ctx.sampling.max_tokens
+        config = {
+            "cli": {"auto_update": False, "use_leader": False},
+            "features": {"telemetry": False, "feedback": False},
+            "memory": {"enabled": False},
+            "models": {
+                "default": MODEL_ALIAS,
+                "web_search": MODEL_ALIAS,
+                # Grok has no switch for UI session-title inference. Keep that
+                # auxiliary request out of the rollout trace; Grok falls back to
+                # a title derived locally from the first user message.
+                "session_summary": SUMMARY_MODEL_ALIAS,
+                "image_description": MODEL_ALIAS,
+                "prompt_suggestion": MODEL_ALIAS,
+                "allowed_models": [MODEL_ALIAS],
+            },
+            "model": {
+                MODEL_ALIAS: model,
+                SUMMARY_MODEL_ALIAS: {
+                    "model": SUMMARY_MODEL_ALIAS,
+                    "base_url": "http://127.0.0.1:1",
+                    "name": "Disabled session summary",
+                    "env_key": KEY_VAR,
+                    "api_backend": "responses",
+                },
+            },
+            # An explicitly selected subagent model could leave interception; keep
+            # Grok's native child-agent surface off in the eval harness.
+            "subagents": {"enabled": False},
+        }
+        await runtime.write(f"{grok_home}/config.toml", tomli_w.dumps(config).encode())
+
+        profile_args: list[str] = []
+        if self.config.disabled_tools:
+            profile = (
+                "---\n"
+                "name: verifiers\n"
+                "description: Grok Build running under Verifiers\n"
+                f"disallowedTools: {json.dumps(self.config.disabled_tools)}\n"
+                "---\n"
+            )
+            profile_path = f"{grok_home}/agent.md"
+            await runtime.write(profile_path, profile.encode())
+            profile_args = ["--agent-profile", profile_path]
+
+        system_prompt, prompt = self.resolve_prompt(data)
+        env = {
+            **self.config.resolved_env,
+            "HOME": grok_home,
+            "USERPROFILE": grok_home,
+            "GIT_CONFIG_GLOBAL": f"{grok_home}/gitconfig",
+            "GROK_HOME": grok_home,
+            KEY_VAR: secret,
+            # Prevent ambient first-party credentials from selecting an xAI endpoint.
+            "XAI_API_KEY": "",
+            "GROK_CODE_XAI_API_KEY": "",
+            "GROK_DEPLOYMENT_KEY": "",
+            "GROK_SUBAGENTS": "0",
+            "GROK_MEMORY": "0",
+            "GROK_MANAGED_MCPS_ENABLED": "false",
+            "GROK_MANAGED_MCP_GATEWAY_TOOLS_ENABLED": "false",
+            "GROK_TELEMETRY_ENABLED": "false",
+            "GROK_TELEMETRY_TRACE_UPLOAD": "false",
+            "GROK_FEEDBACK_ENABLED": "false",
+            "GROK_TRACE_UPLOAD": "false",
+            "GROK_INSTRUMENTATION": "disabled",
+            "GROK_DISABLE_AUTOUPDATER": "1",
+            "GROK_PROMPT_SUGGESTIONS": "false",
+            "GROK_TURN_SUMMARY": "0",
+            "OTEL_SDK_DISABLED": "true",
+            "DISABLE_TELEMETRY": "1",
+            "DISABLE_FEEDBACK_COMMAND": "1",
+        }
+        command = [
+            BINARY,
+            "--no-auto-update",
+            "--disable-web-search",
+            "agent",
+            "--no-leader",
+            "--always-approve",
+            "--model",
+            MODEL_ALIAS,
+            *profile_args,
+            "stdio",
+        ]
+        return ACPConfig(
+            env=env,
+            command=command,
+            prompt=prompt,
+            system_prompt=system_prompt,
+        )
+
+    async def cleanup(self, trace: Trace, runtime: Runtime) -> None:
+        result = await runtime.run(["rm", "-rf", self.grok_home(trace)], {})
+        if result.exit_code != 0:
+            raise RuntimeError(
+                f"failed to clean up Grok home: {result.stderr.strip()[-500:]}"
+            )
+
+    @staticmethod
+    def grok_home(trace: Trace) -> str:
+        return f".vf-grok-build/{trace.id}"


### PR DESCRIPTION
## Summary

- add a native ACP harness for Grok Build, pinned to release 1.0.3
- route model traffic through Verifiers interception with per-trace homes and cleanup
- support MCP servers, uploaded skills, disabled tools, and sampling configuration
- disable ambient xAI credentials, telemetry, memory, web search, subagents, and UI-only helper traffic
- add Docker agentic and two-segment ACP resume/MCP coverage
- set Grok's independent inference-idle watchdog beyond Verifiers' maximum remote runtime, allowing buffered Responses streams without fake model tokens

## Streaming watchdog compatibility

The training-streaming PR, #2369, opens SSE immediately and emits valid content-free protocol events while renderer generation is buffered. Grok Build 1.0.3 treats parsed Responses lifecycle events as activity, which was confirmed against the exact pinned binary.

Newer Grok behavior is stricter: its content watchdog ignores lifecycle and empty-delta events. This harness therefore sets `inference_idle_timeout_secs` to 25 hours—just beyond the 24-hour remote sandbox limit—so Verifiers remains the deadline owner. This avoids corrupting assistant content or tool state with fake nonempty deltas.

## Live validation

Using the repository's `PRIME_API_KEY`:

- MATH-500: 1.0
- HumanEval: 1.0
- glossary MCP lookup: 1.0
- wiki-search completed cleanly across six model turns and exercised search/view/read; the separate judge returned 0.0 despite the response containing the reference fact
- focused Grok Build e2e matrix: 2 passed

## Contributor checks

- `uv run pytest tests/` — 914 passed, 77 skipped (test-created commits used process-local signing disable)
- `uv run pytest tests/v1 -m 'not e2e'` — 70 passed, 77 deselected after rebase
- exact Grok Build 1.0.3 watchdog behavior tested against a delayed local Responses stream
- changed-file pre-commit hooks passed
- pre-push Ruff, format, and `ty` hooks passed
- full markdownlint reports 321 pre-existing MD033 findings in the untouched legacy SWE README

The commit is signed with the contributor's verified SSH signing key.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- Macroscope's pull request summary ends here -->
