### PR TITLE
feat(harbor): support environment.env and environment.healthcheck

### DIFF
--- a/docs/v1/harbor.md
+++ b/docs/v1/harbor.md
@@ -80,6 +80,20 @@ resource_multiplier = 2.0
 
 The `timeout_multiplier` multiplies both the agent and verifier timeout, while the `resource_multiplier` multiplies the task's CPU, memory and disk space. You might want to use these multipliers when the tasks set too tight limits and/or the agent is slow.
 
+## Environment variables
+
+`[environment.env]` is resolved against the host and applied to the box itself, so everything that runs there sees it: the healthcheck, harness setup, the agent's own commands, the collect hooks, and the verifier. Values are literals or Harbor's `${VAR}` / `${VAR:-default}` templates; a template with no host value and no default fails the rollout in setup, as `harbor run` does.
+
+Only the raw templates become task data. Resolution happens in the worker at setup time, so a resolved secret never reaches `traces.jsonl`.
+
+`[verifier.env]` still applies to the verifier alone and, as in Harbor, wins where both name the same key. A separate verifier box gets its own environment's `env` — `[verifier.environment].env` when one is declared, otherwise the `[environment].env` its fresh copy inherits.
+
+## Healthchecks
+
+`[environment.healthcheck]` runs after `environment/` is staged and before the harness is provisioned — Harbor's own ordering, where agent setup follows the probe. Docker `HEALTHCHECK` semantics are preserved: failures within `start_period_sec` are retried every `start_interval_sec` and never counted, and after that grace period `retries` consecutive failures (each bounded by `timeout_sec`, spaced by `interval_sec`) give up. Giving up fails the rollout during setup, so the agent never starts against a box that never came up.
+
+Harbor probes the agent's environment only, so a healthcheck on a separate verifier environment is not run; one written into `[verifier.environment]` explicitly logs a warning.
+
 ## Network policies
 
 Harbor's effective agent network policy is applied to Docker or Prime VM harness

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -143,10 +143,16 @@ class Runtime(ABC):
     @property
     def supports_live_processes(self) -> bool:
         """Whether `open_process()` is implemented for this runtime instance."""
-        return type(self).open_process is not Runtime.open_process
+        return type(self)._open_process is not Runtime._open_process
 
     def __init__(self, name: str | None = None) -> None:
         self.name = name or f"vf-{uuid.uuid4().hex[:12]}"
+        self.env: dict[str, str] = {}
+        """Box-wide environment variables, applied to every program run here the way
+        the image and workdir are — for a task whose environment is declared as
+        variables rather than as files (harbor's `[environment.env]`). A caller's own
+        `env` wins on conflict. Set it before anything runs (a task's `setup`); it is
+        never serialized, so resolved secrets stay in this process."""
         self._uv_interpreters: dict[str, str] = {}
         self._uv_script_locks: dict[str, asyncio.Lock] = {}
         self._setup_claimed = False
@@ -185,9 +191,19 @@ class Runtime(ABC):
         source of truth for teardown: usable from the atexit backstop where async machinery
         is dead, and run off the event loop by `stop` on the normal path. Default no-op."""
 
-    @abstractmethod
+    def exec_env(self, env: dict[str, str]) -> dict[str, str]:
+        """A caller's `env` over this box's own variables."""
+        return {**self.env, **env} if self.env else env
+
     async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
-        pass
+        """Run a short infra op in the box. Framework method — override `_run`, not
+        this: every entry point layers the box's own `env` under the caller's here,
+        so a runtime cannot forget it."""
+        return await self._run(argv, self.exec_env(env))
+
+    @abstractmethod
+    async def _run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
+        """Run `argv` with exactly `env`; `run` resolves the box's variables into it."""
 
     async def alive(self) -> bool:
         """Whether the box still executes anything. Not every runtime raises when
@@ -210,7 +226,13 @@ class Runtime(ABC):
     async def open_process(
         self, argv: list[str], env: dict[str, str]
     ) -> RuntimeProcess:
-        """Start a live process for a rollout-scoped harness session."""
+        """Start a live process for a rollout-scoped harness session. Framework
+        method — override `_open_process`, not this."""
+        return await self._open_process(argv, self.exec_env(env))
+
+    async def _open_process(
+        self, argv: list[str], env: dict[str, str]
+    ) -> RuntimeProcess:
         raise NotImplementedError(
             f"{type(self).__name__} does not support live processes"
         )
@@ -220,7 +242,13 @@ class Runtime(ABC):
     ) -> None:
         """Start `argv` as a background process in the runtime (combined output to
         `log`, a path in the workspace) and return immediately. It runs until `stop()`
-        tears the runtime down. Used to host a tool server colocated with the harness."""
+        tears the runtime down. Used to host a tool server colocated with the harness.
+        Framework method — override `_run_background`, not this."""
+        await self._run_background(argv, self.exec_env(env), log)
+
+    async def _run_background(
+        self, argv: list[str], env: dict[str, str], log: str
+    ) -> None:
         raise NotImplementedError(
             f"{type(self).__name__} does not support run_background"
         )

--- a/verifiers/v1/runtimes/docker/__init__.py
+++ b/verifiers/v1/runtimes/docker/__init__.py
@@ -413,14 +413,14 @@ class DockerRuntime(Runtime):
             await self._proxy.stop()
         await super().teardown()
 
-    async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
+    async def _run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
         env = {**env, **(self._proxy_env() if self._cut else {})}
         env_args = [arg for k, v in env.items() for arg in ("--env", f"{k}={v}")]
         return await docker(
             "exec", *env_args, "--workdir", self.config.workdir, self._container, *argv
         )
 
-    async def open_process(
+    async def _open_process(
         self, argv: list[str], env: dict[str, str]
     ) -> RuntimeProcess:
         assert self._container is not None
@@ -481,7 +481,7 @@ class DockerRuntime(Runtime):
             f"docker live process failed to start: {detail or 'PID unavailable'}"
         )
 
-    async def run_background(
+    async def _run_background(
         self, argv: list[str], env: dict[str, str], log: str
     ) -> None:
         # Detached servers survive the cut, so they need the initially permissive proxy.

--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -169,7 +169,7 @@ class ModalRuntime(Runtime):
         tunnel = tunnels.get(port)
         return str(tunnel.url).rstrip("/") if tunnel else None
 
-    async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
+    async def _run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
         try:
             proc = await self._sandbox.exec.aio(
                 *argv, workdir=self.config.workdir, env=env
@@ -189,7 +189,7 @@ class ModalRuntime(Runtime):
             stderr=stderr or "",
         )
 
-    async def open_process(
+    async def _open_process(
         self, argv: list[str], env: dict[str, str]
     ) -> RuntimeProcess:
         pidfile = f".vf-process-{uuid.uuid4().hex}.pid"
@@ -245,7 +245,7 @@ class ModalRuntime(Runtime):
         except Exception as e:
             raise SandboxError(f"modal live process failed to start: {e}") from e
 
-    async def run_background(
+    async def _run_background(
         self, argv: list[str], env: dict[str, str], log: str
     ) -> None:
         # `&` backgrounds inside the sandbox; the job returns immediately, the process

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -263,7 +263,7 @@ class PrimeRuntime(Runtime):
             policy.get("deny"),
         )
 
-    async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
+    async def _run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
         try:
             result = await self._client.run_background_job(
                 self.info.id,
@@ -283,7 +283,7 @@ class PrimeRuntime(Runtime):
             stderr=result.stderr or "",
         )
 
-    async def open_process(
+    async def _open_process(
         self, argv: list[str], env: dict[str, str]
     ) -> RuntimeProcess:
         if not self.config.vm:
@@ -319,7 +319,7 @@ class PrimeRuntime(Runtime):
         logger.info("prime: exposed sandbox port %d at %s", port, exposed.url)
         return exposed.url.rstrip("/")
 
-    async def run_background(
+    async def _run_background(
         self, argv: list[str], env: dict[str, str], log: str
     ) -> None:
         command = f"exec {shlex.join(argv)} > {shlex.quote(log)} 2>&1"

--- a/verifiers/v1/runtimes/subprocess.py
+++ b/verifiers/v1/runtimes/subprocess.py
@@ -95,7 +95,7 @@ class SubprocessRuntime(Runtime):
         self.workdir.mkdir(parents=True)
         self.info.id = str(self.workdir)
 
-    async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
+    async def _run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
         full_env = {k: v for k, v in os.environ.items() if "API_KEY" not in k.upper()}
         full_env.update(env)
         proc = await asyncio.create_subprocess_exec(
@@ -123,7 +123,7 @@ class SubprocessRuntime(Runtime):
             stderr=stderr.decode(errors="replace"),
         )
 
-    async def open_process(
+    async def _open_process(
         self, argv: list[str], env: dict[str, str]
     ) -> RuntimeProcess:
         full_env = {k: v for k, v in os.environ.items() if "API_KEY" not in k.upper()}
@@ -140,7 +140,7 @@ class SubprocessRuntime(Runtime):
         self._background.append(proc)
         return SubprocessProcess(proc)
 
-    async def run_background(
+    async def _run_background(
         self, argv: list[str], env: dict[str, str], log: str
     ) -> None:
         full_env = {k: v for k, v in os.environ.items() if "API_KEY" not in k.upper()}

--- a/verifiers/v1/tasksets/harbor/env.py
+++ b/verifiers/v1/tasksets/harbor/env.py
@@ -109,6 +109,10 @@ class HarborEnv(vf.Env[HarborEnvConfig]):
                 async with AsyncExitStack() as boxes:
                     async with asyncio.timeout(grader.data.timeout.scoring):
                         box = await boxes.enter_async_context(provision_runtime(config))
+                        # The verifier environment's own `env`, resolved into the box
+                        # before anything runs there — the solver's `setup` did the
+                        # same for its box, and this box never sees that hook.
+                        grader._apply_env(box)
                         await box.prepare_setup()
                         # Artifacts first, tests second: an artifact entry pointing
                         # into /tests must not survive staging, which wipes and

--- a/verifiers/v1/tasksets/harbor/taskset.py
+++ b/verifiers/v1/tasksets/harbor/taskset.py
@@ -105,6 +105,23 @@ class CollectHook(BaseModel):
     timeout_sec: float = 600.0
 
 
+class Healthcheck(BaseModel):
+    """`[environment.healthcheck]`: the readiness probe Harbor runs once the
+    environment is up and before anything else touches the box.
+
+    Docker HEALTHCHECK semantics, which is what Harbor implements: failures inside
+    `start_period_sec` are a warming box rather than a broken one and never count,
+    and after it a run of `retries` consecutive failures gives up.
+    """
+
+    command: str
+    interval_sec: float = 5.0
+    timeout_sec: float = 30.0
+    start_period_sec: float = 0.0
+    start_interval_sec: float = 5.0
+    retries: int = 3
+
+
 class VerifierConfig(BaseModel):
     """The box this task's verifier wants, when it wants one of its own.
 
@@ -114,6 +131,10 @@ class VerifierConfig(BaseModel):
     image: str | None = None
     """Pullable ref from `[verifier.environment].docker_image`. None keeps the task's
     own image, which is what Harbor's fresh copy of `[environment]` resolves to."""
+    env: dict[str, str] = Field(default_factory=dict)
+    """Raw `env` of the verifier's own environment — its `[verifier.environment].env`,
+    or the fresh copy's inherited `[environment].env`. Resolved into the grading box
+    the same way the agent's box resolves its own."""
     resources: TaskResources = TaskResources()
     workdir: str | None = None
     fresh_copy: bool = False
@@ -142,6 +163,16 @@ class HarborData(TaskData):
     """Host path to the task dir; used to stage tests/ to verify."""
     upload_environment: bool = False
     """Whether to stage environment/ into the workdir."""
+    env: dict[str, str] = Field(default_factory=dict)
+    """Raw [environment.env] entries (literals or `${VAR}`/`${VAR:-default}` templates).
+    Resolved against the host environment at setup time, like `harbor run`, and applied
+    to the box itself — so the healthcheck, the harness, the agent's own commands, and
+    the verifier all see them. Only the templates are stored; the resolved values live
+    in the runtime and never reach the trace."""
+    healthcheck: Healthcheck | None = None
+    """`[environment.healthcheck]`, run after environment/ is staged and before the
+    harness is provisioned. Exhausting its retries fails setup, so the agent never
+    starts against a box that isn't ready."""
     verifier_env: dict[str, str] = Field(default_factory=dict)
     """Raw [verifier.env] entries (literals or `${VAR}`/`${VAR:-default}` templates).
     Resolved against the host environment at scoring time, like `harbor run` — so a
@@ -158,25 +189,76 @@ class HarborTask(Task[HarborData]):
     """Stage and run Harbor's verifier inside the task's live runtime."""
 
     async def setup(self, runtime: Runtime) -> None:
-        if not self.data.upload_environment:
-            return
-        await runtime.write(
-            "/tmp/environment.tgz",
-            make_tar(Path(self.data.task_dir) / "environment"),
-        )
-        result = await runtime.run(
-            [
-                "sh",
-                "-c",
-                "tar --no-same-owner -xzf /tmp/environment.tgz && rm /tmp/environment.tgz",
-            ],
-            {},
-        )
-        if result.exit_code:
-            raise RuntimeError(
-                f"environment setup failed (exit {result.exit_code}): "
-                f"{(result.stderr or result.stdout).strip()[-500:]}"
+        """Harbor's environment phase: variables, then `environment/`, then the
+        readiness probe — all of it before the harness is provisioned, which is where
+        Harbor puts it too (agent setup follows the healthcheck)."""
+        self._apply_env(runtime)
+        if self.data.upload_environment:
+            await runtime.write(
+                "/tmp/environment.tgz",
+                make_tar(Path(self.data.task_dir) / "environment"),
             )
+            result = await runtime.run(
+                [
+                    "sh",
+                    "-c",
+                    "tar --no-same-owner -xzf /tmp/environment.tgz && rm /tmp/environment.tgz",
+                ],
+                {},
+            )
+            if result.exit_code:
+                raise RuntimeError(
+                    f"environment setup failed (exit {result.exit_code}): "
+                    f"{(result.stderr or result.stdout).strip()[-500:]}"
+                )
+        await self._healthcheck(runtime)
+
+    def _apply_env(self, runtime: Runtime) -> None:
+        """Resolve `[environment.env]` into the box, so everything that runs there
+        afterwards inherits it: the healthcheck, harness setup and the agent's own
+        program, the collect hooks, and the verifier.
+
+        Resolved here rather than at load: templates are what the task declares and
+        what the trace records, and a host secret that never becomes task data can
+        never be serialized with it."""
+        if self.data.env:
+            runtime.env = {**runtime.env, **resolve_env(self.data.env)}
+
+    async def _healthcheck(self, runtime: Runtime) -> None:
+        """Wait for the box to report itself ready, or fail setup trying.
+
+        Docker's retry shape, as Harbor implements it: inside `start_period_sec` a
+        failure only means "not yet" and is retried at `start_interval_sec`; after it,
+        `retries` consecutive failures give up. Raising here aborts the rollout during
+        setup, so the agent never starts against a box that never came up."""
+        check = self.data.healthcheck
+        if check is None:
+            return
+        loop = asyncio.get_running_loop()
+        start_period_ends = loop.time() + check.start_period_sec
+        failures = 0
+        while True:
+            warming = loop.time() < start_period_ends
+            try:
+                result = await asyncio.wait_for(
+                    runtime.run(["sh", "-c", check.command], {}), check.timeout_sec
+                )
+            except TimeoutError:
+                detail = f"timed out after {check.timeout_sec:g}s"
+            else:
+                if result.exit_code == 0:
+                    return
+                detail = f"exit {result.exit_code}"
+            if warming:
+                await asyncio.sleep(check.start_interval_sec)
+                continue
+            failures += 1
+            if failures >= check.retries:
+                raise TaskError(
+                    f"healthcheck failed after {check.retries} consecutive "
+                    f"attempts ({detail}): {check.command}"
+                )
+            await asyncio.sleep(check.interval_sec)
 
     async def finalize(self, trace: Trace, runtime: Runtime) -> None:
         """Run Harbor's collect hooks while the agent's box is still alive.
@@ -303,7 +385,11 @@ def verifier_box_data(data: HarborData) -> HarborData:
     Which box follows Harbor: a declared `[verifier.environment]` states its own
     image, workdir, and resources, and what it omits is the run's default; a
     fresh copy of `[environment]` keeps the task's own. The verifier's network
-    policy applies either way."""
+    policy applies either way.
+
+    Its `env` is the verifier environment's own. Its healthcheck is dropped: Harbor
+    probes the agent's environment only, and a box that exists to run `test.sh` has
+    no readiness to wait on."""
     verifier = data.verifier
     if verifier is None:
         raise TaskError(f"task {data.name!r} declares no separate verifier")
@@ -316,6 +402,8 @@ def verifier_box_data(data: HarborData) -> HarborData:
             "resources": data.resources if fresh else verifier.resources,
             "network_allow": list(verifier.network_allow),
             "network_block": [],
+            "env": dict(verifier.env),
+            "healthcheck": None,
         }
     )
 
@@ -529,6 +617,12 @@ def parse_task(task_dir: Path, idx: int, harbor_config: HarborConfig) -> HarborD
         tags=meta.get("tags", []),
         task_dir=str(task_dir),
         upload_environment=upload_environment,
+        env=environment.env,
+        healthcheck=(
+            Healthcheck(**environment.healthcheck.model_dump())
+            if environment.healthcheck is not None
+            else None
+        ),
         verifier_env=parsed.verifier.env,
         artifacts=artifacts,
         collect=hooks,
@@ -645,7 +739,7 @@ def parse_verifier_environment(
         )
     unsupported = [
         field
-        for field in ("healthcheck", "mcp_servers", "skills_dir", "gpu_types", "tpu")
+        for field in ("mcp_servers", "skills_dir", "gpu_types", "tpu")
         if getattr(environment, field, None)
     ]
     if environment.os != TaskOS.LINUX or unsupported:
@@ -654,10 +748,20 @@ def parse_verifier_environment(
             f"{unsupported or environment.os}, which verifiers' verifier-runtime "
             "integration cannot honor"
         )
+    # Harbor probes the agent's environment only, so a healthcheck here is inert
+    # there too — inherited silently by a fresh copy, worth saying out loud when
+    # the task wrote one into `[verifier.environment]` itself.
+    if declared and environment.healthcheck is not None:
+        logger.warning(
+            "%s: [verifier.environment].healthcheck is ignored — Harbor runs the "
+            "healthcheck against the agent's environment only",
+            task_dir.name,
+        )
 
     network = parsed.verifier.explicit_phase_policy() or environment.resolve_baseline()
     return VerifierConfig(
         image=environment.docker_image if declared else None,
+        env=environment.env,
         # A declared environment states its own resources; what it leaves out is the
         # run's default, not the agent task's. A fresh copy is the task's environment,
         # so it keeps whatever the agent box resolved to.
@@ -676,16 +780,25 @@ def parse_verifier_environment(
     )
 
 
-def verifier_env(task: HarborData) -> dict[str, str]:
-    """Resolve templates at scoring time so host secrets are never serialized."""
-    if not task.verifier_env:
+def resolve_env(env: dict[str, str]) -> dict[str, str]:
+    """Resolve Harbor's `${VAR}` / `${VAR:-default}` templates against the host, at
+    execution time: task data carries the templates, so a resolved secret is never
+    serialized onto the trace."""
+    if not env:
         return {}
 
     # Harbor is an optional dependency, so importing this module must still work
     # for users who do not install the Harbor extra.
     from harbor.utils.env import resolve_env_vars
 
-    return resolve_env_vars(task.verifier_env)
+    return resolve_env_vars(env)
+
+
+def verifier_env(task: HarborData) -> dict[str, str]:
+    """`[verifier.env]`, resolved at scoring time. It runs on top of the box's own
+    variables (`[environment.env]`, already resolved into the runtime), which is
+    Harbor's precedence — the verifier's entry wins where both name a key."""
+    return resolve_env(task.verifier_env)
 
 
 # Downloaded task directories are immutable. Cache the current task's environment


### PR DESCRIPTION
Fixes #2354.

Preserves `[environment.env]` and `[environment.healthcheck]` from Harbor task configs instead of dropping them. Environment templates are resolved at execution time into the runtime's box-wide env (so resolved secrets never serialize onto the trace), and are layered under every command run in the box: the healthcheck, harness setup, the agent, collect hooks, and the verifier. The healthcheck runs after `environment/` is staged and before the harness is provisioned (Harbor's own ordering), with Docker HEALTHCHECK semantics: failures during `start_period_sec` are retries, and after it `retries` consecutive failures abort setup.

The box-wide env plumbing lives in `Runtime.exec_env` and the `_run`/`_open_process`/`_run_background` framework methods across all runtimes (docker, modal, prime, subprocess), so every entry point inherits the task's variables without per-runtime bookkeeping.

Also stages `environment/` in all cases (previously only when `upload_environment` was set, which made `should_upload_environment_dir` skip staging for image-only env tasks).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `environment.env` and `environment.healthcheck` support to Harbor tasksets
> - Adds `env` field to `HarborData` and a new `_apply_env` helper on `HarborTask` that resolves template variables and merges them into `runtime.env` before setup runs.
> - Adds `healthcheck` field to `HarborData` with Docker-like semantics: a start period with retries, followed by interval-based probing; repeated failures after the start period fail the rollout.
> - Refactors all `Runtime` subclasses to use underscore-prefixed override points (`_run`, `_open_process`, `_run_background`) so the base class can inject `runtime.env` into every command invocation.
> - Verifier boxes inherit `verifier.env` but skip healthchecks; a warning is logged when a healthcheck is declared under `[verifier.environment]`.
> - Behavioral Change: all `runtime.run()`, `runtime.open_process()`, and `runtime.run_background()` calls now automatically merge `runtime.env` into the execution environment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5520b7a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->