### PR TITLE
Rename RLM harness source to nano-rlm

### DIFF
--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 BuiltinSkill = Literal["edit", "search"]
 
-RLM_REPO = "github.com/PrimeIntellect-ai/rlm-harness.git"
+RLM_REPO = "github.com/PrimeIntellect-ai/nano-rlm.git"
 RLM_DIR = "/tmp/vf-rlm"
 RLM_BIN = f"{RLM_DIR}/bin/rlm"
 SKILLS_DIR = "/task/rlm-skills"
@@ -29,7 +29,7 @@ RLM_STATE_DIR = ".vf-rlm"
 
 class RLMHarnessConfig(HarnessConfig):
     version: str = Field(default="main", min_length=1)
-    """Git ref (branch, tag, or commit) of rlm-harness to install."""
+    """Git ref (branch, tag, or commit) of nano-rlm to install."""
     max_depth: int = 0
     """Recursion depth rlm may spawn sub-harnesses to (RLM_MAX_DEPTH)."""
     builtin_skills: list[BuiltinSkill] = Field(default_factory=list)


### PR DESCRIPTION
## Summary

Point `RLM_REPO` at the renamed `PrimeIntellect-ai/nano-rlm` repository and update the `version` docstring. No behavior change — the default `version` stays `main`.

Stacked on #2374 (full revert of #2373); merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and clone URL only; no logic or default version changes.
> 
> **Overview**
> Updates the v1 RLM harness install source from **`PrimeIntellect-ai/rlm-harness`** to **`PrimeIntellect-ai/nano-rlm`** by changing `RLM_REPO`, and aligns the `RLMHarnessConfig.version` docstring with the new name.
> 
> Default ref remains **`main`**; clone/install flow and runtime behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0803cb01a1f67ff1a3f83dab360988010c63a53a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update RLM harness repository URL to `nano-rlm`
> Updates `RLM_REPO` in [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2375/files#diff-3955da24b5fd88f62482297bbda7ba0936f633927f15576db27fed6e58f668ec) to point to `github.com/PrimeIntellect-ai/nano-rlm.git` and updates the `version` field description in `RLMHarnessConfig` to match. Any RLM harness installation will now pull from the renamed repository.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0803cb0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->