### PR TITLE
Support training with streaming harnesses

### DIFF
--- a/verifiers/v1/clients/client.py
+++ b/verifiers/v1/clients/client.py
@@ -20,11 +20,17 @@ router pins a rollout's turns to one engine and its growing prefix stays KV-cach
 
 @dataclass
 class RelayReply:
-    """A relayed upstream response: content type, complete SSE events, and connection cleanup."""
+    """A streaming response: complete SSE events, cleanup, and optional result future.
+
+    Eval clients relay provider bytes and leave ``result`` unset. Renderer-backed training
+    clients synthesize SSE from a completed generation and retain its result future here so the
+    trace keeps the exact token ids and logprobs while the server can send keepalives meanwhile.
+    """
 
     content_type: str
     chunks: AsyncIterator[bytes]
     close: Callable[[], Awaitable[None]]
+    result: Awaitable[Response] | None = None
 
 
 class Client(ABC):
@@ -48,11 +54,16 @@ class Client(ABC):
         self,
         dialect: Dialect,
         body: dict,
+        sampling: SamplingConfig,
         session_id: str | None = None,
+        turn: PendingTurn | None = None,
         headers: Mapping[str, str] | None = None,
     ) -> RelayReply:
-        """Stream a response for the final effective `body`, relaying the provider's bytes.
-        Only the relay (eval) client supports it; the renderer generates and cannot stream."""
+        """Return SSE to the intercepted program.
+
+        Eval clients relay provider bytes. Training clients may render and generate a complete
+        response, then expose it as a protocol-compatible stream.
+        """
         raise NotImplementedError(f"{type(self).__name__} does not support streaming")
 
     async def relay_aux(

--- a/verifiers/v1/clients/eval.py
+++ b/verifiers/v1/clients/eval.py
@@ -163,7 +163,9 @@ class EvalClient(Client):
         self,
         dialect: Dialect,
         body: dict,
+        sampling: SamplingConfig,
         session_id: str | None = None,
+        turn: PendingTurn | None = None,
         headers: Mapping[str, str] | None = None,
     ) -> RelayReply:
         # Relay complete SSE events so the interception server can safely insert keepalives

--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -15,9 +15,9 @@ from renderers import RenderedTokens, Renderer, RendererConfig
 from renderers.base import ToolCallParseStatus
 
 from verifiers.v1.clients.base import build_async_openai
-from verifiers.v1.clients.client import SESSION_ID_HEADER, Client
+from verifiers.v1.clients.client import SESSION_ID_HEADER, Client, RelayReply
 from verifiers.v1.configs.client import TrainClientConfig
-from verifiers.v1.dialects import FINISH_REASONS, ChatDialect, Dialect, parse_tools
+from verifiers.v1.dialects import FINISH_REASONS, Dialect
 from verifiers.v1.dialects.chat import message_to_wire
 from verifiers.v1.errors import OverlongPromptError, model_error
 from verifiers.v1.graph import PendingTurn
@@ -25,6 +25,7 @@ from verifiers.v1.types import (
     AssistantMessage,
     FinishReason,
     KeptTokens,
+    Message,
     Response,
     SamplingConfig,
     Tool,
@@ -49,51 +50,19 @@ def tool_to_wire(tool: Tool) -> dict:
     return {"type": "function", "function": function}
 
 
-def serialize_completion(response: Response, model: str) -> dict:
-    """A vf `Response` -> an OpenAI chat.completion dict the program's SDK expects. The renderer
-    sets this on `Response.raw` (it generates, so has no provider response to relay)."""
-    message: dict = {"role": "assistant", "content": response.message.content}
-    if response.message.reasoning_content is not None:
-        message["reasoning_content"] = response.message.reasoning_content
-    if response.message.tool_calls:
-        message["tool_calls"] = [
-            {
-                "id": c.id,
-                "type": "function",
-                "function": {"name": c.name, "arguments": c.arguments},
-            }
-            for c in response.message.tool_calls
-        ]
-    usage: dict | None = None
-    if response.usage:
-        # Usage is validated earlier in the pipeline; building its wire dict directly saves time.
-        usage = {
-            "completion_tokens": response.usage.completion_tokens,
-            "prompt_tokens": response.usage.input_tokens,
-            "total_tokens": response.usage.total_tokens,
-        }
-        if response.usage.reasoning_tokens is not None:
-            usage["completion_tokens_details"] = {
-                "reasoning_tokens": response.usage.reasoning_tokens
-            }
-        if response.usage.cached_input_tokens is not None:
-            usage["prompt_tokens_details"] = {
-                "cached_tokens": response.usage.cached_input_tokens
-            }
-    return {
-        "id": response.id or "vf-intercept",
-        "object": "chat.completion",
-        "created": response.created,
-        "model": response.model or model,
-        "choices": [
-            {
-                "index": 0,
-                "message": message,
-                "finish_reason": response.finish_reason or "stop",
-            }
-        ],
-        "usage": usage,
-    }
+def message_to_renderer_wire(message: Message) -> dict:
+    """Canonical vf message -> the OpenAI-shaped input expected by renderers.
+
+    Opaque provider state is meaningful only to its native API. A Responses output-item list or
+    Anthropic signed-thinking block is not Chat `reasoning_details`; render the canonical reasoning
+    text instead so crossing dialects cannot leak an incompatible native object into a template.
+    """
+    wire = message_to_wire(message)
+    if isinstance(message, AssistantMessage) and message.provider_state:
+        wire.pop("reasoning_details", None)
+        if message.reasoning_content is not None:
+            wire["reasoning_content"] = message.reasoning_content
+    return wire
 
 
 def response_from_generate(
@@ -324,32 +293,17 @@ class TrainClient(Client):
         turn: PendingTurn | None = None,
         headers: Mapping[str, str] | None = None,
     ) -> Response:
-        # The renderer tokenizes the typed prompt for training (it needs per-token ids + logprobs
-        # back), so it can't forward the raw request — it parses `body` via the dialect and renders
-        # it with a chat template. It leaves `Response.raw` unset; the interception server serializes
-        # its `Response` for the program instead of relaying provider bytes.
-        if not isinstance(dialect, ChatDialect):
-            # The renderer renders a chat template, so it's only validated for chat-completions
-            # input; other dialects' semantics (Responses reasoning items, Anthropic thinking) may
-            # not round-trip faithfully through chat-template tokenization. Refuse them explicitly.
-            raise NotImplementedError(
-                f"The renderer client only supports the chat-completions dialect, got "
-                f"{type(dialect).__name__}. Use the proxy client for this dialect, or add "
-                f"renderer support for it."
-            )
-        # Intercepted turns already own the typed prompt, so only their tools need parsing here.
-        if turn is not None:
-            prompt = turn.prompt
-            tools = parse_tools(body.get("tools"))
-        else:
-            request = dialect.parse_request(body)
-            prompt = request.messages
-            tools = request.tools
+        # The dialect canonicalizes the program's native protocol, then the renderer consumes the
+        # same chat-shaped vf prompt for every harness. Intercepted turns already own the resolved
+        # graph prompt; parsing the request here still supplies dialect-native tools.
+        request = dialect.parse_request(body)
+        prompt = turn.prompt if turn is not None else request.messages
+        tools = request.tools
         from renderers.client import generate
 
         wire_tools = [tool_to_wire(t) for t in tools] if tools else None
         wire_messages = (
-            [message_to_wire(m) for m in turn.tail] if turn is not None else []
+            [message_to_renderer_wire(m) for m in turn.tail] if turn is not None else []
         )
         prompt_ids: list[int] | None = None
         multi_modal_data = None
@@ -405,7 +359,7 @@ class TrainClient(Client):
             # handed prebuilt prompt_ids, generate's own renderer touches are decode-side
             # and stop-id reads, safe on a bare renderer without lock or thread hop.
             if prompt_ids is None:
-                wire_messages = [message_to_wire(m) for m in prompt]
+                wire_messages = [message_to_renderer_wire(m) for m in prompt]
                 rendered = await slot.run(
                     lambda: renderer.render(
                         wire_messages, tools=wire_tools, add_generation_prompt=True
@@ -435,10 +389,48 @@ class TrainClient(Client):
             except OpenAIError as e:
                 raise model_error(e) from e
         response = response_from_generate(result, model, bridged_turn)
-        # No provider response to relay (we generated), so serialize one for the program; the
-        # interception server hands `Response.raw` back regardless of client.
-        response.raw = serialize_completion(response, model)
+        # No provider response exists to relay: the request dialect owns the native response.
+        response.raw = dialect.serialize_response(response, model)
+        dialect.validate_response(response.raw)
         return response
+
+    async def relay(
+        self,
+        dialect: Dialect,
+        body: dict,
+        sampling: SamplingConfig,
+        session_id: str | None = None,
+        turn: PendingTurn | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> RelayReply:
+        """Generate once, then present the completed training response as a short SSE stream."""
+        result = asyncio.create_task(
+            self.get_response(
+                dialect,
+                body,
+                sampling,
+                session_id=session_id,
+                turn=turn,
+                headers=headers,
+            )
+        )
+
+        async def chunks() -> AsyncIterator[bytes]:
+            response = await result
+            for chunk in dialect.stream_events(response.raw or {}):
+                yield chunk
+
+        async def close() -> None:
+            if not result.done():
+                result.cancel()
+            await asyncio.gather(result, return_exceptions=True)
+
+        return RelayReply(
+            content_type="text/event-stream",
+            chunks=chunks(),
+            close=close,
+            result=result,
+        )
 
     async def close(self) -> None:
         await self.client.close()

--- a/verifiers/v1/dialects/anthropic.py
+++ b/verifiers/v1/dialects/anthropic.py
@@ -1,9 +1,9 @@
 """The Anthropic Messages dialect (claude-code and friends).
 
-Request parsing maps Anthropic content blocks onto the typed messages; response parsing reads
-the content blocks of a `Message`. Relay-only: the eval client forwards the program's native JSON to a
-`/v1/messages` endpoint (auth is `x-api-key`, not Bearer) and this dialect parses a copy for the
-trace. `count_tokens` is relayed as native JSON (an `aux_route`), never recorded.
+Request parsing maps Anthropic content blocks onto typed messages; response parsing reads the
+content blocks of a `Message`. Eval clients relay native bytes; renderer-backed clients render the
+canonical request and this dialect serializes their completed response back to native events.
+`count_tokens` is relayed as native JSON (an `aux_route`), never recorded.
 """
 
 import json
@@ -49,6 +49,11 @@ STOP_REASONS = {
     "max_tokens": "length",
     "tool_use": "tool_calls",
     "stop_sequence": "stop",
+}
+FINISH_REASONS = {
+    "stop": "end_turn",
+    "length": "max_tokens",
+    "tool_calls": "tool_use",
 }
 # Claude may reorder mixed thinking block types between a response and its replay.
 THINKING = ("redacted_thinking", "thinking")
@@ -548,6 +553,58 @@ class AnthropicDialect(Dialect[MessageCreateParams, AnthropicMessage]):
     def parse_response(self, response: AnthropicMessage) -> Response:
         return response_from_wire(response)
 
+    def serialize_response(self, response: Response, model: str) -> dict:
+        blocks: list[dict] = []
+        if response.message.reasoning_content is not None:
+            blocks.append(
+                {
+                    "type": "thinking",
+                    "thinking": response.message.reasoning_content,
+                    "signature": "",
+                }
+            )
+        if response.message.content is not None or not (
+            response.message.reasoning_content or response.message.tool_calls
+        ):
+            blocks.append({"type": "text", "text": response.message.content or ""})
+        for call in response.message.tool_calls or []:
+            try:
+                tool_input = json.loads(call.arguments)
+            except json.JSONDecodeError:
+                tool_input = {"_raw": call.arguments}
+            if not isinstance(tool_input, dict):
+                tool_input = {"value": tool_input}
+            blocks.append(
+                {
+                    "type": "tool_use",
+                    "id": call.id,
+                    "name": call.name,
+                    "input": tool_input,
+                }
+            )
+        usage = {
+            "input_tokens": response.usage.prompt_tokens if response.usage else 0,
+            "output_tokens": response.usage.completion_tokens if response.usage else 0,
+        }
+        if response.usage and response.usage.cached_input_tokens is not None:
+            usage["cache_read_input_tokens"] = response.usage.cached_input_tokens
+        if response.usage and response.usage.reasoning_tokens is not None:
+            usage["output_tokens_details"] = {
+                "thinking_tokens": response.usage.reasoning_tokens
+            }
+        return {
+            "id": response.id or "msg_vf_intercept",
+            "content": blocks,
+            "model": response.model or model,
+            "role": "assistant",
+            "stop_reason": FINISH_REASONS.get(
+                response.finish_reason or "stop", "end_turn"
+            ),
+            "stop_sequence": None,
+            "type": "message",
+            "usage": usage,
+        }
+
     def rewrite_request(self, body: dict, before: Request, after: Request) -> None:
         original = [
             m for m in before.messages if isinstance(m, (UserMessage, ToolMessage))
@@ -603,43 +660,111 @@ class AnthropicDialect(Dialect[MessageCreateParams, AnthropicMessage]):
         raw["stop_reason"] = "end_turn"
         raw["stop_sequence"] = None
 
-    def stream_events(self, raw: dict) -> list[bytes]:
+    def stream_events(
+        self,
+        raw: dict,
+        *,
+        include_start: bool = True,
+        sequence_number: int = 0,
+    ) -> list[bytes]:
         def event(kind: str, payload: dict) -> bytes:
             return f"event: {kind}\ndata: {json.dumps(payload)}\n\n".encode()
 
-        text = raw["content"][0]["text"]
         head = {**raw, "content": [], "stop_reason": None, "stop_sequence": None}
         if isinstance(usage := head.get("usage"), dict):
             head["usage"] = {**usage, "output_tokens": 0}
-        return [
-            event("message_start", {"type": "message_start", "message": head}),
-            event(
-                "content_block_start",
-                {
-                    "type": "content_block_start",
-                    "index": 0,
-                    "content_block": {"type": "text", "text": ""},
-                },
-            ),
-            event(
-                "content_block_delta",
-                {
-                    "type": "content_block_delta",
-                    "index": 0,
-                    "delta": {"type": "text_delta", "text": text},
-                },
-            ),
-            event("content_block_stop", {"type": "content_block_stop", "index": 0}),
-            event(
-                "message_delta",
-                {
-                    "type": "message_delta",
-                    "delta": {"stop_reason": "end_turn", "stop_sequence": None},
-                    "usage": raw.get("usage") or {},
-                },
-            ),
-            event("message_stop", {"type": "message_stop"}),
-        ]
+        events = (
+            [event("message_start", {"type": "message_start", "message": head})]
+            if include_start
+            else []
+        )
+        for index, block in enumerate(raw.get("content") or []):
+            kind = block.get("type")
+            if kind == "thinking":
+                start = {**block, "thinking": "", "signature": ""}
+                delta = {
+                    "type": "thinking_delta",
+                    "thinking": block.get("thinking", ""),
+                }
+            elif kind == "tool_use":
+                start = {**block, "input": {}}
+                delta = {
+                    "type": "input_json_delta",
+                    "partial_json": json.dumps(block.get("input") or {}),
+                }
+            else:
+                start = {**block, "text": ""}
+                delta = {"type": "text_delta", "text": block.get("text", "")}
+            events.extend(
+                [
+                    event(
+                        "content_block_start",
+                        {
+                            "type": "content_block_start",
+                            "index": index,
+                            "content_block": start,
+                        },
+                    ),
+                    event(
+                        "content_block_delta",
+                        {
+                            "type": "content_block_delta",
+                            "index": index,
+                            "delta": delta,
+                        },
+                    ),
+                    event(
+                        "content_block_stop",
+                        {"type": "content_block_stop", "index": index},
+                    ),
+                ]
+            )
+        events.extend(
+            [
+                event(
+                    "message_delta",
+                    {
+                        "type": "message_delta",
+                        "delta": {
+                            "stop_reason": raw.get("stop_reason") or "end_turn",
+                            "stop_sequence": raw.get("stop_sequence"),
+                        },
+                        "usage": raw.get("usage") or {},
+                    },
+                ),
+                event("message_stop", {"type": "message_stop"}),
+            ]
+        )
+        return events
+
+    def stream_start(
+        self, body: MessageCreateParams, *, sequence_number: int = 0
+    ) -> list[bytes]:
+        head = {
+            "id": "msg_vf_intercept",
+            "content": [],
+            "model": body.get("model", ""),
+            "role": "assistant",
+            "stop_reason": None,
+            "stop_sequence": None,
+            "type": "message",
+            "usage": {"input_tokens": 0, "output_tokens": 0},
+        }
+        payload = {"type": "message_start", "message": head}
+        return [f"event: message_start\ndata: {json.dumps(payload)}\n\n".encode()]
+
+    def stream_heartbeat(
+        self, body: MessageCreateParams, *, sequence_number: int = 0
+    ) -> bytes:
+        # The Anthropic SDK consumes `ping` internally and does not yield it to callers.
+        # A no-op message delta reaches SDK-level watchdogs without changing content.
+        payload = {"type": "message_delta", "delta": {}, "usage": {"output_tokens": 0}}
+        return f"event: message_delta\ndata: {json.dumps(payload)}\n\n".encode()
+
+    def stream_error(self, message: str, *, sequence_number: int = 0) -> bytes:
+        return (
+            f"event: error\ndata: {json.dumps(self.error_body(message))}\n\n"
+        ).encode()
 
     def stream_parser(self) -> StreamParser:
         return AnthropicStreamParser(self.validate_response)

--- a/verifiers/v1/dialects/base.py
+++ b/verifiers/v1/dialects/base.py
@@ -6,9 +6,10 @@ every registered dialect's `routes` (see `dialects.DIALECTS`), so a request's fo
 from the endpoint the program's SDK posts to — the harness declares nothing.
 
 The eval client preserves a request's native JSON fields except for eval-owned overrides, while a
-dialect-owned `StreamParser` incrementally assembles a response copy for the trace; the renderer is chat-only.
-A dialect is therefore mostly wire -> vf (`parse_request`/`parse_response`/`stream_parser`); the
-exception is `apply_overrides` (impose the eval's model + sampling in this format's shape).
+dialect-owned `StreamParser` incrementally assembles a response copy for the trace. Training clients
+render the canonical request and ask the dialect to serialize the completed canonical response.
+A dialect therefore owns both wire -> vf (`parse_request`/`parse_response`/`stream_parser`) and the
+small vf -> wire surface needed for renderer-backed inference (`serialize_response`/stream events).
 """
 
 import json
@@ -213,6 +214,10 @@ class Dialect(ABC, Generic[ReqT, RespT]):
         return self.response_type.model_validate(raw)
 
     @abstractmethod
+    def serialize_response(self, response: Response, model: str) -> dict:
+        """Serialize a renderer-backed canonical response in this dialect's native shape."""
+
+    @abstractmethod
     def rewrite_request(self, body: ReqT, before: Request, after: Request) -> None:
         """Patch rewritten user/tool messages into the native conversation."""
 
@@ -221,8 +226,30 @@ class Dialect(ABC, Generic[ReqT, RespT]):
         """Replace the native assistant response with inert text."""
 
     @abstractmethod
-    def stream_events(self, raw: dict) -> list[bytes]:
-        """Serialize a rewritten response as a minimal native SSE stream."""
+    def stream_events(
+        self,
+        raw: dict,
+        *,
+        include_start: bool = True,
+        sequence_number: int = 0,
+    ) -> list[bytes]:
+        """Serialize a completed or rewritten response as a minimal native SSE stream."""
+
+    @abstractmethod
+    def stream_start(self, body: ReqT, *, sequence_number: int = 0) -> list[bytes]:
+        """Start a buffered native stream before generation has completed."""
+
+    @abstractmethod
+    def stream_heartbeat(self, body: ReqT, *, sequence_number: int = 0) -> bytes:
+        """One valid, non-content protocol event while buffered generation is in flight.
+
+        Unlike an SSE comment, this reaches clients whose liveness watchdog resets only after
+        decoding an API event. It must not change the assistant content assembled by the client.
+        """
+
+    def stream_error(self, message: str, *, sequence_number: int = 0) -> bytes:
+        """A streamed error in the default OpenAI-compatible envelope."""
+        return f"data: {json.dumps(self.error_body(message))}\n\n".encode()
 
     @abstractmethod
     def stream_parser(self) -> StreamParser:

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -505,6 +505,49 @@ class ChatDialect(Dialect[CompletionCreateParams, ChatCompletion]):
     def parse_response(self, response: ChatCompletion) -> Response:
         return response_from_wire(response)
 
+    def serialize_response(self, response: Response, model: str) -> dict:
+        message: dict = {"role": "assistant", "content": response.message.content}
+        if response.message.reasoning_content is not None:
+            message["reasoning_content"] = response.message.reasoning_content
+        if response.message.tool_calls:
+            message["tool_calls"] = [
+                {
+                    "id": call.id,
+                    "type": "function",
+                    "function": {"name": call.name, "arguments": call.arguments},
+                }
+                for call in response.message.tool_calls
+            ]
+        usage: dict | None = None
+        if response.usage:
+            usage = {
+                "completion_tokens": response.usage.completion_tokens,
+                "prompt_tokens": response.usage.input_tokens,
+                "total_tokens": response.usage.total_tokens,
+            }
+            if response.usage.reasoning_tokens is not None:
+                usage["completion_tokens_details"] = {
+                    "reasoning_tokens": response.usage.reasoning_tokens
+                }
+            if response.usage.cached_input_tokens is not None:
+                usage["prompt_tokens_details"] = {
+                    "cached_tokens": response.usage.cached_input_tokens
+                }
+        return {
+            "id": response.id or "vf-intercept",
+            "object": "chat.completion",
+            "created": response.created,
+            "model": response.model or model,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": message,
+                    "finish_reason": response.finish_reason or "stop",
+                }
+            ],
+            "usage": usage,
+        }
+
     def rewrite_request(self, body: dict, before: Request, after: Request) -> None:
         for native, original, rewritten in zip(
             body.get("messages", []), before.messages, after.messages, strict=True
@@ -524,7 +567,13 @@ class ChatDialect(Dialect[CompletionCreateParams, ChatCompletion]):
                 choice["finish_reason"] = "stop"
                 choice.pop("logprobs", None)
 
-    def stream_events(self, raw: dict) -> list[bytes]:
+    def stream_events(
+        self,
+        raw: dict,
+        *,
+        include_start: bool = True,
+        sequence_number: int = 0,
+    ) -> list[bytes]:
         choice = (raw.get("choices") or [{}])[0]
         chunk = {
             **{key: value for key, value in raw.items() if key != "choices"},
@@ -539,6 +588,30 @@ class ChatDialect(Dialect[CompletionCreateParams, ChatCompletion]):
             ],
         }
         return [f"data: {json.dumps(chunk)}\n\n".encode(), b"data: [DONE]\n\n"]
+
+    def stream_start(
+        self, body: CompletionCreateParams, *, sequence_number: int = 0
+    ) -> list[bytes]:
+        return [self.stream_heartbeat(body, sequence_number=sequence_number)]
+
+    def stream_heartbeat(
+        self, body: CompletionCreateParams, *, sequence_number: int = 0
+    ) -> bytes:
+        # An empty delta is observable to SDK-level watchdogs but contributes no text.
+        chunk = {
+            "id": "vf-intercept",
+            "object": "chat.completion.chunk",
+            "created": 0,
+            "model": body.get("model", ""),
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"content": ""},
+                    "finish_reason": None,
+                }
+            ],
+        }
+        return f"data: {json.dumps(chunk)}\n\n".encode()
 
     def stream_parser(self) -> StreamParser:
         return ChatStreamParser()

--- a/verifiers/v1/dialects/responses.py
+++ b/verifiers/v1/dialects/responses.py
@@ -2,9 +2,9 @@
 
 Request parsing walks the `input` items, folding each run of assistant-side items (reasoning /
 assistant message / function or custom tool call) into one typed assistant message; response
-parsing reads the `output` items. Relay-only: the eval client forwards the program's bytes to a
-`/responses` endpoint and this dialect parses a copy for the trace. Server-side statefulness
-(`previous_response_id`) is not emulated — the endpoint owns it.
+parsing reads the `output` items. Eval clients relay native bytes; renderer-backed clients render
+the canonical request and this dialect serializes their completed response back to native events.
+Server-side statefulness (`previous_response_id`) is not emulated — the endpoint owns it.
 """
 
 import json
@@ -602,6 +602,83 @@ class ResponsesDialect(Dialect[ResponseCreateParams, OpenAIResponse]):
     def parse_response(self, response: OpenAIResponse) -> Response:
         return response_from_wire(response)
 
+    def serialize_response(self, response: Response, model: str) -> dict:
+        output: list[dict] = []
+        if response.message.reasoning_content is not None:
+            output.append(
+                {
+                    "id": "rs_vf_intercept",
+                    "summary": [
+                        {
+                            "type": "summary_text",
+                            "text": response.message.reasoning_content,
+                        }
+                    ],
+                    "type": "reasoning",
+                    "status": "completed",
+                }
+            )
+        if response.message.content is not None or not (
+            response.message.reasoning_content or response.message.tool_calls
+        ):
+            output.append(
+                {
+                    "id": "msg_vf_intercept",
+                    "content": [
+                        {
+                            "annotations": [],
+                            "text": response.message.content or "",
+                            "type": "output_text",
+                        }
+                    ],
+                    "role": "assistant",
+                    "status": "completed",
+                    "type": "message",
+                }
+            )
+        for index, call in enumerate(response.message.tool_calls or []):
+            output.append(
+                {
+                    "arguments": call.arguments,
+                    "call_id": call.id,
+                    "id": f"fc_vf_intercept_{index}",
+                    "name": call.name,
+                    "status": "completed",
+                    "type": "function_call",
+                }
+            )
+        usage = None
+        if response.usage:
+            usage = {
+                "input_tokens": response.usage.input_tokens,
+                "input_tokens_details": {
+                    "cache_write_tokens": 0,
+                    "cached_tokens": response.usage.cached_input_tokens or 0,
+                },
+                "output_tokens": response.usage.completion_tokens,
+                "output_tokens_details": {
+                    "reasoning_tokens": response.usage.reasoning_tokens or 0
+                },
+                "total_tokens": response.usage.total_tokens,
+            }
+        status = "incomplete" if response.finish_reason == "length" else "completed"
+        return {
+            "id": response.id or "resp_vf_intercept",
+            "created_at": response.created,
+            "error": None,
+            "incomplete_details": {"reason": "max_output_tokens"}
+            if status == "incomplete"
+            else None,
+            "model": response.model or model,
+            "object": "response",
+            "output": output,
+            "parallel_tool_calls": True,
+            "status": status,
+            "tool_choice": "auto",
+            "tools": [],
+            "usage": usage,
+        }
+
     def rewrite_request(self, body: dict, before: Request, after: Request) -> None:
         original = [
             m for m in before.messages if isinstance(m, (UserMessage, ToolMessage))
@@ -684,39 +761,188 @@ class ResponsesDialect(Dialect[ResponseCreateParams, OpenAIResponse]):
         if "output_text" in raw:
             raw["output_text"] = text
 
-    def stream_events(self, raw: dict) -> list[bytes]:
-        item = raw["output"][0]
-        part = item["content"][0]
-        common = {"output_index": 0, "item_id": item["id"], "content_index": 0}
+    def stream_events(
+        self,
+        raw: dict,
+        *,
+        include_start: bool = True,
+        sequence_number: int = 0,
+    ) -> list[bytes]:
         head = {
             **raw,
             "status": "in_progress",
             "output": [],
             "completed_at": None,
         }
-        events = [
-            ("response.created", {"response": head}),
-            (
-                "response.output_item.added",
-                {"output_index": 0, "item": {**item, "content": []}},
-            ),
-            (
-                "response.content_part.added",
-                {**common, "part": {**part, "text": ""}},
-            ),
-            ("response.output_text.delta", {**common, "delta": part["text"]}),
-            ("response.output_text.done", {**common, "text": part["text"]}),
-            ("response.content_part.done", {**common, "part": part}),
-            ("response.output_item.done", {"output_index": 0, "item": item}),
-            ("response.completed", {"response": raw}),
-        ]
+        events: list[tuple[str, dict]] = (
+            [("response.created", {"response": head})] if include_start else []
+        )
+        for output_index, item in enumerate(raw.get("output") or []):
+            kind = item.get("type")
+            added = dict(item)
+            if kind == "message":
+                added["content"] = []
+            elif kind == "reasoning":
+                added["summary"] = []
+            elif kind == "function_call":
+                added["arguments"] = ""
+            events.append(
+                (
+                    "response.output_item.added",
+                    {"output_index": output_index, "item": added},
+                )
+            )
+            if kind == "message":
+                for content_index, part in enumerate(item.get("content") or []):
+                    common = {
+                        "output_index": output_index,
+                        "item_id": item["id"],
+                        "content_index": content_index,
+                    }
+                    events.extend(
+                        [
+                            (
+                                "response.content_part.added",
+                                {**common, "part": {**part, "text": ""}},
+                            ),
+                            (
+                                "response.output_text.delta",
+                                {
+                                    **common,
+                                    "delta": part.get("text", ""),
+                                    "logprobs": [],
+                                },
+                            ),
+                            (
+                                "response.output_text.done",
+                                {
+                                    **common,
+                                    "text": part.get("text", ""),
+                                    "logprobs": [],
+                                },
+                            ),
+                            ("response.content_part.done", {**common, "part": part}),
+                        ]
+                    )
+            elif kind == "reasoning":
+                for summary_index, part in enumerate(item.get("summary") or []):
+                    common = {
+                        "output_index": output_index,
+                        "item_id": item["id"],
+                        "summary_index": summary_index,
+                    }
+                    events.extend(
+                        [
+                            (
+                                "response.reasoning_summary_part.added",
+                                {**common, "part": {**part, "text": ""}},
+                            ),
+                            (
+                                "response.reasoning_summary_text.delta",
+                                {**common, "delta": part.get("text", "")},
+                            ),
+                            (
+                                "response.reasoning_summary_text.done",
+                                {**common, "text": part.get("text", "")},
+                            ),
+                            (
+                                "response.reasoning_summary_part.done",
+                                {**common, "part": part},
+                            ),
+                        ]
+                    )
+            elif kind == "function_call":
+                common = {
+                    "output_index": output_index,
+                    "item_id": item["id"],
+                }
+                events.extend(
+                    [
+                        (
+                            "response.function_call_arguments.delta",
+                            {**common, "delta": item.get("arguments", "")},
+                        ),
+                        (
+                            "response.function_call_arguments.done",
+                            {
+                                **common,
+                                "arguments": item.get("arguments", ""),
+                                "name": item.get("name", ""),
+                            },
+                        ),
+                    ]
+                )
+            events.append(
+                (
+                    "response.output_item.done",
+                    {"output_index": output_index, "item": item},
+                )
+            )
+        terminal = (
+            "response.incomplete"
+            if raw.get("status") == "incomplete"
+            else "response.completed"
+        )
+        events.append((terminal, {"response": raw}))
         return [
             *(
                 f"data: {json.dumps({'type': kind, 'sequence_number': i, **data})}\n\n".encode()
-                for i, (kind, data) in enumerate(events)
+                for i, (kind, data) in enumerate(events, start=sequence_number)
             ),
             b"data: [DONE]\n\n",
         ]
+
+    def stream_start(
+        self, body: ResponseCreateParams, *, sequence_number: int = 0
+    ) -> list[bytes]:
+        response = {
+            "id": "resp_vf_intercept",
+            "created_at": 0,
+            "model": body.get("model", ""),
+            "object": "response",
+            "output": [],
+            "parallel_tool_calls": True,
+            "status": "in_progress",
+            "tool_choice": "auto",
+            "tools": [],
+        }
+        event = {
+            "type": "response.created",
+            "sequence_number": sequence_number,
+            "response": response,
+        }
+        return [f"data: {json.dumps(event)}\n\n".encode()]
+
+    def stream_heartbeat(
+        self, body: ResponseCreateParams, *, sequence_number: int = 0
+    ) -> bytes:
+        response = {
+            "id": "resp_vf_intercept",
+            "created_at": 0,
+            "model": body.get("model", ""),
+            "object": "response",
+            "output": [],
+            "parallel_tool_calls": True,
+            "status": "in_progress",
+            "tool_choice": "auto",
+            "tools": [],
+        }
+        event = {
+            "type": "response.in_progress",
+            "sequence_number": sequence_number,
+            "response": response,
+        }
+        return f"data: {json.dumps(event)}\n\n".encode()
+
+    def stream_error(self, message: str, *, sequence_number: int = 0) -> bytes:
+        event = {
+            "type": "error",
+            "sequence_number": sequence_number,
+            "code": "server_error",
+            "message": message,
+            "param": None,
+        }
+        return f"data: {json.dumps(event)}\n\n".encode()
 
     def stream_parser(self) -> StreamParser:
         return ResponsesStreamParser()

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -669,9 +669,8 @@ class InterceptionServer(Interception):
         inspect_response: bool,
         policy_paths: list[str] | None = None,
     ) -> web.StreamResponse:
-        """A streamed (SSE) model turn: relay the provider's stream through to the program,
-        incrementally assembling the response to record on the trace (the only client that
-        streams is the eval relay)."""
+        """A streamed (SSE) model turn: relay or synthesize a stream for the program,
+        incrementally assembling the response to record on the trace."""
         session.error = None
         reply = None
         response: Response | None = None
@@ -683,8 +682,10 @@ class InterceptionServer(Interception):
                 reply = await session.client.relay(
                     dialect,
                     body,
+                    session.ctx.sampling,
                     headers=request.headers,
                     session_id=session.trace.id,
+                    turn=turn,
                 )
             except OverlongPromptError as e:
                 error = e
@@ -710,6 +711,133 @@ class InterceptionServer(Interception):
                 logger.warning("model call failed: id=%s %s", session.trace.id, e)
                 return web.json_response(dialect.error_body(str(e)), status=502)
 
+            if reply.result is not None:
+                # Renderer-backed inference is intentionally buffered: the engine returns exact
+                # completion token ids/logprobs only with the completed generation. Prepare the
+                # SSE response now and emit dialect-valid, content-free progress events until that
+                # result arrives; ordinary SSE comments never reach some SDK watchdogs.
+                resp = web.StreamResponse(
+                    headers={"Cache-Control": "no-cache", "Connection": "keep-alive"}
+                )
+                resp.content_type = reply.content_type.split(";")[0].strip()
+                result = asyncio.ensure_future(reply.result)
+                stream_sequence = 0
+                try:
+                    await resp.prepare(request)
+                    start_events = dialect.stream_start(
+                        body, sequence_number=stream_sequence
+                    )
+                    for event in start_events:
+                        await resp.write(event)
+                    stream_sequence += len(start_events)
+                    while not result.done():
+                        try:
+                            await asyncio.wait_for(
+                                asyncio.shield(result),
+                                timeout=KEEPALIVE_INTERVAL_SECONDS,
+                            )
+                        except TimeoutError:
+                            await resp.write(
+                                dialect.stream_heartbeat(
+                                    body, sequence_number=stream_sequence
+                                )
+                            )
+                            stream_sequence += 1
+                    response = result.result()
+
+                    response_rewrites = []
+                    stopped = None
+                    if inspect_response:
+                        (
+                            response,
+                            response_rewrites,
+                            stopped,
+                        ) = await session.rewrite_response(response)
+                        if response_rewrites:
+                            assert response.raw is not None
+                            dialect.rewrite_response(
+                                response.raw, response.message.content or ""
+                            )
+                            raw_response = response.raw
+                            response = dialect.parse_response(
+                                dialect.validate_response(raw_response)
+                            )
+                            response.raw = raw_response
+
+                    if session.released or session.stopped:
+                        message = (
+                            "rollout concluded"
+                            if session.released
+                            else f"rollout stopped: {session.trace.stop_condition}"
+                        )
+                        await resp.write(
+                            dialect.stream_error(
+                                message, sequence_number=stream_sequence
+                            )
+                        )
+                        await resp.write_eof()
+                        return resp
+
+                    node = turn.commit(response, model_request.tools)
+                    session.consume_prepared(turn.tail)
+                    session.trace.response_rewrites.extend(response_rewrites)
+                    if stopped is not None:
+                        session.trace.stop(stopped)
+                        await resp.write(
+                            dialect.stream_error(
+                                f"rollout stopped: {stopped}",
+                                sequence_number=stream_sequence,
+                            )
+                        )
+                    else:
+                        for event in dialect.stream_events(
+                            response.raw or {},
+                            include_start=False,
+                            sequence_number=stream_sequence,
+                        ):
+                            await resp.write(event)
+                    await resp.write_eof()
+                    return resp
+                except ConnectionResetError as e:
+                    error = e
+                    return resp
+                except OverlongPromptError as e:
+                    error = e
+                    session.trace.stop("context_length")
+                    with contextlib.suppress(ConnectionResetError):
+                        await resp.write(
+                            dialect.stream_error(
+                                "rollout stopped: context_length",
+                                sequence_number=stream_sequence,
+                            )
+                        )
+                        await resp.write_eof()
+                    return resp
+                except RolloutError as e:
+                    error = e
+                    session.error = e
+                    with contextlib.suppress(ConnectionResetError):
+                        await resp.write(
+                            dialect.stream_error(
+                                str(e), sequence_number=stream_sequence
+                            )
+                        )
+                        await resp.write_eof()
+                    return resp
+                except Exception as e:  # noqa: BLE001 - surface as a streamed API error
+                    error = ProviderError(str(e))
+                    session.error = error
+                    with contextlib.suppress(ConnectionResetError):
+                        await resp.write(
+                            dialect.stream_error(
+                                str(error), sequence_number=stream_sequence
+                            )
+                        )
+                        await resp.write_eof()
+                    return resp
+                finally:
+                    await reply.close()
+
             if inspect_response:
                 buffered = SpooledTemporaryFile(  # noqa: SIM115 - closed before every exit
                     max_size=STREAM_MEMORY_BUFFER
@@ -727,7 +855,12 @@ class InterceptionServer(Interception):
                         raise ProviderError(
                             "upstream stream ended before its terminal event"
                         )
-                    response = parser.finish()
+                    parsed_response = parser.finish()
+                    response = (
+                        await reply.result
+                        if reply.result is not None
+                        else parsed_response
+                    )
                     response_rewrites = []
                     stopped = None
                     if session.response_interceptors or session.response_stops:
@@ -875,7 +1008,10 @@ class InterceptionServer(Interception):
             try:
                 if parser_error is not None:
                     raise parser_error
-                response = parser.finish()
+                parsed_response = parser.finish()
+                response = (
+                    await reply.result if reply.result is not None else parsed_response
+                )
                 if not session.released and not session.stopped:
                     node = turn.commit(response, model_request.tools)
                     session.consume_prepared(turn.tail)


### PR DESCRIPTION
## Summary

- support renderer-backed training for harnesses that require `stream=true`
- canonicalize Chat Completions, Responses, and Anthropic requests for rendering, then let each dialect serialize the completed response in its native JSON and SSE shape
- open buffered streams immediately and emit dialect-valid, content-free progress events while generation runs
- commit the authoritative renderer result before terminal events, preserving exact completion token IDs and logprobs

## Why

Streaming harness calls enter the interception server's relay path. Eval clients can relay provider SSE, but the training client previously only implemented non-streaming `get_response()`, so those harnesses failed before generation.

Renderer generation remains intentionally buffered. The engine's completed result is still the source of truth for tokens and logprobs; Verifiers only adapts its delivery to the streaming protocols expected by harness SDKs.

Ordinary SSE comments are insufficient for clients that reset liveness only after decoding an API event. During generation, Verifiers therefore sends native no-content events: an empty Chat delta, Responses lifecycle events, or an empty Anthropic message delta. No fake model text or tool arguments are introduced.

Grok Build's newer content watchdog intentionally ignores lifecycle and empty-delta events. The companion Grok harness PR, #2366, sets that independent watchdog beyond Verifiers' maximum remote runtime instead of fabricating model tokens.

## Scope

- renderer output is buffered, not token-streamed
- Chat Completions, Responses, and Anthropic are supported through the dialect interface
- eval-provider streaming remains unchanged
- request/response rewrites and trace commits happen before the client receives a terminal event

## Validation

- `uv run pytest tests/` — 914 passed, 75 skipped
- `uv run pytest tests/v1 -m 'not e2e'` — 70 passed
- temporary protocol matrix validated text, reasoning, tool calls, and truncation across all three dialect parsers and the installed OpenAI/Anthropic SDK event models
- exact Grok Build 1.0.3 behavioral smoke confirmed parsed Responses lifecycle events keep its pinned watchdog alive
- changed-file pre-commit hooks passed
- pre-push Ruff, format, and `ty` hooks passed

Live Prime requests reached the inference service, but the currently available model deployments did not provide a complete training smoke: attempts encountered a removed model, an unsupported generate route, missing generate logprobs, and a temporary 502. The deterministic protocol and full repository suites above are green.

The all-files markdown hook reports 321 pre-existing MD033 findings in the untouched `verifiers/legacy/envs/experimental/composable/tasksets/swe/README.md`.

The commit is signed with the contributor's verified SSH signing key.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- Macroscope's pull request summary ends here -->
