### PR TITLE
Lock RLM harness to a run-start commit, keep nano-rlm rename

### DIFF
--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -1,8 +1,10 @@
 """RLM over ACP, with MCP tools exposed as pre-imported IPython skills."""
 
+import asyncio
 import json
 import logging
 import random
+import re
 import shlex
 from typing import Literal
 
@@ -25,11 +27,14 @@ RLM_DIR = "/tmp/vf-rlm"
 RLM_BIN = f"{RLM_DIR}/bin/rlm"
 SKILLS_DIR = "/task/rlm-skills"
 RLM_STATE_DIR = ".vf-rlm"
+COMMIT_RE = re.compile(r"[0-9a-f]{40}")
 
 
 class RLMHarnessConfig(HarnessConfig):
     version: str = Field(default="main", min_length=1)
-    """Git ref (branch, tag, or commit) of nano-rlm to install."""
+    """Git ref (branch, tag, or commit) of nano-rlm to install. Branches and tags are
+    resolved to a commit once at the start of the run, so every rollout installs the
+    same harness even if the ref moves mid-run."""
     max_depth: int = 0
     """Recursion depth rlm may spawn sub-harnesses to (RLM_MAX_DEPTH)."""
     builtin_skills: list[BuiltinSkill] = Field(default_factory=list)
@@ -66,7 +71,45 @@ class RLMHarness(ACPHarness[RLMHarnessConfig]):
     SUPPORTS_MCP = True
     SUPPORTS_SKILLS = True
 
+    _version_lock: asyncio.Lock | None = None
+    _resolved_version: str | None = None
+
+    async def _resolve_version(self) -> str:
+        """The configured version as a commit, resolved host-side once per run so
+        concurrent rollouts install the same harness even if the ref moves mid-run.
+        Refs `git ls-remote` doesn't list (e.g. short commits) pass through as-is."""
+        if self._version_lock is None:
+            self._version_lock = asyncio.Lock()
+        async with self._version_lock:
+            if self._resolved_version is None:
+                version = self.config.version
+                if not COMMIT_RE.fullmatch(version):
+                    proc = await asyncio.create_subprocess_exec(
+                        "git",
+                        "ls-remote",
+                        f"https://{RLM_REPO}",
+                        version,
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.PIPE,
+                    )
+                    stdout, stderr = await proc.communicate()
+                    if proc.returncode != 0:
+                        raise RuntimeError(
+                            f"rlm: resolving version {version!r} failed: "
+                            f"{stderr.decode().strip()[-500:]}"
+                        )
+                    if stdout.strip():
+                        version = stdout.split()[0].decode()
+                        logger.info(
+                            "rlm: locked version %s to %s for this run",
+                            self.config.version,
+                            version,
+                        )
+                self._resolved_version = version
+        return self._resolved_version
+
     async def setup(self, runtime: Runtime) -> None:
+        version = await self._resolve_version()
         # Before the installer: install.sh packages the skills it finds.
         await self.install_skills(runtime, SKILLS_DIR)
         # install.sh fetches curl/uv itself; add git only when the image lacks it.
@@ -74,11 +117,11 @@ class RLMHarness(ACPHarness[RLMHarnessConfig]):
             "command -v git >/dev/null 2>&1 || "
             "{ apt-get update -qq && apt-get install -y -qq git; } && "
             f"rm -rf /tmp/rlm && git clone https://{RLM_REPO} /tmp/rlm && "
-            f"git -C /tmp/rlm checkout {shlex.quote(self.config.version)} && "
+            f"git -C /tmp/rlm checkout {shlex.quote(version)} && "
             f"UV_INSTALL_DIR={RLM_DIR}/bin UV_TOOL_BIN_DIR={RLM_DIR}/bin "
             f"RLM_CHECKOUT_PATH=/tmp/rlm bash /tmp/rlm/install.sh"
         )
-        logger.info("rlm: ensuring rlm is installed (version=%s)", self.config.version)
+        logger.info("rlm: ensuring rlm is installed (version=%s)", version)
         ensure = shlex.quote(f"[ -x {RLM_BIN} ] || ({install})")
         guarded = f"mkdir -p {RLM_DIR} && flock {RLM_DIR}/install.lock sh -c {ensure}"
         env = self.config.resolved_env.copy()

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 BuiltinSkill = Literal["edit", "search"]
 
-RLM_REPO = "github.com/PrimeIntellect-ai/rlm-harness.git"
+RLM_REPO = "github.com/PrimeIntellect-ai/nano-rlm.git"
 RLM_DIR = "/tmp/vf-rlm"
 RLM_BIN = f"{RLM_DIR}/bin/rlm"
 SKILLS_DIR = "/task/rlm-skills"
@@ -29,7 +29,7 @@ RLM_STATE_DIR = ".vf-rlm"
 
 class RLMHarnessConfig(HarnessConfig):
     version: str = Field(default="main", min_length=1)
-    """Git ref (branch, tag, or commit) of rlm-harness to install."""
+    """Git ref (branch, tag, or commit) of nano-rlm to install."""
     max_depth: int = 0
     """Recursion depth rlm may spawn sub-harnesses to (RLM_MAX_DEPTH)."""
     builtin_skills: list[BuiltinSkill] = Field(default_factory=list)

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 BuiltinSkill = Literal["edit", "search"]
 
-RLM_REPO = "github.com/PrimeIntellect-ai/nano-rlm.git"
+RLM_REPO = "github.com/PrimeIntellect-ai/rlm-harness.git"
 RLM_DIR = "/tmp/vf-rlm"
 RLM_BIN = f"{RLM_DIR}/bin/rlm"
 SKILLS_DIR = "/task/rlm-skills"
@@ -28,10 +28,8 @@ RLM_STATE_DIR = ".vf-rlm"
 
 
 class RLMHarnessConfig(HarnessConfig):
-    version: str = Field(
-        default="41739cf3c2eb9859a90dc630db0d4739df404d23", min_length=1
-    )
-    """Git ref (branch, tag, or commit) of nano-rlm to install."""
+    version: str = Field(default="main", min_length=1)
+    """Git ref (branch, tag, or commit) of rlm-harness to install."""
     max_depth: int = 0
     """Recursion depth rlm may spawn sub-harnesses to (RLM_MAX_DEPTH)."""
     builtin_skills: list[BuiltinSkill] = Field(default_factory=list)


### PR DESCRIPTION
## Summary

Replaces the #2374/#2375 stack as a single PR on main. Net effect vs current main:

- default `RLMHarnessConfig.version` goes from pinned commit `41739cf` back to `main`
- branch/tag versions are resolved to a commit SHA host-side, once per run (guarded by a lock, cached on the harness instance); all rollouts then check out that exact commit
- full 40-char commit `version` overrides skip resolution and pass through untouched
- the `rlm-harness` -> `nano-rlm` rename from #2373 is kept

## Why

Implements the behavior agreed in Slack: always use the latest harness, but the harness must not change once a run has started. Tracking `main` per-rollout meant a push to nano-rlm mid-eval could make rollouts of the same run use different harness versions; a frozen default commit goes stale. Resolving `main` at run start gives latest *and* internally consistent, with explicit pins still available for reproducibility.

## Validation

- `uv run ruff check` / `ruff format --check` — pass
- `uv run pytest tests/v1 -k rlm` — pass (e2e skipped, needs `PRIME_API_KEY`)
- temp script against the real repo: `main` resolves to a 40-char SHA, repeated + concurrent calls return the same commit, full-SHA overrides pass through unresolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Lock RLM harness to a resolved commit at run start and rename repo to nano-rlm
> - Adds `_resolve_version` to `RLMHarness` in [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2376/files#diff-3955da24b5fd88f62482297bbda7ba0936f633927f15576db27fed6e58f668ec) that resolves branch/tag refs to a 40-hex commit once per run using `git ls-remote` against the `nano-rlm` repo.
> - Uses an `asyncio.Lock` to ensure single-flight resolution, caching the result in `_resolved_version` for concurrent rollouts.
> - `RLMHarness.setup` now checks out the resolved commit instead of the original (potentially moving) ref.
> - The default `version` in `RLMHarnessConfig` changes from a pinned commit to `'main'`.
> - Behavioral Change: callers relying on the old pinned commit default will now track `main` unless they explicitly set a version.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ce80a5c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->