### PR TITLE
Require explicit keys for interception replay

### DIFF
--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -406,7 +406,11 @@ class InterceptionServer(Interception):
         # fresh logical request match — compaction can legitimately regenerate an identical
         # body, and correlating its retries to another request would serve the wrong turn.
         retried = is_retried_request(request.headers)
-        if not retried:
+        if retried:
+            # The original attempt may fail before its body reaches this handler, making a
+            # marked retry the first server-visible copy of the logical request.
+            session.request_generations.setdefault(req_hash, 1)
+        else:
             session.request_generations[req_hash] = (
                 session.request_generations.get(req_hash, 0) + 1
             )

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -402,12 +402,17 @@ class InterceptionServer(Interception):
         )
         # Graph atomicity under retries: sampling a marked SDK retry again would commit a
         # second turn and fork the graph, so serve it the recorded response (or the
-        # still-computing attempt's result). Only marked retries match — a repeated body
-        # alone is no proof of a retry (compaction can legitimately regenerate an identical
-        # request), and a stale replay would loop the rollout.
+        # still-computing attempt's result). Only marked retries whose body identifies one
+        # fresh logical request match — compaction can legitimately regenerate an identical
+        # body, and correlating its retries to another request would serve the wrong turn.
         retried = is_retried_request(request.headers)
+        if not retried:
+            session.request_generations[req_hash] = (
+                session.request_generations.get(req_hash, 0) + 1
+            )
+        unambiguous_retry = retried and session.request_generations.get(req_hash) == 1
         if (
-            retried
+            unambiguous_retry
             and session.last_request == req_hash
             and session.last_response is not None
         ):
@@ -447,7 +452,10 @@ class InterceptionServer(Interception):
 
         fut: asyncio.Future[dict | None] | None = None
         if not streaming:
-            if retried and (inflight := session.inflight.get(req_hash)) is not None:
+            if (
+                unambiguous_retry
+                and (inflight := session.inflight.get(req_hash)) is not None
+            ):
                 return await coalesced(inflight)
             fut = asyncio.get_running_loop().create_future()
             session.inflight[req_hash] = fut

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -80,19 +80,9 @@ STREAM_MEMORY_BUFFER = 4 * 1024**2
 # millisecond; a larger one (bodies may reach `MAX_REQUEST_BODY`) is hashed off the event
 # loop instead — see `_request_digest`.
 HASH_INLINE_MAX = 1024**2  # 1 MiB
-# Attempt counter the stainless-generated SDKs (OpenAI, Anthropic) send on every request:
-# 0 on the first attempt, incremented on each retry of the same request.
-RETRY_COUNT_HEADER = "x-stainless-retry-count"
 IDEMPOTENCY_KEY_HEADER = "Idempotency-Key"
 IDEMPOTENCY_CACHE_TTL_SECONDS = 600
 IDEMPOTENCY_CACHE_MAX_COMPLETED = 64
-
-
-def is_retried_request(headers: Mapping[str, str]) -> bool:
-    try:
-        return int(headers.get(RETRY_COUNT_HEADER, 0)) > 0
-    except ValueError:
-        return False
 
 
 def _body_digest(raw: bytes) -> bytes:
@@ -100,7 +90,7 @@ def _body_digest(raw: bytes) -> bytes:
 
 
 async def _request_digest(raw: bytes) -> bytes:
-    """Digest a request body for the retry-replay guard. Hash a small body inline; offload a
+    """Digest a request body to bind its idempotency key. Hash a small body inline; offload a
     large one to a thread so it does not stall every multiplexed rollout on the event loop
     (blake2b releases the GIL, so the thread runs the hash off the loop)."""
     if len(raw) <= HASH_INLINE_MAX:
@@ -492,7 +482,10 @@ class InterceptionServer(Interception):
             body = json.loads(raw)
         body = dialect.apply_overrides(body, session.ctx.model, session.ctx.sampling)
         streaming = dialect.streaming(body)
-        req_hash = await _request_digest(raw) if not streaming else b""
+        idempotency_key = request.headers.get(IDEMPOTENCY_KEY_HEADER)
+        req_hash = (
+            await _request_digest(raw) if idempotency_key and not streaming else b""
+        )
         # Keep `read()` for aiohttp's size guard, then release its cache and our local
         # alias after parsing so the wire body does not survive model inference.
         request._read_bytes = None
@@ -507,13 +500,9 @@ class InterceptionServer(Interception):
             session.trace.id,
             streaming,
         )
-        # Graph atomicity under retries: one logical non-streaming call must commit at most
-        # one turn. An explicit key identifies that call directly; otherwise only the SDK's
-        # retry marker activates body-digest replay, since an unmarked repeated body can be a
-        # legitimate later turn.
-        retried = is_retried_request(request.headers)
+        # Only an explicit key identifies one logical call across retries. Identical bodies
+        # and SDK retry counters can belong to different calls, so they cannot authorize replay.
         idempotent: IdempotentRequest | None = None
-        idempotency_key = request.headers.get(IDEMPOTENCY_KEY_HEADER)
         replay_key: str | None = None
         binding = (request.path, req_hash)
         if idempotency_key:
@@ -534,14 +523,10 @@ class InterceptionServer(Interception):
                 for name, value in upstream_headers.items()
                 if name.lower() != IDEMPOTENCY_KEY_HEADER.lower()
             }
-        elif not streaming:
-            replay_key = f"retry:{request.path}:{req_hash.hex()}"
-
         if replay_key is not None:
             now = time.monotonic()
             _prune_idempotent_requests(session, now)
-            if idempotency_key or retried:
-                idempotent = session.idempotent_requests.get(replay_key)
+            idempotent = session.idempotent_requests.get(replay_key)
             if idempotent is not None and idempotent.binding != binding:
                 return web.json_response(
                     dialect.error_body(

--- a/verifiers/v1/session.py
+++ b/verifiers/v1/session.py
@@ -122,6 +122,9 @@ class RolloutSession:
     replays the common SDK retry of the latest completed exchange without re-sampling it."""
     last_response: dict | None = None
     """The response returned for `last_request`, replayed verbatim on a retry."""
+    request_generations: dict[bytes, int] = field(default_factory=dict)
+    """Fresh logical request count by body digest. Retry replay is safe only while a digest
+    identifies exactly one request."""
     inflight: dict[bytes, "asyncio.Future[dict | None]"] = field(default_factory=dict)
     """Body digest -> the response currently computing, used to coalesce an in-flight retry."""
     released: bool = False

--- a/verifiers/v1/session.py
+++ b/verifiers/v1/session.py
@@ -136,7 +136,7 @@ class RolloutSession:
     `HarnessError`. A harness that completes cleanly after the failure handled it. Reset before
     each model turn, so a successful retry clears it."""
     idempotent_requests: dict[str, IdempotentRequest] = field(default_factory=dict)
-    """Explicit keys or marked SDK retries mapped to their replay state."""
+    """Explicit idempotency keys mapped to their replay state."""
     released: bool = False
     """Set when the rollout unregisters the session: the trace is sealed (its conclusion is
     what scored and persisted), so a handler still in flight must not commit turns, record


### PR DESCRIPTION
Interception replay now requires `Idempotency-Key`. Identical request bodies and SDK retry counters do not identify a logical model call, so unkeyed attempts run independently instead of receiving another call's completion.

Keyed non-streaming calls retain cached responses and in-flight coalescing, with the existing body/path binding checks and bounded cache. The key remains local to interception and is not sent to the provider.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require explicit `Idempotency-Key` for interception replay lookup
> - Removes the `x-stainless-retry-count` header constant, the `is_retried_request` helper, and the automatic replay-key path based on request path and body digest in [server.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2371/files#diff-84e2f8d027d609e8760ef6d533535ec9d99dfc6384d5ddb6111b4001b2010f35)
> - Body hashing and replay-cache lookup now occur only for non-streaming requests that provide an explicit idempotency key; the existing explicit-key binding and replay response handling remain unchanged
> - Updates `RolloutSession.idempotent_requests` field docs in [session.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2371/files#diff-0eeafa9506eb0d53c459cf476e308ce72a99d147d2f84979affa04baaee79a66) to reflect that the replay map contains only explicit keys
> - Behavioral Change: non-streaming requests without `Idempotency-Key` are now independent calls even when they repeat the same path/body or carry the SDK retry marker
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b4bec9f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes turn-commit atomicity for SDK retries without idempotency keys, which can duplicate provider calls and graph turns where replay previously prevented double commits.
> 
> **Overview**
> **Interception replay is limited to requests that send an explicit `Idempotency-Key`.** The server no longer treats `x-stainless-retry-count` or identical path/body as proof of the same logical model call, so unkeyed retries and repeated payloads each run as separate upstream turns instead of replaying or coalescing onto a prior response.
> 
> For keyed **non-streaming** calls, behavior is unchanged: body digest still binds the key to path + payload, cached completions and in-flight coalescing still apply, and the key is still stripped before the provider. Body hashing is skipped unless a key is present (and still skipped for streaming).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4bec9fe3e4833f87585218d7346678e5ee53ab5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->