### PR TITLE
feat(v1): rho harness — pi's four tools plus code-mode run_code

### DIFF
--- a/docs/v1/harnesses.md
+++ b/docs/v1/harnesses.md
@@ -1,6 +1,6 @@
 # Harnesses
 
-verifiers supports a range of harnesses out of the box, including Claude Code, Codex, the tool-enabled `bash` harness, the CDP-driven `browser_use` harness, and the minimal tool-less `null` harness. However, you may want to build a custom one or extend the selection of third‑party harnesses.
+verifiers supports a range of harnesses out of the box, including Claude Code, Codex, the tool-enabled `bash` harness, the CDP-driven `browser_use` harness, the minimal tool-less `null` harness, and the `rho` harness (pi-style read/write/edit/bash plus a code-mode `run_code` that carries the task's MCP tools, `completion()`, and gated subagents). However, you may want to build a custom one or extend the selection of third‑party harnesses.
 
 ## A minimal harness implementation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -288,6 +288,7 @@ markers = [
     "colocated: v1 e2e cases with a user/tool server colocated in the harness runtime",
     "null: v1 e2e cases on the null harness",
     "bash: v1 e2e cases on the bash harness",
+    "rho: v1 e2e cases on the rho harness",
     "browser_use: v1 e2e cases on the browser_use harness",
     "rlm: v1 e2e cases on the rlm harness",
     "kimi_code: v1 e2e cases on the kimi-code harness",

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -22,6 +22,7 @@ def pair(a: str, b: str, id: str, *extra_marks):
 CHAT_PLACEMENTS = [
     pair("null", "subprocess", "null-harness-in-subprocess"),
     pair("bash", "docker", "bash-harness-in-docker"),
+    pair("rho", "docker", "rho-harness-in-docker"),
     pair("rlm", "docker", "rlm-harness-in-docker"),
     pytest.param(
         {"id": "kimi-code", "transport": "responses"},
@@ -38,6 +39,7 @@ CHAT_PLACEMENTS = [
 # remote row per provider.
 AGENTIC_PLACEMENTS = [
     pair("bash", "subprocess", "bash-harness-in-subprocess"),
+    pair("rho", "docker", "rho-harness-in-docker"),
     pair("rlm", "docker", "rlm-harness-in-docker"),
     pytest.param(
         {"id": "kimi-code", "transport": "responses"},

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -68,6 +68,7 @@ USER_RUNTIMES = [
 # plus remote placements for the sandbox/tunnel and native-process boundaries.
 ACP_RESUME_PLACEMENTS = [
     pair("codex", "docker", "codex-acp-in-docker"),
+    pair("rho", "docker", "rho-acp-in-docker"),
     pair("claude-code", "docker", "claude-code-acp-in-docker"),
     pair("hermes-agent", "docker", "hermes-agent-acp-in-docker"),
     pair("rlm", "docker", "rlm-acp-in-docker"),

--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -22,7 +22,7 @@ from verifiers.v1.utils.aio import run_shielded
 ACP_SOURCE = (Path(__file__).resolve().parent / "runner.py").read_text()
 MAX_PACKET_BYTES = 128 * 1024 * 1024
 
-__all__ = ["ACPConfig", "ACPHarness", "ACPHarnessSession"]
+__all__ = ["ACPConfig", "ACPHarness"]
 
 ConfigT = TypeVar("ConfigT", bound=HarnessConfig)
 JsonValue: TypeAlias = (
@@ -46,9 +46,6 @@ class ACPConfig:
 
 class ACPHarness(Harness[ConfigT]):
     """Harness backed by one live ACP process and native session per rollout."""
-
-    SESSION_CLASS: "type[ACPHarnessSession] | None" = None
-    """Subclass hook for extending the session (e.g. picking up diagnostics on close)."""
 
     async def setup(self, runtime: Runtime) -> None:
         await runtime.prepare_uv_script(
@@ -85,8 +82,7 @@ class ACPHarness(Harness[ConfigT]):
         config = await self.prepare_acp(
             ctx, trace, runtime, endpoint, secret, mcp_urls, data
         )
-        session_cls = type(self).SESSION_CLASS or ACPHarnessSession
-        return session_cls(
+        return ACPHarnessSession(
             self,
             ctx,
             trace,

--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -22,7 +22,7 @@ from verifiers.v1.utils.aio import run_shielded
 ACP_SOURCE = (Path(__file__).resolve().parent / "runner.py").read_text()
 MAX_PACKET_BYTES = 128 * 1024 * 1024
 
-__all__ = ["ACPConfig", "ACPHarness"]
+__all__ = ["ACPConfig", "ACPHarness", "ACPHarnessSession"]
 
 ConfigT = TypeVar("ConfigT", bound=HarnessConfig)
 JsonValue: TypeAlias = (
@@ -46,6 +46,9 @@ class ACPConfig:
 
 class ACPHarness(Harness[ConfigT]):
     """Harness backed by one live ACP process and native session per rollout."""
+
+    SESSION_CLASS: "type[ACPHarnessSession] | None" = None
+    """Subclass hook for extending the session (e.g. picking up diagnostics on close)."""
 
     async def setup(self, runtime: Runtime) -> None:
         await runtime.prepare_uv_script(
@@ -82,7 +85,8 @@ class ACPHarness(Harness[ConfigT]):
         config = await self.prepare_acp(
             ctx, trace, runtime, endpoint, secret, mcp_urls, data
         )
-        return ACPHarnessSession(
+        session_cls = type(self).SESSION_CLASS or ACPHarnessSession
+        return session_cls(
             self,
             ctx,
             trace,

--- a/verifiers/v1/harnesses/rho/__init__.py
+++ b/verifiers/v1/harnesses/rho/__init__.py
@@ -1,7 +1,3 @@
-from verifiers.v1.harnesses.rho.harness import (
-    RhoHarness,
-    RhoHarnessConfig,
-    RhoHarnessSession,
-)
+from verifiers.v1.harnesses.rho.harness import RhoHarness, RhoHarnessConfig
 
-__all__ = ["RhoHarness", "RhoHarnessConfig", "RhoHarnessSession"]
+__all__ = ["RhoHarness", "RhoHarnessConfig"]

--- a/verifiers/v1/harnesses/rho/__init__.py
+++ b/verifiers/v1/harnesses/rho/__init__.py
@@ -1,3 +1,7 @@
-from verifiers.v1.harnesses.rho.harness import RhoHarness, RhoHarnessConfig
+from verifiers.v1.harnesses.rho.harness import (
+    RhoHarness,
+    RhoHarnessConfig,
+    RhoHarnessSession,
+)
 
-__all__ = ["RhoHarness", "RhoHarnessConfig"]
+__all__ = ["RhoHarness", "RhoHarnessConfig", "RhoHarnessSession"]

--- a/verifiers/v1/harnesses/rho/__init__.py
+++ b/verifiers/v1/harnesses/rho/__init__.py
@@ -1,0 +1,3 @@
+from verifiers.v1.harnesses.rho.harness import RhoHarness, RhoHarnessConfig
+
+__all__ = ["RhoHarness", "RhoHarnessConfig"]

--- a/verifiers/v1/harnesses/rho/harness.py
+++ b/verifiers/v1/harnesses/rho/harness.py
@@ -45,6 +45,12 @@ class RhoHarnessConfig(HarnessConfig):
     just a safety net: compacting earlier than the physical limit is how the skill gets
     practiced. 0 disables (tests only)."""
 
+    history_file: bool = True
+    """Write the transcript a checkpoint replaces to a greppable file named in the
+    framing message. Recoverable history licenses tighter summaries — the checkpoint
+    carries decisions and state, and raw data stays a grep away instead of rotting in
+    context. Off for seats where compaction-as-skill is the curriculum."""
+
     max_compactions: int = 8
     """Checkpoint compactions allowed per rollout; past the cap the transcript grows
     uncompacted."""
@@ -98,6 +104,7 @@ class RhoHarness(Harness[RhoHarnessConfig]):
         if self.config.compact_tool:
             args.append("--compact-tool")
         args.append(f"--context-budget-tokens={self.config.context_budget_tokens}")
+        args.append("--history-file" if self.config.history_file else "--no-history-file")
         args.append(f"--max-compactions={self.config.max_compactions}")
         # One cap, owned by the framework: the box spends the budget it is measured
         # against instead of walking into a refused call.

--- a/verifiers/v1/harnesses/rho/harness.py
+++ b/verifiers/v1/harnesses/rho/harness.py
@@ -7,11 +7,10 @@ import json
 import tarfile
 from pathlib import Path
 
+from verifiers.v1.acp import ACPConfig, ACPHarness, ACPHarnessSession
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
-from verifiers.v1.dialects.chat import message_to_wire
-from verifiers.v1.harness import Harness
-from verifiers.v1.runtimes import ProgramResult, Runtime
+from verifiers.v1.runtimes import Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
 
@@ -20,8 +19,8 @@ PROGRAM_SOURCE = (Path(__file__).resolve().parent / "program.py").read_text()
 NATIVE_TOOLS = ("read", "write", "edit", "bash", "run_code")
 
 RUNTIME_DIAGNOSTICS = "/tmp/.rho/runtime.json"
-"""Where the program leaves its stats (mirrors program.py); picked up onto the trace.
-Per-segment, last-write-wins on resume — cumulative truth lives on the trace itself."""
+"""Where the program leaves its stats (mirrors program.py); picked up onto the trace
+when the session closes. The program rewrites it after every segment."""
 
 
 class RhoHarnessConfig(HarnessConfig):
@@ -41,18 +40,30 @@ class RhoHarnessConfig(HarnessConfig):
     practiced. 0 disables (tests only)."""
 
 
-class RhoHarness(Harness[RhoHarnessConfig]):
+class RhoHarnessSession(ACPHarnessSession):
+    async def close(self) -> None:
+        # Diagnostics ride the session's end; failures must never mask teardown.
+        if not self._closed:
+            with contextlib.suppress(Exception):
+                picked = await self.runtime.run(["cat", RUNTIME_DIAGNOSTICS], {})
+                if picked.exit_code == 0 and picked.stdout.strip():
+                    self.trace.info["rho"] = json.loads(picked.stdout)
+        await super().close()
+
+
+class RhoHarness(ACPHarness[RhoHarnessConfig]):
     APPENDS_SYSTEM_PROMPT = True
     SUPPORTS_MCP = True
-    # A resumed segment relaunches on the accreted conversation: the kernel namespace
-    # is fresh (stated to the model), files and the tools tree persist on the runtime.
+    # One live process per rollout: later turns land in the same conversation, so the
+    # kernel namespace, named agent() sessions, and the transcript file all persist.
     SUPPORTS_RESUME = True
     EXECUTES_CODE = True
     NEEDS_CONTAINER = True
+    SESSION_CLASS = RhoHarnessSession
 
     def tool_surface(self) -> list[str]:
         # Seat shaping goes through the base `disabled_tools`: a ptc-style service
-        # seat is disabled_tools=["read", "write", "edit"]. `--tools` is the one
+        # seat is disabled_tools=["read", "write", "edit"]. RHO_TOOLS is the one
         # channel for what the seat offers — compact rides it like everything else.
         tools = [
             name
@@ -64,9 +75,10 @@ class RhoHarness(Harness[RhoHarnessConfig]):
         return tools
 
     async def setup(self, runtime: Runtime) -> None:
+        await super().setup(runtime)
         await runtime.prepare_uv_script(PROGRAM_SOURCE, self.config.resolved_env)
 
-    async def launch(
+    async def prepare_acp(
         self,
         ctx: ModelContext,
         trace: Trace,
@@ -75,77 +87,62 @@ class RhoHarness(Harness[RhoHarnessConfig]):
         secret: str,
         mcp_urls: dict[str, str],
         data: TaskData,
-    ) -> ProgramResult:
+    ) -> ACPConfig:
         system_prompt, prompt = self.resolve_prompt(data)
-        # Stage the task's `inputs/` tree — the file-based taskset convention — on the
-        # first segment only (a Messages prompt is a resumed segment whose workspace is
-        # work in progress). One tarball, one upload, one extraction: a per-file loop
-        # costs 2N gateway round-trips on the prime runtime.
-        if isinstance(prompt, str) or prompt is None:
-            task_dir = Path(raw) if (raw := getattr(data, "dir", "") or "") else None
-            if task_dir is not None and (inputs := task_dir / "inputs").is_dir():
-                buffer = io.BytesIO()
+        # Stage the task's `inputs/` tree — the file-based taskset convention. A session
+        # starts once per rollout, so this always runs on a fresh workspace. One tarball,
+        # one upload, one extraction: a per-file loop costs 2N gateway round-trips on
+        # the prime runtime.
+        task_dir = Path(raw) if (raw := getattr(data, "dir", "") or "") else None
+        if task_dir is not None and (inputs := task_dir / "inputs").is_dir():
+            buffer = io.BytesIO()
 
-                def build_tar() -> None:
-                    with tarfile.open(fileobj=buffer, mode="w") as tar:
-                        tar.add(inputs, arcname="inputs")
+            def build_tar() -> None:
+                with tarfile.open(fileobj=buffer, mode="w") as tar:
+                    tar.add(inputs, arcname="inputs")
 
-                await asyncio.to_thread(build_tar)
-                archive = f".vf-inputs-{trace.id}.tar"
-                await runtime.write(archive, buffer.getvalue())
-                staged = await runtime.run(
-                    ["sh", "-c", f"tar -xf {archive} && rm -f {archive}"], {}
-                )
-                if staged.exit_code != 0:
-                    raise RuntimeError(
-                        f"inputs staging failed (exit {staged.exit_code}): "
-                        f"{staged.stderr.strip()[-300:]}"
-                    )
-        args = [
-            f"--base-url={endpoint}",
-            f"--api-key={secret}",
-            f"--model={ctx.model}",
-            f"--system-prompt={system_prompt or ''}",
-            "--tools=" + ",".join(self.tool_surface()),
-            f"--context-budget-tokens={self.config.context_budget_tokens}",
-        ]
-        if isinstance(prompt, str) or prompt is None:
-            args.append(f"--prompt={prompt or ''}")
-        else:
-            # A resumed segment's prompt is the accreted conversation; hand Messages
-            # over through a file (base64 images can exceed exec limits).
-            path = f".vf-initial-messages-{trace.id}.json"
-            await runtime.write(
-                path, json.dumps([message_to_wire(m) for m in prompt]).encode()
+            await asyncio.to_thread(build_tar)
+            archive = f".vf-inputs-{trace.id}.tar"
+            await runtime.write(archive, buffer.getvalue())
+            staged = await runtime.run(
+                ["sh", "-c", f"tar -xf {archive} && rm -f {archive}"], {}
             )
-            args.append(f"--initial-messages-file={path}")
+            if staged.exit_code != 0:
+                raise RuntimeError(
+                    f"inputs staging failed (exit {staged.exit_code}): "
+                    f"{staged.stderr.strip()[-300:]}"
+                )
+        env = {
+            **self.config.resolved_env,
+            # The program pops RHO_* on startup so the secret never reaches the
+            # kernel's or bash's inherited environment.
+            "RHO_BASE_URL": endpoint,
+            "RHO_API_KEY": secret,
+            "RHO_MODEL": ctx.model,
+            "RHO_TOOLS": ",".join(self.tool_surface()),
+            "RHO_CONTEXT_BUDGET_TOKENS": str(self.config.context_budget_tokens),
+        }
+        if system_prompt:
+            # A file, not an env value: task system prompts can exceed env limits.
+            path = f".vf-rho-system-{trace.id}"
+            await runtime.write(path, system_prompt.encode())
+            env["RHO_SYSTEM_PROMPT_FILE"] = path
         # One effort channel: the framework's sampling config (which interception
         # overlays on every call anyway); no rho-only knob to fight it.
         if ctx.sampling.reasoning_effort:
-            args.append(f"--effort={ctx.sampling.reasoning_effort}")
+            env["RHO_EFFORT"] = ctx.sampling.reasoning_effort
         if self.config.subagents:
-            args.append("--subagents")
+            env["RHO_SUBAGENTS"] = "1"
         # One cap, owned by the framework: the box spends the budget it is measured
-        # against instead of walking into a refused call. A resumed segment gets the
-        # REMAINING allowance — the trace has already spent turns against the cap.
+        # against instead of walking into a refused call. The budget spans the whole
+        # session — every segment's turns draw on it.
         if trace.agent is not None and trace.agent.config.max_turns:
-            args.append(
-                f"--max-turns={max(0, trace.agent.config.max_turns - trace.num_turns)}"
-            )
-        if mcp_urls:
-            args.append(
-                "--mcp-config="
-                + json.dumps(
-                    {"mcpServers": {n: {"url": u} for n, u in mcp_urls.items()}}
-                )
+            env["RHO_MAX_TURNS"] = str(
+                max(0, trace.agent.config.max_turns - trace.num_turns)
             )
         program = await runtime.prepare_uv_script(
             PROGRAM_SOURCE, self.config.resolved_env
         )
-        result = await runtime.run_program([*program, *args], self.config.resolved_env)
-        # Diagnostics ride the segment's end; failures must never mask its result.
-        with contextlib.suppress(Exception):
-            picked = await runtime.run(["cat", RUNTIME_DIAGNOSTICS], {})
-            if picked.exit_code == 0 and picked.stdout.strip():
-                trace.info["rho"] = json.loads(picked.stdout)
-        return result
+        # system_prompt stays out of ACPConfig: the runner would fold it into the first
+        # prompt's text blocks, while rho builds its own system message from the file.
+        return ACPConfig(env=env, command=[*program], prompt=prompt)

--- a/verifiers/v1/harnesses/rho/harness.py
+++ b/verifiers/v1/harnesses/rho/harness.py
@@ -1,7 +1,10 @@
 """Rho: pi's four tools plus run_code — services, sub-LLM calls, and subagents live in code."""
 
+import asyncio
 import contextlib
+import io
 import json
+import tarfile
 from pathlib import Path
 
 from verifiers.v1.clients import ModelContext
@@ -17,8 +20,9 @@ PROGRAM_SOURCE = (Path(__file__).resolve().parent / "program.py").read_text()
 
 NATIVE_TOOLS = ("read", "write", "edit", "bash", "run_code")
 
-RUNTIME_DIAGNOSTICS = "/tmp/.rho-runtime.json"
-"""Where the program leaves its stats (mirrors program.py); picked up onto the trace."""
+RUNTIME_DIAGNOSTICS = "/tmp/.rho/runtime.json"
+"""Where the program leaves its stats (mirrors program.py); picked up onto the trace.
+Per-segment, last-write-wins on resume — cumulative truth lives on the trace itself."""
 
 
 class RhoHarnessConfig(HarnessConfig):
@@ -81,13 +85,30 @@ class RhoHarness(Harness[RhoHarnessConfig]):
     ) -> None:
         # Stage the task's `inputs/` tree into the workspace — the file-based taskset
         # convention — on the FIRST segment only: a resumed segment's workspace is the
-        # model's work in progress, and re-staging would clobber it.
+        # model's work in progress, and re-staging would clobber it. One tarball, one
+        # upload, one extraction: a per-file loop costs 2N gateway round-trips on the
+        # prime runtime, minutes of startup for large trees. (The tarball is built in
+        # memory — an accepted limit of the convention; inputs are task-sized.)
         if messages is None:
             task_dir = Path(raw) if (raw := getattr(data, "dir", "") or "") else None
             if task_dir is not None and (inputs := task_dir / "inputs").is_dir():
-                for path in sorted(p for p in inputs.rglob("*") if p.is_file()):
-                    relative = path.relative_to(inputs).as_posix()
-                    await runtime.write(f"inputs/{relative}", path.read_bytes())
+                buffer = io.BytesIO()
+
+                def build_tar() -> None:
+                    with tarfile.open(fileobj=buffer, mode="w") as tar:
+                        tar.add(inputs, arcname="inputs")
+
+                await asyncio.to_thread(build_tar)
+                archive = f".vf-inputs-{trace.id}.tar"
+                await runtime.write(archive, buffer.getvalue())
+                result = await runtime.run(
+                    ["sh", "-c", f"tar -xf {archive} && rm -f {archive}"], {}
+                )
+                if result.exit_code != 0:
+                    raise RuntimeError(
+                        f"inputs staging failed (exit {result.exit_code}): "
+                        f"{result.stderr.strip()[-300:]}"
+                    )
         try:
             await super().run(
                 ctx, trace, runtime, endpoint, secret, mcp_urls, data, messages

--- a/verifiers/v1/harnesses/rho/harness.py
+++ b/verifiers/v1/harnesses/rho/harness.py
@@ -1,0 +1,114 @@
+"""Rho: pi's four tools plus run_code — services, sub-LLM calls, and subagents live in code."""
+
+import json
+from pathlib import Path
+
+from verifiers.v1.clients import ModelContext
+from verifiers.v1.configs.harness import HarnessConfig
+from verifiers.v1.harness import Harness
+from verifiers.v1.runtimes import ProgramResult, Runtime
+from verifiers.v1.task import TaskData
+from verifiers.v1.trace import Trace
+
+PROGRAM_SOURCE = (Path(__file__).resolve().parent / "program.py").read_text()
+
+NATIVE_TOOLS = ("read", "write", "edit", "bash", "run_code")
+
+
+class RhoHarnessConfig(HarnessConfig):
+    edit: bool = True
+    """Offer the `edit` tool (exact once-only string replacement, batched)."""
+
+    run_code: bool = True
+    """Offer `run_code` (persistent Python kernel; service tools, completion(), agent()).
+    Off is a pure-pi seat. Finer cuts go through the base `disabled_tools`."""
+
+    subagents: bool = False
+    """Expose `agent(...)` inside run_code. Subagents run sequentially with a blank
+    context at depth 1; every subagent turn spends the same trace turn budget."""
+
+    max_subagents: int = 16
+    """Spawn cap per rollout, so exhaustion is a legible error instead of a
+    mid-fleet refusal."""
+
+    compact_tool: bool = False
+    """Offer a zero-param `compact` tool that schedules a context checkpoint before the
+    next work turn (Codex `new_context` precedent). Enabling it also disclosed the
+    current context-token figure each turn — a model can only time compaction well if
+    it can see the clock."""
+
+    effort: str = ""
+    """Reasoning effort forwarded to the model (empty = provider default)."""
+
+    context_budget_tokens: int = 150_000
+    """Prompt-token threshold that triggers checkpoint compaction. A training knob, not
+    just a safety net: compacting earlier than the physical limit is how the skill gets
+    practiced. 0 disables (tests only)."""
+
+    max_compactions: int = 8
+    """Checkpoint compactions allowed per rollout; past the cap the transcript grows
+    uncompacted."""
+
+    disclose_budget: bool = False
+    """Append the remaining-turn-budget line to each turn's last tool result. Off for
+    solver seats: a visible clock is pacing information the task never granted."""
+
+
+class RhoHarness(Harness[RhoHarnessConfig]):
+    APPENDS_SYSTEM_PROMPT = True
+    SUPPORTS_MCP = True
+    SUPPORTS_RESUME = False
+    EXECUTES_CODE = True
+    NEEDS_CONTAINER = True
+
+    def tool_surface(self) -> list[str]:
+        tools = [name for name in NATIVE_TOOLS if name not in (self.config.disabled_tools or [])]
+        if not self.config.edit and "edit" in tools:
+            tools.remove("edit")
+        if not self.config.run_code and "run_code" in tools:
+            tools.remove("run_code")
+        return tools
+
+    async def setup(self, runtime: Runtime) -> None:
+        await runtime.prepare_uv_script(PROGRAM_SOURCE, self.config.resolved_env)
+
+    async def launch(
+        self,
+        ctx: ModelContext,
+        trace: Trace,
+        runtime: Runtime,
+        endpoint: str,
+        secret: str,
+        mcp_urls: dict[str, str],
+        data: TaskData,
+    ) -> ProgramResult:
+        system_prompt, prompt = self.resolve_text_prompt(data)
+        args = [
+            f"--base-url={endpoint}",
+            f"--api-key={secret}",
+            f"--model={ctx.model}",
+            f"--system-prompt={system_prompt or ''}",
+            f"--prompt={prompt or ''}",
+            "--tools=" + ",".join(self.tool_surface()),
+        ]
+        if self.config.effort:
+            args.append(f"--effort={self.config.effort}")
+        if self.config.subagents:
+            args += ["--subagents", f"--max-subagents={self.config.max_subagents}"]
+        if self.config.compact_tool:
+            args.append("--compact-tool")
+        args.append(f"--context-budget-tokens={self.config.context_budget_tokens}")
+        args.append(f"--max-compactions={self.config.max_compactions}")
+        # One cap, owned by the framework: the box spends the budget it is measured
+        # against instead of walking into a refused call.
+        if trace.agent is not None and trace.agent.config.max_turns:
+            args.append(f"--max-turns={trace.agent.config.max_turns}")
+        if self.config.disclose_budget:
+            args.append("--disclose-budget")
+        if mcp_urls:
+            args.append(
+                "--mcp-config="
+                + json.dumps({"mcpServers": {n: {"url": u} for n, u in mcp_urls.items()}})
+            )
+        program = await runtime.prepare_uv_script(PROGRAM_SOURCE, self.config.resolved_env)
+        return await runtime.run_program([*program, *args], self.config.resolved_env)

--- a/verifiers/v1/harnesses/rho/harness.py
+++ b/verifiers/v1/harnesses/rho/harness.py
@@ -14,7 +14,6 @@ from verifiers.v1.harness import Harness
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
-from verifiers.v1.types import Messages
 
 PROGRAM_SOURCE = (Path(__file__).resolve().parent / "program.py").read_text()
 
@@ -67,54 +66,6 @@ class RhoHarness(Harness[RhoHarnessConfig]):
     async def setup(self, runtime: Runtime) -> None:
         await runtime.prepare_uv_script(PROGRAM_SOURCE, self.config.resolved_env)
 
-    async def run(
-        self,
-        ctx: ModelContext,
-        trace: Trace,
-        runtime: Runtime,
-        endpoint: str,
-        secret: str,
-        mcp_urls: dict[str, str],
-        data: TaskData,
-        messages: Messages | None = None,
-    ) -> None:
-        # Stage the task's `inputs/` tree into the workspace — the file-based taskset
-        # convention — on the FIRST segment only: a resumed segment's workspace is the
-        # model's work in progress, and re-staging would clobber it. One tarball, one
-        # upload, one extraction: a per-file loop costs 2N gateway round-trips on the
-        # prime runtime, minutes of startup for large trees. (The tarball is built in
-        # memory — an accepted limit of the convention; inputs are task-sized.)
-        if messages is None:
-            task_dir = Path(raw) if (raw := getattr(data, "dir", "") or "") else None
-            if task_dir is not None and (inputs := task_dir / "inputs").is_dir():
-                buffer = io.BytesIO()
-
-                def build_tar() -> None:
-                    with tarfile.open(fileobj=buffer, mode="w") as tar:
-                        tar.add(inputs, arcname="inputs")
-
-                await asyncio.to_thread(build_tar)
-                archive = f".vf-inputs-{trace.id}.tar"
-                await runtime.write(archive, buffer.getvalue())
-                result = await runtime.run(
-                    ["sh", "-c", f"tar -xf {archive} && rm -f {archive}"], {}
-                )
-                if result.exit_code != 0:
-                    raise RuntimeError(
-                        f"inputs staging failed (exit {result.exit_code}): "
-                        f"{result.stderr.strip()[-300:]}"
-                    )
-        try:
-            await super().run(
-                ctx, trace, runtime, endpoint, secret, mcp_urls, data, messages
-            )
-        finally:
-            # Diagnostics must never mask the actual rollout result.
-            with contextlib.suppress(Exception):
-                result = await runtime.run(["cat", RUNTIME_DIAGNOSTICS], {})
-                if result.exit_code == 0 and result.stdout.strip():
-                    trace.info["rho"] = json.loads(result.stdout)
-
     async def launch(
         self,
         ctx: ModelContext,
@@ -126,6 +77,30 @@ class RhoHarness(Harness[RhoHarnessConfig]):
         data: TaskData,
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(data)
+        # Stage the task's `inputs/` tree — the file-based taskset convention — on the
+        # first segment only (a Messages prompt is a resumed segment whose workspace is
+        # work in progress). One tarball, one upload, one extraction: a per-file loop
+        # costs 2N gateway round-trips on the prime runtime.
+        if isinstance(prompt, str) or prompt is None:
+            task_dir = Path(raw) if (raw := getattr(data, "dir", "") or "") else None
+            if task_dir is not None and (inputs := task_dir / "inputs").is_dir():
+                buffer = io.BytesIO()
+
+                def build_tar() -> None:
+                    with tarfile.open(fileobj=buffer, mode="w") as tar:
+                        tar.add(inputs, arcname="inputs")
+
+                await asyncio.to_thread(build_tar)
+                archive = f".vf-inputs-{trace.id}.tar"
+                await runtime.write(archive, buffer.getvalue())
+                staged = await runtime.run(
+                    ["sh", "-c", f"tar -xf {archive} && rm -f {archive}"], {}
+                )
+                if staged.exit_code != 0:
+                    raise RuntimeError(
+                        f"inputs staging failed (exit {staged.exit_code}): "
+                        f"{staged.stderr.strip()[-300:]}"
+                    )
         args = [
             f"--base-url={endpoint}",
             f"--api-key={secret}",
@@ -167,4 +142,10 @@ class RhoHarness(Harness[RhoHarnessConfig]):
         program = await runtime.prepare_uv_script(
             PROGRAM_SOURCE, self.config.resolved_env
         )
-        return await runtime.run_program([*program, *args], self.config.resolved_env)
+        result = await runtime.run_program([*program, *args], self.config.resolved_env)
+        # Diagnostics ride the segment's end; failures must never mask its result.
+        with contextlib.suppress(Exception):
+            picked = await runtime.run(["cat", RUNTIME_DIAGNOSTICS], {})
+            if picked.exit_code == 0 and picked.stdout.strip():
+                trace.info["rho"] = json.loads(picked.stdout)
+        return result

--- a/verifiers/v1/harnesses/rho/harness.py
+++ b/verifiers/v1/harnesses/rho/harness.py
@@ -44,7 +44,11 @@ class RhoHarnessConfig(HarnessConfig):
     disclose_budget: bool = False
     """Append the remaining-turn-budget line to each turn's last tool result. Off for
     solver seats: a visible clock is pacing information the task never granted. On for
-    synthesis seats, so a round consolidates instead of truncating at the cap."""
+    synthesis seats, so a round consolidates instead of truncating at the cap.
+
+    Discloses the FRAMEWORK's cap (`AgentConfig.max_turns`), the only turn limit that
+    exists — when the framework sets none, there is no budget and nothing is shown.
+    On a resumed segment the figures are this segment's remaining allowance."""
 
 
 class RhoHarness(Harness[RhoHarnessConfig]):

--- a/verifiers/v1/harnesses/rho/harness.py
+++ b/verifiers/v1/harnesses/rho/harness.py
@@ -51,7 +51,11 @@ class RhoHarness(Harness[RhoHarnessConfig]):
         # Seat shaping goes through the base `disabled_tools`: a ptc-style service
         # seat is disabled_tools=["read", "write", "edit"]. `--tools` is the one
         # channel for what the seat offers — compact rides it like everything else.
-        tools = [name for name in NATIVE_TOOLS if name not in (self.config.disabled_tools or [])]
+        tools = [
+            name
+            for name in NATIVE_TOOLS
+            if name not in (self.config.disabled_tools or [])
+        ]
         if self.config.compact_tool:
             tools.append("compact")
         return tools
@@ -98,13 +102,19 @@ class RhoHarness(Harness[RhoHarnessConfig]):
         # against instead of walking into a refused call. A resumed segment gets the
         # REMAINING allowance — the trace has already spent turns against the cap.
         if trace.agent is not None and trace.agent.config.max_turns:
-            args.append(f"--max-turns={max(0, trace.agent.config.max_turns - trace.num_turns)}")
+            args.append(
+                f"--max-turns={max(0, trace.agent.config.max_turns - trace.num_turns)}"
+            )
         if self.config.disclose_budget:
             args.append("--disclose-budget")
         if mcp_urls:
             args.append(
                 "--mcp-config="
-                + json.dumps({"mcpServers": {n: {"url": u} for n, u in mcp_urls.items()}})
+                + json.dumps(
+                    {"mcpServers": {n: {"url": u} for n, u in mcp_urls.items()}}
+                )
             )
-        program = await runtime.prepare_uv_script(PROGRAM_SOURCE, self.config.resolved_env)
+        program = await runtime.prepare_uv_script(
+            PROGRAM_SOURCE, self.config.resolved_env
+        )
         return await runtime.run_program([*program, *args], self.config.resolved_env)

--- a/verifiers/v1/harnesses/rho/harness.py
+++ b/verifiers/v1/harnesses/rho/harness.py
@@ -1,5 +1,6 @@
 """Rho: pi's four tools plus run_code — services, sub-LLM calls, and subagents live in code."""
 
+import contextlib
 import json
 from pathlib import Path
 
@@ -10,10 +11,14 @@ from verifiers.v1.harness import Harness
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
+from verifiers.v1.types import Messages
 
 PROGRAM_SOURCE = (Path(__file__).resolve().parent / "program.py").read_text()
 
 NATIVE_TOOLS = ("read", "write", "edit", "bash", "run_code")
+
+RUNTIME_DIAGNOSTICS = "/tmp/.rho-runtime.json"
+"""Where the program leaves its stats (mirrors program.py); picked up onto the trace."""
 
 
 class RhoHarnessConfig(HarnessConfig):
@@ -62,6 +67,37 @@ class RhoHarness(Harness[RhoHarnessConfig]):
 
     async def setup(self, runtime: Runtime) -> None:
         await runtime.prepare_uv_script(PROGRAM_SOURCE, self.config.resolved_env)
+
+    async def run(
+        self,
+        ctx: ModelContext,
+        trace: Trace,
+        runtime: Runtime,
+        endpoint: str,
+        secret: str,
+        mcp_urls: dict[str, str],
+        data: TaskData,
+        messages: Messages | None = None,
+    ) -> None:
+        # Stage the task's `inputs/` tree into the workspace — the file-based taskset
+        # convention — on the FIRST segment only: a resumed segment's workspace is the
+        # model's work in progress, and re-staging would clobber it.
+        if messages is None:
+            task_dir = Path(raw) if (raw := getattr(data, "dir", "") or "") else None
+            if task_dir is not None and (inputs := task_dir / "inputs").is_dir():
+                for path in sorted(p for p in inputs.rglob("*") if p.is_file()):
+                    relative = path.relative_to(inputs).as_posix()
+                    await runtime.write(f"inputs/{relative}", path.read_bytes())
+        try:
+            await super().run(
+                ctx, trace, runtime, endpoint, secret, mcp_urls, data, messages
+            )
+        finally:
+            # Diagnostics must never mask the actual rollout result.
+            with contextlib.suppress(Exception):
+                result = await runtime.run(["cat", RUNTIME_DIAGNOSTICS], {})
+                if result.exit_code == 0 and result.stdout.strip():
+                    trace.info["rho"] = json.loads(result.stdout)
 
     async def launch(
         self,

--- a/verifiers/v1/harnesses/rho/harness.py
+++ b/verifiers/v1/harnesses/rho/harness.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
+from verifiers.v1.dialects.chat import message_to_wire
 from verifiers.v1.harness import Harness
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.task import TaskData
@@ -43,7 +44,9 @@ class RhoHarnessConfig(HarnessConfig):
 class RhoHarness(Harness[RhoHarnessConfig]):
     APPENDS_SYSTEM_PROMPT = True
     SUPPORTS_MCP = True
-    SUPPORTS_RESUME = False
+    # A resumed segment relaunches on the accreted conversation: the kernel namespace
+    # is fresh (stated to the model), files and the tools tree persist on the runtime.
+    SUPPORTS_RESUME = True
     EXECUTES_CODE = True
     NEEDS_CONTAINER = True
 
@@ -65,16 +68,25 @@ class RhoHarness(Harness[RhoHarnessConfig]):
         mcp_urls: dict[str, str],
         data: TaskData,
     ) -> ProgramResult:
-        system_prompt, prompt = self.resolve_text_prompt(data)
+        system_prompt, prompt = self.resolve_prompt(data)
         args = [
             f"--base-url={endpoint}",
             f"--api-key={secret}",
             f"--model={ctx.model}",
             f"--system-prompt={system_prompt or ''}",
-            f"--prompt={prompt or ''}",
             "--tools=" + ",".join(self.tool_surface()),
             f"--context-budget-tokens={self.config.context_budget_tokens}",
         ]
+        if isinstance(prompt, str) or prompt is None:
+            args.append(f"--prompt={prompt or ''}")
+        else:
+            # A resumed segment's prompt is the accreted conversation; hand Messages
+            # over through a file (base64 images can exceed exec limits).
+            path = f".rho-messages-{trace.id}.json"
+            await runtime.write(
+                path, json.dumps([message_to_wire(m) for m in prompt]).encode()
+            )
+            args.append(f"--initial-messages-file={path}")
         if self.config.effort:
             args.append(f"--effort={self.config.effort}")
         if self.config.subagents:

--- a/verifiers/v1/harnesses/rho/harness.py
+++ b/verifiers/v1/harnesses/rho/harness.py
@@ -16,24 +16,13 @@ NATIVE_TOOLS = ("read", "write", "edit", "bash", "run_code")
 
 
 class RhoHarnessConfig(HarnessConfig):
-    edit: bool = True
-    """Offer the `edit` tool (exact once-only string replacement, batched)."""
-
-    run_code: bool = True
-    """Offer `run_code` (persistent Python kernel; service tools, completion(), agent()).
-    Off is a pure-pi seat. Finer cuts go through the base `disabled_tools`."""
-
     subagents: bool = False
     """Expose `agent(...)` inside run_code. Subagents run sequentially with a blank
     context at depth 1; every subagent turn spends the same trace turn budget."""
 
-    max_subagents: int = 16
-    """Spawn cap per rollout, so exhaustion is a legible error instead of a
-    mid-fleet refusal."""
-
     compact_tool: bool = False
     """Offer a zero-param `compact` tool that schedules a context checkpoint before the
-    next work turn (Codex `new_context` precedent). Enabling it also disclosed the
+    next work turn (Codex `new_context` precedent). Enabling it also discloses the
     current context-token figure each turn — a model can only time compaction well if
     it can see the clock."""
 
@@ -45,19 +34,10 @@ class RhoHarnessConfig(HarnessConfig):
     just a safety net: compacting earlier than the physical limit is how the skill gets
     practiced. 0 disables (tests only)."""
 
-    history_file: bool = True
-    """Write the transcript a checkpoint replaces to a greppable file named in the
-    framing message. Recoverable history licenses tighter summaries — the checkpoint
-    carries decisions and state, and raw data stays a grep away instead of rotting in
-    context. Off for seats where compaction-as-skill is the curriculum."""
-
-    max_compactions: int = 8
-    """Checkpoint compactions allowed per rollout; past the cap the transcript grows
-    uncompacted."""
-
     disclose_budget: bool = False
     """Append the remaining-turn-budget line to each turn's last tool result. Off for
-    solver seats: a visible clock is pacing information the task never granted."""
+    solver seats: a visible clock is pacing information the task never granted. On for
+    synthesis seats, so a round consolidates instead of truncating at the cap."""
 
 
 class RhoHarness(Harness[RhoHarnessConfig]):
@@ -68,12 +48,9 @@ class RhoHarness(Harness[RhoHarnessConfig]):
     NEEDS_CONTAINER = True
 
     def tool_surface(self) -> list[str]:
-        tools = [name for name in NATIVE_TOOLS if name not in (self.config.disabled_tools or [])]
-        if not self.config.edit and "edit" in tools:
-            tools.remove("edit")
-        if not self.config.run_code and "run_code" in tools:
-            tools.remove("run_code")
-        return tools
+        # Seat shaping goes through the base `disabled_tools`: a ptc-style service
+        # seat is disabled_tools=["read", "write", "edit"].
+        return [name for name in NATIVE_TOOLS if name not in (self.config.disabled_tools or [])]
 
     async def setup(self, runtime: Runtime) -> None:
         await runtime.prepare_uv_script(PROGRAM_SOURCE, self.config.resolved_env)
@@ -96,16 +73,14 @@ class RhoHarness(Harness[RhoHarnessConfig]):
             f"--system-prompt={system_prompt or ''}",
             f"--prompt={prompt or ''}",
             "--tools=" + ",".join(self.tool_surface()),
+            f"--context-budget-tokens={self.config.context_budget_tokens}",
         ]
         if self.config.effort:
             args.append(f"--effort={self.config.effort}")
         if self.config.subagents:
-            args += ["--subagents", f"--max-subagents={self.config.max_subagents}"]
+            args.append("--subagents")
         if self.config.compact_tool:
             args.append("--compact-tool")
-        args.append(f"--context-budget-tokens={self.config.context_budget_tokens}")
-        args.append("--history-file" if self.config.history_file else "--no-history-file")
-        args.append(f"--max-compactions={self.config.max_compactions}")
         # One cap, owned by the framework: the box spends the budget it is measured
         # against instead of walking into a refused call.
         if trace.agent is not None and trace.agent.config.max_turns:

--- a/verifiers/v1/harnesses/rho/harness.py
+++ b/verifiers/v1/harnesses/rho/harness.py
@@ -22,13 +22,10 @@ class RhoHarnessConfig(HarnessConfig):
     context at depth 1; every subagent turn spends the same trace turn budget."""
 
     compact_tool: bool = False
-    """Offer a zero-param `compact` tool that schedules a context checkpoint before the
-    next work turn (Codex `new_context` precedent). Enabling it also discloses the
-    current context-token figure each turn — a model can only time compaction well if
-    it can see the clock."""
-
-    effort: str = ""
-    """Reasoning effort forwarded to the model (empty = provider default)."""
+    """Add a zero-param `compact` tool to the surface: it schedules a context checkpoint
+    before the next work turn (Codex `new_context` precedent). Enabling it also
+    discloses the current context-token figure each turn — a model can only time
+    compaction well if it can see the clock."""
 
     context_budget_tokens: int = 150_000
     """Prompt-token threshold that triggers checkpoint compaction. A training knob, not
@@ -52,8 +49,12 @@ class RhoHarness(Harness[RhoHarnessConfig]):
 
     def tool_surface(self) -> list[str]:
         # Seat shaping goes through the base `disabled_tools`: a ptc-style service
-        # seat is disabled_tools=["read", "write", "edit"].
-        return [name for name in NATIVE_TOOLS if name not in (self.config.disabled_tools or [])]
+        # seat is disabled_tools=["read", "write", "edit"]. `--tools` is the one
+        # channel for what the seat offers — compact rides it like everything else.
+        tools = [name for name in NATIVE_TOOLS if name not in (self.config.disabled_tools or [])]
+        if self.config.compact_tool:
+            tools.append("compact")
+        return tools
 
     async def setup(self, runtime: Runtime) -> None:
         await runtime.prepare_uv_script(PROGRAM_SOURCE, self.config.resolved_env)
@@ -82,17 +83,17 @@ class RhoHarness(Harness[RhoHarnessConfig]):
         else:
             # A resumed segment's prompt is the accreted conversation; hand Messages
             # over through a file (base64 images can exceed exec limits).
-            path = f".rho-messages-{trace.id}.json"
+            path = f".vf-initial-messages-{trace.id}.json"
             await runtime.write(
                 path, json.dumps([message_to_wire(m) for m in prompt]).encode()
             )
             args.append(f"--initial-messages-file={path}")
-        if self.config.effort:
-            args.append(f"--effort={self.config.effort}")
+        # One effort channel: the framework's sampling config (which interception
+        # overlays on every call anyway); no rho-only knob to fight it.
+        if ctx.sampling.reasoning_effort:
+            args.append(f"--effort={ctx.sampling.reasoning_effort}")
         if self.config.subagents:
             args.append("--subagents")
-        if self.config.compact_tool:
-            args.append("--compact-tool")
         # One cap, owned by the framework: the box spends the budget it is measured
         # against instead of walking into a refused call.
         if trace.agent is not None and trace.agent.config.max_turns:

--- a/verifiers/v1/harnesses/rho/harness.py
+++ b/verifiers/v1/harnesses/rho/harness.py
@@ -41,15 +41,6 @@ class RhoHarnessConfig(HarnessConfig):
     just a safety net: compacting earlier than the physical limit is how the skill gets
     practiced. 0 disables (tests only)."""
 
-    disclose_budget: bool = False
-    """Append the remaining-turn-budget line to each turn's last tool result. Off for
-    solver seats: a visible clock is pacing information the task never granted. On for
-    synthesis seats, so a round consolidates instead of truncating at the cap.
-
-    Discloses the FRAMEWORK's cap (`AgentConfig.max_turns`), the only turn limit that
-    exists — when the framework sets none, there is no budget and nothing is shown.
-    On a resumed segment the figures are this segment's remaining allowance."""
-
 
 class RhoHarness(Harness[RhoHarnessConfig]):
     APPENDS_SYSTEM_PROMPT = True
@@ -166,8 +157,6 @@ class RhoHarness(Harness[RhoHarnessConfig]):
             args.append(
                 f"--max-turns={max(0, trace.agent.config.max_turns - trace.num_turns)}"
             )
-        if self.config.disclose_budget:
-            args.append("--disclose-budget")
         if mcp_urls:
             args.append(
                 "--mcp-config="

--- a/verifiers/v1/harnesses/rho/harness.py
+++ b/verifiers/v1/harnesses/rho/harness.py
@@ -95,9 +95,10 @@ class RhoHarness(Harness[RhoHarnessConfig]):
         if self.config.subagents:
             args.append("--subagents")
         # One cap, owned by the framework: the box spends the budget it is measured
-        # against instead of walking into a refused call.
+        # against instead of walking into a refused call. A resumed segment gets the
+        # REMAINING allowance — the trace has already spent turns against the cap.
         if trace.agent is not None and trace.agent.config.max_turns:
-            args.append(f"--max-turns={trace.agent.config.max_turns}")
+            args.append(f"--max-turns={max(0, trace.agent.config.max_turns - trace.num_turns)}")
         if self.config.disclose_budget:
             args.append("--disclose-budget")
         if mcp_urls:

--- a/verifiers/v1/harnesses/rho/harness.py
+++ b/verifiers/v1/harnesses/rho/harness.py
@@ -7,7 +7,7 @@ import json
 import tarfile
 from pathlib import Path
 
-from verifiers.v1.acp import ACPConfig, ACPHarness, ACPHarnessSession
+from verifiers.v1.acp import ACPConfig, ACPHarness
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.runtimes import Runtime
@@ -19,8 +19,9 @@ PROGRAM_SOURCE = (Path(__file__).resolve().parent / "program.py").read_text()
 NATIVE_TOOLS = ("read", "write", "edit", "bash", "run_code")
 
 RUNTIME_DIAGNOSTICS = "/tmp/.rho/runtime.json"
-"""Where the program leaves its stats (mirrors program.py); picked up onto the trace
-when the session closes. The program rewrites it after every segment."""
+"""Where the program leaves its stats (mirrors program.py); picked up onto the trace at
+cleanup. The program rewrites it after every segment — one process per rollout, so the
+counters are cumulative."""
 
 
 class RhoHarnessConfig(HarnessConfig):
@@ -40,17 +41,6 @@ class RhoHarnessConfig(HarnessConfig):
     practiced. 0 disables (tests only)."""
 
 
-class RhoHarnessSession(ACPHarnessSession):
-    async def close(self) -> None:
-        # Diagnostics ride the session's end; failures must never mask teardown.
-        if not self._closed:
-            with contextlib.suppress(Exception):
-                picked = await self.runtime.run(["cat", RUNTIME_DIAGNOSTICS], {})
-                if picked.exit_code == 0 and picked.stdout.strip():
-                    self.trace.info["rho"] = json.loads(picked.stdout)
-        await super().close()
-
-
 class RhoHarness(ACPHarness[RhoHarnessConfig]):
     APPENDS_SYSTEM_PROMPT = True
     SUPPORTS_MCP = True
@@ -59,7 +49,6 @@ class RhoHarness(ACPHarness[RhoHarnessConfig]):
     SUPPORTS_RESUME = True
     EXECUTES_CODE = True
     NEEDS_CONTAINER = True
-    SESSION_CLASS = RhoHarnessSession
 
     def tool_surface(self) -> list[str]:
         # Seat shaping goes through the base `disabled_tools`: a ptc-style service
@@ -93,8 +82,9 @@ class RhoHarness(ACPHarness[RhoHarnessConfig]):
         # starts once per rollout, so this always runs on a fresh workspace. One tarball,
         # one upload, one extraction: a per-file loop costs 2N gateway round-trips on
         # the prime runtime.
-        task_dir = Path(raw) if (raw := getattr(data, "dir", "") or "") else None
-        if task_dir is not None and (inputs := task_dir / "inputs").is_dir():
+        if (raw := getattr(data, "dir", None)) and (
+            inputs := Path(raw) / "inputs"
+        ).is_dir():
             buffer = io.BytesIO()
 
             def build_tar() -> None:
@@ -114,19 +104,14 @@ class RhoHarness(ACPHarness[RhoHarnessConfig]):
                 )
         env = {
             **self.config.resolved_env,
-            # The program pops RHO_* on startup so the secret never reaches the
-            # kernel's or bash's inherited environment.
+            # The program pops RHO_* on startup, so the secret never reaches bash
+            # children (the kernel builds its env from an allowlist regardless).
             "RHO_BASE_URL": endpoint,
             "RHO_API_KEY": secret,
             "RHO_MODEL": ctx.model,
             "RHO_TOOLS": ",".join(self.tool_surface()),
             "RHO_CONTEXT_BUDGET_TOKENS": str(self.config.context_budget_tokens),
         }
-        if system_prompt:
-            # A file, not an env value: task system prompts can exceed env limits.
-            path = f".vf-rho-system-{trace.id}"
-            await runtime.write(path, system_prompt.encode())
-            env["RHO_SYSTEM_PROMPT_FILE"] = path
         # One effort channel: the framework's sampling config (which interception
         # overlays on every call anyway); no rho-only knob to fight it.
         if ctx.sampling.reasoning_effort:
@@ -135,14 +120,26 @@ class RhoHarness(ACPHarness[RhoHarnessConfig]):
             env["RHO_SUBAGENTS"] = "1"
         # One cap, owned by the framework: the box spends the budget it is measured
         # against instead of walking into a refused call. The budget spans the whole
-        # session — every segment's turns draw on it.
+        # session — every segment's turns draw on it — and the session opens on a
+        # fresh trace, so the full allowance is the remaining allowance.
         if trace.agent is not None and trace.agent.config.max_turns:
-            env["RHO_MAX_TURNS"] = str(
-                max(0, trace.agent.config.max_turns - trace.num_turns)
-            )
+            env["RHO_MAX_TURNS"] = str(trace.agent.config.max_turns)
         program = await runtime.prepare_uv_script(
             PROGRAM_SOURCE, self.config.resolved_env
         )
-        # system_prompt stays out of ACPConfig: the runner would fold it into the first
-        # prompt's text blocks, while rho builds its own system message from the file.
-        return ACPConfig(env=env, command=[*program], prompt=prompt)
+        # The task system prompt rides session_meta, NOT ACPConfig.system_prompt: the
+        # runner folds the latter into the first prompt's text blocks, while rho builds
+        # its own system message at session/new.
+        return ACPConfig(
+            env=env,
+            command=program,
+            prompt=prompt,
+            session_meta={"system_prompt": system_prompt} if system_prompt else None,
+        )
+
+    async def cleanup(self, trace: Trace, runtime: Runtime) -> None:
+        # Diagnostics ride the rollout's end — the session is closed by now, but the
+        # runtime outlives it (the RLM harness relies on the same ordering). Failures
+        # must never mask teardown.
+        with contextlib.suppress(Exception):
+            trace.info["rho"] = json.loads(await runtime.read(RUNTIME_DIAGNOSTICS))

--- a/verifiers/v1/harnesses/rho/program.py
+++ b/verifiers/v1/harnesses/rho/program.py
@@ -1684,12 +1684,6 @@ class Driver:
         """Root-loop notices, appended to the turn's last tool result — the observation
         channel, never the system prompt, so every request extends the one before."""
         notices = []
-        if self.args.disclose_budget and self.budget.max_turns is not None:
-            spent = self.budget.spent
-            notices.append(
-                f"[harness] Turn budget: {spent}/{self.budget.max_turns} used, "
-                f"{self.budget.max_turns - spent} remaining."
-            )
         if "compact" in self.tools and self.last_prompt_tokens:
             notices.append(
                 f"[harness] Context: ~{self.last_prompt_tokens} prompt tokens "
@@ -1854,7 +1848,6 @@ def parse_args():
     p.add_argument("--subagents", action="store_true")
     p.add_argument("--context-budget-tokens", type=int, default=150_000)
     p.add_argument("--max-turns", type=int, default=None)
-    p.add_argument("--disclose-budget", action="store_true")
     return p.parse_args()
 
 

--- a/verifiers/v1/harnesses/rho/program.py
+++ b/verifiers/v1/harnesses/rho/program.py
@@ -144,8 +144,25 @@ HISTORY_PROMPT_NOTE = (
 )
 HISTORY_FRAMING_NOTE = (
     "\n\nThe full transcript this summary replaced is at {path} — grep it (bash) if a "
-    "detail you need is missing from the summary."
+    "detail you need is missing from the summary. Work from evidence: the workspace is "
+    "authoritative — inspect the current state of files before relying on the summary "
+    "or the history."
 )
+
+RESUME_NOTE = (
+    "This session continues an earlier exchange: run_code variables from previous "
+    "segments are gone; files, ./tools/, and /tmp/.rho artifacts are intact."
+)
+
+
+def assemble_messages(system: str, prompt: str, initial: list[dict] | None) -> list[dict]:
+    """The loop's starting transcript. A resumed segment replays the exchange's
+    conversation (system messages dropped — the harness rebuilds its own system prompt
+    every segment); a fresh one opens with the task prompt."""
+    head = {"role": "system", "content": system}
+    if initial is not None:
+        return [head, *(m for m in initial if m.get("role") != "system")]
+    return [head, {"role": "user", "content": prompt}]
 
 
 def render_history(messages: list[dict]) -> str:
@@ -1396,6 +1413,7 @@ def parse_args():
     p.add_argument("--model", required=True)
     p.add_argument("--system-prompt", default="")
     p.add_argument("--prompt", default="")
+    p.add_argument("--initial-messages-file", default="")
     p.add_argument("--mcp-config", default="")
     p.add_argument("--effort", default="")
     p.add_argument("--tools", default="read,write,edit,bash,run_code")
@@ -1416,13 +1434,15 @@ async def main() -> None:
         tools = list(driver.tools)
         if args.compact_tool:
             tools.append("compact")
+        initial = None
+        if args.initial_messages_file:
+            initial = json.loads(Path(args.initial_messages_file).read_text())
         system = driver.system_prompt_base(tools)
+        if initial is not None and "run_code" in driver.tools:
+            system += "\n\n" + RESUME_NOTE
         if args.system_prompt:
             system += "\n\n" + args.system_prompt
-        messages = [
-            {"role": "system", "content": system},
-            {"role": "user", "content": args.prompt},
-        ]
+        messages = assemble_messages(system, args.prompt, initial)
         await driver.run_loop(messages, tools=tools, depth=0, max_turns=args.max_turns)
         write_diagnostics(
             "complete",

--- a/verifiers/v1/harnesses/rho/program.py
+++ b/verifiers/v1/harnesses/rho/program.py
@@ -28,8 +28,8 @@ The program is an ACP agent: the harness's runner spawns it once per rollout, se
 builds the driver and its MCP surface, and each session/prompt runs one loop segment on
 the same conversation — kernel namespace, named agent() sessions, and the transcript all
 persist across segments. Config rides RHO_* environment variables, popped on read so the
-API secret never reaches the kernel's or bash's inherited environment; the final reply of
-each segment goes back as an agent message chunk.
+API secret never reaches bash's inherited environment (the kernel builds its env from an
+allowlist); the final reply of each segment goes back as an agent message chunk.
 
 The transcript is append-only between compaction boundaries: assistant messages (reasoning
 included) are re-sent complete, and the only rewriting event is Codex-style checkpoint
@@ -144,7 +144,7 @@ TOOLS_DIR = "tools"
 DISCOVERY_CATALOG = "tools_catalog"
 RUNTIME_DIAGNOSTICS = "/tmp/.rho/runtime.json"
 """Box-side stats, inside the one harness-owned dir (mirrored in harness.py).
-Per-segment and last-write-wins on resume — cumulative truth lives on the trace."""
+Rewritten after every segment; one process per rollout, so counters are cumulative."""
 
 OVERFLOW_PATTERNS = (
     "context length",
@@ -188,7 +188,7 @@ COMPACTION_FRAMING = (
 TRANSCRIPT_PATH = SPILL_DIR / "transcript.txt"
 """The live transcript: every root-loop message is appended here as it happens, so the
 model can grep its own history at any time — not only after a checkpoint. One stable
-path per runtime, surviving compactions and resumed segments."""
+path per runtime, surviving compactions and later prompt segments."""
 
 # With the transcript file, the summary is licensed to be tight: raw data stays
 # greppable, so the checkpoint carries decisions and state, not hedged payloads.
@@ -248,9 +248,13 @@ def write_diagnostics(phase: str, **values) -> None:
 # --------------------------------------------------------------------------------------
 
 
+def image_part(mime: str, encoded: str) -> dict:
+    return {"type": "image_url", "image_url": {"url": f"data:{mime};base64,{encoded}"}}
+
+
 def _spill(text: str, label: str) -> str:
-    # mkstemp, not a counter: the counter resets per process, and a resumed segment
-    # (or a shared /tmp) would overwrite files an earlier transcript still names.
+    # mkstemp, not a counter: a counter would overwrite files an earlier transcript
+    # still names when /tmp is shared across rollouts on one runtime.
     SPILL_DIR.mkdir(parents=True, exist_ok=True)
     fd, path = tempfile.mkstemp(dir=SPILL_DIR, prefix=f"{label}-", suffix=".txt")
     os.write(fd, text.encode())
@@ -325,10 +329,7 @@ def run_read(path: str, offset=None, limit=None, cwd: Path | None = None):
         encoded = base64.b64encode(p.read_bytes()).decode()
         return [
             {"type": "text", "text": f"{path} ({mime}, {size} bytes)"},
-            {
-                "type": "image_url",
-                "image_url": {"url": f"data:{mime};base64,{encoded}"},
-            },
+            image_part(mime, encoded),
         ]
 
     try:
@@ -791,15 +792,12 @@ class BridgeError(Exception):
 # --------------------------------------------------------------------------------------
 
 
-def mcp_clients(config: dict) -> dict[str, httpx.AsyncClient]:
+def mcp_clients(servers: dict[str, str]) -> dict[str, httpx.AsyncClient]:
     return {
         name: httpx.AsyncClient(
-            follow_redirects=True,
-            timeout=TUNNEL_TIMEOUT,
-            limits=TUNNEL_POOL,
-            headers=spec.get("headers") or None,
+            follow_redirects=True, timeout=TUNNEL_TIMEOUT, limits=TUNNEL_POOL
         )
-        for name, spec in config.get("mcpServers", {}).items()
+        for name in servers
     }
 
 
@@ -847,26 +845,26 @@ async def with_retry(call):
             return await call()
 
 
-async def connect_mcp(config: dict, clients: dict):
+async def connect_mcp(servers: dict[str, str], clients: dict):
     """Enumerate tools across all servers concurrently (startup pays the slowest
     tunnel, not the sum); return (dispatch {(app, verb) -> (server, raw, params)},
     docs, catalog ref)."""
     dispatch: dict[tuple[str, str], tuple[str, str, list[str]]] = {}
     docs: dict = {}
     catalog_server: tuple[str, str] | None = None
-    servers = list(config.get("mcpServers", {}).items())
+    entries = list(servers.items())
 
-    async def list_tools(name: str, spec: dict):
-        async with mcp_session(clients[name], spec["url"]) as session:
+    async def list_tools(name: str, url: str):
+        async with mcp_session(clients[name], url) as session:
             return (await session.list_tools()).tools
 
     listed = await asyncio.gather(
         *(
-            with_retry(lambda name=name, spec=spec: list_tools(name, spec))
-            for name, spec in servers
+            with_retry(lambda name=name, url=url: list_tools(name, url))
+            for name, url in entries
         )
     )
-    for (name, _spec), tools in zip(servers, listed):
+    for (name, _url), tools in zip(entries, listed):
         for tool in tools:
             if tool.name == DISCOVERY_CATALOG:
                 # The box's own channel: read once at startup, never bound or documented.
@@ -915,9 +913,7 @@ def mcp_content(result):
 
 async def call_mcp_raw(servers, clients, server_name, raw_name, arguments):
     async def call():
-        async with mcp_session(
-            clients[server_name], servers[server_name]["url"]
-        ) as session:
+        async with mcp_session(clients[server_name], servers[server_name]) as session:
             return await session.call_tool(raw_name, arguments)
 
     result = await with_retry(call)
@@ -948,9 +944,9 @@ def _safe_component(name: str) -> str:
 
 def _fresh_tools_root(box: Path) -> Path:
     """Recreate the docs tree from nothing each time it is written. The tree is
-    harness-owned; on a resumed segment the previous segment's model code may have
-    replaced parts of it (a symlink at tools/<app> would route writes outside the
-    box), so nothing pre-existing is trusted or followed."""
+    harness-owned but the path may be occupied by image- or task-supplied content
+    (a symlink at tools/<app> would route writes outside the box), so nothing
+    pre-existing is trusted or followed."""
     root = box / TOOLS_DIR
     if root.is_symlink():
         root.unlink()
@@ -1177,7 +1173,7 @@ class Driver:
         )
         self.budget = TurnBudget(config.max_turns)
         self.box = Path.cwd()
-        self.tools: list[str] = list(config.tools)
+        self.tools: list[str] = config.tools
         self.kernel: Kernel | None = None
         self.apps_payload: dict = {}
         self.dispatch: dict = {}
@@ -1187,6 +1183,8 @@ class Driver:
         self.tool_discovery: dict[str, int] = {}
         self.subagents_spawned = 0
         self.completions = 0
+        self.messages: list[dict] = []
+        """The root conversation — one list for the whole rollout, grown per segment."""
         self.transcript_pos = 0
         """Messages of the root loop already appended to the live transcript file."""
         self.sessions: dict[str, dict] = {}
@@ -1206,10 +1204,10 @@ class Driver:
     def served_apps(self) -> set[str]:
         return {app for app, _ in self.dispatch}
 
-    async def setup(self, mcp_config: dict) -> None:
-        self.servers = mcp_config.get("mcpServers", {})
-        self.clients = mcp_clients(mcp_config)
-        self.dispatch, docs, catalog_ref = await connect_mcp(mcp_config, self.clients)
+    async def setup(self, servers: dict[str, str]) -> None:
+        self.servers = servers
+        self.clients = mcp_clients(servers)
+        self.dispatch, docs, catalog_ref = await connect_mcp(servers, self.clients)
         apps_payload = {}
         for (app, verb), (_, _, params) in self.dispatch.items():
             apps_payload.setdefault(app, {})[verb] = params
@@ -1813,12 +1811,13 @@ class Driver:
 @dataclass
 class Config:
     """The RHO_* environment contract with the harness (ACPConfig.env reaches the
-    runner, which spawns this program with an inherited environment)."""
+    runner, which spawns this program with an inherited environment). Values are
+    popped on read, so the secret never reaches bash children — spawned long after
+    this runs — and the kernel builds its env from an allowlist regardless."""
 
     base_url: str
     api_key: str
     model: str
-    system_prompt: str
     effort: str
     tools: list[str]
     subagents: bool
@@ -1828,12 +1827,6 @@ class Config:
     @classmethod
     def from_env(cls) -> "Config":
         env = os.environ
-        system_prompt = ""
-        if path := env.pop("RHO_SYSTEM_PROMPT_FILE", ""):
-            # A file, not an env value: task system prompts can exceed env limits.
-            file = Path(path)
-            system_prompt = file.read_text()
-            file.unlink(missing_ok=True)
         # Defaults below are manual-run conveniences; the harness always sets these.
         raw_tools = env.pop("RHO_TOOLS", "read,write,edit,bash,run_code")
         max_turns = env.pop("RHO_MAX_TURNS", "")
@@ -1841,7 +1834,6 @@ class Config:
             base_url=env.pop("RHO_BASE_URL"),
             api_key=env.pop("RHO_API_KEY"),
             model=env.pop("RHO_MODEL"),
-            system_prompt=system_prompt,
             effort=env.pop("RHO_EFFORT", ""),
             tools=[name for name in raw_tools.split(",") if name],
             subagents=env.pop("RHO_SUBAGENTS", "") == "1",
@@ -1858,8 +1850,10 @@ def blocks_to_content(blocks: list) -> str | list[dict]:
         if isinstance(block, TextContentBlock):
             parts.append({"type": "text", "text": block.text})
         elif isinstance(block, ImageContentBlock):
-            url = block.uri or f"data:{block.mime_type};base64,{block.data}"
-            parts.append({"type": "image_url", "image_url": {"url": url}})
+            if block.uri:
+                parts.append({"type": "image_url", "image_url": {"url": block.uri}})
+            else:
+                parts.append(image_part(block.mime_type, block.data))
         else:
             kind = getattr(block, "type", type(block).__name__)
             raise TypeError(f"unsupported prompt content block: {kind!r}")
@@ -1877,7 +1871,6 @@ class RhoAgent(Agent):
         self.config = config
         self.conn: Client | None = None
         self.driver: Driver | None = None
-        self.messages: list[dict] = []
 
     def on_connect(self, conn: Client) -> None:
         self.conn = conn
@@ -1895,33 +1888,29 @@ class RhoAgent(Agent):
     async def new_session(
         self, cwd, additional_directories=None, mcp_servers=None, **kwargs
     ) -> NewSessionResponse:
-        mcp_config = {
-            "mcpServers": {
-                server.name: {"url": url}
-                for server in mcp_servers or []
-                if (url := getattr(server, "url", None))
-            }
-        }
-        self.driver = Driver(self.config)
-        await self.driver.setup(mcp_config)
-        system = self.driver.system_prompt_base(
-            self.driver.tools, advertise_agent=self.config.subagents
+        driver = self.driver = Driver(self.config)
+        await driver.setup({server.name: server.url for server in mcp_servers or []})
+        system = driver.system_prompt_base(
+            driver.tools, advertise_agent=self.config.subagents
         )
         system += "\n\n" + TRANSCRIPT_SYSTEM_NOTE.format(path=TRANSCRIPT_PATH)
-        if self.config.system_prompt:
-            system += "\n\n" + self.config.system_prompt
-        self.messages = [{"role": "system", "content": system}]
-        self.driver.append_transcript(self.messages)
-        self.driver.write_stats("ready")
+        # The task system prompt rides session_meta (the runner's `(system)` prompt
+        # block is a fallback for agents without a system-prompt channel of their own).
+        if task_system := kwargs.get("system_prompt"):
+            system += "\n\n" + task_system
+        driver.messages = [{"role": "system", "content": system}]
+        driver.append_transcript(driver.messages)
+        driver.write_stats("ready")
         return NewSessionResponse(session_id="rho")
 
     async def prompt(self, session_id, prompt, **kwargs) -> PromptResponse:
         assert self.conn is not None and self.driver is not None
-        self.messages.append({"role": "user", "content": blocks_to_content(prompt)})
-        self.driver.append_transcript(self.messages)
+        messages = self.driver.messages
+        messages.append({"role": "user", "content": blocks_to_content(prompt)})
+        self.driver.append_transcript(messages)
         # The turn budget, not this call, is the authority on stopping.
         final = await self.driver.run_loop(
-            self.messages, tools=self.driver.tools, depth=0, max_turns=None
+            messages, tools=self.driver.tools, depth=0, max_turns=None
         )
         self.driver.write_stats("segment")
         await self.conn.session_update(

--- a/verifiers/v1/harnesses/rho/program.py
+++ b/verifiers/v1/harnesses/rho/program.py
@@ -155,18 +155,27 @@ COMPACTION_FRAMING = (
     "model, use the information in this summary to assist with your own analysis:"
 )
 
-# With a history file, the summary is licensed to be tight: raw data stays greppable, so
-# the checkpoint carries decisions and state instead of hedging with carried payloads.
+TRANSCRIPT_PATH = SPILL_DIR / "transcript.txt"
+"""The live transcript: every root-loop message is appended here as it happens, so the
+model can grep its own history at any time — not only after a checkpoint. One stable
+path per runtime, surviving compactions and resumed segments."""
+
+# With the transcript file, the summary is licensed to be tight: raw data stays
+# greppable, so the checkpoint carries decisions and state, not hedged payloads.
 HISTORY_PROMPT_NOTE = (
     "\nThe full transcript you are summarizing will remain available to the next LLM in a "
     "file it can grep, so keep the summary tight and targeted — decisions, state, and next "
     "steps. Raw data, long outputs, and exact quotes can be recovered from the file."
 )
 HISTORY_FRAMING_NOTE = (
-    "\n\nThe full transcript this summary replaced is at {path} — grep it (bash) if a "
-    "detail you need is missing from the summary. Work from evidence: the workspace is "
-    "authoritative — inspect the current state of files before relying on the summary "
-    "or the history."
+    "\n\nThe full transcript (including everything this summary replaced) is at {path} — "
+    "grep it (bash) if a detail you need is missing from the summary. Work from evidence: "
+    "the workspace is authoritative — inspect the current state of files before relying "
+    "on the summary or the history."
+)
+TRANSCRIPT_SYSTEM_NOTE = (
+    "Your full transcript so far is appended to {path} — grep it (bash) to recover "
+    "earlier details, tool outputs, or exact quotes at any time."
 )
 
 RESUME_NOTE = (
@@ -1155,6 +1164,8 @@ class Driver:
         self.documented_apps: set[str] = set()
         self.tool_discovery: dict[str, int] = {}
         self.subagents_spawned = 0
+        self.transcript_pos = 0
+        """Messages of the root loop already appended to the live transcript file."""
         self.sessions: dict[str, dict] = {}
         """Named persistent subagents: session name -> {"messages", "tools"}. A
         continued session appends the new prompt and keeps its context — the caller
@@ -1507,9 +1518,21 @@ class Driver:
 
     # --- compaction -------------------------------------------------------------------
 
+    def append_transcript(self, messages: list[dict]) -> None:
+        """Append the root loop's not-yet-persisted messages to the live transcript."""
+        new = messages[self.transcript_pos :]
+        if not new:
+            return
+        SPILL_DIR.mkdir(parents=True, exist_ok=True)
+        with TRANSCRIPT_PATH.open("a") as f:
+            f.write(render_history(new) + "\n")
+        self.transcript_pos = len(messages)
+
     async def checkpoint(self, messages: list[dict], tool_schemas: list[dict]) -> None:
         keep = 2  # the protected prefix: system + the opening user message (assemble_messages)
-        history_path = _spill(render_history(messages[keep:]), "history")
+        self.append_transcript(
+            messages
+        )  # everything summarized-away is already on disk
         request = [
             *messages,
             {"role": "user", "content": COMPACTION_PROMPT + HISTORY_PROMPT_NOTE},
@@ -1545,9 +1568,12 @@ class Driver:
             COMPACTION_FRAMING
             + "\n\n"
             + summary
-            + HISTORY_FRAMING_NOTE.format(path=history_path)
+            + HISTORY_FRAMING_NOTE.format(path=TRANSCRIPT_PATH)
         )
         messages[:] = [*messages[:keep], {"role": "user", "content": framing}]
+        # The rebuilt prefix is already on disk; only the framing+summary is new.
+        self.transcript_pos = keep
+        self.append_transcript(messages)
         self.last_prompt_tokens = 0
         self.compactions += 1
         self.compaction_pending = False
@@ -1688,7 +1714,10 @@ class Driver:
             if depth == 0:
                 if isinstance(messages[-1]["content"], str):
                     messages[-1]["content"] += self._notices()
+                self.append_transcript(messages)
                 self.write_stats("loop")
+        if depth == 0:
+            self.append_transcript(messages)  # the final, tool-free assistant reply
         return final
 
     def write_stats(self, phase: str) -> None:
@@ -1750,11 +1779,25 @@ async def main() -> None:
             initial = json.loads(path.read_text())
             path.unlink(missing_ok=True)
         system = driver.system_prompt_base(driver.tools)
+        system += "\n\n" + TRANSCRIPT_SYSTEM_NOTE.format(path=TRANSCRIPT_PATH)
         if initial is not None and "run_code" in driver.tools:
             system += "\n\n" + RESUME_NOTE
         if args.system_prompt:
             system += "\n\n" + args.system_prompt
         messages = assemble_messages(system, args.prompt, initial)
+        if initial is not None:
+            # Replayed conversation is already on disk from earlier segments; persist
+            # only what follows the last assistant/tool message (the injected turns).
+            last = max(
+                (
+                    i
+                    for i, m in enumerate(messages)
+                    if m.get("role") in ("assistant", "tool")
+                ),
+                default=0,
+            )
+            driver.transcript_pos = last + 1
+        driver.append_transcript(messages)
         # The turn budget, not this call, is the authority on stopping.
         await driver.run_loop(messages, tools=driver.tools, depth=0, max_turns=None)
         driver.write_stats("complete")

--- a/verifiers/v1/harnesses/rho/program.py
+++ b/verifiers/v1/harnesses/rho/program.py
@@ -44,6 +44,7 @@ import itertools
 import json
 import os
 import platform
+import shutil
 import signal
 import subprocess
 import sys
@@ -821,20 +822,38 @@ async def call_mcp_raw(servers, clients, server_name, raw_name, arguments):
 
 
 def _safe_component(name: str) -> str:
-    """Doc-tree names come from the task's MCP server; keep them single path components."""
+    """Doc-tree names come from the task's MCP server; keep them single path components.
+    README is reserved for the tree's own summaries at both levels."""
     if not name or name in (".", "..") or "/" in name or "\\" in name or name.startswith("."):
         raise ValueError(f"unsafe tool doc path component: {name!r}")
+    if name.upper() == "README":
+        raise ValueError("app/verb name 'README' is reserved for the doc tree's summaries")
     return name
 
 
+def _fresh_tools_root(box: Path) -> Path:
+    """Recreate the docs tree from nothing each time it is written. The tree is
+    harness-owned; on a resumed segment the previous segment's model code may have
+    replaced parts of it (a symlink at tools/<app> would route writes outside the
+    box), so nothing pre-existing is trusted or followed."""
+    root = box / TOOLS_DIR
+    if root.is_symlink():
+        root.unlink()
+    elif root.exists():
+        shutil.rmtree(root)
+    root.mkdir(parents=True)
+    return root
+
+
 def write_tool_docs(box: Path, docs: dict) -> None:
+    root = _fresh_tools_root(box)
     for (app, verb), text in docs.items():
-        d = box / TOOLS_DIR / _safe_component(app)
+        d = root / _safe_component(app)
         d.mkdir(parents=True, exist_ok=True)
         (d / _safe_component(verb)).write_text(text)
     if docs:
         app, verb = next(iter(docs))
-        (box / TOOLS_DIR / "README").write_text(
+        (root / "README").write_text(
             "Each file under ./tools/<app>/<verb> documents one tool. The <app> names are "
             "pre-bound globals in run_code — call them directly; nothing to import.\n"
             "Worked example:\n"
@@ -848,7 +867,7 @@ def write_catalog_docs(box: Path, catalog: dict) -> None:
     """The discovery mode's doc tree: the whole documented surface, served or not."""
     if not catalog:
         return
-    root = box / TOOLS_DIR
+    root = _fresh_tools_root(box)
     for app, entry in sorted(catalog.items()):
         directory = root / _safe_component(app)
         directory.mkdir(parents=True, exist_ok=True)

--- a/verifiers/v1/harnesses/rho/program.py
+++ b/verifiers/v1/harnesses/rho/program.py
@@ -213,12 +213,13 @@ _spill_counter = 0
 
 
 def _spill(text: str, label: str) -> str:
-    global _spill_counter
+    # mkstemp, not a counter: the counter resets per process, and a resumed segment
+    # (or a shared /tmp) would overwrite files an earlier transcript still names.
     SPILL_DIR.mkdir(parents=True, exist_ok=True)
-    _spill_counter += 1
-    path = SPILL_DIR / f"{label}-{_spill_counter}.txt"
-    path.write_text(text)
-    return str(path)
+    fd, path = tempfile.mkstemp(dir=SPILL_DIR, prefix=f"{label}-", suffix=".txt")
+    os.write(fd, text.encode())
+    os.close(fd)
+    return path
 
 
 def cap_output(text: str, label: str = "output") -> str:
@@ -460,7 +461,13 @@ class App:
         params = self._verbs.get(verb, [])
 
         def proxy(*args, **kwargs):
-            kwargs.update(zip(params, args))
+            if len(args) > len(params):
+                raise TypeError(f"{self._name}.{verb}() takes at most {len(params)} positional arguments ({len(args)} given)")
+            positional = dict(zip(params, args))
+            collisions = set(positional) & set(kwargs)
+            if collisions:
+                raise TypeError(f"{self._name}.{verb}() got multiple values for {sorted(collisions)}")
+            kwargs.update(positional)
             kwargs = {k: v for k, v in kwargs.items() if v is not None}
             return bridge("mcp", {"app": self._name, "verb": verb, "args": kwargs})
 
@@ -542,7 +549,8 @@ except BaseException:
 '''
 
 KERNEL_ENV_KEEP = ("PATH", "HOME", "LANG", "TERM", "TMPDIR", "PYTHONPATH", "VIRTUAL_ENV")
-KERNEL_ENV_PREFIXES = ("LC_", "UV_", "XDG_")
+# No UV_ prefix: UV_INDEX_<NAME>_PASSWORD and credential-bearing index URLs ride it.
+KERNEL_ENV_PREFIXES = ("LC_", "XDG_")
 
 
 def kernel_env() -> dict[str, str]:
@@ -768,6 +776,11 @@ async def connect_mcp(config: dict, clients: dict):
             app, _, verb = bare.partition("_")
             if not verb:
                 app, verb = "misc", bare
+            if (app, verb) in dispatch:
+                other = dispatch[(app, verb)][0]
+                raise ValueError(
+                    f"tool name collision: {app}.{verb} is served by both {other!r} and {name!r}"
+                )
             props = (tool.inputSchema or {}).get("properties", {})
             required = set((tool.inputSchema or {}).get("required", []))
             dispatch[(app, verb)] = (name, tool.name, list(props))
@@ -807,11 +820,18 @@ async def call_mcp_raw(servers, clients, server_name, raw_name, arguments):
         return text
 
 
+def _safe_component(name: str) -> str:
+    """Doc-tree names come from the task's MCP server; keep them single path components."""
+    if not name or name in (".", "..") or "/" in name or "\\" in name or name.startswith("."):
+        raise ValueError(f"unsafe tool doc path component: {name!r}")
+    return name
+
+
 def write_tool_docs(box: Path, docs: dict) -> None:
     for (app, verb), text in docs.items():
-        d = box / TOOLS_DIR / app
+        d = box / TOOLS_DIR / _safe_component(app)
         d.mkdir(parents=True, exist_ok=True)
-        (d / verb).write_text(text)
+        (d / _safe_component(verb)).write_text(text)
     if docs:
         app, verb = next(iter(docs))
         (box / TOOLS_DIR / "README").write_text(
@@ -830,11 +850,11 @@ def write_catalog_docs(box: Path, catalog: dict) -> None:
         return
     root = box / TOOLS_DIR
     for app, entry in sorted(catalog.items()):
-        directory = root / app
+        directory = root / _safe_component(app)
         directory.mkdir(parents=True, exist_ok=True)
         (directory / "README").write_text(f"{app} — {entry['summary']}\n")
         for verb, doc in sorted(entry["verbs"].items()):
-            (directory / verb).write_text(doc)
+            (directory / _safe_component(verb)).write_text(doc)
     (root / "README").write_text(
         f"{len(catalog)} apps are documented here, one directory each. ./tools/<app>/README says\n"
         "what an app is, ./tools/<app>/<verb> documents one of its tools. The <app> names are\n"
@@ -1012,6 +1032,7 @@ class Driver:
         self.box = Path.cwd()
         self.tools: list[str] = args.tools.split(",") if args.tools else []
         self.kernel: Kernel | None = None
+        self.apps_payload: dict = {}
         self.dispatch: dict = {}
         self.servers: dict = {}
         self.clients: dict = {}
@@ -1059,6 +1080,10 @@ class Driver:
         else:
             write_tool_docs(self.box, docs)
             self.documented_apps = set(self.served_apps)
+        reserved = {"json", "completion", "agent"} & set(apps_payload)
+        if reserved:
+            raise ValueError(f"app names collide with run_code globals: {sorted(reserved)}")
+        self.apps_payload = apps_payload
         if "run_code" in self.tools:
             self.kernel = Kernel(
                 {"apps": apps_payload, "subagents": self.args.subagents}
@@ -1109,7 +1134,7 @@ class Driver:
         messages = []
         if system:
             messages.append({"role": "system", "content": str(system)})
-        body = str(prompt) + (schema_suffix("Respond with", schema) if schema else "")
+        body = str(prompt) + (schema_suffix("Respond with", schema) if schema is not None else "")
         messages.append({"role": "user", "content": body})
         problem = "no attempts left"
         for attempt in range(2):
@@ -1119,7 +1144,7 @@ class Driver:
                 model=self.args.model, messages=messages, **self._effort_kwargs()
             )
             text = completion.choices[0].message.content or ""
-            if not schema:
+            if schema is None:
                 return text
             value, problem = parse_reply(text, schema)
             if problem is None:
@@ -1137,12 +1162,12 @@ class Driver:
                 "finish the task directly",
             )
         self.subagents_spawned += 1
-        body = str(prompt) + (schema_suffix("Your final message must be", schema) if schema else "")
+        body = str(prompt) + (schema_suffix("Your final message must be", schema) if schema is not None else "")
         if session and session in self.sessions:
-            # Continue the named session: same transcript, same tool surface — the
-            # follow-up rides the context already paid for.
+            # Continue the named session: same transcript, tool surface, and kernel —
+            # the follow-up rides the context already paid for.
             stored = self.sessions[session]
-            messages, allowed = stored["messages"], stored["tools"]
+            messages, allowed, kernel = stored["messages"], stored["tools"], stored["kernel"]
             messages.append({"role": "user", "content": body})
         else:
             allowed = [t for t in self.tools if t != "compact"]
@@ -1151,40 +1176,54 @@ class Driver:
                 if unknown:
                     raise BridgeError("ValueError", f"unknown subagent tools: {unknown} (available: {allowed})")
                 allowed = [t for t in allowed if t in tools]
+            # A subagent gets its own kernel: agent() is only reachable from inside a
+            # parent cell, whose kernel is blocked in bridge() — routing sub-cells to
+            # it would corrupt the frame stream. Blank context means blank namespace.
+            kernel = Kernel({"apps": self.apps_payload, "subagents": False}) if "run_code" in allowed else None
             messages = [
-                {"role": "system", "content": self.subagent_system_prompt()},
+                {"role": "system", "content": self.subagent_system_prompt(allowed)},
                 {"role": "user", "content": body},
             ]
             if session:
-                self.sessions[session] = {"messages": messages, "tools": allowed}
-        final = await self.run_loop(
-            messages,
-            tools=allowed,
-            depth=1,
-            # No per-spawn ceiling: allocation is the policy's call; the shared budget
-            # binds, minus the reserve that keeps the parent able to act.
-            max_turns=None if self.budget.remaining is None else self.budget.remaining - (SPAWN_RESERVE_TURNS - 1),
-            effort=effort,
-        )
-        if final is None:
-            return None
-        if not schema:
-            return final
-        for _ in range(2):
-            value, problem = parse_reply(final, schema)
-            if problem is None:
-                return value
-            if self.budget.remaining is not None and self.budget.remaining < 1:
-                break
-            messages.append({"role": "user", "content": f"{problem}. Reply with only the corrected JSON."})
-            final = await self.run_loop(messages, tools=[], depth=1, max_turns=1, effort=effort)
+                self.sessions[session] = {"messages": messages, "tools": allowed, "kernel": kernel}
+        try:
+            final = await self.run_loop(
+                messages,
+                tools=allowed,
+                depth=1,
+                # No per-spawn ceiling: allocation is the policy's call; the shared budget
+                # binds, minus the reserve that keeps the parent able to act.
+                max_turns=None if self.budget.remaining is None else self.budget.remaining - (SPAWN_RESERVE_TURNS - 1),
+                effort=effort,
+                kernel=kernel,
+            )
             if final is None:
-                break
-        raise BridgeError("ValueError", "subagent did not return JSON matching the schema")
+                return None
+            if schema is None:
+                return final
+            problem = None
+            for _ in range(2):
+                value, problem = parse_reply(final, schema)
+                if problem is None:
+                    return value
+                if self.budget.remaining is not None and self.budget.remaining < 1:
+                    break
+                messages.append({"role": "user", "content": f"{problem}. Reply with only the corrected JSON."})
+                final = await self.run_loop(messages, tools=[], depth=1, max_turns=1, effort=effort, kernel=kernel)
+                if final is None:
+                    break
+            if final is not None:
+                value, problem = parse_reply(final, schema)
+                if problem is None:
+                    return value
+            raise BridgeError("ValueError", f"subagent did not return JSON matching the schema: {problem}")
+        finally:
+            if kernel is not None and not session:
+                await kernel.close()
 
     # --- native tool dispatch -------------------------------------------------------
 
-    async def execute_tool(self, name: str, arguments: dict, depth: int):
+    async def execute_tool(self, name: str, arguments: dict, depth: int, kernel: Kernel | None = None):
         if name == "read":
             return await asyncio.to_thread(
                 run_read, arguments.get("path", ""), arguments.get("offset"), arguments.get("limit"), self.box
@@ -1202,8 +1241,9 @@ class Driver:
                 run_bash, arguments.get("command", ""), arguments.get("timeout"), self.box
             )
         if name == "run_code":
-            assert self.kernel is not None
-            return await self.kernel.run_cell(
+            kernel = kernel if kernel is not None else self.kernel
+            assert kernel is not None
+            return await kernel.run_cell(
                 arguments.get("code", ""), lambda call: self.handle_call(call, depth=depth)
             )
         if name == "compact" and depth == 0:
@@ -1213,7 +1253,7 @@ class Driver:
 
     # --- prompts --------------------------------------------------------------------
 
-    def system_prompt_base(self, tools: list[str]) -> str:
+    def system_prompt_base(self, tools: list[str], advertise_agent: bool | None = None) -> str:
         parts = ["You are an agent operating in a minimal harness."]
         lines = []
         if "read" in tools:
@@ -1239,7 +1279,7 @@ class Driver:
                     "bash) and pre-bound in run_code as <app>.<verb>(...) returning Python objects."
                 )
             lines.append("`completion(prompt, schema=None)` makes one standalone model call from code.")
-            if self.args.subagents:
+            if self.args.subagents if advertise_agent is None else advertise_agent:
                 lines.append(
                     "`agent(prompt, schema=None, effort=None, tools=None, session=None)` runs a "
                     "subagent with a blank context and returns its final message (parsed when "
@@ -1255,8 +1295,10 @@ class Driver:
         parts.append(" ".join(lines))
         return "\n\n".join(p for p in parts if p)
 
-    def subagent_system_prompt(self) -> str:
-        base = self.system_prompt_base([t for t in self.tools if t != "compact"])
+    def subagent_system_prompt(self, allowed: list[str]) -> str:
+        # Built from the seat's actual surface: no advertised tools it can't call,
+        # and never agent() — depth 1 rejects it.
+        base = self.system_prompt_base(allowed, advertise_agent=False)
         return base + (
             "\n\nYou are a subagent. Work the task to completion; your final message is returned "
             "verbatim to the caller as data, not prose for a human."
@@ -1266,9 +1308,7 @@ class Driver:
 
     async def checkpoint(self, messages: list[dict], tool_schemas: list[dict]) -> None:
         keep = 2  # the protected prefix: system + the opening user message (assemble_messages)
-        SPILL_DIR.mkdir(parents=True, exist_ok=True)
-        history_path = str(SPILL_DIR / f"history-{self.compactions + 1}.txt")
-        Path(history_path).write_text(render_history(messages[keep:]))
+        history_path = _spill(render_history(messages[keep:]), "history")
         request = [*messages, {"role": "user", "content": COMPACTION_PROMPT + HISTORY_PROMPT_NOTE}]
         while True:
             try:
@@ -1282,9 +1322,13 @@ class Driver:
                 break
             except Exception as error:
                 # A compaction request that itself overflows trims oldest non-protected
-                # messages and retries until it fits (Codex's trim loop).
+                # messages and retries until it fits (Codex's trim loop). Drop one
+                # message plus any contiguous tool results, so an assistant turn with
+                # parallel tool calls never leaves orphaned tool messages behind.
                 if is_overflow_error(error) and len(request) > keep + 2:
-                    del request[keep : keep + 2]
+                    del request[keep]
+                    while keep < len(request) - 1 and request[keep].get("role") == "tool":
+                        del request[keep]
                     continue
                 raise
         summary = completion.choices[0].message.content or "(no summary available)"
@@ -1340,6 +1384,7 @@ class Driver:
         depth: int,
         max_turns: int | None,
         effort: str | None = None,
+        kernel: Kernel | None = None,
     ) -> str | None:
         """Drive one agent loop. Returns the final assistant text (None if none)."""
         tool_schemas = build_tool_schemas(tools)
@@ -1368,6 +1413,10 @@ class Driver:
                 )
             except Exception as error:
                 if depth == 0 and is_overflow_error(error) and not overflow_retried:
+                    if self.budget.remaining is not None and self.budget.remaining <= 1:
+                        # No budget for the checkpoint the retry needs: end cleanly
+                        # with what we have instead of re-sending the same request.
+                        return final
                     # A work turn rejected for context length forces a compaction and
                     # retries exactly once. The refused call cost nothing — refund it.
                     # (Assumes the interception server's ledger also skipped the refused
@@ -1397,9 +1446,11 @@ class Driver:
             msg = completion.choices[0].message
             # Append complete — reasoning included. The transcript is append-only.
             messages.append(msg.model_dump(exclude_none=True))
-            if msg.content:
-                final = msg.content
             if not msg.tool_calls:
+                # Only a tool-free reply is a final answer; preparatory text alongside
+                # tool calls must not pass as a truncated subagent's result.
+                if msg.content:
+                    final = msg.content
                 break
             for tc in msg.tool_calls:
                 try:
@@ -1409,7 +1460,12 @@ class Driver:
                 except Exception as e:  # noqa: BLE001 - malformed calls become retryable tool errors
                     out = f"invalid tool arguments ({e}) — send a JSON object matching the tool's schema"
                 else:
-                    out = await self.execute_tool(tc.function.name, arguments, depth)
+                    try:
+                        out = await self.execute_tool(tc.function.name, arguments, depth, kernel)
+                    except BridgeError as e:
+                        out = f"{tc.function.name} failed: {e}"
+                    except Exception as e:  # noqa: BLE001 - tool faults are observations, not rollout failures
+                        out = f"{tc.function.name} failed: {type(e).__name__}: {e}"
                 content = out if isinstance(out, list) else str(out)
                 messages.append({"role": "tool", "tool_call_id": tc.id, "content": content})
             if depth == 0:
@@ -1431,6 +1487,9 @@ class Driver:
     async def close(self) -> None:
         if self.kernel is not None:
             await self.kernel.close()
+        for stored in self.sessions.values():
+            if stored.get("kernel") is not None:
+                await stored["kernel"].close()
         for client in self.clients.values():
             await client.aclose()
 

--- a/verifiers/v1/harnesses/rho/program.py
+++ b/verifiers/v1/harnesses/rho/program.py
@@ -80,12 +80,10 @@ IMAGE_MAGIC = {
 }
 MAX_IMAGE_BYTES = 5 * 1024 * 1024
 
-MAX_TURNS = 250
-SUBAGENT_MAX_TURNS = 40
-"""Per-spawn ceiling on a subagent's own loop; the shared trace budget binds first."""
-MAX_SUBAGENTS = 100
-"""Runaway-loop backstop, not a budget: the turn budget is the real bound on subagent
-work (every subagent turn spends it), so this sits far above any real rollout."""
+SPAWN_RESERVE_TURNS = 3
+"""Refuse to delegate when fewer turns than this remain: a subagent can spend the whole
+shared budget, but the parent must keep enough to act on the result. A reserve, not a
+cap — the box imposes no limits of its own; the framework's turn budget is the bound."""
 
 TUNNEL_TIMEOUT = httpx.Timeout(600.0, connect=30.0)
 TUNNEL_POOL = httpx.Limits(max_connections=16, max_keepalive_connections=16, keepalive_expiry=900.0)
@@ -915,19 +913,19 @@ class TurnBudget:
     """One counter for every model call this rollout makes — work turns, compactions,
     completions, subagent turns — mirroring the framework's single per-trace cap."""
 
-    def __init__(self, max_turns: int):
-        self.max_turns = max_turns
+    def __init__(self, max_turns: int | None):
+        self.max_turns = max_turns  # None = no cap set by the framework: unbounded
         self.spent = 0
 
     def take(self) -> bool:
-        if self.spent >= self.max_turns:
+        if self.max_turns is not None and self.spent >= self.max_turns:
             return False
         self.spent += 1
         return True
 
     @property
-    def remaining(self) -> int:
-        return self.max_turns - self.spent
+    def remaining(self) -> int | None:
+        return None if self.max_turns is None else self.max_turns - self.spent
 
 
 def is_overflow_error(error: Exception) -> bool:
@@ -1089,9 +1087,12 @@ class Driver:
         raise BridgeError("ValueError", f"completion did not return JSON matching the schema: {problem}")
 
     async def do_agent(self, prompt: str, schema, effort, tools):
-        if self.subagents_spawned >= MAX_SUBAGENTS:
+        remaining = self.budget.remaining
+        if remaining is not None and remaining < SPAWN_RESERVE_TURNS:
             raise BridgeError(
-                "RuntimeError", f"subagent backstop reached ({MAX_SUBAGENTS} per session)"
+                "RuntimeError",
+                f"not enough turn budget left to delegate ({remaining} turns remain) — "
+                "finish the task directly",
             )
         self.subagents_spawned += 1
         allowed = [t for t in self.tools if t != "compact"]
@@ -1114,7 +1115,9 @@ class Driver:
             messages,
             tools=allowed,
             depth=1,
-            max_turns=min(SUBAGENT_MAX_TURNS, self.budget.remaining),
+            # No per-spawn ceiling: allocation is the policy's call; the shared budget
+            # binds, minus the reserve that keeps the parent able to act.
+            max_turns=None if self.budget.remaining is None else self.budget.remaining - 2,
             effort=effort or self.args.effort,
         )
         if final is None:
@@ -1130,7 +1133,7 @@ class Driver:
                 problem = validate_schema(value, schema)
                 if problem is None:
                     return value
-            if self.budget.remaining < 1:
+            if self.budget.remaining is not None and self.budget.remaining < 1:
                 break
             messages.append({"role": "user", "content": f"{problem}. Reply with only the corrected JSON."})
             final = await self.run_loop(messages, tools=[], depth=1, max_turns=1, effort=effort or self.args.effort)
@@ -1272,7 +1275,7 @@ class Driver:
 
     def _notices(self, depth: int) -> str:
         notices = []
-        if depth == 0 and self.args.disclose_budget:
+        if depth == 0 and self.args.disclose_budget and self.budget.max_turns is not None:
             spent = self.budget.spent
             notices.append(
                 f"[harness] Turn budget: {spent}/{self.budget.max_turns} used, "
@@ -1290,7 +1293,7 @@ class Driver:
         messages: list[dict],
         tools: list[str],
         depth: int,
-        max_turns: int,
+        max_turns: int | None,
         effort: str | None = None,
     ) -> str | None:
         """Drive one agent loop. Returns the final assistant text (None if none)."""
@@ -1298,10 +1301,14 @@ class Driver:
         local_turns = 0
         final: str | None = None
         overflow_retried = False
-        while local_turns < max_turns:
+        while max_turns is None or local_turns < max_turns:
             # A checkpoint is a model call on the same budget: only spend one while the
             # work turn it protects still fits under the cap.
-            if depth == 0 and self.should_checkpoint() and self.budget.remaining > 1:
+            if (
+                depth == 0
+                and self.should_checkpoint()
+                and (self.budget.remaining is None or self.budget.remaining > 1)
+            ):
                 if not self.budget.take():
                     break
                 await self.checkpoint(messages, tool_schemas)
@@ -1395,7 +1402,7 @@ def parse_args():
     p.add_argument("--subagents", action="store_true")
     p.add_argument("--compact-tool", action="store_true")
     p.add_argument("--context-budget-tokens", type=int, default=150_000)
-    p.add_argument("--max-turns", type=int, default=MAX_TURNS)
+    p.add_argument("--max-turns", type=int, default=None)
     p.add_argument("--disclose-budget", action="store_true")
     return p.parse_args()
 

--- a/verifiers/v1/harnesses/rho/program.py
+++ b/verifiers/v1/harnesses/rho/program.py
@@ -135,6 +135,42 @@ COMPACTION_FRAMING = (
     "model, use the information in this summary to assist with your own analysis:"
 )
 
+# With a history file, the summary is licensed to be tight: raw data stays greppable, so
+# the checkpoint carries decisions and state instead of hedging with carried payloads.
+HISTORY_PROMPT_NOTE = (
+    "\nThe full transcript you are summarizing will remain available to the next LLM in a "
+    "file it can grep, so keep the summary tight and targeted — decisions, state, and next "
+    "steps. Raw data, long outputs, and exact quotes can be recovered from the file."
+)
+HISTORY_FRAMING_NOTE = (
+    "\n\nThe full transcript this summary replaced is at {path} — grep it (bash) if a "
+    "detail you need is missing from the summary."
+)
+
+
+def render_history(messages: list[dict]) -> str:
+    """Render discarded transcript messages as greppable role-tagged text."""
+    blocks = []
+    for m in messages:
+        role = m.get("role", "?")
+        parts = []
+        if m.get("reasoning_content"):
+            parts.append(f"(reasoning)\n{m['reasoning_content']}")
+        content = m.get("content")
+        if isinstance(content, list):
+            for part in content:
+                if part.get("type") == "text":
+                    parts.append(part.get("text", ""))
+                else:
+                    parts.append(f"[{part.get('type', 'attachment')}]")
+        elif content:
+            parts.append(str(content))
+        for tc in m.get("tool_calls") or []:
+            fn = tc.get("function", {})
+            parts.append(f"(tool call) {fn.get('name')}({fn.get('arguments', '')})")
+        blocks.append(f"[{role}]\n" + "\n".join(parts))
+    return "\n\n".join(blocks) + "\n"
+
 
 def write_diagnostics(phase: str, **values) -> None:
     path = Path(RUNTIME_DIAGNOSTICS)
@@ -1180,7 +1216,14 @@ class Driver:
 
     async def checkpoint(self, messages: list[dict], tool_schemas: list[dict]) -> None:
         keep = 2 if messages and messages[0].get("role") == "system" else 1
-        request = [*messages, {"role": "user", "content": COMPACTION_PROMPT}]
+        prompt = COMPACTION_PROMPT
+        history_path = ""
+        if self.args.history_file:
+            SPILL_DIR.mkdir(parents=True, exist_ok=True)
+            history_path = str(SPILL_DIR / f"history-{self.compactions + 1}.txt")
+            Path(history_path).write_text(render_history(messages[keep:]))
+            prompt += HISTORY_PROMPT_NOTE
+        request = [*messages, {"role": "user", "content": prompt}]
         while True:
             try:
                 completion = await self.client.chat.completions.create(
@@ -1202,10 +1245,10 @@ class Driver:
         usage = getattr(completion, "usage", None)
         if usage and usage.prompt_tokens:
             self.peak_prompt_tokens = max(self.peak_prompt_tokens, usage.prompt_tokens)
-        messages[:] = [
-            *messages[:keep],
-            {"role": "user", "content": COMPACTION_FRAMING + "\n\n" + summary},
-        ]
+        framing = COMPACTION_FRAMING + "\n\n" + summary
+        if history_path:
+            framing += HISTORY_FRAMING_NOTE.format(path=history_path)
+        messages[:] = [*messages[:keep], {"role": "user", "content": framing}]
         self.last_prompt_tokens = 0
         self.compactions += 1
         self.compaction_pending = False
@@ -1348,6 +1391,7 @@ def parse_args():
     p.add_argument("--max-subagents", type=int, default=16)
     p.add_argument("--compact-tool", action="store_true")
     p.add_argument("--context-budget-tokens", type=int, default=150_000)
+    p.add_argument("--history-file", action=argparse.BooleanOptionalAction, default=True)
     p.add_argument("--max-compactions", type=int, default=MAX_COMPACTIONS)
     p.add_argument("--max-turns", type=int, default=MAX_TURNS)
     p.add_argument("--disclose-budget", action="store_true")

--- a/verifiers/v1/harnesses/rho/program.py
+++ b/verifiers/v1/harnesses/rho/program.py
@@ -27,6 +27,13 @@ The transcript is append-only between compaction boundaries: assistant messages 
 included) are re-sent complete, and the only rewriting event is Codex-style checkpoint
 compaction — triggered by the token budget, a context overflow, or the model's own
 `compact` tool call.
+
+Deliberate absences (known, may be wanted later, not built yet):
+- Parallel tool calls: multiple calls in one turn execute sequentially, and the kernel
+  bridge is a serial stdio channel — code-side `gather` over tools needs bridge
+  multiplexing (frame ids), one coherent upgrade with interception-side concurrency.
+- Background tools: no `background`/yield machinery (Codex's session+wait stack); the
+  documented answer for long-running processes is bash: nohup, redirect to a file, read.
 """
 
 import argparse
@@ -157,11 +164,15 @@ RESUME_NOTE = (
 
 def assemble_messages(system: str, prompt: str, initial: list[dict] | None) -> list[dict]:
     """The loop's starting transcript. A resumed segment replays the exchange's
-    conversation (system messages dropped — the harness rebuilds its own system prompt
-    every segment); a fresh one opens with the task prompt."""
+    conversation: a LEADING system message is the previous segment's harness-built
+    system prompt and is replaced by the fresh rebuild; any later explicit system
+    messages survive (the base `Harness.resume` contract). A fresh segment opens
+    with the task prompt."""
     head = {"role": "system", "content": system}
     if initial is not None:
-        return [head, *(m for m in initial if m.get("role") != "system")]
+        if initial and initial[0].get("role") == "system":
+            initial = initial[1:]
+        return [head, *initial]
     return [head, {"role": "user", "content": prompt}]
 
 
@@ -190,13 +201,8 @@ def render_history(messages: list[dict]) -> str:
 
 
 def write_diagnostics(phase: str, **values) -> None:
-    path = Path(RUNTIME_DIAGNOSTICS)
-    current = {}
-    if path.exists():
-        with contextlib.suppress(Exception):
-            current = json.loads(path.read_text())
-    current |= {"phase": phase, "python": platform.python_version(), **values}
-    path.write_text(json.dumps(current, sort_keys=True))
+    payload = {"phase": phase, "python": platform.python_version(), **values}
+    Path(RUNTIME_DIAGNOSTICS).write_text(json.dumps(payload, sort_keys=True))
 
 
 # --------------------------------------------------------------------------------------
@@ -215,27 +221,27 @@ def _spill(text: str, label: str) -> str:
     return str(path)
 
 
-def _clamp_lines(lines: list[str]) -> tuple[list[str], int]:
-    clamped, hits = [], 0
-    for line in lines:
-        if len(line) > MAX_LINE_CHARS:
-            clamped.append(line[:MAX_LINE_CHARS] + f" …[line clipped, {len(line)} chars total]")
-            hits += 1
-        else:
-            clamped.append(line)
-    return clamped, hits
-
-
 def cap_output(text: str, label: str = "output") -> str:
     """Bound execution output (bash, run_code): keep the tail, spill the full text."""
     if not text.strip():
         return "(no output)"
-    lines, clipped = _clamp_lines(text.splitlines())
+    lines = text.splitlines()
     total = len(lines)
-    kept = lines[-MAX_LINES:]
-    while len(kept) > 1 and sum(len(line) + 1 for line in kept) > MAX_BYTES:
-        kept = kept[1:]
-    if len(kept) == total and not clipped and sum(len(line) + 1 for line in kept) <= MAX_BYTES:
+    # Walk the tail window backwards, clamping and accumulating until the byte
+    # budget fills — one pass over at most MAX_LINES lines, however big the text.
+    kept: list[str] = []
+    size = 0
+    clipped = False
+    for line in reversed(lines[-MAX_LINES:]):
+        if len(line) > MAX_LINE_CHARS:
+            line = line[:MAX_LINE_CHARS] + f" …[line clipped, {len(line)} chars total]"
+            clipped = True
+        if kept and size + len(line) + 1 > MAX_BYTES:
+            break
+        size += len(line) + 1
+        kept.append(line)
+    kept.reverse()
+    if len(kept) == total and not clipped:
         return "\n".join(kept)
     path = _spill(text, label)
     start = total - len(kept) + 1
@@ -253,25 +259,29 @@ READ_LEDGER: set[str] = set()
 """Paths read this rollout; write consults it before overwriting an existing file."""
 
 
-def run_read(path: str, offset=None, limit=None, cwd: Path | None = None):
+def _resolve(path: str, cwd: Path | None) -> Path:
     p = Path(path)
-    if not p.is_absolute():
-        p = (cwd or Path.cwd()) / p
+    return p if p.is_absolute() else (cwd or Path.cwd()) / p
+
+
+def run_read(path: str, offset=None, limit=None, cwd: Path | None = None):
+    p = _resolve(path, cwd)
     if not p.exists():
         return f"{path} not found"
     if p.is_dir():
         entries = sorted(e.name + ("/" if e.is_dir() else "") for e in p.iterdir())
         return f"{path} is a directory ({len(entries)} entries) — use bash ls; first entries: " + ", ".join(entries[:20])
-    head = p.open("rb").read(8)
+    with p.open("rb") as f:
+        head = f.read(8)
     for magic, mime in IMAGE_MAGIC.items():
         if head.startswith(magic):
-            data = p.read_bytes()
-            if len(data) > MAX_IMAGE_BYTES:
-                return f"{path} is a {mime} of {len(data)} bytes — over the {MAX_IMAGE_BYTES} byte image cap"
+            size = p.stat().st_size
+            if size > MAX_IMAGE_BYTES:
+                return f"{path} is a {mime} of {size} bytes — over the {MAX_IMAGE_BYTES} byte image cap"
             READ_LEDGER.add(str(p))
-            encoded = base64.b64encode(data).decode()
+            encoded = base64.b64encode(p.read_bytes()).decode()
             return [
-                {"type": "text", "text": f"{path} ({mime}, {len(data)} bytes)"},
+                {"type": "text", "text": f"{path} ({mime}, {size} bytes)"},
                 {"type": "image_url", "image_url": {"url": f"data:{mime};base64,{encoded}"}},
             ]
 
@@ -286,16 +296,22 @@ def run_read(path: str, offset=None, limit=None, cwd: Path | None = None):
     window: list[str] = []
     budget = MAX_BYTES
     clipped_mid_line = False
+    more_follows = False
     with p.open("r", encoding="utf-8", errors="replace") as f:
         for i, line in enumerate(f, start=1):
             total = i
-            if i < offset or len(window) >= limit or budget <= 0:
+            if i < offset:
                 continue
+            if len(window) >= limit or budget <= 0:
+                # The window is full: one extra line proves more follows, and the
+                # scan stops — paging a huge file must not decode its whole tail.
+                more_follows = True
+                break
             line = line.rstrip("\n")
             if len(line) > MAX_LINE_CHARS:
                 line = line[:MAX_LINE_CHARS] + " …[line clipped, use bash to see the rest]"
             if len(line) + 1 > budget:
-                window.append(line[: max(0, budget)])
+                window.append(line[:budget])
                 budget = 0
                 clipped_mid_line = True
                 continue
@@ -309,17 +325,15 @@ def run_read(path: str, offset=None, limit=None, cwd: Path | None = None):
         return f"offset {offset} is past the end of {path} — {total} lines total"
     end = offset + len(window) - 1
     body = "\n".join(window)
-    if end < total or clipped_mid_line:
+    if more_follows or clipped_mid_line:
         # Resume ON the clipped line when the byte cap cut it short, else the next line.
         resume = end if clipped_mid_line else end + 1
-        return body + f"\n[Showing lines {offset}-{end} of {total}. Use offset={resume} to continue.]"
+        return body + f"\n[Showing lines {offset}-{end}; more of the file follows. Use offset={resume} to continue.]"
     return body
 
 
 def run_write(path: str, content: str, cwd: Path | None = None) -> str:
-    p = Path(path)
-    if not p.is_absolute():
-        p = (cwd or Path.cwd()) / p
+    p = _resolve(path, cwd)
     if p.exists() and p.stat().st_size > 0 and str(p) not in READ_LEDGER:
         return (
             f"refusing to overwrite {path}: it exists and was never read this session — "
@@ -334,9 +348,7 @@ def run_write(path: str, content: str, cwd: Path | None = None) -> str:
 def run_edit(path: str, edits, cwd: Path | None = None) -> str:
     if not isinstance(edits, list) or not edits:
         return "edits must be a non-empty array of {oldText, newText}"
-    p = Path(path)
-    if not p.is_absolute():
-        p = (cwd or Path.cwd()) / p
+    p = _resolve(path, cwd)
     if not p.exists():
         return f"{path} not found"
     try:
@@ -422,19 +434,19 @@ def send(frame):
 
 def bridge(kind, payload):
     send({"call": {"kind": kind, **payload}})
-    while True:
-        line = sys.stdin.readline()
-        if not line:
-            os._exit(0)
-        frame = json.loads(line)
-        if "result" in frame:
-            return frame["result"]
-        if "error" in frame:
-            err = frame["error"]
-            exc = getattr(builtins, err.get("type", ""), None)
-            if isinstance(exc, type) and issubclass(exc, BaseException):
-                raise exc(err.get("message", ""))
-            raise RuntimeError(err.get("message", ""))
+    line = sys.stdin.readline()
+    if not line:
+        os._exit(0)
+    frame = json.loads(line)
+    if "result" in frame:
+        return frame["result"]
+    err = frame.get("error")
+    if err is None:
+        raise RuntimeError(f"unexpected bridge frame: {frame!r}")
+    exc = getattr(builtins, err.get("type", ""), None)
+    if isinstance(exc, type) and issubclass(exc, BaseException):
+        raise exc(err.get("message", ""))
+    raise RuntimeError(err.get("message", ""))
 
 
 class App:
@@ -476,8 +488,9 @@ def init(payload):
     NS["completion"] = completion
 
     if payload.get("subagents"):
-        def agent(prompt, schema=None, effort=None, tools=None):
-            return bridge("agent", {"prompt": prompt, "schema": schema, "effort": effort, "tools": tools})
+        def agent(prompt, schema=None, effort=None, tools=None, session=None):
+            return bridge("agent", {"prompt": prompt, "schema": schema, "effort": effort,
+                                    "tools": tools, "session": session})
 
         NS["agent"] = agent
     send({"initialized": True})
@@ -658,10 +671,7 @@ class Kernel:
         )
 
     async def close(self) -> None:
-        if self._proc is not None and self._proc.returncode is None:
-            with contextlib.suppress(ProcessLookupError):
-                self._proc.kill()
-        self._proc = None
+        self._mark_dead("")
 
 
 class BridgeError(Exception):
@@ -675,9 +685,6 @@ class BridgeError(Exception):
 # --------------------------------------------------------------------------------------
 # MCP: pooled clients, retried sessions, docs-on-disk, decoy-aware dispatch
 # --------------------------------------------------------------------------------------
-
-TOOL_DISCOVERY: dict[str, int] = {}
-
 
 def mcp_clients(config: dict) -> dict[str, httpx.AsyncClient]:
     return {
@@ -699,12 +706,10 @@ def _only_cause(error: Exception) -> Exception:
 
 @contextlib.asynccontextmanager
 async def mcp_session(http_client: httpx.AsyncClient, url: str):
-    from contextlib import AsyncExitStack
-
     from mcp import ClientSession
     from mcp.client.streamable_http import streamable_http_client
 
-    stack = AsyncExitStack()
+    stack = contextlib.AsyncExitStack()
     cancelled: BaseException | None = None
     try:
         read, write, *_ = await stack.enter_async_context(streamable_http_client(url, http_client=http_client))
@@ -736,22 +741,29 @@ async def with_retry(call):
 
 
 async def connect_mcp(config: dict, clients: dict):
-    """Enumerate tools; return (dispatch {(app, verb) -> (server, raw, params)}, servers, docs)."""
+    """Enumerate tools across all servers concurrently (startup pays the slowest
+    tunnel, not the sum); return (dispatch {(app, verb) -> (server, raw, params)},
+    docs, catalog ref)."""
     dispatch: dict[tuple[str, str], tuple[str, str, list[str]]] = {}
-    servers, docs = {}, {}
+    docs: dict = {}
     catalog_server: tuple[str, str] | None = None
-    for name, spec in config.get("mcpServers", {}).items():
-        servers[name] = spec
+    servers = list(config.get("mcpServers", {}).items())
 
-        async def list_tools(name: str = name, spec: dict = spec):
-            async with mcp_session(clients[name], spec["url"]) as session:
-                return (await session.list_tools()).tools
+    async def list_tools(name: str, spec: dict):
+        async with mcp_session(clients[name], spec["url"]) as session:
+            return (await session.list_tools()).tools
 
-        for tool in await with_retry(list_tools):
+    listed = await asyncio.gather(
+        *(with_retry(lambda name=name, spec=spec: list_tools(name, spec)) for name, spec in servers)
+    )
+    for (name, _spec), tools in zip(servers, listed):
+        for tool in tools:
             if tool.name == DISCOVERY_CATALOG:
                 # The box's own channel: read once at startup, never bound or documented.
                 catalog_server = (name, tool.name)
                 continue
+            # Wire contract with task authors: tools are named <app>_<verb> (first
+            # underscore splits); a verb-less name lands in the shared `misc` app.
             bare = tool.name.split("_", 1)[1] if tool.name.startswith("tools_") else tool.name
             app, _, verb = bare.partition("_")
             if not verb:
@@ -769,7 +781,7 @@ async def connect_mcp(config: dict, clients: dict):
                     f"{' — ' + s['description'] if s.get('description') else ''}"
                 )
             docs[(app, verb)] = "\n".join(lines) + "\n"
-    return dispatch, servers, docs, catalog_server
+    return dispatch, docs, catalog_server
 
 
 def mcp_content(result):
@@ -972,6 +984,20 @@ def validate_schema(value, schema) -> str | None:
     return None
 
 
+def schema_suffix(lead: str, schema) -> str:
+    return f"\n\n{lead} only valid JSON matching this schema (no prose, no code fences):\n" + json.dumps(schema)
+
+
+def parse_reply(text: str, schema) -> tuple[object, str | None]:
+    """Parse a schema-bound model reply; returns (value, None) or (None, problem)."""
+    try:
+        value = json.loads(strip_fences(text))
+    except Exception:  # noqa: BLE001 - malformed JSON is retried with feedback
+        return None, "the reply was not valid JSON"
+    problem = validate_schema(value, schema)
+    return (value, None) if problem is None else (None, problem)
+
+
 class Driver:
     """Owns the client, kernel, MCP dispatch, and both loops (main + subagents)."""
 
@@ -989,9 +1015,13 @@ class Driver:
         self.dispatch: dict = {}
         self.servers: dict = {}
         self.clients: dict = {}
-        self.served_apps: set[str] = set()
         self.documented_apps: set[str] = set()
+        self.tool_discovery: dict[str, int] = {}
         self.subagents_spawned = 0
+        self.sessions: dict[str, dict] = {}
+        """Named persistent subagents: session name -> {"messages", "tools"}. A
+        continued session appends the new prompt and keeps its context — the caller
+        pays for the delta, not a re-briefing — and extends the same trace branch."""
         self.compactions = 0
         self.compaction_pending = False
         self.just_compacted = False
@@ -1001,11 +1031,15 @@ class Driver:
 
     # --- setup ------------------------------------------------------------------
 
+    @property
+    def served_apps(self) -> set[str]:
+        return {app for app, _ in self.dispatch}
+
     async def setup(self) -> None:
         config = json.loads(self.args.mcp_config) if self.args.mcp_config else {}
+        self.servers = config.get("mcpServers", {})
         self.clients = mcp_clients(config)
-        self.dispatch, self.servers, docs, catalog_ref = await connect_mcp(config, self.clients)
-        self.served_apps = {app for app, _ in self.dispatch}
+        self.dispatch, docs, catalog_ref = await connect_mcp(config, self.clients)
         apps_payload = {}
         for (app, verb), (_, _, params) in self.dispatch.items():
             apps_payload.setdefault(app, {})[verb] = params
@@ -1014,7 +1048,7 @@ class Driver:
             catalog = await call_mcp_raw(self.servers, self.clients, server, raw, {})
             write_catalog_docs(self.box, catalog)
             self.documented_apps = set(catalog)
-            TOOL_DISCOVERY.update(
+            self.tool_discovery.update(
                 decoy_calls=0,
                 surface_apps=len(catalog),
                 surface_tools=sum(len(e["verbs"]) for e in catalog.values()),
@@ -1032,7 +1066,7 @@ class Driver:
 
     # --- bridge handlers ----------------------------------------------------------
 
-    async def handle_call(self, call: dict, depth: int = 0):
+    async def handle_call(self, call: dict, depth: int):
         kind = call.get("kind")
         if kind == "mcp":
             return await self.do_mcp(call.get("app", ""), call.get("verb", ""), call.get("args") or {})
@@ -1044,7 +1078,8 @@ class Driver:
             if depth > 0:
                 raise BridgeError("RuntimeError", "subagents cannot spawn subagents (depth 1)")
             return await self.do_agent(
-                call.get("prompt", ""), call.get("schema"), call.get("effort"), call.get("tools")
+                call.get("prompt", ""), call.get("schema"), call.get("effort"),
+                call.get("tools"), call.get("session"),
             )
         raise BridgeError("RuntimeError", f"unknown bridge call {kind!r}")
 
@@ -1056,7 +1091,7 @@ class Driver:
                     "AttributeError", f"{app} has no {verb!r} tool — its tools are documented in ./tools/{app}/"
                 )
             if app in self.documented_apps:
-                TOOL_DISCOVERY["decoy_calls"] = TOOL_DISCOVERY.get("decoy_calls", 0) + 1
+                self.tool_discovery["decoy_calls"] = self.tool_discovery.get("decoy_calls", 0) + 1
                 raise BridgeError(
                     "NameError",
                     f"no such app in this workspace: {app!r} — it is documented, but this workspace "
@@ -1074,12 +1109,7 @@ class Driver:
         messages = []
         if system:
             messages.append({"role": "system", "content": str(system)})
-        body = str(prompt)
-        if schema:
-            body += (
-                "\n\nRespond with only valid JSON matching this schema (no prose, no code fences):\n"
-                + json.dumps(schema)
-            )
+        body = str(prompt) + (schema_suffix("Respond with", schema) if schema else "")
         messages.append({"role": "user", "content": body})
         problem = "no attempts left"
         for attempt in range(2):
@@ -1091,19 +1121,14 @@ class Driver:
             text = completion.choices[0].message.content or ""
             if not schema:
                 return text
-            try:
-                value = json.loads(strip_fences(text))
-            except Exception:  # noqa: BLE001 - malformed JSON is retried with feedback
-                problem = "the reply was not valid JSON"
-            else:
-                problem = validate_schema(value, schema)
-                if problem is None:
-                    return value
+            value, problem = parse_reply(text, schema)
+            if problem is None:
+                return value
             messages.append({"role": "assistant", "content": text})
             messages.append({"role": "user", "content": f"{problem}. Reply with only the corrected JSON."})
         raise BridgeError("ValueError", f"completion did not return JSON matching the schema: {problem}")
 
-    async def do_agent(self, prompt: str, schema, effort, tools):
+    async def do_agent(self, prompt: str, schema, effort, tools, session=None):
         remaining = self.budget.remaining
         if remaining is not None and remaining < SPAWN_RESERVE_TURNS:
             raise BridgeError(
@@ -1112,48 +1137,47 @@ class Driver:
                 "finish the task directly",
             )
         self.subagents_spawned += 1
-        allowed = [t for t in self.tools if t != "compact"]
-        if tools is not None:
-            unknown = [t for t in tools if t not in allowed]
-            if unknown:
-                raise BridgeError("ValueError", f"unknown subagent tools: {unknown} (available: {allowed})")
-            allowed = [t for t in allowed if t in tools]
-        body = str(prompt)
-        if schema:
-            body += (
-                "\n\nYour final message must be only valid JSON matching this schema "
-                "(no prose, no code fences):\n" + json.dumps(schema)
-            )
-        messages = [
-            {"role": "system", "content": self.subagent_system_prompt()},
-            {"role": "user", "content": body},
-        ]
+        body = str(prompt) + (schema_suffix("Your final message must be", schema) if schema else "")
+        if session and session in self.sessions:
+            # Continue the named session: same transcript, same tool surface — the
+            # follow-up rides the context already paid for.
+            stored = self.sessions[session]
+            messages, allowed = stored["messages"], stored["tools"]
+            messages.append({"role": "user", "content": body})
+        else:
+            allowed = [t for t in self.tools if t != "compact"]
+            if tools is not None:
+                unknown = [t for t in tools if t not in allowed]
+                if unknown:
+                    raise BridgeError("ValueError", f"unknown subagent tools: {unknown} (available: {allowed})")
+                allowed = [t for t in allowed if t in tools]
+            messages = [
+                {"role": "system", "content": self.subagent_system_prompt()},
+                {"role": "user", "content": body},
+            ]
+            if session:
+                self.sessions[session] = {"messages": messages, "tools": allowed}
         final = await self.run_loop(
             messages,
             tools=allowed,
             depth=1,
             # No per-spawn ceiling: allocation is the policy's call; the shared budget
             # binds, minus the reserve that keeps the parent able to act.
-            max_turns=None if self.budget.remaining is None else self.budget.remaining - 2,
-            effort=effort or self.args.effort,
+            max_turns=None if self.budget.remaining is None else self.budget.remaining - (SPAWN_RESERVE_TURNS - 1),
+            effort=effort,
         )
         if final is None:
             return None
         if not schema:
             return final
         for _ in range(2):
-            try:
-                value = json.loads(strip_fences(final))
-            except Exception:  # noqa: BLE001 - malformed JSON is retried with feedback
-                problem = "the reply was not valid JSON"
-            else:
-                problem = validate_schema(value, schema)
-                if problem is None:
-                    return value
+            value, problem = parse_reply(final, schema)
+            if problem is None:
+                return value
             if self.budget.remaining is not None and self.budget.remaining < 1:
                 break
             messages.append({"role": "user", "content": f"{problem}. Reply with only the corrected JSON."})
-            final = await self.run_loop(messages, tools=[], depth=1, max_turns=1, effort=effort or self.args.effort)
+            final = await self.run_loop(messages, tools=[], depth=1, max_turns=1, effort=effort)
             if final is None:
                 break
         raise BridgeError("ValueError", "subagent did not return JSON matching the schema")
@@ -1217,9 +1241,11 @@ class Driver:
             lines.append("`completion(prompt, schema=None)` makes one standalone model call from code.")
             if self.args.subagents:
                 lines.append(
-                    "`agent(prompt, schema=None, effort=None, tools=None)` runs a subagent with a "
-                    "blank context and returns its final message (parsed when schema is given); "
-                    "give it complete, self-contained instructions."
+                    "`agent(prompt, schema=None, effort=None, tools=None, session=None)` runs a "
+                    "subagent with a blank context and returns its final message (parsed when "
+                    "schema is given); give it complete, self-contained instructions. Pass a "
+                    "session name to make it persistent: later calls with the same name continue "
+                    "that subagent's conversation instead of starting over."
                 )
         if "compact" in tools:
             lines.append(
@@ -1239,7 +1265,7 @@ class Driver:
     # --- compaction -------------------------------------------------------------------
 
     async def checkpoint(self, messages: list[dict], tool_schemas: list[dict]) -> None:
-        keep = 2 if messages and messages[0].get("role") == "system" else 1
+        keep = 2  # the protected prefix: system + the opening user message (assemble_messages)
         SPILL_DIR.mkdir(parents=True, exist_ok=True)
         history_path = str(SPILL_DIR / f"history-{self.compactions + 1}.txt")
         Path(history_path).write_text(render_history(messages[keep:]))
@@ -1290,15 +1316,17 @@ class Driver:
         value = effort if effort is not None else self.args.effort
         return {"reasoning_effort": value} if value else {}
 
-    def _notices(self, depth: int) -> str:
+    def _notices(self) -> str:
+        """Root-loop notices, appended to the turn's last tool result — the observation
+        channel, never the system prompt, so every request extends the one before."""
         notices = []
-        if depth == 0 and self.args.disclose_budget and self.budget.max_turns is not None:
+        if self.args.disclose_budget and self.budget.max_turns is not None:
             spent = self.budget.spent
             notices.append(
                 f"[harness] Turn budget: {spent}/{self.budget.max_turns} used, "
                 f"{self.budget.max_turns - spent} remaining."
             )
-        if depth == 0 and self.args.compact_tool and self.last_prompt_tokens:
+        if "compact" in self.tools and self.last_prompt_tokens:
             notices.append(
                 f"[harness] Context: ~{self.last_prompt_tokens} prompt tokens "
                 f"(checkpoint threshold {self.args.context_budget_tokens})."
@@ -1342,6 +1370,9 @@ class Driver:
                 if depth == 0 and is_overflow_error(error) and not overflow_retried:
                     # A work turn rejected for context length forces a compaction and
                     # retries exactly once. The refused call cost nothing — refund it.
+                    # (Assumes the interception server's ledger also skipped the refused
+                    # call; if that ever drifts, the box just walks into the refused
+                    # call the mirror was meant to avoid — degraded, not wrong.)
                     self.budget.spent -= 1
                     overflow_retried = True
                     self.compaction_pending = True
@@ -1381,18 +1412,21 @@ class Driver:
                     out = await self.execute_tool(tc.function.name, arguments, depth)
                 content = out if isinstance(out, list) else str(out)
                 messages.append({"role": "tool", "tool_call_id": tc.id, "content": content})
-            if isinstance(messages[-1]["content"], str):
-                messages[-1]["content"] += self._notices(depth)
             if depth == 0:
-                write_diagnostics(
-                    "loop",
-                    turns=self.budget.spent,
-                    compactions=self.compactions,
-                    peak_prompt_tokens=self.peak_prompt_tokens,
-                    subagents=self.subagents_spawned,
-                    **({"tool_discovery": dict(TOOL_DISCOVERY)} if TOOL_DISCOVERY else {}),
-                )
+                if isinstance(messages[-1]["content"], str):
+                    messages[-1]["content"] += self._notices()
+                self.write_stats("loop")
         return final
+
+    def write_stats(self, phase: str) -> None:
+        write_diagnostics(
+            phase,
+            turns=self.budget.spent,
+            compactions=self.compactions,
+            peak_prompt_tokens=self.peak_prompt_tokens,
+            subagents=self.subagents_spawned,
+            **({"tool_discovery": dict(self.tool_discovery)} if self.tool_discovery else {}),
+        )
 
     async def close(self) -> None:
         if self.kernel is not None:
@@ -1418,7 +1452,6 @@ def parse_args():
     p.add_argument("--effort", default="")
     p.add_argument("--tools", default="read,write,edit,bash,run_code")
     p.add_argument("--subagents", action="store_true")
-    p.add_argument("--compact-tool", action="store_true")
     p.add_argument("--context-budget-tokens", type=int, default=150_000)
     p.add_argument("--max-turns", type=int, default=None)
     p.add_argument("--disclose-budget", action="store_true")
@@ -1431,27 +1464,20 @@ async def main() -> None:
     driver = Driver(args)
     try:
         await driver.setup()
-        tools = list(driver.tools)
-        if args.compact_tool:
-            tools.append("compact")
         initial = None
         if args.initial_messages_file:
-            initial = json.loads(Path(args.initial_messages_file).read_text())
-        system = driver.system_prompt_base(tools)
+            path = Path(args.initial_messages_file)
+            initial = json.loads(path.read_text())
+            path.unlink(missing_ok=True)
+        system = driver.system_prompt_base(driver.tools)
         if initial is not None and "run_code" in driver.tools:
             system += "\n\n" + RESUME_NOTE
         if args.system_prompt:
             system += "\n\n" + args.system_prompt
         messages = assemble_messages(system, args.prompt, initial)
-        await driver.run_loop(messages, tools=tools, depth=0, max_turns=args.max_turns)
-        write_diagnostics(
-            "complete",
-            turns=driver.budget.spent,
-            compactions=driver.compactions,
-            peak_prompt_tokens=driver.peak_prompt_tokens,
-            subagents=driver.subagents_spawned,
-            **({"tool_discovery": dict(TOOL_DISCOVERY)} if TOOL_DISCOVERY else {}),
-        )
+        # The turn budget, not this call, is the authority on stopping.
+        await driver.run_loop(messages, tools=driver.tools, depth=0, max_turns=None)
+        driver.write_stats("complete")
     finally:
         await driver.close()
 

--- a/verifiers/v1/harnesses/rho/program.py
+++ b/verifiers/v1/harnesses/rho/program.py
@@ -1,0 +1,1387 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "openai==2.49.0",
+#     "mcp==1.28.1",
+#     "httpx==0.28.1",
+#     "tenacity==9.1.4",
+#     "jsonschema==4.25.1",
+#     # Office-format libraries for run_code: without them models hand-roll OOXML
+#     # zips and zlib-decode PDF streams instead of doing the task.
+#     "openpyxl==3.1.5",
+#     "pypdf==6.14.2",
+#     "python-docx==1.2.0",
+#     "python-pptx==1.0.2",
+# ]
+# ///
+"""In-box driver for the rho harness: pi's four tools plus run_code.
+
+Five native tools — read, write, edit, bash (pi semantics), and run_code. Everything
+compositional lives inside run_code: the task's MCP tools are documented as files under
+./tools/<app>/<verb> and pre-bound as `<app>.<verb>(...)` callables, `completion()` makes
+one-shot sub-LLM calls, and `agent()` spawns subagents (config-gated, depth 1). Model code
+executes in a persistent kernel subprocess reached over stdio NDJSON; the same channel is
+the tool bridge, so the kernel holds capabilities, never credentials.
+
+The transcript is append-only between compaction boundaries: assistant messages (reasoning
+included) are re-sent complete, and the only rewriting event is Codex-style checkpoint
+compaction — triggered by the token budget, a context overflow, or the model's own
+`compact` tool call.
+"""
+
+import argparse
+import asyncio
+import base64
+import contextlib
+import itertools
+import json
+import os
+import platform
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import httpx
+from openai import AsyncOpenAI
+from tenacity import AsyncRetrying, stop_after_attempt, wait_exponential_jitter
+
+# --------------------------------------------------------------------------------------
+# Constants
+# --------------------------------------------------------------------------------------
+
+MAX_LINES = 2000
+MAX_BYTES = 50 * 1024
+MAX_LINE_CHARS = 2000
+"""Three ceilings on every output path: line window, byte budget, per-line clamp.
+Omitting any one leaves a file shape unhandled (one minified line inside the line
+window can eat the whole byte budget)."""
+
+SPILL_DIR = Path("/tmp/.rho")
+"""Overflowing output is spilled here in full; the truncation footer names the path so
+recovery is a read/grep, not a guess. Outside the workspace so spills never pollute
+task deliverables."""
+
+CELL_TIMEOUT = 30.0
+"""run_code compute budget per cell, seconds. The clock pauses while bridged tool calls
+are in flight, so tool latency never triggers it. Long pure compute is not a knob — it
+is bash: write a script, run it under the tool with no timeout."""
+
+KERNEL_KILL_GRACE = 5.0
+"""After SIGINT, seconds to wait for the cell to unwind before escalating to SIGKILL."""
+
+IMAGE_MAGIC = {
+    b"\xff\xd8\xff": "image/jpeg",
+    b"\x89PNG": "image/png",
+    b"GIF8": "image/gif",
+    b"RIFF": "image/webp",
+}
+MAX_IMAGE_BYTES = 5 * 1024 * 1024
+
+MAX_TURNS = 250
+MAX_COMPACTIONS = 8
+SUBAGENT_MAX_TURNS = 40
+"""Per-spawn ceiling on a subagent's own loop; the shared trace budget binds first."""
+
+TUNNEL_TIMEOUT = httpx.Timeout(600.0, connect=30.0)
+TUNNEL_POOL = httpx.Limits(max_connections=16, max_keepalive_connections=16, keepalive_expiry=900.0)
+"""Everything the box talks to is the host reached back through the runtime's tunnel,
+where opening a connection is the slow part (measured 3-16s, up to 55s). Pool for the
+whole rollout so that cost is paid per rollout, not per call."""
+
+MCP_CALL_ATTEMPTS = 6
+TOOLS_DIR = "tools"
+DISCOVERY_CATALOG = "tools_catalog"
+RUNTIME_DIAGNOSTICS = "/tmp/.rho-runtime.json"
+
+OVERFLOW_PATTERNS = (
+    "context length",
+    "context_length",
+    "prompt is too long",
+    "exceeds the context window",
+    "maximum context",
+    "too many tokens",
+    "input is too long",
+)
+
+# Checkpoint prompt shared verbatim with openai/codex (compact.rs), plus the kernel
+# persistence note Codex lacks and pi's update-style wording for repeat compactions.
+COMPACTION_PROMPT = (
+    "You are performing a CONTEXT CHECKPOINT COMPACTION. Create a handoff summary for another "
+    "LLM that will resume the task.\n"
+    "\n"
+    "Include:\n"
+    "- Current progress and key decisions made\n"
+    "- Important context, constraints, or user preferences\n"
+    "- What remains to be done (clear next steps)\n"
+    "- Any critical data, examples, or references needed to continue\n"
+    "\n"
+    "Be concise, structured, and focused on helping the next LLM seamlessly continue the work."
+    "\n\n"
+    "Note: the workspace and the Python namespace used by run_code stay as they are across "
+    "this compaction — files you wrote and variables you defined are still there. Mention "
+    "important file paths and variable names so the next LLM knows what's available.\n"
+    "If the conversation already contains a previous checkpoint summary, update it: preserve "
+    "all information that is still relevant and move completed items to done — do not drop "
+    "carried context."
+)
+COMPACTION_FRAMING = (
+    "Another language model started to solve this problem and produced a summary of its "
+    "thinking process. It worked in this same environment: the workspace files and run_code "
+    "variables it mentions are still present. Use this to build on the work that has already "
+    "been done and avoid duplicating work. Here is the summary produced by the other language "
+    "model, use the information in this summary to assist with your own analysis:"
+)
+
+
+def write_diagnostics(phase: str, **values) -> None:
+    path = Path(RUNTIME_DIAGNOSTICS)
+    current = {}
+    if path.exists():
+        with contextlib.suppress(Exception):
+            current = json.loads(path.read_text())
+    current |= {"phase": phase, "python": platform.python_version(), **values}
+    path.write_text(json.dumps(current, sort_keys=True))
+
+
+# --------------------------------------------------------------------------------------
+# Output bounding: three ceilings, tail-kept, spill to a named path
+# --------------------------------------------------------------------------------------
+
+_spill_counter = 0
+
+
+def _spill(text: str, label: str) -> str:
+    global _spill_counter
+    SPILL_DIR.mkdir(parents=True, exist_ok=True)
+    _spill_counter += 1
+    path = SPILL_DIR / f"{label}-{_spill_counter}.txt"
+    path.write_text(text)
+    return str(path)
+
+
+def _clamp_lines(lines: list[str]) -> tuple[list[str], int]:
+    clamped, hits = [], 0
+    for line in lines:
+        if len(line) > MAX_LINE_CHARS:
+            clamped.append(line[:MAX_LINE_CHARS] + f" …[line clipped, {len(line)} chars total]")
+            hits += 1
+        else:
+            clamped.append(line)
+    return clamped, hits
+
+
+def cap_output(text: str, label: str = "output") -> str:
+    """Bound execution output (bash, run_code): keep the tail, spill the full text."""
+    if not text.strip():
+        return "(no output)"
+    lines, clipped = _clamp_lines(text.splitlines())
+    total = len(lines)
+    kept = lines[-MAX_LINES:]
+    while len(kept) > 1 and sum(len(line) + 1 for line in kept) > MAX_BYTES:
+        kept = kept[1:]
+    if len(kept) == total and not clipped and sum(len(line) + 1 for line in kept) <= MAX_BYTES:
+        return "\n".join(kept)
+    path = _spill(text, label)
+    start = total - len(kept) + 1
+    return (
+        "\n".join(kept)
+        + f"\n[Showing lines {start}-{total} of {total}. Full output: {path} — read or grep it, or print less.]"
+    )
+
+
+# --------------------------------------------------------------------------------------
+# Native tools: read / write / edit / bash (pi semantics)
+# --------------------------------------------------------------------------------------
+
+READ_LEDGER: set[str] = set()
+"""Paths read this rollout; write consults it before overwriting an existing file."""
+
+
+def run_read(path: str, offset=None, limit=None, cwd: Path | None = None):
+    p = Path(path)
+    if not p.is_absolute():
+        p = (cwd or Path.cwd()) / p
+    if not p.exists():
+        return f"{path} not found"
+    if p.is_dir():
+        entries = sorted(e.name + ("/" if e.is_dir() else "") for e in p.iterdir())
+        return f"{path} is a directory ({len(entries)} entries) — use bash ls; first entries: " + ", ".join(entries[:20])
+    head = p.open("rb").read(8)
+    for magic, mime in IMAGE_MAGIC.items():
+        if head.startswith(magic):
+            data = p.read_bytes()
+            if len(data) > MAX_IMAGE_BYTES:
+                return f"{path} is a {mime} of {len(data)} bytes — over the {MAX_IMAGE_BYTES} byte image cap"
+            READ_LEDGER.add(str(p))
+            encoded = base64.b64encode(data).decode()
+            return [
+                {"type": "text", "text": f"{path} ({mime}, {len(data)} bytes)"},
+                {"type": "image_url", "image_url": {"url": f"data:{mime};base64,{encoded}"}},
+            ]
+
+    try:
+        offset = max(1, int(offset)) if offset is not None else 1
+        limit = max(1, int(limit)) if limit is not None else MAX_LINES
+    except (TypeError, ValueError):
+        return "offset and limit must be integers"
+    limit = min(limit, MAX_LINES)
+
+    total = 0
+    window: list[str] = []
+    budget = MAX_BYTES
+    clipped_mid_line = False
+    with p.open("r", encoding="utf-8", errors="replace") as f:
+        for i, line in enumerate(f, start=1):
+            total = i
+            if i < offset or len(window) >= limit or budget <= 0:
+                continue
+            line = line.rstrip("\n")
+            if len(line) > MAX_LINE_CHARS:
+                line = line[:MAX_LINE_CHARS] + " …[line clipped, use bash to see the rest]"
+            if len(line) + 1 > budget:
+                window.append(line[: max(0, budget)])
+                budget = 0
+                clipped_mid_line = True
+                continue
+            budget -= len(line) + 1
+            window.append(line)
+
+    READ_LEDGER.add(str(p))
+    if total == 0:
+        return f"{path} is empty"
+    if offset > total:
+        return f"offset {offset} is past the end of {path} — {total} lines total"
+    end = offset + len(window) - 1
+    body = "\n".join(window)
+    if end < total or clipped_mid_line:
+        # Resume ON the clipped line when the byte cap cut it short, else the next line.
+        resume = end if clipped_mid_line else end + 1
+        return body + f"\n[Showing lines {offset}-{end} of {total}. Use offset={resume} to continue.]"
+    return body
+
+
+def run_write(path: str, content: str, cwd: Path | None = None) -> str:
+    p = Path(path)
+    if not p.is_absolute():
+        p = (cwd or Path.cwd()) / p
+    if p.exists() and p.stat().st_size > 0 and str(p) not in READ_LEDGER:
+        return (
+            f"refusing to overwrite {path}: it exists and was never read this session — "
+            "read it first, or write to a new path"
+        )
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content)
+    READ_LEDGER.add(str(p))
+    return f"Wrote {len(content.encode())} bytes to {path}"
+
+
+def run_edit(path: str, edits, cwd: Path | None = None) -> str:
+    if not isinstance(edits, list) or not edits:
+        return "edits must be a non-empty array of {oldText, newText}"
+    p = Path(path)
+    if not p.is_absolute():
+        p = (cwd or Path.cwd()) / p
+    if not p.exists():
+        return f"{path} not found"
+    try:
+        original = p.read_text()
+    except Exception as e:  # noqa: BLE001 - tool failures are returned to the model
+        return f"could not read {path}: {e}"
+
+    spans: list[tuple[int, int, str]] = []
+    for i, edit in enumerate(edits):
+        old, new = edit.get("oldText"), edit.get("newText")
+        if not isinstance(old, str) or not old or not isinstance(new, str):
+            return f"edits[{i}]: oldText must be a non-empty string and newText a string"
+        count = original.count(old)
+        if count != 1:
+            return f"edits[{i}]: oldText must appear exactly once in the original {path} (found {count})"
+        start = original.index(old)
+        spans.append((start, start + len(old), new))
+    spans.sort()
+    for (_, prev_end, _), (start, _, _) in itertools.pairwise(spans):
+        if start < prev_end:
+            return "edits overlap in the original file — merge them into one edit"
+
+    result, cursor = [], 0
+    for start, end, new in spans:
+        result.append(original[cursor:start])
+        result.append(new)
+        cursor = end
+    result.append(original[cursor:])
+    try:
+        p.write_text("".join(result))
+    except Exception as e:  # noqa: BLE001 - tool failures are returned to the model
+        return f"could not write {path}: {e}"
+    READ_LEDGER.add(str(p))
+    return f"Applied {len(spans)} edit(s) to {path}"
+
+
+def run_bash(command: str, timeout=None, cwd: Path | None = None) -> str:
+    try:
+        timeout = float(timeout) if timeout is not None else None
+    except (TypeError, ValueError):
+        return "timeout must be a number of seconds"
+    proc = subprocess.Popen(
+        ["bash", "-c", command],
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        errors="replace",
+        start_new_session=True,
+    )
+    try:
+        out, _ = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(proc.pid, signal.SIGKILL)
+        out, _ = proc.communicate()
+        return cap_output((out or "") + f"\n[command timed out after {timeout:g}s and was killed]", "bash")
+    text = out or "(no output)"
+    if proc.returncode != 0:
+        text += f"\n[exit code {proc.returncode}]"
+    return cap_output(text, "bash")
+
+
+# --------------------------------------------------------------------------------------
+# The kernel: persistent Python subprocess, stdio NDJSON = cells + tool bridge
+# --------------------------------------------------------------------------------------
+
+RUNNER_SOURCE = r'''
+import builtins, json, os, sys, tempfile, traceback
+
+PROTO = os.fdopen(os.dup(1), "w", buffering=1)
+DEVNULL = os.open(os.devnull, os.O_WRONLY)
+os.dup2(DEVNULL, 1)
+os.dup2(DEVNULL, 2)
+
+NS = {"__name__": "__main__"}
+
+
+def send(frame):
+    PROTO.write(json.dumps(frame) + "\n")
+    PROTO.flush()
+
+
+def bridge(kind, payload):
+    send({"call": {"kind": kind, **payload}})
+    while True:
+        line = sys.stdin.readline()
+        if not line:
+            os._exit(0)
+        frame = json.loads(line)
+        if "result" in frame:
+            return frame["result"]
+        if "error" in frame:
+            err = frame["error"]
+            exc = getattr(builtins, err.get("type", ""), None)
+            if isinstance(exc, type) and issubclass(exc, BaseException):
+                raise exc(err.get("message", ""))
+            raise RuntimeError(err.get("message", ""))
+
+
+class App:
+    """One service app: verbs resolve on attribute access, calls go over the bridge."""
+
+    def __init__(self, name, verbs):
+        self._name = name
+        self._verbs = verbs  # verb -> param name list (empty for documented-only verbs)
+
+    def __getattr__(self, verb):
+        params = self._verbs.get(verb, [])
+
+        def proxy(*args, **kwargs):
+            kwargs.update(zip(params, args))
+            kwargs = {k: v for k, v in kwargs.items() if v is not None}
+            return bridge("mcp", {"app": self._name, "verb": verb, "args": kwargs})
+
+        return proxy
+
+
+def init(payload):
+    apps = {name: App(name, verbs) for name, verbs in payload.get("apps", {}).items()}
+    NS.update(apps)
+    NS["json"] = json
+
+    # `import <app>` resolves to the service proxy — measured rollouts hit this friction.
+    real_import = builtins.__import__
+
+    def import_app_or_python(name, globals=None, locals=None, fromlist=(), level=0):
+        if level == 0 and name in apps:
+            return apps[name]
+        return real_import(name, globals, locals, fromlist, level)
+
+    NS["__builtins__"] = dict(vars(builtins), __import__=import_app_or_python)
+
+    def completion(prompt, schema=None, system=None):
+        return bridge("completion", {"prompt": prompt, "schema": schema, "system": system})
+
+    NS["completion"] = completion
+
+    if payload.get("subagents"):
+        def agent(prompt, schema=None, effort=None, tools=None):
+            return bridge("agent", {"prompt": prompt, "schema": schema, "effort": effort, "tools": tools})
+
+        NS["agent"] = agent
+    send({"initialized": True})
+
+
+def run_cell(code):
+    fd, cap_path = tempfile.mkstemp(prefix=".rho-cell-")
+    os.dup2(fd, 1)
+    os.dup2(fd, 2)
+    error = None
+    try:
+        exec(compile(code, "<cell>", "exec"), NS)
+    except KeyboardInterrupt:
+        error = "KeyboardInterrupt: cell interrupted"
+    except BaseException as e:
+        tb = e.__traceback__.tb_next  # drop the runner's own exec frame
+        error = "".join(traceback.format_exception(type(e), e, tb))
+    finally:
+        try:
+            sys.stdout.flush()
+            sys.stderr.flush()
+        except Exception:
+            pass
+        os.dup2(DEVNULL, 1)
+        os.dup2(DEVNULL, 2)
+        os.close(fd)
+    with open(cap_path, "r", errors="replace") as f:
+        output = f.read()
+    os.unlink(cap_path)
+    send({"done": {"output": output, "error": error}})
+
+
+def main():
+    for line in sys.stdin:
+        try:
+            frame = json.loads(line)
+            if "init" in frame:
+                init(frame["init"])
+            elif "code" in frame:
+                run_cell(frame["code"])
+        except KeyboardInterrupt:
+            continue
+
+
+try:
+    main()
+except BaseException:
+    send({"fatal": traceback.format_exc()})
+'''
+
+KERNEL_ENV_KEEP = ("PATH", "HOME", "LANG", "TERM", "TMPDIR", "PYTHONPATH", "VIRTUAL_ENV")
+KERNEL_ENV_PREFIXES = ("LC_", "UV_", "XDG_")
+
+
+def kernel_env() -> dict[str, str]:
+    """Allowlisted env for the kernel: model code gets capabilities, not credentials."""
+    return {
+        k: v
+        for k, v in os.environ.items()
+        if k in KERNEL_ENV_KEEP or k.startswith(KERNEL_ENV_PREFIXES)
+    }
+
+
+class Kernel:
+    """Driver side of the kernel: lifecycle, cells, and the paused-clock timeout."""
+
+    def __init__(self, init_payload: dict):
+        self._init_payload = init_payload
+        self._proc: asyncio.subprocess.Process | None = None
+        self._runner_path: str | None = None
+        self._death_note = ""
+
+    async def _ensure(self) -> None:
+        if self._proc is not None and self._proc.returncode is None:
+            return
+        if self._runner_path is None:
+            fd, self._runner_path = tempfile.mkstemp(prefix=".rho-runner-", suffix=".py")
+            os.write(fd, RUNNER_SOURCE.encode())
+            os.close(fd)
+        self._proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-u",
+            self._runner_path,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+            env=kernel_env(),
+        )
+        self._send({"init": self._init_payload})
+        frame = await self._read_frame(timeout=30.0)
+        if not (frame and frame.get("initialized")):
+            raise RuntimeError(f"kernel failed to initialize: {frame!r}")
+
+    def _send(self, frame: dict) -> None:
+        assert self._proc is not None and self._proc.stdin is not None
+        self._proc.stdin.write((json.dumps(frame) + "\n").encode())
+
+    async def _read_frame(self, timeout: float | None) -> dict | None:
+        assert self._proc is not None and self._proc.stdout is not None
+        line = await asyncio.wait_for(self._proc.stdout.readline(), timeout)
+        if not line:
+            return None
+        return json.loads(line)
+
+    def _mark_dead(self, note: str) -> None:
+        if self._proc is not None and self._proc.returncode is None:
+            with contextlib.suppress(ProcessLookupError):
+                self._proc.kill()
+        self._proc = None
+        self._death_note = note
+
+    async def run_cell(self, code: str, handle_call) -> str:
+        """Execute one cell; `handle_call` answers bridge frames. The compute clock
+        pauses while a bridged call is in flight."""
+        restart_note = ""
+        if self._death_note:
+            restart_note = f"[{self._death_note} — fresh kernel started: variables lost, files intact.]\n"
+            self._death_note = ""
+        await self._ensure()
+        self._send({"code": code})
+        budget = CELL_TIMEOUT
+        while True:
+            started = time.monotonic()
+            try:
+                frame = await self._read_frame(timeout=budget)
+            except TimeoutError:
+                return restart_note + await self._interrupt()
+            budget -= time.monotonic() - started
+            if frame is None:
+                self._mark_dead("kernel died running your cell")
+                return restart_note + "[kernel died running this cell — fresh kernel next call: variables lost, files intact.]"
+            if "fatal" in frame:
+                self._mark_dead("kernel crashed")
+                return restart_note + cap_output(f"[kernel crashed]\n{frame['fatal']}", "run_code")
+            if "call" in frame:
+                # Bridge time is the tool's, not the cell's: clock paused.
+                try:
+                    result = await handle_call(frame["call"])
+                    self._send({"result": result})
+                except BridgeError as e:
+                    self._send({"error": {"type": e.type, "message": str(e)}})
+                except Exception as e:  # noqa: BLE001 - bridge failures raise inside the kernel
+                    self._send({"error": {"type": "RuntimeError", "message": f"{type(e).__name__}: {e}"}})
+                continue
+            if "done" in frame:
+                done = frame["done"]
+                text = done.get("output") or ""
+                if done.get("error"):
+                    text = (text + "\n" if text else "") + done["error"]
+                return restart_note + cap_output(text or "(ran, no output)", "run_code")
+
+    async def _interrupt(self) -> str:
+        assert self._proc is not None
+        with contextlib.suppress(ProcessLookupError):
+            self._proc.send_signal(signal.SIGINT)
+        try:
+            deadline = time.monotonic() + KERNEL_KILL_GRACE
+            while True:
+                frame = await self._read_frame(timeout=max(0.1, deadline - time.monotonic()))
+                if frame is None:
+                    break
+                if "done" in frame:
+                    done = frame["done"]
+                    partial = done.get("output") or ""
+                    return cap_output(
+                        partial
+                        + f"\n[cell exceeded the {CELL_TIMEOUT:g}s compute budget and was interrupted; "
+                        "variables and earlier statements' effects persist. For long compute, write a "
+                        "script and run it with bash.]",
+                        "run_code",
+                    )
+        except TimeoutError:
+            pass
+        self._mark_dead("cell was stuck (uninterruptible) and the kernel was killed")
+        return (
+            f"[cell exceeded the {CELL_TIMEOUT:g}s compute budget and could not be interrupted — "
+            "kernel killed; fresh kernel next call: variables lost, files intact.]"
+        )
+
+    async def close(self) -> None:
+        if self._proc is not None and self._proc.returncode is None:
+            with contextlib.suppress(ProcessLookupError):
+                self._proc.kill()
+        self._proc = None
+
+
+class BridgeError(Exception):
+    """A bridge failure delivered into the kernel as a typed exception."""
+
+    def __init__(self, type_: str, message: str):
+        super().__init__(message)
+        self.type = type_
+
+
+# --------------------------------------------------------------------------------------
+# MCP: pooled clients, retried sessions, docs-on-disk, decoy-aware dispatch
+# --------------------------------------------------------------------------------------
+
+TOOL_DISCOVERY: dict[str, int] = {}
+
+
+def mcp_clients(config: dict) -> dict[str, httpx.AsyncClient]:
+    return {
+        name: httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=TUNNEL_TIMEOUT,
+            limits=TUNNEL_POOL,
+            headers=spec.get("headers") or None,
+        )
+        for name, spec in config.get("mcpServers", {}).items()
+    }
+
+
+def _only_cause(error: Exception) -> Exception:
+    while len(group := getattr(error, "exceptions", ())) == 1:
+        error = group[0]
+    return error
+
+
+@contextlib.asynccontextmanager
+async def mcp_session(http_client: httpx.AsyncClient, url: str):
+    from contextlib import AsyncExitStack
+
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamable_http_client
+
+    stack = AsyncExitStack()
+    cancelled: BaseException | None = None
+    try:
+        read, write, *_ = await stack.enter_async_context(streamable_http_client(url, http_client=http_client))
+        session = await stack.enter_async_context(ClientSession(read, write))
+        await session.initialize()
+        yield session
+    except asyncio.CancelledError as error:
+        cancelled = error
+        raise
+    finally:
+        try:
+            await stack.aclose()
+        except Exception as error:  # noqa: BLE001 - teardown noise must not lose the result
+            # The transport's real failure surfaces here as the task group unwinds;
+            # when the body was cancelled it IS the story (and becomes retryable).
+            if cancelled is not None:
+                raise _only_cause(error) from cancelled
+            # Teardown noise on a completed call must not lose the result.
+
+
+async def with_retry(call):
+    async for attempt in AsyncRetrying(
+        stop=stop_after_attempt(MCP_CALL_ATTEMPTS),
+        wait=wait_exponential_jitter(initial=0.5, max=30),
+        reraise=True,
+    ):
+        with attempt:
+            return await call()
+
+
+async def connect_mcp(config: dict, clients: dict):
+    """Enumerate tools; return (dispatch {(app, verb) -> (server, raw, params)}, servers, docs)."""
+    dispatch: dict[tuple[str, str], tuple[str, str, list[str]]] = {}
+    servers, docs = {}, {}
+    catalog_server: tuple[str, str] | None = None
+    for name, spec in config.get("mcpServers", {}).items():
+        servers[name] = spec
+
+        async def list_tools(name: str = name, spec: dict = spec):
+            async with mcp_session(clients[name], spec["url"]) as session:
+                return (await session.list_tools()).tools
+
+        for tool in await with_retry(list_tools):
+            if tool.name == DISCOVERY_CATALOG:
+                # The box's own channel: read once at startup, never bound or documented.
+                catalog_server = (name, tool.name)
+                continue
+            bare = tool.name.split("_", 1)[1] if tool.name.startswith("tools_") else tool.name
+            app, _, verb = bare.partition("_")
+            if not verb:
+                app, verb = "misc", bare
+            props = (tool.inputSchema or {}).get("properties", {})
+            required = set((tool.inputSchema or {}).get("required", []))
+            dispatch[(app, verb)] = (name, tool.name, list(props))
+            params = ", ".join(p + ("" if p in required else "=...") for p in props)
+            lines = [f"{app}.{verb}({params})", ""]
+            if tool.description:
+                lines.append(tool.description.strip())
+            for p, s in props.items():
+                lines.append(
+                    f"  {p}: {s.get('type', 'any')}{' (required)' if p in required else ''}"
+                    f"{' — ' + s['description'] if s.get('description') else ''}"
+                )
+            docs[(app, verb)] = "\n".join(lines) + "\n"
+    return dispatch, servers, docs, catalog_server
+
+
+def mcp_content(result):
+    parts = []
+    for block in result.content:
+        if getattr(block, "type", None) == "text":
+            parts.append(block.text)
+        else:
+            parts.append(str(block))
+    return "\n".join(parts) if parts else str(result.content)
+
+
+async def call_mcp_raw(servers, clients, server_name, raw_name, arguments):
+    async def call():
+        async with mcp_session(clients[server_name], servers[server_name]["url"]) as session:
+            return await session.call_tool(raw_name, arguments)
+
+    result = await with_retry(call)
+    text = mcp_content(result)
+    try:
+        return json.loads(text)
+    except Exception:  # noqa: BLE001 - non-JSON results pass through as text
+        return text
+
+
+def write_tool_docs(box: Path, docs: dict) -> None:
+    for (app, verb), text in docs.items():
+        d = box / TOOLS_DIR / app
+        d.mkdir(parents=True, exist_ok=True)
+        (d / verb).write_text(text)
+    if docs:
+        app, verb = next(iter(docs))
+        (box / TOOLS_DIR / "README").write_text(
+            "Each file under ./tools/<app>/<verb> documents one tool. The <app> names are "
+            "pre-bound globals in run_code — call them directly; nothing to import.\n"
+            "Worked example:\n"
+            f"  bash:     cat tools/{app}/{verb}            # read the doc\n"
+            f"  run_code: result = {app}.{verb}(...)        # call the pre-bound global\n"
+            "  run_code: print(result)\n"
+        )
+
+
+def write_catalog_docs(box: Path, catalog: dict) -> None:
+    """The discovery mode's doc tree: the whole documented surface, served or not."""
+    if not catalog:
+        return
+    root = box / TOOLS_DIR
+    for app, entry in sorted(catalog.items()):
+        directory = root / app
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "README").write_text(f"{app} — {entry['summary']}\n")
+        for verb, doc in sorted(entry["verbs"].items()):
+            (directory / verb).write_text(doc)
+    (root / "README").write_text(
+        f"{len(catalog)} apps are documented here, one directory each. ./tools/<app>/README says\n"
+        "what an app is, ./tools/<app>/<verb> documents one of its tools. The <app> names are\n"
+        "pre-bound globals in run_code — call them directly; nothing to import.\n"
+        "\n"
+        "This deployment's catalog is documented in full; the workspace's integrations are not\n"
+        "all provisioned. Calling an app this workspace does not have fails, and the work has to\n"
+        "go through one it does.\n"
+        "\n"
+        "Worked example:\n"
+        "  bash:     ls tools/                     # the apps this deployment documents\n"
+        "  bash:     grep -ril refund tools/       # the docs that mention your work\n"
+        "  bash:     cat tools/<app>/<verb>        # read one tool's doc\n"
+        "  run_code: result = <app>.<verb>(...)    # call the pre-bound global\n"
+        "  run_code: print(result)\n"
+    )
+
+
+# --------------------------------------------------------------------------------------
+# Tool schemas (wire surface): five small tools, conditionally advertised
+# --------------------------------------------------------------------------------------
+
+
+def build_tool_schemas(tools: list[str]) -> list[dict]:
+    def fn(name, description, properties, required):
+        return {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": description,
+                "parameters": {"type": "object", "properties": properties, "required": required},
+            },
+        }
+
+    schemas = {
+        "read": fn(
+            "read",
+            "Read a file. Head-truncated with a resume offset; images are returned visually.",
+            {
+                "path": {"type": "string"},
+                "offset": {"type": "integer", "description": "1-indexed first line"},
+                "limit": {"type": "integer", "description": "max lines"},
+            },
+            ["path"],
+        ),
+        "write": fn(
+            "write",
+            "Write a file (creates parent directories, overwrites).",
+            {"path": {"type": "string"}, "content": {"type": "string"}},
+            ["path", "content"],
+        ),
+        "edit": fn(
+            "edit",
+            "Edit a file by exact string replacement. Each oldText must appear exactly once "
+            "in the original file; all edits are matched against the original and applied together.",
+            {
+                "path": {"type": "string"},
+                "edits": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {"oldText": {"type": "string"}, "newText": {"type": "string"}},
+                        "required": ["oldText", "newText"],
+                    },
+                },
+            },
+            ["path", "edits"],
+        ),
+        "bash": fn(
+            "bash",
+            "Run a shell command in the workspace. No default timeout.",
+            {
+                "command": {"type": "string"},
+                "timeout": {"type": "number", "description": "seconds (optional, no default)"},
+            },
+            ["command"],
+        ),
+        "run_code": fn(
+            "run_code",
+            "Run Python in a persistent kernel. Variables persist across calls and survive context "
+            f"checkpoints. Up to {CELL_TIMEOUT:g}s of compute per cell (time inside tool calls does "
+            "not count); for longer compute write a script and run it with bash. Use print(...) to "
+            "see output. A cell that raises has already applied its earlier statements' effects — "
+            "resume from the failure, don't re-run the whole cell.",
+            {"code": {"type": "string"}},
+            ["code"],
+        ),
+        "compact": fn(
+            "compact",
+            "Checkpoint your context before the next turn: the conversation is replaced by a "
+            "handoff summary you write. Workspace files and run_code variables survive.",
+            {},
+            [],
+        ),
+    }
+    return [schemas[name] for name in tools if name in schemas]
+
+
+# --------------------------------------------------------------------------------------
+# The model loop: shared turn budget, compaction, overflow recovery
+# --------------------------------------------------------------------------------------
+
+
+class TurnBudget:
+    """One counter for every model call this rollout makes — work turns, compactions,
+    completions, subagent turns — mirroring the framework's single per-trace cap."""
+
+    def __init__(self, max_turns: int):
+        self.max_turns = max_turns
+        self.spent = 0
+
+    def take(self) -> bool:
+        if self.spent >= self.max_turns:
+            return False
+        self.spent += 1
+        return True
+
+    @property
+    def remaining(self) -> int:
+        return self.max_turns - self.spent
+
+
+def is_overflow_error(error: Exception) -> bool:
+    text = str(error).lower()
+    return any(pattern in text for pattern in OVERFLOW_PATTERNS)
+
+
+def strip_fences(text: str) -> str:
+    text = text.strip()
+    if text.startswith("```"):
+        text = text.split("\n", 1)[1] if "\n" in text else ""
+        if text.rstrip().endswith("```"):
+            text = text.rstrip()[:-3]
+    return text.strip()
+
+
+def validate_schema(value, schema) -> str | None:
+    """Best-effort JSON Schema validation; returns an error message or None."""
+    try:
+        import jsonschema
+
+        jsonschema.validate(value, schema)
+    except jsonschema.ValidationError as e:
+        return e.message
+    except Exception:  # noqa: BLE001 - validation is best-effort, never fatal
+        return None
+    return None
+
+
+class Driver:
+    """Owns the client, kernel, MCP dispatch, and both loops (main + subagents)."""
+
+    def __init__(self, args):
+        self.args = args
+        self.client = AsyncOpenAI(
+            base_url=args.base_url,
+            api_key=args.api_key,
+            http_client=httpx.AsyncClient(timeout=TUNNEL_TIMEOUT, limits=TUNNEL_POOL),
+        )
+        self.budget = TurnBudget(args.max_turns)
+        self.box = Path.cwd()
+        self.tools: list[str] = args.tools.split(",") if args.tools else []
+        self.kernel: Kernel | None = None
+        self.dispatch: dict = {}
+        self.servers: dict = {}
+        self.clients: dict = {}
+        self.served_apps: set[str] = set()
+        self.documented_apps: set[str] = set()
+        self.subagents_spawned = 0
+        self.compactions = 0
+        self.compaction_pending = False
+        self.last_prompt_tokens = 0
+        self.peak_prompt_tokens = 0
+
+    # --- setup ------------------------------------------------------------------
+
+    async def setup(self) -> None:
+        config = json.loads(self.args.mcp_config) if self.args.mcp_config else {}
+        self.clients = mcp_clients(config)
+        self.dispatch, self.servers, docs, catalog_ref = await connect_mcp(config, self.clients)
+        self.served_apps = {app for app, _ in self.dispatch}
+        apps_payload = {}
+        for (app, verb), (_, _, params) in self.dispatch.items():
+            apps_payload.setdefault(app, {})[verb] = params
+        if catalog_ref is not None:
+            server, raw = catalog_ref
+            catalog = await call_mcp_raw(self.servers, self.clients, server, raw, {})
+            write_catalog_docs(self.box, catalog)
+            self.documented_apps = set(catalog)
+            TOOL_DISCOVERY.update(
+                decoy_calls=0,
+                surface_apps=len(catalog),
+                surface_tools=sum(len(e["verbs"]) for e in catalog.values()),
+                served_apps=len(self.served_apps),
+            )
+            for app in catalog:
+                apps_payload.setdefault(app, {})
+        else:
+            write_tool_docs(self.box, docs)
+            self.documented_apps = set(self.served_apps)
+        if "run_code" in self.tools:
+            self.kernel = Kernel(
+                {"apps": apps_payload, "subagents": self.args.subagents}
+            )
+
+    # --- bridge handlers ----------------------------------------------------------
+
+    async def handle_call(self, call: dict, depth: int = 0):
+        kind = call.get("kind")
+        if kind == "mcp":
+            return await self.do_mcp(call.get("app", ""), call.get("verb", ""), call.get("args") or {})
+        if kind == "completion":
+            return await self.do_completion(call.get("prompt", ""), call.get("schema"), call.get("system"))
+        if kind == "agent":
+            if not self.args.subagents:
+                raise BridgeError("NameError", "agent() is not enabled in this session")
+            if depth > 0:
+                raise BridgeError("RuntimeError", "subagents cannot spawn subagents (depth 1)")
+            return await self.do_agent(
+                call.get("prompt", ""), call.get("schema"), call.get("effort"), call.get("tools")
+            )
+        raise BridgeError("RuntimeError", f"unknown bridge call {kind!r}")
+
+    async def do_mcp(self, app: str, verb: str, arguments: dict):
+        entry = self.dispatch.get((app, verb))
+        if entry is None:
+            if app in self.served_apps:
+                raise BridgeError(
+                    "AttributeError", f"{app} has no {verb!r} tool — its tools are documented in ./tools/{app}/"
+                )
+            if app in self.documented_apps:
+                TOOL_DISCOVERY["decoy_calls"] = TOOL_DISCOVERY.get("decoy_calls", 0) + 1
+                raise BridgeError(
+                    "NameError",
+                    f"no such app in this workspace: {app!r} — it is documented, but this workspace "
+                    "has no such integration; the work has to go through an app that is connected",
+                )
+            raise BridgeError(
+                "NameError", f"no tool named {app}.{verb!r} — explore ./tools/<app>/ and call <app>.<verb>(...)"
+            )
+        server, raw, _ = entry
+        return await call_mcp_raw(self.servers, self.clients, server, raw, arguments)
+
+    async def do_completion(self, prompt: str, schema, system):
+        if not self.budget.take():
+            raise BridgeError("RuntimeError", "turn budget exhausted — no model calls left")
+        messages = []
+        if system:
+            messages.append({"role": "system", "content": str(system)})
+        body = str(prompt)
+        if schema:
+            body += (
+                "\n\nRespond with only valid JSON matching this schema (no prose, no code fences):\n"
+                + json.dumps(schema)
+            )
+        messages.append({"role": "user", "content": body})
+        problem = "no attempts left"
+        for attempt in range(2):
+            if attempt and not self.budget.take():
+                break
+            completion = await self.client.chat.completions.create(
+                model=self.args.model, messages=messages, **self._effort_kwargs()
+            )
+            text = completion.choices[0].message.content or ""
+            if not schema:
+                return text
+            try:
+                value = json.loads(strip_fences(text))
+            except Exception:  # noqa: BLE001 - malformed JSON is retried with feedback
+                problem = "the reply was not valid JSON"
+            else:
+                problem = validate_schema(value, schema)
+                if problem is None:
+                    return value
+            messages.append({"role": "assistant", "content": text})
+            messages.append({"role": "user", "content": f"{problem}. Reply with only the corrected JSON."})
+        raise BridgeError("ValueError", f"completion did not return JSON matching the schema: {problem}")
+
+    async def do_agent(self, prompt: str, schema, effort, tools):
+        if self.subagents_spawned >= self.args.max_subagents:
+            raise BridgeError(
+                "RuntimeError", f"subagent cap reached ({self.args.max_subagents} per session)"
+            )
+        self.subagents_spawned += 1
+        allowed = [t for t in self.tools if t != "compact"]
+        if tools is not None:
+            unknown = [t for t in tools if t not in allowed]
+            if unknown:
+                raise BridgeError("ValueError", f"unknown subagent tools: {unknown} (available: {allowed})")
+            allowed = [t for t in allowed if t in tools]
+        body = str(prompt)
+        if schema:
+            body += (
+                "\n\nYour final message must be only valid JSON matching this schema "
+                "(no prose, no code fences):\n" + json.dumps(schema)
+            )
+        messages = [
+            {"role": "system", "content": self.subagent_system_prompt()},
+            {"role": "user", "content": body},
+        ]
+        final = await self.run_loop(
+            messages,
+            tools=allowed,
+            depth=1,
+            max_turns=min(SUBAGENT_MAX_TURNS, self.budget.remaining),
+            effort=effort or self.args.effort,
+        )
+        if final is None:
+            return None
+        if not schema:
+            return final
+        for _ in range(2):
+            try:
+                value = json.loads(strip_fences(final))
+            except Exception:  # noqa: BLE001 - malformed JSON is retried with feedback
+                problem = "the reply was not valid JSON"
+            else:
+                problem = validate_schema(value, schema)
+                if problem is None:
+                    return value
+            if self.budget.remaining < 1:
+                break
+            messages.append({"role": "user", "content": f"{problem}. Reply with only the corrected JSON."})
+            final = await self.run_loop(messages, tools=[], depth=1, max_turns=1, effort=effort or self.args.effort)
+            if final is None:
+                break
+        raise BridgeError("ValueError", "subagent did not return JSON matching the schema")
+
+    # --- native tool dispatch -------------------------------------------------------
+
+    async def execute_tool(self, name: str, arguments: dict, depth: int):
+        if name == "read":
+            return await asyncio.to_thread(
+                run_read, arguments.get("path", ""), arguments.get("offset"), arguments.get("limit"), self.box
+            )
+        if name == "write":
+            return await asyncio.to_thread(
+                run_write, arguments.get("path", ""), arguments.get("content", ""), self.box
+            )
+        if name == "edit":
+            return await asyncio.to_thread(
+                run_edit, arguments.get("path", ""), arguments.get("edits"), self.box
+            )
+        if name == "bash":
+            return await asyncio.to_thread(
+                run_bash, arguments.get("command", ""), arguments.get("timeout"), self.box
+            )
+        if name == "run_code":
+            assert self.kernel is not None
+            return await self.kernel.run_cell(
+                arguments.get("code", ""), lambda call: self.handle_call(call, depth=depth)
+            )
+        if name == "compact" and depth == 0:
+            self.compaction_pending = True
+            return "[context checkpoint scheduled before your next turn]"
+        return f"unknown tool {name}"
+
+    # --- prompts --------------------------------------------------------------------
+
+    def system_prompt_base(self, tools: list[str]) -> str:
+        parts = ["You are an agent operating in a minimal harness."]
+        lines = []
+        if "read" in tools:
+            lines.append("`read` reads files (images render visually).")
+        if "write" in tools or "edit" in tools:
+            lines.append(
+                "`write` creates files; `edit` does exact once-only string replacement."
+                if "edit" in tools
+                else "`write` creates files."
+            )
+        if "bash" in tools:
+            lines.append("`bash` runs shell commands (no default timeout).")
+        if "run_code" in tools:
+            lines.append(
+                "`run_code` runs Python in a persistent kernel: variables survive across calls "
+                "and context checkpoints; never re-import or re-define what already exists. "
+                "Chain tool results inside one cell only when their format is known — otherwise "
+                "print first and continue next turn."
+            )
+            if self.served_apps or self.documented_apps:
+                lines.append(
+                    "Service tools are documented as files under ./tools/<app>/<verb> (explore with "
+                    "bash) and pre-bound in run_code as <app>.<verb>(...) returning Python objects."
+                )
+            lines.append("`completion(prompt, schema=None)` makes one standalone model call from code.")
+            if self.args.subagents:
+                lines.append(
+                    "`agent(prompt, schema=None, effort=None, tools=None)` runs a subagent with a "
+                    "blank context and returns its final message (parsed when schema is given); "
+                    "give it complete, self-contained instructions."
+                )
+        if "compact" in tools:
+            lines.append(
+                "`compact` checkpoints your context: call it when the transcript holds spent "
+                "exploration you no longer need verbatim."
+            )
+        parts.append(" ".join(lines))
+        return "\n\n".join(p for p in parts if p)
+
+    def subagent_system_prompt(self) -> str:
+        base = self.system_prompt_base([t for t in self.tools if t != "compact"])
+        return base + (
+            "\n\nYou are a subagent. Work the task to completion; your final message is returned "
+            "verbatim to the caller as data, not prose for a human."
+        )
+
+    # --- compaction -------------------------------------------------------------------
+
+    async def checkpoint(self, messages: list[dict], tool_schemas: list[dict]) -> None:
+        keep = 2 if messages and messages[0].get("role") == "system" else 1
+        request = [*messages, {"role": "user", "content": COMPACTION_PROMPT}]
+        while True:
+            try:
+                completion = await self.client.chat.completions.create(
+                    model=self.args.model,
+                    messages=request,
+                    tools=tool_schemas or None,
+                    tool_choice="none" if tool_schemas else None,
+                    **self._effort_kwargs(),
+                )
+                break
+            except Exception as error:
+                # A compaction request that itself overflows trims oldest non-protected
+                # messages and retries until it fits (Codex's trim loop).
+                if is_overflow_error(error) and len(request) > keep + 2:
+                    del request[keep : keep + 2]
+                    continue
+                raise
+        summary = completion.choices[0].message.content or "(no summary available)"
+        usage = getattr(completion, "usage", None)
+        if usage and usage.prompt_tokens:
+            self.peak_prompt_tokens = max(self.peak_prompt_tokens, usage.prompt_tokens)
+        messages[:] = [
+            *messages[:keep],
+            {"role": "user", "content": COMPACTION_FRAMING + "\n\n" + summary},
+        ]
+        self.last_prompt_tokens = 0
+        self.compactions += 1
+        self.compaction_pending = False
+
+    def should_checkpoint(self) -> bool:
+        if self.compactions >= self.args.max_compactions:
+            return False
+        if self.compaction_pending:
+            return True
+        return bool(
+            self.args.context_budget_tokens
+            and self.last_prompt_tokens >= self.args.context_budget_tokens
+        )
+
+    # --- the loop ----------------------------------------------------------------------
+
+    def _effort_kwargs(self, effort: str | None = None) -> dict:
+        value = effort if effort is not None else self.args.effort
+        return {"reasoning_effort": value} if value else {}
+
+    def _notices(self, depth: int) -> str:
+        notices = []
+        if depth == 0 and self.args.disclose_budget:
+            spent = self.budget.spent
+            notices.append(
+                f"[harness] Turn budget: {spent}/{self.budget.max_turns} used, "
+                f"{self.budget.max_turns - spent} remaining."
+            )
+        if depth == 0 and self.args.compact_tool and self.last_prompt_tokens:
+            notices.append(
+                f"[harness] Context: ~{self.last_prompt_tokens} prompt tokens "
+                f"(checkpoint threshold {self.args.context_budget_tokens}, "
+                f"{self.args.max_compactions - self.compactions} checkpoints left)."
+            )
+        return ("\n\n" + "\n".join(notices)) if notices else ""
+
+    async def run_loop(
+        self,
+        messages: list[dict],
+        tools: list[str],
+        depth: int,
+        max_turns: int,
+        effort: str | None = None,
+    ) -> str | None:
+        """Drive one agent loop. Returns the final assistant text (None if none)."""
+        tool_schemas = build_tool_schemas(tools)
+        local_turns = 0
+        final: str | None = None
+        overflow_retried = False
+        while local_turns < max_turns:
+            # A checkpoint is a model call on the same budget: only spend one while the
+            # work turn it protects still fits under the cap.
+            if depth == 0 and self.should_checkpoint() and self.budget.remaining > 1:
+                if not self.budget.take():
+                    break
+                await self.checkpoint(messages, tool_schemas)
+            if not self.budget.take():
+                break
+            try:
+                completion = await self.client.chat.completions.create(
+                    model=self.args.model,
+                    messages=messages,
+                    tools=tool_schemas or None,
+                    **self._effort_kwargs(effort),
+                )
+            except Exception as error:
+                if (
+                    depth == 0
+                    and is_overflow_error(error)
+                    and not overflow_retried
+                    and self.compactions < self.args.max_compactions
+                ):
+                    # A work turn rejected for context length forces a compaction and
+                    # retries exactly once. The refused call cost nothing — refund it.
+                    self.budget.spent -= 1
+                    overflow_retried = True
+                    self.compaction_pending = True
+                    continue
+                raise
+            overflow_retried = False
+            local_turns += 1
+            usage = getattr(completion, "usage", None)
+            if usage and usage.prompt_tokens and depth == 0:
+                self.last_prompt_tokens = usage.prompt_tokens
+                self.peak_prompt_tokens = max(self.peak_prompt_tokens, usage.prompt_tokens)
+            msg = completion.choices[0].message
+            # Append complete — reasoning included. The transcript is append-only.
+            messages.append(msg.model_dump(exclude_none=True))
+            if msg.content:
+                final = msg.content
+            if not msg.tool_calls:
+                break
+            for tc in msg.tool_calls:
+                try:
+                    arguments = json.loads(tc.function.arguments or "{}")
+                    if not isinstance(arguments, dict):
+                        raise TypeError("arguments must be a JSON object")
+                except Exception as e:  # noqa: BLE001 - malformed calls become retryable tool errors
+                    out = f"invalid tool arguments ({e}) — send a JSON object matching the tool's schema"
+                else:
+                    out = await self.execute_tool(tc.function.name, arguments, depth)
+                content = out if isinstance(out, list) else str(out)
+                messages.append({"role": "tool", "tool_call_id": tc.id, "content": content})
+            if isinstance(messages[-1]["content"], str):
+                messages[-1]["content"] += self._notices(depth)
+            if depth == 0:
+                write_diagnostics(
+                    "loop",
+                    turns=self.budget.spent,
+                    compactions=self.compactions,
+                    peak_prompt_tokens=self.peak_prompt_tokens,
+                    subagents=self.subagents_spawned,
+                    **({"tool_discovery": dict(TOOL_DISCOVERY)} if TOOL_DISCOVERY else {}),
+                )
+        return final
+
+    async def close(self) -> None:
+        if self.kernel is not None:
+            await self.kernel.close()
+        for client in self.clients.values():
+            await client.aclose()
+
+
+# --------------------------------------------------------------------------------------
+# Entry
+# --------------------------------------------------------------------------------------
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("--base-url", required=True)
+    p.add_argument("--api-key", required=True)
+    p.add_argument("--model", required=True)
+    p.add_argument("--system-prompt", default="")
+    p.add_argument("--prompt", default="")
+    p.add_argument("--mcp-config", default="")
+    p.add_argument("--effort", default="")
+    p.add_argument("--tools", default="read,write,edit,bash,run_code")
+    p.add_argument("--subagents", action="store_true")
+    p.add_argument("--max-subagents", type=int, default=16)
+    p.add_argument("--compact-tool", action="store_true")
+    p.add_argument("--context-budget-tokens", type=int, default=150_000)
+    p.add_argument("--max-compactions", type=int, default=MAX_COMPACTIONS)
+    p.add_argument("--max-turns", type=int, default=MAX_TURNS)
+    p.add_argument("--disclose-budget", action="store_true")
+    return p.parse_args()
+
+
+async def main() -> None:
+    args = parse_args()
+    write_diagnostics("started")
+    driver = Driver(args)
+    try:
+        await driver.setup()
+        tools = list(driver.tools)
+        if args.compact_tool:
+            tools.append("compact")
+        system = driver.system_prompt_base(tools)
+        if args.system_prompt:
+            system += "\n\n" + args.system_prompt
+        messages = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": args.prompt},
+        ]
+        await driver.run_loop(messages, tools=tools, depth=0, max_turns=args.max_turns)
+        write_diagnostics(
+            "complete",
+            turns=driver.budget.spent,
+            compactions=driver.compactions,
+            peak_prompt_tokens=driver.peak_prompt_tokens,
+            subagents=driver.subagents_spawned,
+            **({"tool_discovery": dict(TOOL_DISCOVERY)} if TOOL_DISCOVERY else {}),
+        )
+    finally:
+        await driver.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/verifiers/v1/harnesses/rho/program.py
+++ b/verifiers/v1/harnesses/rho/program.py
@@ -28,12 +28,21 @@ included) are re-sent complete, and the only rewriting event is Codex-style chec
 compaction — triggered by the token budget, a context overflow, or the model's own
 `compact` tool call.
 
+Two standing recovery stores: the live transcript (every root-loop message appended to
+one greppable file as it happens; subagent transcripts land beside it under agents/) and
+spill files (full payloads named by truncation footers, whose pointers ride inside the
+transcript). `agent()` supports named persistent sessions — transcript, tool surface,
+and kernel continue across calls; sessions survive checkpoints but die with the segment
+(per-process state), and the boundary prompts say so.
+
 Deliberate absences (known, may be wanted later, not built yet):
 - Parallel tool calls: multiple calls in one turn execute sequentially, and the kernel
   bridge is a serial stdio channel — code-side `gather` over tools needs bridge
   multiplexing (frame ids), one coherent upgrade with interception-side concurrency.
 - Background tools: no `background`/yield machinery (Codex's session+wait stack); the
   documented answer for long-running processes is bash: nohup, redirect to a file, read.
+- Session compaction: a session that outgrows the model context is refused with a fact
+  (start a fresh session), not compacted — subagent loops have no checkpoint machinery.
 """
 
 import argparse
@@ -44,6 +53,7 @@ import itertools
 import json
 import os
 import platform
+import re
 import shutil
 import signal
 import subprocess
@@ -114,7 +124,9 @@ whole rollout so that cost is paid per rollout, not per call."""
 MCP_CALL_ATTEMPTS = 6
 TOOLS_DIR = "tools"
 DISCOVERY_CATALOG = "tools_catalog"
-RUNTIME_DIAGNOSTICS = "/tmp/.rho-runtime.json"
+RUNTIME_DIAGNOSTICS = "/tmp/.rho/runtime.json"
+"""Box-side stats, inside the one harness-owned dir (mirrored in harness.py).
+Per-segment and last-write-wins on resume — cumulative truth lives on the trace."""
 
 OVERFLOW_PATTERNS = (
     "context length",
@@ -162,25 +174,33 @@ path per runtime, surviving compactions and resumed segments."""
 
 # With the transcript file, the summary is licensed to be tight: raw data stays
 # greppable, so the checkpoint carries decisions and state, not hedged payloads.
-HISTORY_PROMPT_NOTE = (
+TRANSCRIPT_PROMPT_NOTE = (
     "\nThe full transcript you are summarizing will remain available to the next LLM in a "
     "file it can grep, so keep the summary tight and targeted — decisions, state, and next "
-    "steps. Raw data, long outputs, and exact quotes can be recovered from the file."
+    "steps. Raw data and exact quotes can be recovered from the file, or from the spill "
+    "files its truncation footers name."
 )
-HISTORY_FRAMING_NOTE = (
+TRANSCRIPT_FRAMING_NOTE = (
     "\n\nThe full transcript (including everything this summary replaced) is at {path} — "
-    "grep it (bash) if a detail you need is missing from the summary. Work from evidence: "
+    "grep it if a detail you need is missing from the summary. Work from evidence: "
     "the workspace is authoritative — inspect the current state of files before relying "
     "on the summary or the history."
 )
 TRANSCRIPT_SYSTEM_NOTE = (
-    "Your full transcript so far is appended to {path} — grep it (bash) to recover "
+    "Your full transcript so far is appended to {path} — read or grep it to recover "
     "earlier details, tool outputs, or exact quotes at any time."
+)
+SESSIONS_CHECKPOINT_CLAUSE = (
+    " Named agent() sessions also persist across this compaction."
+)
+SESSIONS_RESUME_CLAUSE = (
+    " Named agent() sessions from previous segments are gone too — reusing a session "
+    "name now starts a fresh subagent."
 )
 
 RESUME_NOTE = (
     "This session continues an earlier exchange: run_code variables from previous "
-    "segments are gone; files, ./tools/, and /tmp/.rho artifacts are intact."
+    "segments are gone; files, ./tools/, and {dir} artifacts are intact."
 )
 
 
@@ -201,7 +221,7 @@ def assemble_messages(
 
 
 def render_history(messages: list[dict]) -> str:
-    """Render discarded transcript messages as greppable role-tagged text."""
+    """Render messages as greppable role-tagged text (the transcript file format)."""
     blocks = []
     for m in messages:
         role = m.get("role", "?")
@@ -225,6 +245,7 @@ def render_history(messages: list[dict]) -> str:
 
 
 def write_diagnostics(phase: str, **values) -> None:
+    SPILL_DIR.mkdir(parents=True, exist_ok=True)
     payload = {"phase": phase, "python": platform.python_version(), **values}
     Path(RUNTIME_DIAGNOSTICS).write_text(json.dumps(payload, sort_keys=True))
 
@@ -232,8 +253,6 @@ def write_diagnostics(phase: str, **values) -> None:
 # --------------------------------------------------------------------------------------
 # Output bounding: three ceilings, tail-kept, spill to a named path
 # --------------------------------------------------------------------------------------
-
-_spill_counter = 0
 
 
 def _spill(text: str, label: str) -> str:
@@ -246,7 +265,7 @@ def _spill(text: str, label: str) -> str:
     return path
 
 
-def cap_output(text: str, label: str = "output") -> str:
+def cap_output(text: str, label: str) -> str:
     """Bound execution output (bash, run_code): keep the tail, spill the full text."""
     if not text.strip():
         return "(no output)"
@@ -305,7 +324,10 @@ def run_read(path: str, offset=None, limit=None, cwd: Path | None = None):
     if mime is not None:
         size = p.stat().st_size
         if size > MAX_IMAGE_BYTES:
-            return f"{path} is a {mime} of {size} bytes — over the {MAX_IMAGE_BYTES} byte image cap"
+            return (
+                f"{path} is a {mime} of {size} bytes — over the {MAX_IMAGE_BYTES} byte "
+                "image cap; downscale it first (bash or run_code)"
+            )
         READ_LEDGER.add(str(p))
         encoded = base64.b64encode(p.read_bytes()).decode()
         return [
@@ -341,7 +363,8 @@ def run_read(path: str, offset=None, limit=None, cwd: Path | None = None):
             line = line.rstrip("\n")
             if len(line) > MAX_LINE_CHARS:
                 line = (
-                    line[:MAX_LINE_CHARS] + " …[line clipped, use bash to see the rest]"
+                    line[:MAX_LINE_CHARS]
+                    + " …[line clipped; read the file to see the rest]"
                 )
             if len(line) + 1 > budget:
                 window.append(line[:budget])
@@ -620,28 +643,34 @@ def kernel_env() -> dict[str, str]:
     }
 
 
+_RUNNER_PATH: str | None = None
+
+
+def _shared_runner_path() -> str:
+    """One runner file per process — RUNNER_SOURCE is constant, every kernel execs it."""
+    global _RUNNER_PATH
+    if _RUNNER_PATH is None:
+        fd, _RUNNER_PATH = tempfile.mkstemp(prefix=".rho-runner-", suffix=".py")
+        os.write(fd, RUNNER_SOURCE.encode())
+        os.close(fd)
+    return _RUNNER_PATH
+
+
 class Kernel:
     """Driver side of the kernel: lifecycle, cells, and the paused-clock timeout."""
 
     def __init__(self, init_payload: dict):
         self._init_payload = init_payload
         self._proc: asyncio.subprocess.Process | None = None
-        self._runner_path: str | None = None
         self._death_note = ""
 
     async def _ensure(self) -> None:
         if self._proc is not None and self._proc.returncode is None:
             return
-        if self._runner_path is None:
-            fd, self._runner_path = tempfile.mkstemp(
-                prefix=".rho-runner-", suffix=".py"
-            )
-            os.write(fd, RUNNER_SOURCE.encode())
-            os.close(fd)
         self._proc = await asyncio.create_subprocess_exec(
             sys.executable,
             "-u",
-            self._runner_path,
+            _shared_runner_path(),
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.DEVNULL,
@@ -986,7 +1015,7 @@ def write_catalog_docs(box: Path, catalog: dict) -> None:
 
 
 # --------------------------------------------------------------------------------------
-# Tool schemas (wire surface): five small tools, conditionally advertised
+# Tool schemas (wire surface): the native tools plus compact, conditionally advertised
 # --------------------------------------------------------------------------------------
 
 
@@ -1018,7 +1047,7 @@ def build_tool_schemas(tools: list[str]) -> list[dict]:
         ),
         "write": fn(
             "write",
-            "Write a file (creates parent directories, overwrites).",
+            "Write a file (creates parent directories; overwrites only files already read this session).",
             {"path": {"type": "string"}, "content": {"type": "string"}},
             ["path", "content"],
         ),
@@ -1164,6 +1193,7 @@ class Driver:
         self.documented_apps: set[str] = set()
         self.tool_discovery: dict[str, int] = {}
         self.subagents_spawned = 0
+        self.completions = 0
         self.transcript_pos = 0
         """Messages of the root loop already appended to the live transcript file."""
         self.sessions: dict[str, dict] = {}
@@ -1271,6 +1301,7 @@ class Driver:
         return await call_mcp_raw(self.servers, self.clients, server, raw, arguments)
 
     async def do_completion(self, prompt: str, schema, system):
+        self.completions += 1
         if not self.budget.take():
             raise BridgeError(
                 "RuntimeError", "turn budget exhausted — no model calls left"
@@ -1315,7 +1346,6 @@ class Driver:
                 f"not enough turn budget left to delegate ({remaining} turns remain) — "
                 "finish the task directly",
             )
-        self.subagents_spawned += 1
         body = str(prompt) + (
             schema_suffix("Your final message must be", schema)
             if schema is not None
@@ -1323,15 +1353,23 @@ class Driver:
         )
         if session and session in self.sessions:
             # Continue the named session: same transcript, tool surface, and kernel —
-            # the follow-up rides the context already paid for.
+            # the follow-up rides the context already paid for. The surface is locked
+            # at creation (the stored system prompt was built from it).
             stored = self.sessions[session]
             messages, allowed, kernel = (
                 stored["messages"],
                 stored["tools"],
                 stored["kernel"],
             )
+            if tools is not None and sorted(tools) != sorted(allowed):
+                raise BridgeError(
+                    "ValueError",
+                    f"session {session!r} already has tool surface {allowed}; "
+                    "tools cannot change on continuation",
+                )
             messages.append({"role": "user", "content": body})
         else:
+            self.subagents_spawned += 1
             allowed = [t for t in self.tools if t != "compact"]
             if tools is not None:
                 unknown = [t for t in tools if t not in allowed]
@@ -1360,18 +1398,30 @@ class Driver:
                     "kernel": kernel,
                 }
         try:
-            final = await self.run_loop(
-                messages,
-                tools=allowed,
-                depth=1,
-                # No per-spawn ceiling: allocation is the policy's call; the shared budget
-                # binds, minus the reserve that keeps the parent able to act.
-                max_turns=None
-                if self.budget.remaining is None
-                else self.budget.remaining - (SPAWN_RESERVE_TURNS - 1),
-                effort=effort,
-                kernel=kernel,
-            )
+            try:
+                final = await self.run_loop(
+                    messages,
+                    tools=allowed,
+                    depth=1,
+                    # No per-spawn ceiling: allocation is the policy's call; the shared budget
+                    # binds, minus the reserve that keeps the parent able to act.
+                    max_turns=None
+                    if self.budget.remaining is None
+                    else self.budget.remaining - (SPAWN_RESERVE_TURNS - 1),
+                    effort=effort,
+                    kernel=kernel,
+                )
+            except Exception as error:
+                # Subagent loops have no compaction by design: an outgrown context is
+                # a fact with a recovery path, not a raw provider error in the cell.
+                if is_overflow_error(error):
+                    who = f"session {session!r}" if session else "the subagent"
+                    raise BridgeError(
+                        "RuntimeError",
+                        f"{who} has outgrown the model context — start a new session "
+                        "with a fresh, self-contained brief",
+                    ) from error
+                raise
             if final is None:
                 return None
             if schema is None:
@@ -1413,8 +1463,22 @@ class Driver:
                 f"subagent did not return JSON matching the schema: {problem}",
             )
         finally:
+            self.save_agent_transcript(session, messages)
             if kernel is not None and not session:
                 await kernel.close()
+
+    def save_agent_transcript(self, session: str | None, messages: list[dict]) -> None:
+        """Persist a subagent's full conversation under the agents/ recovery store.
+
+        One mechanism, three affordances: subagent work is recoverable (the one
+        otherwise-lossy channel), `ls` of the directory lists sessions, and a session
+        name survives compaction even when the summary drops it."""
+        name = session or f"anon-{self.subagents_spawned}"
+        safe = re.sub(r"[^A-Za-z0-9._-]", "_", name).strip(".") or "agent"
+        with contextlib.suppress(Exception):
+            agents_dir = SPILL_DIR / "agents"
+            agents_dir.mkdir(parents=True, exist_ok=True)
+            (agents_dir / f"{safe}.txt").write_text(render_history(messages))
 
     # --- native tool dispatch -------------------------------------------------------
 
@@ -1457,13 +1521,11 @@ class Driver:
         if name == "compact" and depth == 0:
             self.compaction_pending = True
             return "[context checkpoint scheduled before your next turn]"
-        return f"unknown tool {name}"
+        return f"unknown tool {name} — available: {', '.join(self.tools)}"
 
     # --- prompts --------------------------------------------------------------------
 
-    def system_prompt_base(
-        self, tools: list[str], advertise_agent: bool | None = None
-    ) -> str:
+    def system_prompt_base(self, tools: list[str], advertise_agent: bool) -> str:
         parts = ["You are an agent operating in a minimal harness."]
         lines = []
         if "read" in tools:
@@ -1489,13 +1551,14 @@ class Driver:
                     "bash) and pre-bound in run_code as <app>.<verb>(...) returning Python objects."
                 )
             lines.append(
-                "`completion(prompt, schema=None)` makes one standalone model call from code."
+                "`completion(prompt, schema=None, system=None)` makes one standalone model call from code."
             )
-            if self.args.subagents if advertise_agent is None else advertise_agent:
+            if advertise_agent:
                 lines.append(
                     "`agent(prompt, schema=None, effort=None, tools=None, session=None)` runs a "
                     "subagent with a blank context and returns its final message (parsed when "
-                    "schema is given); give it complete, self-contained instructions. Pass a "
+                    "schema is given); give it complete, self-contained instructions; its full "
+                    "transcript is saved under /tmp/.rho/agents/. Pass a "
                     "session name to make it persistent: later calls with the same name continue "
                     "that subagent's conversation instead of starting over."
                 )
@@ -1528,14 +1591,34 @@ class Driver:
             f.write(render_history(new) + "\n")
         self.transcript_pos = len(messages)
 
+    def mark_replayed(self, messages: list[dict]) -> None:
+        """Position the transcript pointer for a resumed segment: the replayed
+        conversation is already on disk from earlier segments; only what follows the
+        last assistant/tool message (the caller-injected turns) is new. With none
+        present, only the trailing injected message is appended."""
+        last = max(
+            (
+                i
+                for i, m in enumerate(messages)
+                if m.get("role") in ("assistant", "tool")
+            ),
+            default=len(messages) - 2,
+        )
+        self.transcript_pos = last + 1
+
     async def checkpoint(self, messages: list[dict], tool_schemas: list[dict]) -> None:
         keep = 2  # the protected prefix: system + the opening user message (assemble_messages)
-        self.append_transcript(
-            messages
-        )  # everything summarized-away is already on disk
+        # Normally a no-op — per-turn appends already persisted everything; kept as
+        # a safety net so the file's completeness never depends on call-site order.
+        self.append_transcript(messages)
         request = [
             *messages,
-            {"role": "user", "content": COMPACTION_PROMPT + HISTORY_PROMPT_NOTE},
+            {
+                "role": "user",
+                "content": COMPACTION_PROMPT
+                + TRANSCRIPT_PROMPT_NOTE
+                + (SESSIONS_CHECKPOINT_CLAUSE if self.sessions else ""),
+            },
         ]
         while True:
             try:
@@ -1568,7 +1651,7 @@ class Driver:
             COMPACTION_FRAMING
             + "\n\n"
             + summary
-            + HISTORY_FRAMING_NOTE.format(path=TRANSCRIPT_PATH)
+            + TRANSCRIPT_FRAMING_NOTE.format(path=TRANSCRIPT_PATH)
         )
         messages[:] = [*messages[:keep], {"role": "user", "content": framing}]
         # The rebuilt prefix is already on disk; only the framing+summary is new.
@@ -1636,8 +1719,7 @@ class Driver:
                 and self.should_checkpoint()
                 and (self.budget.remaining is None or self.budget.remaining > 1)
             ):
-                if not self.budget.take():
-                    break
+                self.budget.take()  # cannot fail: the guard ensured remaining > 1
                 await self.checkpoint(messages, tool_schemas)
             if not self.budget.take():
                 break
@@ -1667,11 +1749,12 @@ class Driver:
             overflow_retried = False
             local_turns += 1
             usage = getattr(completion, "usage", None)
-            if usage and usage.prompt_tokens and depth == 0:
-                self.last_prompt_tokens = usage.prompt_tokens
+            if usage and usage.prompt_tokens:
                 self.peak_prompt_tokens = max(
                     self.peak_prompt_tokens, usage.prompt_tokens
                 )
+            if usage and usage.prompt_tokens and depth == 0:
+                self.last_prompt_tokens = usage.prompt_tokens
                 if self.just_compacted:
                     # The first work turn after a checkpoint is the effectiveness probe:
                     # still over the threshold means the protected prefix itself is too
@@ -1721,12 +1804,19 @@ class Driver:
         return final
 
     def write_stats(self, phase: str) -> None:
+        transcript_bytes = 0
+        with contextlib.suppress(OSError):
+            transcript_bytes = TRANSCRIPT_PATH.stat().st_size
         write_diagnostics(
             phase,
             turns=self.budget.spent,
             compactions=self.compactions,
+            auto_compact_disabled=self.auto_compact_disabled,
             peak_prompt_tokens=self.peak_prompt_tokens,
             subagents=self.subagents_spawned,
+            completions=self.completions,
+            sessions=sorted(self.sessions),
+            transcript_bytes=transcript_bytes,
             **(
                 {"tool_discovery": dict(self.tool_discovery)}
                 if self.tool_discovery
@@ -1759,6 +1849,7 @@ def parse_args():
     p.add_argument("--initial-messages-file", default="")
     p.add_argument("--mcp-config", default="")
     p.add_argument("--effort", default="")
+    # Defaults below are manual-run conveniences; the harness always passes these.
     p.add_argument("--tools", default="read,write,edit,bash,run_code")
     p.add_argument("--subagents", action="store_true")
     p.add_argument("--context-budget-tokens", type=int, default=150_000)
@@ -1778,25 +1869,17 @@ async def main() -> None:
             path = Path(args.initial_messages_file)
             initial = json.loads(path.read_text())
             path.unlink(missing_ok=True)
-        system = driver.system_prompt_base(driver.tools)
+        system = driver.system_prompt_base(driver.tools, advertise_agent=args.subagents)
         system += "\n\n" + TRANSCRIPT_SYSTEM_NOTE.format(path=TRANSCRIPT_PATH)
         if initial is not None and "run_code" in driver.tools:
-            system += "\n\n" + RESUME_NOTE
+            system += "\n\n" + RESUME_NOTE.format(dir=SPILL_DIR)
+            if args.subagents:
+                system += SESSIONS_RESUME_CLAUSE
         if args.system_prompt:
             system += "\n\n" + args.system_prompt
         messages = assemble_messages(system, args.prompt, initial)
         if initial is not None:
-            # Replayed conversation is already on disk from earlier segments; persist
-            # only what follows the last assistant/tool message (the injected turns).
-            last = max(
-                (
-                    i
-                    for i, m in enumerate(messages)
-                    if m.get("role") in ("assistant", "tool")
-                ),
-                default=0,
-            )
-            driver.transcript_pos = last + 1
+            driver.mark_replayed(messages)
         driver.append_transcript(messages)
         # The turn budget, not this call, is the authority on stopping.
         await driver.run_loop(messages, tools=driver.tools, depth=0, max_turns=None)

--- a/verifiers/v1/harnesses/rho/program.py
+++ b/verifiers/v1/harnesses/rho/program.py
@@ -94,7 +94,9 @@ shared budget, but the parent must keep enough to act on the result. A reserve, 
 cap — the box imposes no limits of its own; the framework's turn budget is the bound."""
 
 TUNNEL_TIMEOUT = httpx.Timeout(600.0, connect=30.0)
-TUNNEL_POOL = httpx.Limits(max_connections=16, max_keepalive_connections=16, keepalive_expiry=900.0)
+TUNNEL_POOL = httpx.Limits(
+    max_connections=16, max_keepalive_connections=16, keepalive_expiry=900.0
+)
 """Everything the box talks to is the host reached back through the runtime's tunnel,
 where opening a connection is the slow part (measured 3-16s, up to 55s). Pool for the
 whole rollout so that cost is paid per rollout, not per call."""
@@ -163,7 +165,9 @@ RESUME_NOTE = (
 )
 
 
-def assemble_messages(system: str, prompt: str, initial: list[dict] | None) -> list[dict]:
+def assemble_messages(
+    system: str, prompt: str, initial: list[dict] | None
+) -> list[dict]:
     """The loop's starting transcript. A resumed segment replays the exchange's
     conversation: a LEADING system message is the previous segment's harness-built
     system prompt and is replaced by the fresh rebuild; any later explicit system
@@ -272,7 +276,10 @@ def run_read(path: str, offset=None, limit=None, cwd: Path | None = None):
         return f"{path} not found"
     if p.is_dir():
         entries = sorted(e.name + ("/" if e.is_dir() else "") for e in p.iterdir())
-        return f"{path} is a directory ({len(entries)} entries) — use bash ls; first entries: " + ", ".join(entries[:20])
+        return (
+            f"{path} is a directory ({len(entries)} entries) — use bash ls; first entries: "
+            + ", ".join(entries[:20])
+        )
     with p.open("rb") as f:
         head = f.read(8)
     for magic, mime in IMAGE_MAGIC.items():
@@ -284,7 +291,10 @@ def run_read(path: str, offset=None, limit=None, cwd: Path | None = None):
             encoded = base64.b64encode(p.read_bytes()).decode()
             return [
                 {"type": "text", "text": f"{path} ({mime}, {size} bytes)"},
-                {"type": "image_url", "image_url": {"url": f"data:{mime};base64,{encoded}"}},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:{mime};base64,{encoded}"},
+                },
             ]
 
     try:
@@ -311,7 +321,9 @@ def run_read(path: str, offset=None, limit=None, cwd: Path | None = None):
                 break
             line = line.rstrip("\n")
             if len(line) > MAX_LINE_CHARS:
-                line = line[:MAX_LINE_CHARS] + " …[line clipped, use bash to see the rest]"
+                line = (
+                    line[:MAX_LINE_CHARS] + " …[line clipped, use bash to see the rest]"
+                )
             if len(line) + 1 > budget:
                 window.append(line[:budget])
                 budget = 0
@@ -330,7 +342,10 @@ def run_read(path: str, offset=None, limit=None, cwd: Path | None = None):
     if more_follows or clipped_mid_line:
         # Resume ON the clipped line when the byte cap cut it short, else the next line.
         resume = end if clipped_mid_line else end + 1
-        return body + f"\n[Showing lines {offset}-{end}; more of the file follows. Use offset={resume} to continue.]"
+        return (
+            body
+            + f"\n[Showing lines {offset}-{end}; more of the file follows. Use offset={resume} to continue.]"
+        )
     return body
 
 
@@ -362,7 +377,9 @@ def run_edit(path: str, edits, cwd: Path | None = None) -> str:
     for i, edit in enumerate(edits):
         old, new = edit.get("oldText"), edit.get("newText")
         if not isinstance(old, str) or not old or not isinstance(new, str):
-            return f"edits[{i}]: oldText must be a non-empty string and newText a string"
+            return (
+                f"edits[{i}]: oldText must be a non-empty string and newText a string"
+            )
         count = original.count(old)
         if count != 1:
             return f"edits[{i}]: oldText must appear exactly once in the original {path} (found {count})"
@@ -407,7 +424,10 @@ def run_bash(command: str, timeout=None, cwd: Path | None = None) -> str:
         with contextlib.suppress(ProcessLookupError):
             os.killpg(proc.pid, signal.SIGKILL)
         out, _ = proc.communicate()
-        return cap_output((out or "") + f"\n[command timed out after {timeout:g}s and was killed]", "bash")
+        return cap_output(
+            (out or "") + f"\n[command timed out after {timeout:g}s and was killed]",
+            "bash",
+        )
     text = out or "(no output)"
     if proc.returncode != 0:
         text += f"\n[exit code {proc.returncode}]"
@@ -549,7 +569,15 @@ except BaseException:
     send({"fatal": traceback.format_exc()})
 '''
 
-KERNEL_ENV_KEEP = ("PATH", "HOME", "LANG", "TERM", "TMPDIR", "PYTHONPATH", "VIRTUAL_ENV")
+KERNEL_ENV_KEEP = (
+    "PATH",
+    "HOME",
+    "LANG",
+    "TERM",
+    "TMPDIR",
+    "PYTHONPATH",
+    "VIRTUAL_ENV",
+)
 # No UV_ prefix: UV_INDEX_<NAME>_PASSWORD and credential-bearing index URLs ride it.
 KERNEL_ENV_PREFIXES = ("LC_", "XDG_")
 
@@ -576,7 +604,9 @@ class Kernel:
         if self._proc is not None and self._proc.returncode is None:
             return
         if self._runner_path is None:
-            fd, self._runner_path = tempfile.mkstemp(prefix=".rho-runner-", suffix=".py")
+            fd, self._runner_path = tempfile.mkstemp(
+                prefix=".rho-runner-", suffix=".py"
+            )
             os.write(fd, RUNNER_SOURCE.encode())
             os.close(fd)
         self._proc = await asyncio.create_subprocess_exec(
@@ -630,10 +660,15 @@ class Kernel:
             budget -= time.monotonic() - started
             if frame is None:
                 self._mark_dead("kernel died running your cell")
-                return restart_note + "[kernel died running this cell — fresh kernel next call: variables lost, files intact.]"
+                return (
+                    restart_note
+                    + "[kernel died running this cell — fresh kernel next call: variables lost, files intact.]"
+                )
             if "fatal" in frame:
                 self._mark_dead("kernel crashed")
-                return restart_note + cap_output(f"[kernel crashed]\n{frame['fatal']}", "run_code")
+                return restart_note + cap_output(
+                    f"[kernel crashed]\n{frame['fatal']}", "run_code"
+                )
             if "call" in frame:
                 # Bridge time is the tool's, not the cell's: clock paused.
                 try:
@@ -642,7 +677,14 @@ class Kernel:
                 except BridgeError as e:
                     self._send({"error": {"type": e.type, "message": str(e)}})
                 except Exception as e:  # noqa: BLE001 - bridge failures raise inside the kernel
-                    self._send({"error": {"type": "RuntimeError", "message": f"{type(e).__name__}: {e}"}})
+                    self._send(
+                        {
+                            "error": {
+                                "type": "RuntimeError",
+                                "message": f"{type(e).__name__}: {e}",
+                            }
+                        }
+                    )
                 continue
             if "done" in frame:
                 done = frame["done"]
@@ -658,7 +700,9 @@ class Kernel:
         try:
             deadline = time.monotonic() + KERNEL_KILL_GRACE
             while True:
-                frame = await self._read_frame(timeout=max(0.1, deadline - time.monotonic()))
+                frame = await self._read_frame(
+                    timeout=max(0.1, deadline - time.monotonic())
+                )
                 if frame is None:
                     break
                 if "done" in frame:
@@ -695,6 +739,7 @@ class BridgeError(Exception):
 # MCP: pooled clients, retried sessions, docs-on-disk, decoy-aware dispatch
 # --------------------------------------------------------------------------------------
 
+
 def mcp_clients(config: dict) -> dict[str, httpx.AsyncClient]:
     return {
         name: httpx.AsyncClient(
@@ -721,7 +766,9 @@ async def mcp_session(http_client: httpx.AsyncClient, url: str):
     stack = contextlib.AsyncExitStack()
     cancelled: BaseException | None = None
     try:
-        read, write, *_ = await stack.enter_async_context(streamable_http_client(url, http_client=http_client))
+        read, write, *_ = await stack.enter_async_context(
+            streamable_http_client(url, http_client=http_client)
+        )
         session = await stack.enter_async_context(ClientSession(read, write))
         await session.initialize()
         yield session
@@ -763,7 +810,10 @@ async def connect_mcp(config: dict, clients: dict):
             return (await session.list_tools()).tools
 
     listed = await asyncio.gather(
-        *(with_retry(lambda name=name, spec=spec: list_tools(name, spec)) for name, spec in servers)
+        *(
+            with_retry(lambda name=name, spec=spec: list_tools(name, spec))
+            for name, spec in servers
+        )
     )
     for (name, _spec), tools in zip(servers, listed):
         for tool in tools:
@@ -773,7 +823,11 @@ async def connect_mcp(config: dict, clients: dict):
                 continue
             # Wire contract with task authors: tools are named <app>_<verb> (first
             # underscore splits); a verb-less name lands in the shared `misc` app.
-            bare = tool.name.split("_", 1)[1] if tool.name.startswith("tools_") else tool.name
+            bare = (
+                tool.name.split("_", 1)[1]
+                if tool.name.startswith("tools_")
+                else tool.name
+            )
             app, _, verb = bare.partition("_")
             if not verb:
                 app, verb = "misc", bare
@@ -810,7 +864,9 @@ def mcp_content(result):
 
 async def call_mcp_raw(servers, clients, server_name, raw_name, arguments):
     async def call():
-        async with mcp_session(clients[server_name], servers[server_name]["url"]) as session:
+        async with mcp_session(
+            clients[server_name], servers[server_name]["url"]
+        ) as session:
             return await session.call_tool(raw_name, arguments)
 
     result = await with_retry(call)
@@ -824,10 +880,18 @@ async def call_mcp_raw(servers, clients, server_name, raw_name, arguments):
 def _safe_component(name: str) -> str:
     """Doc-tree names come from the task's MCP server; keep them single path components.
     README is reserved for the tree's own summaries at both levels."""
-    if not name or name in (".", "..") or "/" in name or "\\" in name or name.startswith("."):
+    if (
+        not name
+        or name in (".", "..")
+        or "/" in name
+        or "\\" in name
+        or name.startswith(".")
+    ):
         raise ValueError(f"unsafe tool doc path component: {name!r}")
     if name.upper() == "README":
-        raise ValueError("app/verb name 'README' is reserved for the doc tree's summaries")
+        raise ValueError(
+            "app/verb name 'README' is reserved for the doc tree's summaries"
+        )
     return name
 
 
@@ -904,7 +968,11 @@ def build_tool_schemas(tools: list[str]) -> list[dict]:
             "function": {
                 "name": name,
                 "description": description,
-                "parameters": {"type": "object", "properties": properties, "required": required},
+                "parameters": {
+                    "type": "object",
+                    "properties": properties,
+                    "required": required,
+                },
             },
         }
 
@@ -935,7 +1003,10 @@ def build_tool_schemas(tools: list[str]) -> list[dict]:
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "properties": {"oldText": {"type": "string"}, "newText": {"type": "string"}},
+                        "properties": {
+                            "oldText": {"type": "string"},
+                            "newText": {"type": "string"},
+                        },
                         "required": ["oldText", "newText"],
                     },
                 },
@@ -947,7 +1018,10 @@ def build_tool_schemas(tools: list[str]) -> list[dict]:
             "Run a shell command in the workspace. No default timeout.",
             {
                 "command": {"type": "string"},
-                "timeout": {"type": "number", "description": "seconds (optional, no default)"},
+                "timeout": {
+                    "type": "number",
+                    "description": "seconds (optional, no default)",
+                },
             },
             ["command"],
         ),
@@ -1024,7 +1098,10 @@ def validate_schema(value, schema) -> str | None:
 
 
 def schema_suffix(lead: str, schema) -> str:
-    return f"\n\n{lead} only valid JSON matching this schema (no prose, no code fences):\n" + json.dumps(schema)
+    return (
+        f"\n\n{lead} only valid JSON matching this schema (no prose, no code fences):\n"
+        + json.dumps(schema)
+    )
 
 
 def parse_reply(text: str, schema) -> tuple[object, str | None]:
@@ -1101,7 +1178,9 @@ class Driver:
             self.documented_apps = set(self.served_apps)
         reserved = {"json", "completion", "agent"} & set(apps_payload)
         if reserved:
-            raise ValueError(f"app names collide with run_code globals: {sorted(reserved)}")
+            raise ValueError(
+                f"app names collide with run_code globals: {sorted(reserved)}"
+            )
         self.apps_payload = apps_payload
         if "run_code" in self.tools:
             self.kernel = Kernel(
@@ -1113,17 +1192,26 @@ class Driver:
     async def handle_call(self, call: dict, depth: int):
         kind = call.get("kind")
         if kind == "mcp":
-            return await self.do_mcp(call.get("app", ""), call.get("verb", ""), call.get("args") or {})
+            return await self.do_mcp(
+                call.get("app", ""), call.get("verb", ""), call.get("args") or {}
+            )
         if kind == "completion":
-            return await self.do_completion(call.get("prompt", ""), call.get("schema"), call.get("system"))
+            return await self.do_completion(
+                call.get("prompt", ""), call.get("schema"), call.get("system")
+            )
         if kind == "agent":
             if not self.args.subagents:
                 raise BridgeError("NameError", "agent() is not enabled in this session")
             if depth > 0:
-                raise BridgeError("RuntimeError", "subagents cannot spawn subagents (depth 1)")
+                raise BridgeError(
+                    "RuntimeError", "subagents cannot spawn subagents (depth 1)"
+                )
             return await self.do_agent(
-                call.get("prompt", ""), call.get("schema"), call.get("effort"),
-                call.get("tools"), call.get("session"),
+                call.get("prompt", ""),
+                call.get("schema"),
+                call.get("effort"),
+                call.get("tools"),
+                call.get("session"),
             )
         raise BridgeError("RuntimeError", f"unknown bridge call {kind!r}")
 
@@ -1132,28 +1220,36 @@ class Driver:
         if entry is None:
             if app in self.served_apps:
                 raise BridgeError(
-                    "AttributeError", f"{app} has no {verb!r} tool — its tools are documented in ./tools/{app}/"
+                    "AttributeError",
+                    f"{app} has no {verb!r} tool — its tools are documented in ./tools/{app}/",
                 )
             if app in self.documented_apps:
-                self.tool_discovery["decoy_calls"] = self.tool_discovery.get("decoy_calls", 0) + 1
+                self.tool_discovery["decoy_calls"] = (
+                    self.tool_discovery.get("decoy_calls", 0) + 1
+                )
                 raise BridgeError(
                     "NameError",
                     f"no such app in this workspace: {app!r} — it is documented, but this workspace "
                     "has no such integration; the work has to go through an app that is connected",
                 )
             raise BridgeError(
-                "NameError", f"no tool named {app}.{verb!r} — explore ./tools/<app>/ and call <app>.<verb>(...)"
+                "NameError",
+                f"no tool named {app}.{verb!r} — explore ./tools/<app>/ and call <app>.<verb>(...)",
             )
         server, raw, _ = entry
         return await call_mcp_raw(self.servers, self.clients, server, raw, arguments)
 
     async def do_completion(self, prompt: str, schema, system):
         if not self.budget.take():
-            raise BridgeError("RuntimeError", "turn budget exhausted — no model calls left")
+            raise BridgeError(
+                "RuntimeError", "turn budget exhausted — no model calls left"
+            )
         messages = []
         if system:
             messages.append({"role": "system", "content": str(system)})
-        body = str(prompt) + (schema_suffix("Respond with", schema) if schema is not None else "")
+        body = str(prompt) + (
+            schema_suffix("Respond with", schema) if schema is not None else ""
+        )
         messages.append({"role": "user", "content": body})
         problem = "no attempts left"
         for attempt in range(2):
@@ -1169,8 +1265,16 @@ class Driver:
             if problem is None:
                 return value
             messages.append({"role": "assistant", "content": text})
-            messages.append({"role": "user", "content": f"{problem}. Reply with only the corrected JSON."})
-        raise BridgeError("ValueError", f"completion did not return JSON matching the schema: {problem}")
+            messages.append(
+                {
+                    "role": "user",
+                    "content": f"{problem}. Reply with only the corrected JSON.",
+                }
+            )
+        raise BridgeError(
+            "ValueError",
+            f"completion did not return JSON matching the schema: {problem}",
+        )
 
     async def do_agent(self, prompt: str, schema, effort, tools, session=None):
         remaining = self.budget.remaining
@@ -1181,30 +1285,49 @@ class Driver:
                 "finish the task directly",
             )
         self.subagents_spawned += 1
-        body = str(prompt) + (schema_suffix("Your final message must be", schema) if schema is not None else "")
+        body = str(prompt) + (
+            schema_suffix("Your final message must be", schema)
+            if schema is not None
+            else ""
+        )
         if session and session in self.sessions:
             # Continue the named session: same transcript, tool surface, and kernel —
             # the follow-up rides the context already paid for.
             stored = self.sessions[session]
-            messages, allowed, kernel = stored["messages"], stored["tools"], stored["kernel"]
+            messages, allowed, kernel = (
+                stored["messages"],
+                stored["tools"],
+                stored["kernel"],
+            )
             messages.append({"role": "user", "content": body})
         else:
             allowed = [t for t in self.tools if t != "compact"]
             if tools is not None:
                 unknown = [t for t in tools if t not in allowed]
                 if unknown:
-                    raise BridgeError("ValueError", f"unknown subagent tools: {unknown} (available: {allowed})")
+                    raise BridgeError(
+                        "ValueError",
+                        f"unknown subagent tools: {unknown} (available: {allowed})",
+                    )
                 allowed = [t for t in allowed if t in tools]
             # A subagent gets its own kernel: agent() is only reachable from inside a
             # parent cell, whose kernel is blocked in bridge() — routing sub-cells to
             # it would corrupt the frame stream. Blank context means blank namespace.
-            kernel = Kernel({"apps": self.apps_payload, "subagents": False}) if "run_code" in allowed else None
+            kernel = (
+                Kernel({"apps": self.apps_payload, "subagents": False})
+                if "run_code" in allowed
+                else None
+            )
             messages = [
                 {"role": "system", "content": self.subagent_system_prompt(allowed)},
                 {"role": "user", "content": body},
             ]
             if session:
-                self.sessions[session] = {"messages": messages, "tools": allowed, "kernel": kernel}
+                self.sessions[session] = {
+                    "messages": messages,
+                    "tools": allowed,
+                    "kernel": kernel,
+                }
         try:
             final = await self.run_loop(
                 messages,
@@ -1212,7 +1335,9 @@ class Driver:
                 depth=1,
                 # No per-spawn ceiling: allocation is the policy's call; the shared budget
                 # binds, minus the reserve that keeps the parent able to act.
-                max_turns=None if self.budget.remaining is None else self.budget.remaining - (SPAWN_RESERVE_TURNS - 1),
+                max_turns=None
+                if self.budget.remaining is None
+                else self.budget.remaining - (SPAWN_RESERVE_TURNS - 1),
                 effort=effort,
                 kernel=kernel,
             )
@@ -1227,29 +1352,53 @@ class Driver:
                     return value
                 if self.budget.remaining is not None and self.budget.remaining < 1:
                     break
-                messages.append({"role": "user", "content": f"{problem}. Reply with only the corrected JSON."})
-                final = await self.run_loop(messages, tools=[], depth=1, max_turns=1, effort=effort, kernel=kernel)
+                messages.append(
+                    {
+                        "role": "user",
+                        "content": f"{problem}. Reply with only the corrected JSON.",
+                    }
+                )
+                final = await self.run_loop(
+                    messages,
+                    tools=[],
+                    depth=1,
+                    max_turns=1,
+                    effort=effort,
+                    kernel=kernel,
+                )
                 if final is None:
                     break
             if final is not None:
                 value, problem = parse_reply(final, schema)
                 if problem is None:
                     return value
-            raise BridgeError("ValueError", f"subagent did not return JSON matching the schema: {problem}")
+            raise BridgeError(
+                "ValueError",
+                f"subagent did not return JSON matching the schema: {problem}",
+            )
         finally:
             if kernel is not None and not session:
                 await kernel.close()
 
     # --- native tool dispatch -------------------------------------------------------
 
-    async def execute_tool(self, name: str, arguments: dict, depth: int, kernel: Kernel | None = None):
+    async def execute_tool(
+        self, name: str, arguments: dict, depth: int, kernel: Kernel | None = None
+    ):
         if name == "read":
             return await asyncio.to_thread(
-                run_read, arguments.get("path", ""), arguments.get("offset"), arguments.get("limit"), self.box
+                run_read,
+                arguments.get("path", ""),
+                arguments.get("offset"),
+                arguments.get("limit"),
+                self.box,
             )
         if name == "write":
             return await asyncio.to_thread(
-                run_write, arguments.get("path", ""), arguments.get("content", ""), self.box
+                run_write,
+                arguments.get("path", ""),
+                arguments.get("content", ""),
+                self.box,
             )
         if name == "edit":
             return await asyncio.to_thread(
@@ -1257,13 +1406,17 @@ class Driver:
             )
         if name == "bash":
             return await asyncio.to_thread(
-                run_bash, arguments.get("command", ""), arguments.get("timeout"), self.box
+                run_bash,
+                arguments.get("command", ""),
+                arguments.get("timeout"),
+                self.box,
             )
         if name == "run_code":
             kernel = kernel if kernel is not None else self.kernel
             assert kernel is not None
             return await kernel.run_cell(
-                arguments.get("code", ""), lambda call: self.handle_call(call, depth=depth)
+                arguments.get("code", ""),
+                lambda call: self.handle_call(call, depth=depth),
             )
         if name == "compact" and depth == 0:
             self.compaction_pending = True
@@ -1272,7 +1425,9 @@ class Driver:
 
     # --- prompts --------------------------------------------------------------------
 
-    def system_prompt_base(self, tools: list[str], advertise_agent: bool | None = None) -> str:
+    def system_prompt_base(
+        self, tools: list[str], advertise_agent: bool | None = None
+    ) -> str:
         parts = ["You are an agent operating in a minimal harness."]
         lines = []
         if "read" in tools:
@@ -1297,7 +1452,9 @@ class Driver:
                     "Service tools are documented as files under ./tools/<app>/<verb> (explore with "
                     "bash) and pre-bound in run_code as <app>.<verb>(...) returning Python objects."
                 )
-            lines.append("`completion(prompt, schema=None)` makes one standalone model call from code.")
+            lines.append(
+                "`completion(prompt, schema=None)` makes one standalone model call from code."
+            )
             if self.args.subagents if advertise_agent is None else advertise_agent:
                 lines.append(
                     "`agent(prompt, schema=None, effort=None, tools=None, session=None)` runs a "
@@ -1328,7 +1485,10 @@ class Driver:
     async def checkpoint(self, messages: list[dict], tool_schemas: list[dict]) -> None:
         keep = 2  # the protected prefix: system + the opening user message (assemble_messages)
         history_path = _spill(render_history(messages[keep:]), "history")
-        request = [*messages, {"role": "user", "content": COMPACTION_PROMPT + HISTORY_PROMPT_NOTE}]
+        request = [
+            *messages,
+            {"role": "user", "content": COMPACTION_PROMPT + HISTORY_PROMPT_NOTE},
+        ]
         while True:
             try:
                 completion = await self.client.chat.completions.create(
@@ -1346,7 +1506,9 @@ class Driver:
                 # parallel tool calls never leaves orphaned tool messages behind.
                 if is_overflow_error(error) and len(request) > keep + 2:
                     del request[keep]
-                    while keep < len(request) - 1 and request[keep].get("role") == "tool":
+                    while (
+                        keep < len(request) - 1 and request[keep].get("role") == "tool"
+                    ):
                         del request[keep]
                     continue
                 raise
@@ -1354,7 +1516,12 @@ class Driver:
         usage = getattr(completion, "usage", None)
         if usage and usage.prompt_tokens:
             self.peak_prompt_tokens = max(self.peak_prompt_tokens, usage.prompt_tokens)
-        framing = COMPACTION_FRAMING + "\n\n" + summary + HISTORY_FRAMING_NOTE.format(path=history_path)
+        framing = (
+            COMPACTION_FRAMING
+            + "\n\n"
+            + summary
+            + HISTORY_FRAMING_NOTE.format(path=history_path)
+        )
         messages[:] = [*messages[:keep], {"role": "user", "content": framing}]
         self.last_prompt_tokens = 0
         self.compactions += 1
@@ -1451,7 +1618,9 @@ class Driver:
             usage = getattr(completion, "usage", None)
             if usage and usage.prompt_tokens and depth == 0:
                 self.last_prompt_tokens = usage.prompt_tokens
-                self.peak_prompt_tokens = max(self.peak_prompt_tokens, usage.prompt_tokens)
+                self.peak_prompt_tokens = max(
+                    self.peak_prompt_tokens, usage.prompt_tokens
+                )
                 if self.just_compacted:
                     # The first work turn after a checkpoint is the effectiveness probe:
                     # still over the threshold means the protected prefix itself is too
@@ -1480,13 +1649,17 @@ class Driver:
                     out = f"invalid tool arguments ({e}) — send a JSON object matching the tool's schema"
                 else:
                     try:
-                        out = await self.execute_tool(tc.function.name, arguments, depth, kernel)
+                        out = await self.execute_tool(
+                            tc.function.name, arguments, depth, kernel
+                        )
                     except BridgeError as e:
                         out = f"{tc.function.name} failed: {e}"
                     except Exception as e:  # noqa: BLE001 - tool faults are observations, not rollout failures
                         out = f"{tc.function.name} failed: {type(e).__name__}: {e}"
                 content = out if isinstance(out, list) else str(out)
-                messages.append({"role": "tool", "tool_call_id": tc.id, "content": content})
+                messages.append(
+                    {"role": "tool", "tool_call_id": tc.id, "content": content}
+                )
             if depth == 0:
                 if isinstance(messages[-1]["content"], str):
                     messages[-1]["content"] += self._notices()
@@ -1500,7 +1673,11 @@ class Driver:
             compactions=self.compactions,
             peak_prompt_tokens=self.peak_prompt_tokens,
             subagents=self.subagents_spawned,
-            **({"tool_discovery": dict(self.tool_discovery)} if self.tool_discovery else {}),
+            **(
+                {"tool_discovery": dict(self.tool_discovery)}
+                if self.tool_discovery
+                else {}
+            ),
         )
 
     async def close(self) -> None:

--- a/verifiers/v1/harnesses/rho/program.py
+++ b/verifiers/v1/harnesses/rho/program.py
@@ -81,9 +81,11 @@ IMAGE_MAGIC = {
 MAX_IMAGE_BYTES = 5 * 1024 * 1024
 
 MAX_TURNS = 250
-MAX_COMPACTIONS = 8
 SUBAGENT_MAX_TURNS = 40
 """Per-spawn ceiling on a subagent's own loop; the shared trace budget binds first."""
+MAX_SUBAGENTS = 100
+"""Runaway-loop backstop, not a budget: the turn budget is the real bound on subagent
+work (every subagent turn spends it), so this sits far above any real rollout."""
 
 TUNNEL_TIMEOUT = httpx.Timeout(600.0, connect=30.0)
 TUNNEL_POOL = httpx.Limits(max_connections=16, max_keepalive_connections=16, keepalive_expiry=900.0)
@@ -977,6 +979,8 @@ class Driver:
         self.subagents_spawned = 0
         self.compactions = 0
         self.compaction_pending = False
+        self.just_compacted = False
+        self.auto_compact_disabled = False
         self.last_prompt_tokens = 0
         self.peak_prompt_tokens = 0
 
@@ -1085,9 +1089,9 @@ class Driver:
         raise BridgeError("ValueError", f"completion did not return JSON matching the schema: {problem}")
 
     async def do_agent(self, prompt: str, schema, effort, tools):
-        if self.subagents_spawned >= self.args.max_subagents:
+        if self.subagents_spawned >= MAX_SUBAGENTS:
             raise BridgeError(
-                "RuntimeError", f"subagent cap reached ({self.args.max_subagents} per session)"
+                "RuntimeError", f"subagent backstop reached ({MAX_SUBAGENTS} per session)"
             )
         self.subagents_spawned += 1
         allowed = [t for t in self.tools if t != "compact"]
@@ -1216,14 +1220,10 @@ class Driver:
 
     async def checkpoint(self, messages: list[dict], tool_schemas: list[dict]) -> None:
         keep = 2 if messages and messages[0].get("role") == "system" else 1
-        prompt = COMPACTION_PROMPT
-        history_path = ""
-        if self.args.history_file:
-            SPILL_DIR.mkdir(parents=True, exist_ok=True)
-            history_path = str(SPILL_DIR / f"history-{self.compactions + 1}.txt")
-            Path(history_path).write_text(render_history(messages[keep:]))
-            prompt += HISTORY_PROMPT_NOTE
-        request = [*messages, {"role": "user", "content": prompt}]
+        SPILL_DIR.mkdir(parents=True, exist_ok=True)
+        history_path = str(SPILL_DIR / f"history-{self.compactions + 1}.txt")
+        Path(history_path).write_text(render_history(messages[keep:]))
+        request = [*messages, {"role": "user", "content": COMPACTION_PROMPT + HISTORY_PROMPT_NOTE}]
         while True:
             try:
                 completion = await self.client.chat.completions.create(
@@ -1245,21 +1245,22 @@ class Driver:
         usage = getattr(completion, "usage", None)
         if usage and usage.prompt_tokens:
             self.peak_prompt_tokens = max(self.peak_prompt_tokens, usage.prompt_tokens)
-        framing = COMPACTION_FRAMING + "\n\n" + summary
-        if history_path:
-            framing += HISTORY_FRAMING_NOTE.format(path=history_path)
+        framing = COMPACTION_FRAMING + "\n\n" + summary + HISTORY_FRAMING_NOTE.format(path=history_path)
         messages[:] = [*messages[:keep], {"role": "user", "content": framing}]
         self.last_prompt_tokens = 0
         self.compactions += 1
         self.compaction_pending = False
+        self.just_compacted = True
 
     def should_checkpoint(self) -> bool:
-        if self.compactions >= self.args.max_compactions:
-            return False
+        # An explicit `compact` call is always honored; the automatic trigger stops once
+        # a compaction proved ineffective (see the guard in `run_loop`) — no count cap,
+        # matching Codex, because the turn budget is the real bound.
         if self.compaction_pending:
             return True
         return bool(
-            self.args.context_budget_tokens
+            not self.auto_compact_disabled
+            and self.args.context_budget_tokens
             and self.last_prompt_tokens >= self.args.context_budget_tokens
         )
 
@@ -1280,8 +1281,7 @@ class Driver:
         if depth == 0 and self.args.compact_tool and self.last_prompt_tokens:
             notices.append(
                 f"[harness] Context: ~{self.last_prompt_tokens} prompt tokens "
-                f"(checkpoint threshold {self.args.context_budget_tokens}, "
-                f"{self.args.max_compactions - self.compactions} checkpoints left)."
+                f"(checkpoint threshold {self.args.context_budget_tokens})."
             )
         return ("\n\n" + "\n".join(notices)) if notices else ""
 
@@ -1315,12 +1315,7 @@ class Driver:
                     **self._effort_kwargs(effort),
                 )
             except Exception as error:
-                if (
-                    depth == 0
-                    and is_overflow_error(error)
-                    and not overflow_retried
-                    and self.compactions < self.args.max_compactions
-                ):
+                if depth == 0 and is_overflow_error(error) and not overflow_retried:
                     # A work turn rejected for context length forces a compaction and
                     # retries exactly once. The refused call cost nothing — refund it.
                     self.budget.spent -= 1
@@ -1334,6 +1329,16 @@ class Driver:
             if usage and usage.prompt_tokens and depth == 0:
                 self.last_prompt_tokens = usage.prompt_tokens
                 self.peak_prompt_tokens = max(self.peak_prompt_tokens, usage.prompt_tokens)
+                if self.just_compacted:
+                    # The first work turn after a checkpoint is the effectiveness probe:
+                    # still over the threshold means the protected prefix itself is too
+                    # big — further automatic compaction would loop without shrinking.
+                    self.just_compacted = False
+                    if (
+                        self.args.context_budget_tokens
+                        and usage.prompt_tokens >= self.args.context_budget_tokens
+                    ):
+                        self.auto_compact_disabled = True
             msg = completion.choices[0].message
             # Append complete — reasoning included. The transcript is append-only.
             messages.append(msg.model_dump(exclude_none=True))
@@ -1388,11 +1393,8 @@ def parse_args():
     p.add_argument("--effort", default="")
     p.add_argument("--tools", default="read,write,edit,bash,run_code")
     p.add_argument("--subagents", action="store_true")
-    p.add_argument("--max-subagents", type=int, default=16)
     p.add_argument("--compact-tool", action="store_true")
     p.add_argument("--context-budget-tokens", type=int, default=150_000)
-    p.add_argument("--history-file", action=argparse.BooleanOptionalAction, default=True)
-    p.add_argument("--max-compactions", type=int, default=MAX_COMPACTIONS)
     p.add_argument("--max-turns", type=int, default=MAX_TURNS)
     p.add_argument("--disclose-budget", action="store_true")
     return p.parse_args()

--- a/verifiers/v1/harnesses/rho/program.py
+++ b/verifiers/v1/harnesses/rho/program.py
@@ -1,6 +1,7 @@
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [
+#     "agent-client-protocol==0.11.0",
 #     "openai==2.49.0",
 #     "mcp==1.28.1",
 #     "httpx==0.28.1",
@@ -23,6 +24,13 @@ one-shot sub-LLM calls, and `agent()` spawns subagents (config-gated, depth 1). 
 executes in a persistent kernel subprocess reached over stdio NDJSON; the same channel is
 the tool bridge, so the kernel holds capabilities, never credentials.
 
+The program is an ACP agent: the harness's runner spawns it once per rollout, session/new
+builds the driver and its MCP surface, and each session/prompt runs one loop segment on
+the same conversation — kernel namespace, named agent() sessions, and the transcript all
+persist across segments. Config rides RHO_* environment variables, popped on read so the
+API secret never reaches the kernel's or bash's inherited environment; the final reply of
+each segment goes back as an agent message chunk.
+
 The transcript is append-only between compaction boundaries: assistant messages (reasoning
 included) are re-sent complete, and the only rewriting event is Codex-style checkpoint
 compaction — triggered by the token budget, a context overflow, or the model's own
@@ -32,8 +40,8 @@ Two standing recovery stores: the live transcript (every root-loop message appen
 one greppable file as it happens; subagent transcripts land beside it under agents/) and
 spill files (full payloads named by truncation footers, whose pointers ride inside the
 transcript). `agent()` supports named persistent sessions — transcript, tool surface,
-and kernel continue across calls; sessions survive checkpoints but die with the segment
-(per-process state), and the boundary prompts say so.
+and kernel continue across calls; sessions survive checkpoints and later prompt
+segments alike, because the process is the rollout.
 
 Deliberate absences (known, may be wanted later, not built yet):
 - Parallel tool calls: multiple calls in one turn execute sequentially, and the kernel
@@ -45,7 +53,6 @@ Deliberate absences (known, may be wanted later, not built yet):
   (start a fresh session), not compacted — subagent loops have no checkpoint machinery.
 """
 
-import argparse
 import asyncio
 import base64
 import contextlib
@@ -60,9 +67,20 @@ import subprocess
 import sys
 import tempfile
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
 import httpx
+from acp import PROTOCOL_VERSION, Agent, Client, run_agent, update_agent_message_text
+from acp.schema import (
+    AgentCapabilities,
+    ImageContentBlock,
+    InitializeResponse,
+    NewSessionResponse,
+    PromptCapabilities,
+    PromptResponse,
+    TextContentBlock,
+)
 from openai import AsyncOpenAI
 from tenacity import AsyncRetrying, stop_after_attempt, wait_exponential_jitter
 
@@ -193,31 +211,6 @@ TRANSCRIPT_SYSTEM_NOTE = (
 SESSIONS_CHECKPOINT_CLAUSE = (
     " Named agent() sessions also persist across this compaction."
 )
-SESSIONS_RESUME_CLAUSE = (
-    " Named agent() sessions from previous segments are gone too — reusing a session "
-    "name now starts a fresh subagent."
-)
-
-RESUME_NOTE = (
-    "This session continues an earlier exchange: run_code variables from previous "
-    "segments are gone; files, ./tools/, and {dir} artifacts are intact."
-)
-
-
-def assemble_messages(
-    system: str, prompt: str, initial: list[dict] | None
-) -> list[dict]:
-    """The loop's starting transcript. A resumed segment replays the exchange's
-    conversation: a LEADING system message is the previous segment's harness-built
-    system prompt and is replaced by the fresh rebuild; any later explicit system
-    messages survive (the base `Harness.resume` contract). A fresh segment opens
-    with the task prompt."""
-    head = {"role": "system", "content": system}
-    if initial is not None:
-        if initial and initial[0].get("role") == "system":
-            initial = initial[1:]
-        return [head, *initial]
-    return [head, {"role": "user", "content": prompt}]
 
 
 def render_history(messages: list[dict]) -> str:
@@ -1175,16 +1168,16 @@ def parse_reply(text: str, schema) -> tuple[object, str | None]:
 class Driver:
     """Owns the client, kernel, MCP dispatch, and both loops (main + subagents)."""
 
-    def __init__(self, args):
-        self.args = args
+    def __init__(self, config: "Config"):
+        self.config = config
         self.client = AsyncOpenAI(
-            base_url=args.base_url,
-            api_key=args.api_key,
+            base_url=config.base_url,
+            api_key=config.api_key,
             http_client=httpx.AsyncClient(timeout=TUNNEL_TIMEOUT, limits=TUNNEL_POOL),
         )
-        self.budget = TurnBudget(args.max_turns)
+        self.budget = TurnBudget(config.max_turns)
         self.box = Path.cwd()
-        self.tools: list[str] = args.tools.split(",") if args.tools else []
+        self.tools: list[str] = list(config.tools)
         self.kernel: Kernel | None = None
         self.apps_payload: dict = {}
         self.dispatch: dict = {}
@@ -1213,11 +1206,10 @@ class Driver:
     def served_apps(self) -> set[str]:
         return {app for app, _ in self.dispatch}
 
-    async def setup(self) -> None:
-        config = json.loads(self.args.mcp_config) if self.args.mcp_config else {}
-        self.servers = config.get("mcpServers", {})
-        self.clients = mcp_clients(config)
-        self.dispatch, docs, catalog_ref = await connect_mcp(config, self.clients)
+    async def setup(self, mcp_config: dict) -> None:
+        self.servers = mcp_config.get("mcpServers", {})
+        self.clients = mcp_clients(mcp_config)
+        self.dispatch, docs, catalog_ref = await connect_mcp(mcp_config, self.clients)
         apps_payload = {}
         for (app, verb), (_, _, params) in self.dispatch.items():
             apps_payload.setdefault(app, {})[verb] = params
@@ -1245,7 +1237,7 @@ class Driver:
         self.apps_payload = apps_payload
         if "run_code" in self.tools:
             self.kernel = Kernel(
-                {"apps": apps_payload, "subagents": self.args.subagents}
+                {"apps": apps_payload, "subagents": self.config.subagents}
             )
 
     # --- bridge handlers ----------------------------------------------------------
@@ -1261,7 +1253,7 @@ class Driver:
                 call.get("prompt", ""), call.get("schema"), call.get("system")
             )
         if kind == "agent":
-            if not self.args.subagents:
+            if not self.config.subagents:
                 raise BridgeError("NameError", "agent() is not enabled in this session")
             if depth > 0:
                 raise BridgeError(
@@ -1318,7 +1310,7 @@ class Driver:
             if attempt and not self.budget.take():
                 break
             completion = await self.client.chat.completions.create(
-                model=self.args.model, messages=messages, **self._effort_kwargs()
+                model=self.config.model, messages=messages, **self._effort_kwargs()
             )
             text = completion.choices[0].message.content or ""
             if schema is None:
@@ -1591,23 +1583,8 @@ class Driver:
             f.write(render_history(new) + "\n")
         self.transcript_pos = len(messages)
 
-    def mark_replayed(self, messages: list[dict]) -> None:
-        """Position the transcript pointer for a resumed segment: the replayed
-        conversation is already on disk from earlier segments; only what follows the
-        last assistant/tool message (the caller-injected turns) is new. With none
-        present, only the trailing injected message is appended."""
-        last = max(
-            (
-                i
-                for i, m in enumerate(messages)
-                if m.get("role") in ("assistant", "tool")
-            ),
-            default=len(messages) - 2,
-        )
-        self.transcript_pos = last + 1
-
     async def checkpoint(self, messages: list[dict], tool_schemas: list[dict]) -> None:
-        keep = 2  # the protected prefix: system + the opening user message (assemble_messages)
+        keep = 2  # the protected prefix: the system message + the opening user prompt
         # Normally a no-op — per-turn appends already persisted everything; kept as
         # a safety net so the file's completeness never depends on call-site order.
         self.append_transcript(messages)
@@ -1623,7 +1600,7 @@ class Driver:
         while True:
             try:
                 completion = await self.client.chat.completions.create(
-                    model=self.args.model,
+                    model=self.config.model,
                     messages=request,
                     tools=tool_schemas or None,
                     tool_choice="none" if tool_schemas else None,
@@ -1670,14 +1647,14 @@ class Driver:
             return True
         return bool(
             not self.auto_compact_disabled
-            and self.args.context_budget_tokens
-            and self.last_prompt_tokens >= self.args.context_budget_tokens
+            and self.config.context_budget_tokens
+            and self.last_prompt_tokens >= self.config.context_budget_tokens
         )
 
     # --- the loop ----------------------------------------------------------------------
 
     def _effort_kwargs(self, effort: str | None = None) -> dict:
-        value = effort if effort is not None else self.args.effort
+        value = effort if effort is not None else self.config.effort
         return {"reasoning_effort": value} if value else {}
 
     def _notices(self) -> str:
@@ -1687,7 +1664,7 @@ class Driver:
         if "compact" in self.tools and self.last_prompt_tokens:
             notices.append(
                 f"[harness] Context: ~{self.last_prompt_tokens} prompt tokens "
-                f"(checkpoint threshold {self.args.context_budget_tokens})."
+                f"(checkpoint threshold {self.config.context_budget_tokens})."
             )
         return ("\n\n" + "\n".join(notices)) if notices else ""
 
@@ -1719,7 +1696,7 @@ class Driver:
                 break
             try:
                 completion = await self.client.chat.completions.create(
-                    model=self.args.model,
+                    model=self.config.model,
                     messages=messages,
                     tools=tool_schemas or None,
                     **self._effort_kwargs(effort),
@@ -1755,8 +1732,8 @@ class Driver:
                     # big — further automatic compaction would loop without shrinking.
                     self.just_compacted = False
                     if (
-                        self.args.context_budget_tokens
-                        and usage.prompt_tokens >= self.args.context_budget_tokens
+                        self.config.context_budget_tokens
+                        and usage.prompt_tokens >= self.config.context_budget_tokens
                     ):
                         self.auto_compact_disabled = True
             msg = completion.choices[0].message
@@ -1833,52 +1810,143 @@ class Driver:
 # --------------------------------------------------------------------------------------
 
 
-def parse_args():
-    p = argparse.ArgumentParser()
-    p.add_argument("--base-url", required=True)
-    p.add_argument("--api-key", required=True)
-    p.add_argument("--model", required=True)
-    p.add_argument("--system-prompt", default="")
-    p.add_argument("--prompt", default="")
-    p.add_argument("--initial-messages-file", default="")
-    p.add_argument("--mcp-config", default="")
-    p.add_argument("--effort", default="")
-    # Defaults below are manual-run conveniences; the harness always passes these.
-    p.add_argument("--tools", default="read,write,edit,bash,run_code")
-    p.add_argument("--subagents", action="store_true")
-    p.add_argument("--context-budget-tokens", type=int, default=150_000)
-    p.add_argument("--max-turns", type=int, default=None)
-    return p.parse_args()
+@dataclass
+class Config:
+    """The RHO_* environment contract with the harness (ACPConfig.env reaches the
+    runner, which spawns this program with an inherited environment)."""
+
+    base_url: str
+    api_key: str
+    model: str
+    system_prompt: str
+    effort: str
+    tools: list[str]
+    subagents: bool
+    context_budget_tokens: int
+    max_turns: int | None
+
+    @classmethod
+    def from_env(cls) -> "Config":
+        env = os.environ
+        system_prompt = ""
+        if path := env.pop("RHO_SYSTEM_PROMPT_FILE", ""):
+            # A file, not an env value: task system prompts can exceed env limits.
+            file = Path(path)
+            system_prompt = file.read_text()
+            file.unlink(missing_ok=True)
+        # Defaults below are manual-run conveniences; the harness always sets these.
+        raw_tools = env.pop("RHO_TOOLS", "read,write,edit,bash,run_code")
+        max_turns = env.pop("RHO_MAX_TURNS", "")
+        return cls(
+            base_url=env.pop("RHO_BASE_URL"),
+            api_key=env.pop("RHO_API_KEY"),
+            model=env.pop("RHO_MODEL"),
+            system_prompt=system_prompt,
+            effort=env.pop("RHO_EFFORT", ""),
+            tools=[name for name in raw_tools.split(",") if name],
+            subagents=env.pop("RHO_SUBAGENTS", "") == "1",
+            context_budget_tokens=int(env.pop("RHO_CONTEXT_BUDGET_TOKENS", "150000")),
+            max_turns=int(max_turns) if max_turns else None,
+        )
+
+
+def blocks_to_content(blocks: list) -> str | list[dict]:
+    """One prompt turn's ACP content blocks as one chat message content. Text-only
+    turns stay a plain string (transcript-friendly); images ride as data-URI parts."""
+    parts: list[dict] = []
+    for block in blocks:
+        if isinstance(block, TextContentBlock):
+            parts.append({"type": "text", "text": block.text})
+        elif isinstance(block, ImageContentBlock):
+            url = block.uri or f"data:{block.mime_type};base64,{block.data}"
+            parts.append({"type": "image_url", "image_url": {"url": url}})
+        else:
+            kind = getattr(block, "type", type(block).__name__)
+            raise TypeError(f"unsupported prompt content block: {kind!r}")
+    if all(part["type"] == "text" for part in parts):
+        return "\n\n".join(part["text"] for part in parts)
+    return parts
+
+
+class RhoAgent(Agent):
+    """The driver's ACP face: one native session per process, one loop segment per
+    prompt turn. The conversation accretes across turns — a later prompt lands as a
+    user message on the same transcript, kernel, and named sessions."""
+
+    def __init__(self, config: Config) -> None:
+        self.config = config
+        self.conn: Client | None = None
+        self.driver: Driver | None = None
+        self.messages: list[dict] = []
+
+    def on_connect(self, conn: Client) -> None:
+        self.conn = conn
+
+    async def initialize(
+        self, protocol_version, client_capabilities=None, client_info=None, **kwargs
+    ) -> InitializeResponse:
+        return InitializeResponse(
+            protocol_version=min(protocol_version, PROTOCOL_VERSION),
+            agent_capabilities=AgentCapabilities(
+                prompt_capabilities=PromptCapabilities(image=True)
+            ),
+        )
+
+    async def new_session(
+        self, cwd, additional_directories=None, mcp_servers=None, **kwargs
+    ) -> NewSessionResponse:
+        mcp_config = {
+            "mcpServers": {
+                server.name: {"url": url}
+                for server in mcp_servers or []
+                if (url := getattr(server, "url", None))
+            }
+        }
+        self.driver = Driver(self.config)
+        await self.driver.setup(mcp_config)
+        system = self.driver.system_prompt_base(
+            self.driver.tools, advertise_agent=self.config.subagents
+        )
+        system += "\n\n" + TRANSCRIPT_SYSTEM_NOTE.format(path=TRANSCRIPT_PATH)
+        if self.config.system_prompt:
+            system += "\n\n" + self.config.system_prompt
+        self.messages = [{"role": "system", "content": system}]
+        self.driver.append_transcript(self.messages)
+        self.driver.write_stats("ready")
+        return NewSessionResponse(session_id="rho")
+
+    async def prompt(self, session_id, prompt, **kwargs) -> PromptResponse:
+        assert self.conn is not None and self.driver is not None
+        self.messages.append({"role": "user", "content": blocks_to_content(prompt)})
+        self.driver.append_transcript(self.messages)
+        # The turn budget, not this call, is the authority on stopping.
+        final = await self.driver.run_loop(
+            self.messages, tools=self.driver.tools, depth=0, max_turns=None
+        )
+        self.driver.write_stats("segment")
+        await self.conn.session_update(
+            session_id=session_id,
+            update=update_agent_message_text(
+                final or "(the loop ended without a final reply)"
+            ),
+        )
+        return PromptResponse(stop_reason="end_turn")
+
+    async def cancel(self, session_id, **kwargs) -> None:
+        pass  # the verifiers runner never cancels a prompt turn
 
 
 async def main() -> None:
-    args = parse_args()
+    config = Config.from_env()
     write_diagnostics("started")
-    driver = Driver(args)
+    agent = RhoAgent(config)
     try:
-        await driver.setup()
-        initial = None
-        if args.initial_messages_file:
-            path = Path(args.initial_messages_file)
-            initial = json.loads(path.read_text())
-            path.unlink(missing_ok=True)
-        system = driver.system_prompt_base(driver.tools, advertise_agent=args.subagents)
-        system += "\n\n" + TRANSCRIPT_SYSTEM_NOTE.format(path=TRANSCRIPT_PATH)
-        if initial is not None and "run_code" in driver.tools:
-            system += "\n\n" + RESUME_NOTE.format(dir=SPILL_DIR)
-            if args.subagents:
-                system += SESSIONS_RESUME_CLAUSE
-        if args.system_prompt:
-            system += "\n\n" + args.system_prompt
-        messages = assemble_messages(system, args.prompt, initial)
-        if initial is not None:
-            driver.mark_replayed(messages)
-        driver.append_transcript(messages)
-        # The turn budget, not this call, is the authority on stopping.
-        await driver.run_loop(messages, tools=driver.tools, depth=0, max_turns=None)
-        driver.write_stats("complete")
+        # Serves the ACP connection over stdio until the client disconnects; stdout
+        # is the protocol channel, so nothing else may print to it.
+        await run_agent(agent)
     finally:
-        await driver.close()
+        if agent.driver is not None:
+            await agent.driver.close()
 
 
 if __name__ == "__main__":

--- a/verifiers/v1/harnesses/rho/program.py
+++ b/verifiers/v1/harnesses/rho/program.py
@@ -84,9 +84,19 @@ IMAGE_MAGIC = {
     b"\xff\xd8\xff": "image/jpeg",
     b"\x89PNG": "image/png",
     b"GIF8": "image/gif",
-    b"RIFF": "image/webp",
 }
 MAX_IMAGE_BYTES = 5 * 1024 * 1024
+
+
+def image_mime(head: bytes) -> str | None:
+    for magic, mime in IMAGE_MAGIC.items():
+        if head.startswith(magic):
+            return mime
+    # RIFF alone matches WAV/AVI too; webp needs the form type at offset 8.
+    if head[:4] == b"RIFF" and head[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
 
 SPAWN_RESERVE_TURNS = 3
 """Refuse to delegate when fewer turns than this remain: a subagent can spend the whole
@@ -281,21 +291,21 @@ def run_read(path: str, offset=None, limit=None, cwd: Path | None = None):
             + ", ".join(entries[:20])
         )
     with p.open("rb") as f:
-        head = f.read(8)
-    for magic, mime in IMAGE_MAGIC.items():
-        if head.startswith(magic):
-            size = p.stat().st_size
-            if size > MAX_IMAGE_BYTES:
-                return f"{path} is a {mime} of {size} bytes — over the {MAX_IMAGE_BYTES} byte image cap"
-            READ_LEDGER.add(str(p))
-            encoded = base64.b64encode(p.read_bytes()).decode()
-            return [
-                {"type": "text", "text": f"{path} ({mime}, {size} bytes)"},
-                {
-                    "type": "image_url",
-                    "image_url": {"url": f"data:{mime};base64,{encoded}"},
-                },
-            ]
+        head = f.read(12)
+    mime = image_mime(head)
+    if mime is not None:
+        size = p.stat().st_size
+        if size > MAX_IMAGE_BYTES:
+            return f"{path} is a {mime} of {size} bytes — over the {MAX_IMAGE_BYTES} byte image cap"
+        READ_LEDGER.add(str(p))
+        encoded = base64.b64encode(p.read_bytes()).decode()
+        return [
+            {"type": "text", "text": f"{path} ({mime}, {size} bytes)"},
+            {
+                "type": "image_url",
+                "image_url": {"url": f"data:{mime};base64,{encoded}"},
+            },
+        ]
 
     try:
         offset = max(1, int(offset)) if offset is not None else 1
@@ -369,7 +379,10 @@ def run_edit(path: str, edits, cwd: Path | None = None) -> str:
     if not p.exists():
         return f"{path} not found"
     try:
-        original = p.read_text()
+        # newline="" preserves the file's own line endings: a localized edit must not
+        # silently rewrite CRLF to LF across every untouched line.
+        with p.open("r", newline="") as f:
+            original = f.read()
     except Exception as e:  # noqa: BLE001 - tool failures are returned to the model
         return f"could not read {path}: {e}"
 
@@ -397,7 +410,8 @@ def run_edit(path: str, edits, cwd: Path | None = None) -> str:
         cursor = end
     result.append(original[cursor:])
     try:
-        p.write_text("".join(result))
+        with p.open("w", newline="") as f:
+            f.write("".join(result))
     except Exception as e:  # noqa: BLE001 - tool failures are returned to the model
         return f"could not write {path}: {e}"
     READ_LEDGER.add(str(p))
@@ -423,7 +437,13 @@ def run_bash(command: str, timeout=None, cwd: Path | None = None) -> str:
     except subprocess.TimeoutExpired:
         with contextlib.suppress(ProcessLookupError):
             os.killpg(proc.pid, signal.SIGKILL)
-        out, _ = proc.communicate()
+        try:
+            # Bounded: a descendant that escaped the process group can hold the
+            # stdout pipe open forever; the tool must return regardless.
+            out, _ = proc.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.stdout.close()
+            out = ""
         return cap_output(
             (out or "") + f"\n[command timed out after {timeout:g}s and was killed]",
             "bash",
@@ -1350,7 +1370,12 @@ class Driver:
                 value, problem = parse_reply(final, schema)
                 if problem is None:
                     return value
-                if self.budget.remaining is not None and self.budget.remaining < 1:
+                # Correction retries honor the same reserve as the spawn: they must
+                # not drain the turns kept for the parent to act on the result.
+                if (
+                    self.budget.remaining is not None
+                    and self.budget.remaining < SPAWN_RESERVE_TURNS
+                ):
                     break
                 messages.append(
                     {


### PR DESCRIPTION
## Summary

New built-in harness `rho`: pi's four core tools (`read`, `write`, `edit`, `bash`) plus a single code-mode tool, `run_code`, that carries everything compositional — the task's MCP tools, one-shot sub-LLM calls, and (config-gated) subagents. Five small wire schemas; service-tool schemas never enter context.

Design anchors, read at source: pi/tau (tool semantics, truncate-with-recovery), ptc_harness (proxies, docs-on-disk, compaction machinery, tunnel pooling), Codex `compact.rs` (checkpoint compaction, overflow recovery, reasoning preservation), Anthropic PTC / code-execution-with-MCP (code-mode economics, limits told to the model), oh-my-pi `eval`/`task` (kernel design, paused-clock timeout, `agent()` contract), Claude Code dynamic workflows (schema-validated subagent returns, null-on-failure), Command Code harness-engineering (three-ceiling input bounding, precomputed recovery paths, facts-not-errors), and Cursor's dynamic context discovery (history-as-recovery; their A/B measured **46.9% token reduction** for the MCP-docs-lazy-loading pattern this harness uses).

## How it works

- **`run_code`** (one `code` param): model Python executes in a persistent kernel subprocess speaking NDJSON over stdio; the same channel is the tool bridge, so the kernel holds capabilities, never credentials (allowlisted env). ~30s compute per cell with the clock **paused during bridged calls**; SIGINT → SIGKILL escalation; kernel death/restart reported as a fact with the state delta. Namespace persists across cells and compactions.
- **Prelude**: MCP tools pre-bound as `<app>.<verb>(...)` returning parsed objects (positional→kwarg mapping, `None`-dropping, `import <app>` tolerance), docs written as files under `./tools/<app>/<verb>` (the ptc discovery-catalog/decoy mode carries over intact), `completion(prompt, schema=None)`, and `agent(prompt, schema=None, effort=None, tools=None, session=None)` — blank context, depth 1, sequential, schema-validated return with retry at the boundary, 3-turn spawn reserve. Passing a `session` name makes a subagent **persistent**: later calls with the same name continue its transcript and tool surface instead of re-briefing from zero (Claude Code resume / oh-my-pi `agent://` precedent), extending the same trace branch.
- **Output bounding everywhere**: 2,000 lines / 50KB / ~2,000-char-per-line ceilings; execution output tail-kept with the full text spilled to a named path; `read` head-truncated with precomputed resume offsets (resuming *on* the line the byte cap clipped).
- **Compaction** (Codex-style): triggered by the token budget, a context overflow, or the model's own gated `compact` tool (Codex `new_context` precedent). Same-model checkpoint call with tools advertised and `tool_choice="none"`; rebuild is `[system, task instruction, bridge framing + summary]`. No count cap (matching Codex — the turn budget is the real bound); instead an **effectiveness guard**: if the first work turn after a checkpoint still reports over-threshold tokens, the protected prefix itself is too big and automatic compaction disables rather than looping. Overflow recovery both ways: a rejected work turn forces a compaction and retries exactly once; an overflowing compaction call trims oldest non-protected messages until it fits.
- **agents/ recovery store**: every subagent conversation is saved under `/tmp/.rho/agents/<name>.txt` — one mechanism giving subagent-work recovery (the one otherwise-lossy channel), an `ls`-able session listing, and post-compaction session-name recovery. Session lifecycle facts live in the boundary prompts: the checkpoint prompt says sessions survive compaction (and they survive later interaction segments too — the process is the rollout); continuation rejects a changed tool surface and an outgrown session with facts, not raw errors.
- **Live transcript, history always greppable**: every root-loop message is appended to `/tmp/.rho/transcript.txt` as it happens (advertised once in the system prompt, surviving compactions and resumed segments), so recovery is a standing capability, not a compaction-time artifact. The compaction framing points at the same path, and the summarizer is told raw data stays recoverable — licensing tight, targeted summaries (less carried context, less rot) with grep as the fallback. Precedent: dsh's `DSH_SESSION_JSONL` + Cursor's history-as-recovery.
- **Append-only transcript**: assistant messages are re-sent complete (`reasoning_content` included); no message is ever mutated — the only rewriting event is checkpoint compaction at a declared boundary.
- **One turn budget** shared by work turns, compactions, completions, and subagent turns, mirroring the framework's per-trace cap (read off `trace.agent.config.max_turns`); the budget spans the whole session, so every segment's turns draw on it.
- **Harness-free envs**: rho stages a task dir's `inputs/` tree into the workspace at session start and picks the program's diagnostics up onto `trace.info["rho"]` when the session closes (the program rewrites them after every segment). Combined with `Task.score` threading `runtime` into taskset scoring, an env like general-agent can delete its harness packages entirely — tools ride MCP, workspace capture becomes a runtime-requiring taskset reward, rho does the rest.
- **Live ACP sessions** (`ACPHarness`, `SUPPORTS_RESUME`): one rho process per rollout serving the Agent Client Protocol — the in-runtime runner does `initialize` → `session/new` (MCP servers arrive here) and each `Agent.interaction()` turn is a `session/prompt` that lands as a user message on the same conversation. Nothing relaunches, nothing replays: kernel namespace, named `agent()` sessions, and the transcript file persist across segments, and the resume-by-relaunch apparatus (messages-by-file handover, replay assembly, resume notes) is gone. Critic-in-the-loop curation pipelines inject critique as the next user turn and own all alternation/stop policy outside the harness (the swe-universe pattern). The post-compaction framing carries Codex's work-from-evidence hedge: the workspace is authoritative over both summary and history file.

## Config

Three fields: `subagents`, `compact_tool`, `context_budget_tokens`. `disclose_budget` was removed — it only ever disclosed the framework's `max_turns`, and no seat will run with a turn cap; the context clock stays tied to `compact_tool`. Everything else that was a knob is now a decision: the five tools are always on (seat shaping via the base `disabled_tools` — a ptc-style service seat is `disabled_tools=["read","write","edit"]`), history-as-recovery is always on, the compaction count cap is replaced by the effectiveness guard, and reasoning effort rides the framework's one channel (`ctx.sampling.reasoning_effort` — which interception overlays on every call anyway) instead of a rho-only knob it would silently clobber. Config reaches the program as `RHO_*` env vars on the ACP process, popped on read so the interception secret never reaches the kernel's or bash's inherited environment; the task system prompt rides a staged file (env values have size limits) rather than the runner's `(system)` prompt block, so rho builds its own system message. `compact` reaches the program through `RHO_TOOLS` like every other tool: one channel for the seat's surface.

Known absences, recorded in the module docstring as wanted-later: parallel tool calls (needs bridge multiplexing + interception-side concurrency, one coherent upgrade) and background tools (the documented answer is bash: nohup, redirect, read the log).

**The box imposes no limits of its own** (Codex/Claude Code parity): the turn cap is the framework's (`AgentConfig.max_turns`, enforced by interception), mirrored only so the loop stops on its own last turn instead of walking into a refused call — when no cap is set, the box runs unbounded and the framework's token budget and wall-clock timeout are the bounds, exactly as configured. Subagents have no per-spawn turn ceiling (allocation is the policy's call); the only guard is a 3-turn **spawn reserve** so a delegation can never strand the parent with zero turns to act on the result.

## Verification

- `uv run ruff check` + `ruff format --check` clean; `uv run pytest tests/v1` unit suite green.
- 104 scripted smoke checks, all passing: 41 tool/kernel checks (pi read/write/edit/bash semantics, ceilings + spill recovery, kernel state persistence, stderr capture, typed bridge errors, timeout-interrupt survival, kernel death → restart note, env allowlist), 56 loop checks against a scripted fake client (compaction trigger + rebuild shape, `compact` tool, both overflow-recovery paths, the effectiveness guard, history-file write/framing/tight-summary-note, subagent blank-context/schema-retry/spawn-reserve/depth enforcement, persistent-session continuation, unbounded no-cap mode, `RHO_*` env contract + secret scrubbing, `prepare_acp` staging/env/system-prompt-file, two-segment agent flow on one conversation, observation-channel notices, reasoning preservation), and 7 ACP loopback checks driving the **real program process** through the acp client API (handshake + image capability, `session/new`, two prompt segments accreting one conversation on one process, secret hygiene in model-visible messages, per-segment diagnostics) against a fake OpenAI endpoint.
- Live e2e (CI): `rho-harness-in-docker` green for both the chat and agentic cases; this push adds `rho-acp-in-docker` to the ACP resume suite (context + MCP preserved across two interaction segments).
- Terminal-Bench 2 smoke (pre-ACP architecture): 10 tasks, DeepSeek V4 Flash at low reasoning effort — 10/10 episodes completed, 4 solved, **zero branching** across all traces (up to 64 turns), diagnostics on every trace.
- A four-angle review pass (reuse / simplification / efficiency / altitude) was applied: concurrent MCP server enumeration at startup, single-pass output capping, read pagination that stops at the window instead of decoding the file tail, stat-before-read image handling, deduplicated JSON-retry/diagnostics/path-resolution logic.

## Follow-ups

- Parallel subagents are deliberately out of scope: they need a per-branch replay cache in the interception server (its retry atomicity assumes one outstanding request per session).
- "rho" is a working codename — happy to rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new agent runtime (~2k LOC) handling secrets, MCP, and model loops in containers; mitigated by extensive tests and isolation via ACP/env allowlists, but it's new critical-path harness code.
> 
> **Overview**
> Adds a new built-in **`rho`** harness: pi-style **`read` / `write` / `edit` / `bash`** plus **`run_code`**, with optional **`compact`** and config for subagents and context-budget compaction.
> 
> **`RhoHarness`** extends **`ACPHarness`**: one ACP process per rollout (resume across interaction segments), container required, MCP supported. It stages task **`inputs/`** via tarball, passes **`RHO_*`** env (secrets popped in the program), and attaches runtime diagnostics to **`trace.info["rho"]`** on cleanup.
> 
> **`program.py`** is the in-box agent: tool loop, Codex-style checkpoint compaction, live greppable transcript, MCP tools as **`./tools`** docs and **`run_code`** globals, **`completion()`** / gated **`agent()`**, and a persistent kernel subprocess for code execution.
> 
> Docs and CI/e2e matrices gain **`rho`** rows (chat, agentic, ACP resume in docker).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bb547ca3ff0318cad26cbd893a0b4bc2e25f90c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `rho` ACP harness with native tools and persistent `run_code` kernel
> - Introduces [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2367/files#diff-66b7d4f72429325a9a936a90708ae5ce3ad896dba42b123b4581f76ea6e77b20) (`RhoHarness`/`RhoHarnessConfig`) as a new ACP-backed harness that stages task inputs, passes MCP endpoints, and supports session resume across segments.
> - Adds [program.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2367/files#diff-acde00d6077d6442a710ec705653b98fd6d9713fb4875fb73e8abafd92a0296d), a ~1900-line ACP agent program implementing the rho runtime: native read/write/edit/bash/run_code tools, a persistent Python kernel subprocess with NDJSON protocol, MCP tool discovery and dispatch, optional subagent spawning, and context compaction with transcript spill files.
> - Exposes `run_code` as a first-class tool alongside pi's four native tools; subagents and a `compact` tool are opt-in via `RhoHarnessConfig`.
> - Extends the e2e test matrices in [test_e2e.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2367/files#diff-ebbbd919487889487f891b359a756e6c4630e106b16ddaef8ccddc6b900a96e1) to run the rho harness in Docker for chat, agentic, and ACP resume scenarios.
> - On teardown, runtime diagnostics are read from `/tmp/.rho/runtime.json` inside the container and attached to the trace under `rho`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5bb547c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->