### PR TITLE
Revert nano-rlm harness pin, default version back to main

### DIFF
--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 BuiltinSkill = Literal["edit", "search"]
 
-RLM_REPO = "github.com/PrimeIntellect-ai/nano-rlm.git"
+RLM_REPO = "github.com/PrimeIntellect-ai/rlm-harness.git"
 RLM_DIR = "/tmp/vf-rlm"
 RLM_BIN = f"{RLM_DIR}/bin/rlm"
 SKILLS_DIR = "/task/rlm-skills"
@@ -28,10 +28,8 @@ RLM_STATE_DIR = ".vf-rlm"
 
 
 class RLMHarnessConfig(HarnessConfig):
-    version: str = Field(
-        default="41739cf3c2eb9859a90dc630db0d4739df404d23", min_length=1
-    )
-    """Git ref (branch, tag, or commit) of nano-rlm to install."""
+    version: str = Field(default="main", min_length=1)
+    """Git ref (branch, tag, or commit) of rlm-harness to install."""
     max_depth: int = 0
     """Recursion depth rlm may spawn sub-harnesses to (RLM_MAX_DEPTH)."""
     builtin_skills: list[BuiltinSkill] = Field(default_factory=list)

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -28,9 +28,7 @@ RLM_STATE_DIR = ".vf-rlm"
 
 
 class RLMHarnessConfig(HarnessConfig):
-    version: str = Field(
-        default="41739cf3c2eb9859a90dc630db0d4739df404d23", min_length=1
-    )
+    version: str = Field(default="main", min_length=1)
     """Git ref (branch, tag, or commit) of nano-rlm to install."""
     max_depth: int = 0
     """Recursion depth rlm may spawn sub-harnesses to (RLM_MAX_DEPTH)."""


### PR DESCRIPTION
## Summary

- revert the default `RLMHarnessConfig.version` from pinned commit `41739cf` back to `main`
- keep the `rlm-harness` -> `nano-rlm` rename from #2373

## Why

#2373 changed the default-install behavior (tracking `main` -> frozen commit) alongside the rename. Per the Slack discussion, the rename is fine but the behavior change shouldn't ride along in that PR — the default should stay latest `main`, and anyone who needs a reproducible eval can pin an explicit `version` override.

Note: #2376 builds on this and additionally locks the resolved commit at run start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)