### PR TITLE
Pin RLM harness to nano-rlm

### DIFF
--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 BuiltinSkill = Literal["edit", "search"]
 
-RLM_REPO = "github.com/PrimeIntellect-ai/rlm-harness.git"
+RLM_REPO = "github.com/PrimeIntellect-ai/nano-rlm.git"
 RLM_DIR = "/tmp/vf-rlm"
 RLM_BIN = f"{RLM_DIR}/bin/rlm"
 SKILLS_DIR = "/task/rlm-skills"
@@ -28,8 +28,10 @@ RLM_STATE_DIR = ".vf-rlm"
 
 
 class RLMHarnessConfig(HarnessConfig):
-    version: str = Field(default="main", min_length=1)
-    """Git ref (branch, tag, or commit) of rlm-harness to install."""
+    version: str = Field(
+        default="41739cf3c2eb9859a90dc630db0d4739df404d23", min_length=1
+    )
+    """Git ref (branch, tag, or commit) of nano-rlm to install."""
     max_depth: int = 0
     """Recursion depth rlm may spawn sub-harnesses to (RLM_MAX_DEPTH)."""
     builtin_skills: list[BuiltinSkill] = Field(default_factory=list)


### PR DESCRIPTION
## Summary

- switch the v1 RLM harness clone target from `PrimeIntellect-ai/rlm-harness` to `PrimeIntellect-ai/nano-rlm`
- pin the default harness version to nano-rlm main commit `41739cf3c2eb9859a90dc630db0d4739df404d23`
- update the config field documentation to name nano-rlm

## Why

The harness should follow the renamed nano-rlm repository, and pinning the exact commit makes default installs reproducible instead of tracking a moving branch.

## Impact

Default v1 RLM harness setup now installs nano-rlm at a deterministic revision. Explicit `version` overrides continue to work as before.

## Validation

- `uv run ruff check --fix .`
- `uv run pytest tests/` — 914 passed, 75 skipped
- touched-file pre-commit hooks — passed
- pre-push hooks (`ruff check`, `ruff format`, `ty`) — passed

`pre-commit run --all-files` additionally reports 321 existing MD033 errors in `verifiers/legacy/envs/experimental/composable/tasksets/swe/README.md`; the changed file and all Python hooks pass.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin RLM harness to `nano-rlm` repo at a specific commit
> Updates [`harness.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/2373/files#diff-3955da24b5fd88f62482297bbda7ba0936f633927f15576db27fed6e58f668ec) to point `RLM_REPO` at `github.com/PrimeIntellect-ai/nano-rlm.git` and pins the default `version` in `RLMHarnessConfig` to commit `41739cf3c2eb9859a90dc630db0d4739df404d23` instead of `main`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 979aeef.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file constant and default-config change; install behavior is the same except repo name and pinned revision, with explicit version overrides still supported.
> 
> **Overview**
> The v1 RLM harness **install target** moves from `PrimeIntellect-ai/rlm-harness` to **`PrimeIntellect-ai/nano-rlm`**, matching the renamed upstream repo.
> 
> The default **`RLMHarnessConfig.version`** is no longer `main`; it is pinned to commit `41739cf3c2eb9859a90dc630db0d4739df404d23` so default installs are reproducible. The `version` field docstring now refers to nano-rlm. Callers can still override `version` with any git ref; install flow in `setup()` is unchanged aside from repo URL and checkout ref.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 979aeefff289e22164cf175e04605a53d88dcefe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->