### PR TITLE
feat(v1): add DeepSeek Harness ACP integration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,9 @@ def pytest_configure(config) -> None:
     config.addinivalue_line(
         "markers", "hermes_agent: v1 e2e cases on the hermes-agent harness"
     )
+    config.addinivalue_line(
+        "markers", "deepseek_harness: v1 e2e cases on the deepseek-harness harness"
+    )
 
 
 @pytest.fixture

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -25,7 +25,7 @@ Every combination carries its axes' pytest marks, so subsets select with `-m`:
 
 Marks: runtimes `subprocess` / `docker` / `prime` / `modal`, placement `colocated`,
 harnesses `null` / `bash` / `rlm` / `kimi_code` / `pi` / `pool` / `openclaw` / `codex` /
-`claude_code` / `hermes_agent`.
+`claude_code` / `hermes_agent` / `deepseek_harness`.
 A mark is applied per axis, so it selects every case touching that value on ANY axis; for one exact
 combination use `-k` on the test id (e.g. `-k "harness-in-docker-with-tool-in-subprocess"`).
 prime/modal provision real remote sandboxes (slow, infra-flaky, need setup), so they're local-only.
@@ -71,8 +71,8 @@ def tool_runtime(request) -> dict:
 
 
 # Built-in harnesses are bundled in the `harnesses` package; the agent CLIs (`rlm` /
-# `kimi-code` / `openclaw` / `codex` / `claude-code` / `hermes-agent`) install their
-# dependencies at rollout.
+# `kimi-code` / `openclaw` / `codex` / `claude-code` / `hermes-agent` /
+# `deepseek-harness`) install their dependencies at rollout.
 # `compact` (an example harness) and `terminus-2` (drives the host tmux) are excluded from e2e.
 @pytest.fixture
 def harness(request) -> HarnessConfig:

--- a/tests/v1/fixtures/echo_acp_resume_v1.py
+++ b/tests/v1/fixtures/echo_acp_resume_v1.py
@@ -59,9 +59,8 @@ class ACPResumeEnv(vf.SingleAgentEnv):
             if not first.terminated:
                 segments.append(
                     await interaction.turn(
-                        "Call the `recall` tool from the `resume` MCP server with the "
-                        "codeword from my previous message, then reply with exactly the "
-                        "tool result."
+                        "Call the tool that returns a supplied codeword with the codeword "
+                        "from my previous message, then reply with exactly the tool result."
                     )
                 )
             interaction.trace.info["acp_segments"] = [

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -48,6 +48,7 @@ AGENTIC_PLACEMENTS = [
     pair("codex", "docker", "codex-harness-in-docker"),
     pair("claude-code", "docker", "claude-code-harness-in-docker"),
     pair("hermes-agent", "docker", "hermes-agent-harness-in-docker"),
+    pair("deepseek-harness", "docker", "dsh-agent-in-docker"),
     pair("bash", "prime", "bash-harness-in-prime"),
     pair("bash", "modal", "bash-harness-in-modal"),
 ]
@@ -83,6 +84,7 @@ ACP_RESUME_PLACEMENTS = [
     ),
     pair("pool", "docker", "pool-acp-in-docker"),
     pair("openclaw", "docker", "openclaw-acp-in-docker"),
+    pair("deepseek-harness", "docker", "dsh-acp-in-docker"),
     pair("pool", "prime", "pool-acp-in-prime"),
     pair("rlm", "prime", "rlm-acp-in-prime-vm"),
 ]

--- a/verifiers/v1/harnesses/__init__.py
+++ b/verifiers/v1/harnesses/__init__.py
@@ -8,6 +8,10 @@ from verifiers.v1.harnesses.claude_code import (
     ClaudeCodeHarnessConfig,
 )
 from verifiers.v1.harnesses.codex import CodexHarness, CodexHarnessConfig
+from verifiers.v1.harnesses.deepseek_harness import (
+    DeepSeekHarness,
+    DeepSeekHarnessConfig,
+)
 from verifiers.v1.harnesses.hermes_agent import (
     HermesAgentHarness,
     HermesAgentHarnessConfig,
@@ -33,6 +37,8 @@ __all__ = [
     "ClaudeCodeHarnessConfig",
     "CodexHarness",
     "CodexHarnessConfig",
+    "DeepSeekHarness",
+    "DeepSeekHarnessConfig",
     "HermesAgentHarness",
     "HermesAgentHarnessConfig",
     "KimiCodeHarness",

--- a/verifiers/v1/harnesses/deepseek_harness/__init__.py
+++ b/verifiers/v1/harnesses/deepseek_harness/__init__.py
@@ -1,0 +1,6 @@
+from verifiers.v1.harnesses.deepseek_harness.harness import (
+    DeepSeekHarness,
+    DeepSeekHarnessConfig,
+)
+
+__all__ = ["DeepSeekHarness", "DeepSeekHarnessConfig"]

--- a/verifiers/v1/harnesses/deepseek_harness/adapter.mjs
+++ b/verifiers/v1/harnesses/deepseek_harness/adapter.mjs
@@ -29,6 +29,44 @@ function toolCallsOf(blocks) {
   return blocks.filter((block) => block.type === "tool-call");
 }
 
+function toolNameMaps(tools, bareToolPrefixes) {
+  const internalToProvider = new Map();
+  const providerToInternal = new Map();
+  // DSH requires namespaced MCP names internally; only Verifiers' bare tools cross the API bare.
+  for (const tool of tools || []) {
+    const prefix = bareToolPrefixes.find((candidate) => tool.name.startsWith(candidate));
+    const providerName = prefix === undefined ? tool.name : tool.name.slice(prefix.length);
+    const existing = providerToInternal.get(providerName);
+    if (existing !== undefined && existing !== tool.name) {
+      throw new LlmError(
+        `Tools ${existing} and ${tool.name} both map to ${providerName}.`,
+        "INVALID_REQUEST",
+      );
+    }
+    internalToProvider.set(tool.name, providerName);
+    providerToInternal.set(providerName, tool.name);
+  }
+  return { internalToProvider, providerToInternal };
+}
+
+function providerOptions(options, internalToProvider) {
+  return {
+    ...options,
+    tools: options.tools?.map((tool) => ({
+      ...tool,
+      name: internalToProvider.get(tool.name) || tool.name,
+    })),
+    messages: options.messages.map((message) => ({
+      ...message,
+      content: message.content.map((block) =>
+        block.type === "tool-call"
+          ? { ...block, name: internalToProvider.get(block.name) || block.name }
+          : block,
+      ),
+    })),
+  };
+}
+
 function replayOf(message, transport) {
   const source = message.source.kind === "model" ? message.source : undefined;
   const state = source?.replayState;
@@ -232,8 +270,8 @@ function responsesResponse(raw) {
       reasoning.push(...(item.content || []).map((part) => part?.text || ""));
     } else if (item.type === "message") {
       text += (item.content || [])
-        .filter((part) => part?.type === "output_text")
-        .map((part) => part.text || "")
+        .filter((part) => part?.type === "output_text" || part?.type === "refusal")
+        .map((part) => part.text || part.refusal || "")
         .join("");
     } else if (item.type === "function_call" || item.type === "custom_tool_call") {
       blocks.push({
@@ -245,14 +283,23 @@ function responsesResponse(raw) {
     }
   }
   const reasoningText = reasoning.filter(Boolean).join("\n");
+  const incompleteReason = raw.incomplete_details?.reason || "incomplete";
   if (reasoningText) blocks.unshift({ type: "reasoning", text: reasoningText });
   if (text) blocks.splice(reasoningText ? 1 : 0, 0, { type: "text", text });
   return {
     blocks,
     usage: responsesUsage(raw.usage),
-    reason: raw.status === "incomplete"
-      ? { kind: "max-tokens" }
-      : finishReason(undefined, blocks),
+    reason: raw.status !== "incomplete"
+      ? finishReason(undefined, blocks)
+      : incompleteReason === "max_output_tokens"
+        ? { kind: "max-tokens" }
+        : {
+            kind: "error",
+            failure: {
+              message: `model stopped: ${incompleteReason}`,
+              code: String(incompleteReason).toUpperCase(),
+            },
+          },
     replayState: {
       transport: "responses",
       data: output,
@@ -280,9 +327,12 @@ function anthropicRequest(options) {
       for (const call of toolCallsOf(message.content)) {
         let input = {};
         try {
-          input = JSON.parse(call.arguments);
+          const parsed = JSON.parse(call.arguments);
+          if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+            input = parsed;
+          }
         } catch {
-          // Anthropic requires an object; malformed provider arguments stay executable as {}.
+          // Anthropic requires an object; invalid tool arguments stay executable as {}.
         }
         content.push({ type: "tool_use", id: call.id, name: call.name, input });
       }
@@ -484,7 +534,8 @@ class VerifiersAdapter extends LlmAdapter {
     const codec = CODECS[this.config.transport];
     const apiKey = process.env.DSH_INTERCEPT_KEY;
     if (!apiKey) throw new LlmError("Missing DSH_INTERCEPT_KEY.", "MISSING_CREDENTIAL");
-    const body = codec.request(options);
+    const names = toolNameMaps(options.tools, this.config.bareToolPrefixes || []);
+    const body = codec.request(providerOptions(options, names.internalToProvider));
     const url = `${this.config.endpoint.replace(/\/$/, "")}/${codec.path}`;
     const raw = await postJson(
       url,
@@ -494,10 +545,15 @@ class VerifiersAdapter extends LlmAdapter {
       options.signal,
     );
     const result = codec.response(raw);
-    if (result.blocks.length === 0) {
+    const blocks = result.blocks.map((block) =>
+      block.type === "tool-call"
+        ? { ...block, name: names.providerToInternal.get(block.name) || block.name }
+        : block,
+    );
+    if (blocks.length === 0) {
       throw new LlmError(`Model ${options.model} returned no content.`, "EMPTY_RESPONSE");
     }
-    for (const [index, block] of result.blocks.entries()) {
+    for (const [index, block] of blocks.entries()) {
       yield { type: "block-start", index, blockType: block.type };
       if (block.type === "text") {
         yield { type: "text-delta", index, text: block.text };

--- a/verifiers/v1/harnesses/deepseek_harness/adapter.mjs
+++ b/verifiers/v1/harnesses/deepseek_harness/adapter.mjs
@@ -69,7 +69,7 @@ function providerOptions(options, internalToProvider) {
 
 function replayOf(message, transport) {
   const source = message.source.kind === "model" ? message.source : undefined;
-  const state = source?.replayState;
+  const state = source?.replayState?.response;
   return state?.transport === transport ? state.data : undefined;
 }
 
@@ -174,11 +174,12 @@ function chatResponse(raw) {
   const blocks = [];
   const reasoning = reasoningText(message);
   if (reasoning) blocks.push({ type: "reasoning", text: reasoning });
-  const text = typeof message.content === "string"
+  const contentText = typeof message.content === "string"
     ? message.content
     : Array.isArray(message.content)
-      ? message.content.map((part) => part?.text || "").join("")
+      ? message.content.map((part) => part?.text || part?.refusal || "").join("")
       : "";
+  const text = contentText || (typeof message.refusal === "string" ? message.refusal : "");
   if (text) blocks.push({ type: "text", text });
   for (const call of message.tool_calls || []) {
     blocks.push({
@@ -577,7 +578,11 @@ class VerifiersAdapter extends LlmAdapter {
       };
     }
     yield { type: "usage", usage: result.usage };
-    yield { type: "finish", reason: result.reason, replayState: result.replayState };
+    yield {
+      type: "finish",
+      reason: result.reason,
+      replayState: { response: result.replayState },
+    };
   }
 }
 

--- a/verifiers/v1/harnesses/deepseek_harness/adapter.mjs
+++ b/verifiers/v1/harnesses/deepseek_harness/adapter.mjs
@@ -520,7 +520,6 @@ class VerifiersAdapter extends LlmAdapter {
       id: model,
       name: model,
       inputModalities: ["text"],
-      context: { contextWindow: this.config.contextWindow },
       ...(this.config.maxTokens === undefined
         ? {}
         : { defaultMaxTokens: this.config.maxTokens }),

--- a/verifiers/v1/harnesses/deepseek_harness/adapter.mjs
+++ b/verifiers/v1/harnesses/deepseek_harness/adapter.mjs
@@ -1,0 +1,531 @@
+/** DSH LLM adapter that talks directly to a Verifiers interception server. */
+
+import {
+  attributionHeaders,
+  CallId,
+  contentHasImage,
+  LlmAdapter,
+  LlmError,
+} from "@deepseek-ai/dsh-llm";
+
+function textOf(blocks) {
+  return blocks
+    .map((block) => {
+      if (block.type === "text") return block.text;
+      if (block.type === "tool-result") return textOf(block.content);
+      return "";
+    })
+    .join("");
+}
+
+function reasoningOf(blocks) {
+  return blocks
+    .filter((block) => block.type === "reasoning")
+    .map((block) => block.text)
+    .join("");
+}
+
+function toolCallsOf(blocks) {
+  return blocks.filter((block) => block.type === "tool-call");
+}
+
+function replayOf(message, transport) {
+  const source = message.source.kind === "model" ? message.source : undefined;
+  const state = source?.replayState;
+  return state?.transport === transport ? state.data : undefined;
+}
+
+const TOOL_ENCODERS = {
+  chat_completions: (tool) => ({
+    type: "function",
+    function: {
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.parameters,
+    },
+  }),
+  responses: (tool) => ({ type: "function", ...tool }),
+  anthropic_messages: (tool) => ({
+    name: tool.name,
+    description: tool.description,
+    input_schema: tool.parameters,
+  }),
+};
+
+function toolsOf(options, transport) {
+  return options.tools?.length
+    ? { tools: options.tools.map(TOOL_ENCODERS[transport]) }
+    : {};
+}
+
+function chatRequest(options) {
+  const messages = [];
+  if (options.system !== undefined) messages.push({ role: "system", content: options.system });
+
+  for (const message of options.messages) {
+    if (message.role === "system") {
+      messages.push({ role: "system", content: textOf(message.content) });
+      continue;
+    }
+    if (message.role === "assistant") {
+      const text = textOf(message.content);
+      const reasoning = reasoningOf(message.content);
+      const calls = toolCallsOf(message.content);
+      const replay = replayOf(message, "chat_completions");
+      messages.push({
+        role: "assistant",
+        content: text || (calls.length > 0 ? null : ""),
+        ...(Array.isArray(replay)
+          ? { reasoning_details: replay }
+          : reasoning
+            ? { reasoning_content: reasoning }
+            : {}),
+        ...(calls.length === 0
+          ? {}
+          : {
+              tool_calls: calls.map((call) => ({
+                id: call.id,
+                type: "function",
+                function: { name: call.name, arguments: call.arguments },
+              })),
+            }),
+      });
+      continue;
+    }
+
+    const results = message.content.filter((block) => block.type === "tool-result");
+    const text = textOf(message.content.filter((block) => block.type !== "tool-result"));
+    if (text || results.length === 0) messages.push({ role: "user", content: text });
+    for (const result of results) {
+      messages.push({
+        role: "tool",
+        tool_call_id: result.toolCallId,
+        content: textOf(result.content) || "(no output)",
+      });
+    }
+  }
+
+  return {
+    model: options.model,
+    messages,
+    stream: false,
+    ...(options.temperature === undefined ? {} : { temperature: options.temperature }),
+    ...(options.stop === undefined ? {} : { stop: options.stop }),
+    ...(options.maxTokens === undefined ? {} : { max_tokens: options.maxTokens }),
+    ...toolsOf(options, "chat_completions"),
+  };
+}
+
+function reasoningText(message) {
+  for (const field of ["reasoning", "reasoning_content"]) {
+    if (typeof message[field] === "string" && message[field]) return message[field];
+  }
+  if (!Array.isArray(message.reasoning_details)) return "";
+  return message.reasoning_details
+    .map((detail) => detail?.text || detail?.summary || "")
+    .filter(Boolean)
+    .join("\n");
+}
+
+function chatResponse(raw) {
+  const choice = raw.choices?.[0];
+  const message = choice?.message;
+  if (message === undefined) {
+    throw new LlmError("Chat Completions response has no assistant message.", "MALFORMED_RESPONSE");
+  }
+  const blocks = [];
+  const reasoning = reasoningText(message);
+  if (reasoning) blocks.push({ type: "reasoning", text: reasoning });
+  const text = typeof message.content === "string"
+    ? message.content
+    : Array.isArray(message.content)
+      ? message.content.map((part) => part?.text || "").join("")
+      : "";
+  if (text) blocks.push({ type: "text", text });
+  for (const call of message.tool_calls || []) {
+    blocks.push({
+      type: "tool-call",
+      id: String(call.id || ""),
+      name: String(call.function?.name || ""),
+      arguments: String(call.function?.arguments || ""),
+    });
+  }
+  return {
+    blocks,
+    usage: openAiUsage(raw.usage),
+    reason: finishReason(choice?.finish_reason, blocks),
+    replayState: {
+      transport: "chat_completions",
+      data: Array.isArray(message.reasoning_details)
+        ? message.reasoning_details
+        : null,
+    },
+  };
+}
+
+function responsesRequest(options) {
+  const input = [];
+  for (const message of options.messages) {
+    if (message.role === "assistant") {
+      const replay = replayOf(message, "responses");
+      if (Array.isArray(replay)) {
+        input.push(...replay);
+        continue;
+      }
+      const text = textOf(message.content);
+      if (text) {
+        input.push({
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text }],
+        });
+      }
+      for (const call of toolCallsOf(message.content)) {
+        input.push({
+          type: "function_call",
+          call_id: call.id,
+          name: call.name,
+          arguments: call.arguments,
+        });
+      }
+      continue;
+    }
+    if (message.role === "system") {
+      input.push({ role: "system", content: textOf(message.content) });
+      continue;
+    }
+    const results = message.content.filter((block) => block.type === "tool-result");
+    const text = textOf(message.content.filter((block) => block.type !== "tool-result"));
+    if (text || results.length === 0) input.push({ role: "user", content: text });
+    for (const result of results) {
+      input.push({
+        type: "function_call_output",
+        call_id: result.toolCallId,
+        output: textOf(result.content) || "(no output)",
+      });
+    }
+  }
+
+  return {
+    model: options.model,
+    input,
+    stream: false,
+    ...(options.system === undefined ? {} : { instructions: options.system }),
+    include: ["reasoning.encrypted_content"],
+    ...(options.temperature === undefined ? {} : { temperature: options.temperature }),
+    ...(options.maxTokens === undefined ? {} : { max_output_tokens: options.maxTokens }),
+    ...toolsOf(options, "responses"),
+  };
+}
+
+function responsesResponse(raw) {
+  const output = raw.output;
+  if (!Array.isArray(output)) {
+    throw new LlmError("Responses response has no output array.", "MALFORMED_RESPONSE");
+  }
+  const blocks = [];
+  const reasoning = [];
+  let text = "";
+  for (const item of output) {
+    if (item.type === "reasoning") {
+      reasoning.push(...(item.summary || []).map((part) => part?.text || ""));
+      reasoning.push(...(item.content || []).map((part) => part?.text || ""));
+    } else if (item.type === "message") {
+      text += (item.content || [])
+        .filter((part) => part?.type === "output_text")
+        .map((part) => part.text || "")
+        .join("");
+    } else if (item.type === "function_call" || item.type === "custom_tool_call") {
+      blocks.push({
+        type: "tool-call",
+        id: String(item.call_id || ""),
+        name: String(item.name || ""),
+        arguments: String(item.arguments ?? item.input ?? ""),
+      });
+    }
+  }
+  const reasoningText = reasoning.filter(Boolean).join("\n");
+  if (reasoningText) blocks.unshift({ type: "reasoning", text: reasoningText });
+  if (text) blocks.splice(reasoningText ? 1 : 0, 0, { type: "text", text });
+  return {
+    blocks,
+    usage: responsesUsage(raw.usage),
+    reason: raw.status === "incomplete"
+      ? { kind: "max-tokens" }
+      : finishReason(undefined, blocks),
+    replayState: {
+      transport: "responses",
+      data: output,
+    },
+  };
+}
+
+function anthropicRequest(options) {
+  const messages = [];
+  const system = options.system === undefined ? [] : [options.system];
+  for (const message of options.messages) {
+    if (message.role === "system") {
+      system.push(textOf(message.content));
+      continue;
+    }
+    if (message.role === "assistant") {
+      const replay = replayOf(message, "anthropic_messages");
+      if (Array.isArray(replay)) {
+        messages.push({ role: "assistant", content: replay });
+        continue;
+      }
+      const content = [];
+      const text = textOf(message.content);
+      if (text) content.push({ type: "text", text });
+      for (const call of toolCallsOf(message.content)) {
+        let input = {};
+        try {
+          input = JSON.parse(call.arguments);
+        } catch {
+          // Anthropic requires an object; malformed provider arguments stay executable as {}.
+        }
+        content.push({ type: "tool_use", id: call.id, name: call.name, input });
+      }
+      messages.push({ role: "assistant", content });
+      continue;
+    }
+    const content = [];
+    const text = textOf(message.content.filter((block) => block.type !== "tool-result"));
+    if (text) content.push({ type: "text", text });
+    for (const result of message.content.filter((block) => block.type === "tool-result")) {
+      content.push({
+        type: "tool_result",
+        tool_use_id: result.toolCallId,
+        content: textOf(result.content) || "(no output)",
+        ...(result.isError === undefined ? {} : { is_error: result.isError }),
+      });
+    }
+    if (content.length === 0) content.push({ type: "text", text: "" });
+    messages.push({ role: "user", content });
+  }
+
+  return {
+    model: options.model,
+    messages,
+    stream: false,
+    max_tokens: options.maxTokens,
+    ...(system.length === 0 ? {} : { system: system.join("\n\n") }),
+    ...(options.temperature === undefined ? {} : { temperature: options.temperature }),
+    ...(options.stop === undefined ? {} : { stop_sequences: options.stop }),
+    ...toolsOf(options, "anthropic_messages"),
+  };
+}
+
+function anthropicResponse(raw) {
+  if (!Array.isArray(raw.content)) {
+    throw new LlmError("Anthropic response has no content array.", "MALFORMED_RESPONSE");
+  }
+  const blocks = [];
+  const reasoning = raw.content
+    .filter((block) => block.type === "thinking")
+    .map((block) => block.thinking || "")
+    .join("");
+  if (reasoning) blocks.push({ type: "reasoning", text: reasoning });
+  const text = raw.content
+    .filter((block) => block.type === "text")
+    .map((block) => block.text || "")
+    .join("");
+  if (text) blocks.push({ type: "text", text });
+  for (const call of raw.content.filter((block) => block.type === "tool_use")) {
+    blocks.push({
+      type: "tool-call",
+      id: String(call.id || ""),
+      name: String(call.name || ""),
+      arguments: JSON.stringify(call.input || {}),
+    });
+  }
+  const stopReasons = {
+    end_turn: "stop",
+    stop_sequence: "stop",
+    max_tokens: "max-tokens",
+    tool_use: "tool-calls",
+  };
+  const kind = stopReasons[raw.stop_reason] || finishReason(undefined, blocks).kind;
+  return {
+    blocks,
+    usage: anthropicUsage(raw.usage),
+    reason: { kind },
+    replayState: {
+      transport: "anthropic_messages",
+      data: raw.content,
+    },
+  };
+}
+
+function openAiUsage(usage = {}) {
+  const cached = usage.prompt_tokens_details?.cached_tokens || 0;
+  const reasoning = usage.completion_tokens_details?.reasoning_tokens;
+  return {
+    inputTokens: Math.max(0, (usage.prompt_tokens || 0) - cached),
+    outputTokens: usage.completion_tokens || 0,
+    ...(cached ? { cacheReadTokens: cached } : {}),
+    ...(reasoning ? { reasoningTokens: reasoning } : {}),
+  };
+}
+
+function responsesUsage(usage = {}) {
+  const cached = usage.input_tokens_details?.cached_tokens || 0;
+  const reasoning = usage.output_tokens_details?.reasoning_tokens;
+  return {
+    inputTokens: Math.max(0, (usage.input_tokens || 0) - cached),
+    outputTokens: usage.output_tokens || 0,
+    ...(cached ? { cacheReadTokens: cached } : {}),
+    ...(reasoning ? { reasoningTokens: reasoning } : {}),
+  };
+}
+
+function anthropicUsage(usage = {}) {
+  const read = usage.cache_read_input_tokens || 0;
+  const write = usage.cache_creation_input_tokens || 0;
+  const reasoning = usage.output_tokens_details?.thinking_tokens;
+  return {
+    inputTokens: usage.input_tokens || 0,
+    outputTokens: usage.output_tokens || 0,
+    ...(read ? { cacheReadTokens: read } : {}),
+    ...(write ? { cacheWriteTokens: write } : {}),
+    ...(reasoning ? { reasoningTokens: reasoning } : {}),
+  };
+}
+
+function finishReason(raw, blocks) {
+  if (raw === "length") return { kind: "max-tokens" };
+  if (raw === "tool_calls" || blocks.some((block) => block.type === "tool-call")) {
+    return { kind: "tool-calls" };
+  }
+  return { kind: "stop" };
+}
+
+function errorCode(status) {
+  if (status === 401 || status === 403) return "AUTH";
+  if (status === 429) return "RATE_LIMIT";
+  if (status === 400) return "INVALID_REQUEST";
+  if (status >= 500) return "SERVER";
+  return `HTTP_${status}`;
+}
+
+async function postJson(url, apiKey, transport, body, signal) {
+  const headers = {
+    "content-type": "application/json",
+    ...attributionHeaders(),
+    ...(transport === "anthropic_messages"
+      ? { "x-api-key": apiKey, "anthropic-version": "2023-06-01" }
+      : { authorization: `Bearer ${apiKey}` }),
+  };
+  let response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal,
+    });
+  } catch (error) {
+    if (signal?.aborted) throw new LlmError("Verifiers request aborted.", "ABORTED", { cause: error });
+    throw new LlmError(`Verifiers request to ${url} failed.`, "TRANSPORT", { cause: error });
+  }
+  const raw = await response.json().catch(() => undefined);
+  if (!response.ok) {
+    const detail = raw?.error?.message || raw?.error?.type || response.statusText;
+    throw new LlmError(`Verifiers request failed (${response.status}): ${detail}`, errorCode(response.status));
+  }
+  if (raw === undefined || raw === null || typeof raw !== "object") {
+    throw new LlmError("Verifiers returned malformed JSON.", "MALFORMED_RESPONSE");
+  }
+  return raw;
+}
+
+const CODECS = {
+  chat_completions: {
+    path: "chat/completions",
+    request: chatRequest,
+    response: chatResponse,
+  },
+  responses: {
+    path: "responses",
+    request: responsesRequest,
+    response: responsesResponse,
+  },
+  anthropic_messages: {
+    path: "messages",
+    request: anthropicRequest,
+    response: anthropicResponse,
+  },
+};
+
+class VerifiersAdapter extends LlmAdapter {
+  constructor(config) {
+    super();
+    this.config = config;
+  }
+
+  resolveModel(provider, model) {
+    return Promise.resolve({
+      provider,
+      id: model,
+      name: model,
+      inputModalities: ["text"],
+      context: { contextWindow: this.config.contextWindow },
+      defaultMaxTokens: this.config.maxTokens,
+    });
+  }
+
+  async *stream(options) {
+    if (options.messages.some((message) => contentHasImage(message.content))) {
+      throw new LlmError(
+        "The Verifiers DSH adapter does not support image content.",
+        "UNSUPPORTED_CONTENT",
+      );
+    }
+    const codec = CODECS[this.config.transport];
+    const apiKey = process.env.DSH_INTERCEPT_KEY;
+    if (!apiKey) throw new LlmError("Missing DSH_INTERCEPT_KEY.", "MISSING_CREDENTIAL");
+    const body = codec.request(options);
+    const url = `${this.config.endpoint.replace(/\/$/, "")}/${codec.path}`;
+    const raw = await postJson(
+      url,
+      apiKey,
+      this.config.transport,
+      body,
+      options.signal,
+    );
+    const result = codec.response(raw);
+    if (result.blocks.length === 0) {
+      throw new LlmError(`Model ${options.model} returned no content.`, "EMPTY_RESPONSE");
+    }
+    for (const [index, block] of result.blocks.entries()) {
+      yield { type: "block-start", index, blockType: block.type };
+      if (block.type === "text") {
+        yield { type: "text-delta", index, text: block.text };
+      } else if (block.type === "reasoning") {
+        yield { type: "reasoning-delta", index, text: block.text };
+      } else {
+        yield {
+          type: "tool-call-delta",
+          index,
+          id: CallId(block.id),
+          name: block.name,
+          argumentsDelta: block.arguments,
+        };
+      }
+      yield {
+        type: "block-end",
+        index,
+        block: block.type === "tool-call" ? { ...block, id: CallId(block.id) } : block,
+      };
+    }
+    yield { type: "usage", usage: result.usage };
+    yield { type: "finish", reason: result.reason, replayState: result.replayState };
+  }
+}
+
+export const name = "llm-verifiers";
+export const inject = ["llm"];
+
+export function apply(ctx, config) {
+  ctx.llm.registerAdapter(["verifiers"], new VerifiersAdapter(config));
+}

--- a/verifiers/v1/harnesses/deepseek_harness/adapter.mjs
+++ b/verifiers/v1/harnesses/deepseek_harness/adapter.mjs
@@ -520,7 +520,9 @@ class VerifiersAdapter extends LlmAdapter {
       name: model,
       inputModalities: ["text"],
       context: { contextWindow: this.config.contextWindow },
-      defaultMaxTokens: this.config.maxTokens,
+      ...(this.config.maxTokens === undefined
+        ? {}
+        : { defaultMaxTokens: this.config.maxTokens }),
     });
   }
 

--- a/verifiers/v1/harnesses/deepseek_harness/harness.py
+++ b/verifiers/v1/harnesses/deepseek_harness/harness.py
@@ -227,4 +227,5 @@ class DeepSeekHarness(ACPHarness[DeepSeekHarnessConfig]):
     def run_dir(trace: Trace) -> str:
         # Keeping the config below the npm prefix lets Cordis resolve its bare
         # plugin specifiers while the trace id isolates concurrent rollouts.
-        return f"{PACKAGES_DIR}/runs/{trace.id}"
+        trace_dir = hashlib.sha256(trace.id.encode()).hexdigest()
+        return f"{PACKAGES_DIR}/runs/{trace_dir}"

--- a/verifiers/v1/harnesses/deepseek_harness/harness.py
+++ b/verifiers/v1/harnesses/deepseek_harness/harness.py
@@ -25,7 +25,6 @@ DSH_DIR = "/var/tmp/vf-deepseek-harness"
 PACKAGES_DIR = f"{DSH_DIR}/packages"
 DSH_BIN = f"{PACKAGES_DIR}/node_modules/.bin/dsh-acp-demo"
 NODE_ADDON_VERSION = "0.1.4"
-DEFAULT_CONTEXT_WINDOW = 262_144
 ADAPTER_SOURCE = (Path(__file__).resolve().parent / "adapter.mjs").read_bytes()
 
 INSTALL = r"""
@@ -142,7 +141,6 @@ class DeepSeekHarness(ACPHarness[DeepSeekHarnessConfig]):
                     "endpoint": endpoint,
                     "transport": self.config.transport,
                     "model": ctx.model,
-                    "contextWindow": DEFAULT_CONTEXT_WINDOW,
                     "bareToolPrefixes": bare_tool_prefixes,
                     **(
                         {"maxTokens": ctx.sampling.max_tokens}

--- a/verifiers/v1/harnesses/deepseek_harness/harness.py
+++ b/verifiers/v1/harnesses/deepseek_harness/harness.py
@@ -26,7 +26,6 @@ PACKAGES_DIR = f"{DSH_DIR}/packages"
 DSH_BIN = f"{PACKAGES_DIR}/node_modules/.bin/dsh-acp-demo"
 NODE_ADDON_VERSION = "0.1.4"
 DEFAULT_CONTEXT_WINDOW = 262_144
-DEFAULT_MAX_TOKENS = 32_768
 ADAPTER_SOURCE = (Path(__file__).resolve().parent / "adapter.mjs").read_bytes()
 
 INSTALL = r"""
@@ -81,9 +80,14 @@ class DeepSeekHarness(ACPHarness[DeepSeekHarnessConfig]):
             "deepseek-harness: ensuring DeepSeek Harness %s is installed",
             self.config.version,
         )
+        lock = f"{DSH_DIR}.install.lock"
         guarded = (
-            f"mkdir -p {DSH_DIR} && "
-            f'"$(command -v flock || command -v lockf)" {DSH_DIR}/install.lock '
+            f'until ln -s "$$" {lock} 2>/dev/null; do '
+            f"owner=$(readlink {lock}); "
+            f'if ! kill -0 "$owner" 2>/dev/null; then '
+            f'[ "$(readlink {lock})" != "$owner" ] || rm -f {lock}; fi; '
+            f"sleep 0.1; done; "
+            f'trap \'[ "$(readlink {lock})" != "$$" ] || rm -f {lock}\' EXIT; '
             f"sh -c {shlex.quote(INSTALL)}"
         )
         install = await runtime.run(
@@ -128,8 +132,12 @@ class DeepSeekHarness(ACPHarness[DeepSeekHarnessConfig]):
                     "transport": self.config.transport,
                     "model": ctx.model,
                     "contextWindow": DEFAULT_CONTEXT_WINDOW,
-                    "maxTokens": ctx.sampling.max_tokens or DEFAULT_MAX_TOKENS,
                     "bareToolPrefixes": bare_tool_prefixes,
+                    **(
+                        {"maxTokens": ctx.sampling.max_tokens}
+                        if ctx.sampling.max_tokens is not None
+                        else {}
+                    ),
                 },
             },
             {

--- a/verifiers/v1/harnesses/deepseek_harness/harness.py
+++ b/verifiers/v1/harnesses/deepseek_harness/harness.py
@@ -1,0 +1,204 @@
+"""Run DeepSeek Harness against interception through its ACP server."""
+
+import hashlib
+import json
+import logging
+import re
+import shlex
+from pathlib import Path
+from typing import Literal
+
+from pydantic import Field
+
+from verifiers.v1.acp import ACPConfig, ACPHarness
+from verifiers.v1.clients import ModelContext
+from verifiers.v1.configs.harness import HarnessConfig
+from verifiers.v1.harnesses.node import NODE_BIN_DIR, ensure_node
+from verifiers.v1.runtimes import Runtime
+from verifiers.v1.task import TaskData
+from verifiers.v1.trace import Trace
+
+logger = logging.getLogger(__name__)
+
+KEY_VAR = "DSH_INTERCEPT_KEY"
+DSH_DIR = "/var/tmp/vf-deepseek-harness"
+PACKAGES_DIR = f"{DSH_DIR}/packages"
+DSH_BIN = f"{PACKAGES_DIR}/node_modules/.bin/dsh-acp-demo"
+NODE_ADDON_VERSION = "0.1.4"
+DEFAULT_CONTEXT_WINDOW = 262_144
+DEFAULT_MAX_TOKENS = 32_768
+ADAPTER_SOURCE = (Path(__file__).resolve().parent / "adapter.mjs").read_bytes()
+
+INSTALL = r"""
+set -e
+packages=/var/tmp/vf-deepseek-harness/packages
+export PATH="/var/tmp/vf-node/bin:$PATH"
+
+if ! command -v python3 >/dev/null || ! command -v make >/dev/null || ! command -v c++ >/dev/null; then
+    if ! command -v apt-get >/dev/null; then
+        echo "DeepSeek Harness requires Python, make, and a C++ compiler to build node-pty" >&2
+        exit 1
+    fi
+    apt-get update -qq
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends python3 make g++ >/dev/null
+    rm -rf /var/lib/apt/lists/*
+fi
+
+versions="$VF_DEEPSEEK_HARNESS_VERSION:$VF_NODE_ADDON_VERSION"
+if [ "$(cat "$packages/.versions" 2>/dev/null)" != "$versions" ]; then
+    npm install --prefix "$packages" --no-audit --no-fund --omit=dev \
+        "node-addon-require-builtin@$VF_NODE_ADDON_VERSION" \
+        "@deepseek-ai/dsh-acp-demo@$VF_DEEPSEEK_HARNESS_VERSION" \
+        "@deepseek-ai/dsh-bash-local@$VF_DEEPSEEK_HARNESS_VERSION" \
+        "@deepseek-ai/dsh-llm@$VF_DEEPSEEK_HARNESS_VERSION" \
+        "@deepseek-ai/dsh-mcp-client@$VF_DEEPSEEK_HARNESS_VERSION" \
+        "@deepseek-ai/dsh-subprocess-local@$VF_DEEPSEEK_HARNESS_VERSION" >/dev/null
+    printf %s "$versions" > "$packages/.versions"
+fi
+"""
+
+
+class DeepSeekHarnessConfig(HarnessConfig):
+    version: str = Field(default="0.1.0-rc.6", pattern=r"^[A-Za-z0-9._+-]+$")
+    """DeepSeek Harness release to install, pinned for reproducibility."""
+    transport: Literal["chat_completions", "responses", "anthropic_messages"] = (
+        "chat_completions"
+    )
+    """Model API transport."""
+
+
+class DeepSeekHarness(ACPHarness[DeepSeekHarnessConfig]):
+    APPENDS_SYSTEM_PROMPT = True
+    SUPPORTS_MCP = True
+    SUPPORTS_SKILLS = True
+
+    async def setup(self, runtime: Runtime) -> None:
+        await ensure_node(runtime)
+        logger.info(
+            "deepseek-harness: ensuring DeepSeek Harness %s is installed",
+            self.config.version,
+        )
+        guarded = (
+            f"mkdir -p {DSH_DIR} && "
+            f'"$(command -v flock || command -v lockf)" {DSH_DIR}/install.lock '
+            f"sh -c {shlex.quote(INSTALL)}"
+        )
+        install = await runtime.run(
+            ["sh", "-c", guarded],
+            {
+                "VF_DEEPSEEK_HARNESS_VERSION": self.config.version,
+                "VF_NODE_ADDON_VERSION": NODE_ADDON_VERSION,
+            },
+        )
+        if install.exit_code != 0:
+            detail = (install.stderr or install.stdout).strip()[-500:]
+            raise RuntimeError(f"DeepSeek Harness install failed: {detail}")
+        await super().setup(runtime)
+
+    async def prepare_acp(
+        self,
+        ctx: ModelContext,
+        trace: Trace,
+        runtime: Runtime,
+        endpoint: str,
+        secret: str,
+        mcp_urls: dict[str, str],
+        data: TaskData,
+    ) -> ACPConfig:
+        if self.config.disabled_tools:
+            raise ValueError("DeepSeek Harness ACP does not support disabling tools")
+
+        system_prompt, prompt = self.resolve_prompt(data)
+        run_dir = self.run_dir(trace)
+        dsh_home = f"{run_dir}/dsh"
+        await self.install_skills(runtime, f"{dsh_home}/skills")
+
+        adapter_path = f"{run_dir}/adapter.mjs"
+        await runtime.write(adapter_path, ADAPTER_SOURCE)
+        composition = [
+            {
+                "id": "llm-verifiers",
+                "name": "./adapter.mjs",
+                "config": {
+                    "endpoint": endpoint,
+                    "transport": self.config.transport,
+                    "model": ctx.model,
+                    "contextWindow": DEFAULT_CONTEXT_WINDOW,
+                    "maxTokens": ctx.sampling.max_tokens or DEFAULT_MAX_TOKENS,
+                },
+            },
+            {
+                "id": "subprocess",
+                "name": "@deepseek-ai/dsh-subprocess-local",
+            },
+            {"id": "bash", "name": "@deepseek-ai/dsh-bash-local"},
+            {
+                "id": "acp-agent",
+                "name": "@deepseek-ai/dsh-acp-demo",
+                "config": {
+                    "provider": "verifiers",
+                    "model": ctx.model,
+                    "dshHome": dsh_home,
+                    "persistenceRoot": f"{run_dir}/sessions",
+                    "persistenceCompression": "none",
+                    "persona": system_prompt or "",
+                    "workspaceContext": {"maxBytes": 65536},
+                    "skills": {"filesystem": {"watch": False}},
+                    "toolBash": {"enableRunInBackground": False},
+                    "toolJobs": False,
+                    "goals": False,
+                },
+            },
+        ]
+
+        for index, (name, url) in enumerate(mcp_urls.items()):
+            server_name = re.sub(r"[^A-Za-z0-9_-]", "_", name) or "server"
+            if server_name != name or len(server_name) > 32:
+                digest = hashlib.sha1(name.encode()).hexdigest()[:8]
+                server_name = f"{server_name[:23]}_{digest}"
+            composition.append(
+                {
+                    "id": f"mcp-{index}",
+                    "name": "@deepseek-ai/dsh-mcp-client",
+                    "config": {
+                        "serverName": server_name,
+                        "transport": "streamable-http",
+                        "url": url,
+                        "toolCallTimeoutMs": int(self.config.tool_timeout * 1000),
+                        "failOnStartupError": True,
+                    },
+                }
+            )
+
+        config_path = f"{run_dir}/cordis.yml"
+        await runtime.write(
+            config_path, json.dumps(composition, ensure_ascii=False).encode()
+        )
+        return ACPConfig(
+            env={
+                **self.config.resolved_env,
+                KEY_VAR: secret,
+                "DSH_HOME": dsh_home,
+                "DSH_AGENTS_HOME": f"{run_dir}/agents",
+                "NO_COLOR": "1",
+            },
+            command=[f"{NODE_BIN_DIR}/node", DSH_BIN, "--config", config_path],
+            prompt=prompt,
+            # DeepSeek's ACP server rejects per-session MCP declarations. Its
+            # Cordis MCP plugins above own the equivalent rollout-scoped tools.
+            mcp_urls={},
+        )
+
+    async def cleanup(self, trace: Trace, runtime: Runtime) -> None:
+        result = await runtime.run(["rm", "-rf", self.run_dir(trace)], {})
+        if result.exit_code != 0:
+            raise RuntimeError(
+                f"failed to clean up DeepSeek Harness state: "
+                f"{result.stderr.strip()[-500:]}"
+            )
+
+    @staticmethod
+    def run_dir(trace: Trace) -> str:
+        # Keeping the config below the npm prefix lets Cordis resolve its bare
+        # plugin specifiers while the trace id isolates concurrent rollouts.
+        return f"{PACKAGES_DIR}/runs/{trace.id}"

--- a/verifiers/v1/harnesses/deepseek_harness/harness.py
+++ b/verifiers/v1/harnesses/deepseek_harness/harness.py
@@ -81,13 +81,17 @@ class DeepSeekHarness(ACPHarness[DeepSeekHarnessConfig]):
             self.config.version,
         )
         lock = f"{DSH_DIR}.install.lock"
+        # Process start time distinguishes a live installer from a reused stale PID.
         guarded = (
-            f'until ln -s "$$" {lock} 2>/dev/null; do '
+            f"identity=\"$$:$(awk '{{print $22}}' /proc/$$/stat)\"; "
+            f'until ln -s "$identity" {lock} 2>/dev/null; do '
             f"owner=$(readlink {lock}); "
-            f'if ! kill -0 "$owner" 2>/dev/null; then '
+            f"pid=${{owner%%:*}}; started=${{owner#*:}}; "
+            f'if [ "$(awk \'{{print $22}}\' "/proc/$pid/stat" 2>/dev/null)" '
+            f'!= "$started" ]; then '
             f'[ "$(readlink {lock})" != "$owner" ] || rm -f {lock}; fi; '
             f"sleep 0.1; done; "
-            f'trap \'[ "$(readlink {lock})" != "$$" ] || rm -f {lock}\' EXIT; '
+            f'trap \'[ "$(readlink {lock})" != "$identity" ] || rm -f {lock}\' EXIT; '
             f"sh -c {shlex.quote(INSTALL)}"
         )
         install = await runtime.run(
@@ -114,6 +118,13 @@ class DeepSeekHarness(ACPHarness[DeepSeekHarnessConfig]):
     ) -> ACPConfig:
         if self.config.disabled_tools:
             raise ValueError("DeepSeek Harness ACP does not support disabling tools")
+        if (
+            self.config.transport == "anthropic_messages"
+            and ctx.sampling.max_tokens is None
+        ):
+            raise ValueError(
+                "DeepSeek Harness anthropic_messages transport requires max_tokens"
+            )
 
         system_prompt, prompt = self.resolve_prompt(data)
         run_dir = self.run_dir(trace)

--- a/verifiers/v1/harnesses/deepseek_harness/harness.py
+++ b/verifiers/v1/harnesses/deepseek_harness/harness.py
@@ -35,13 +35,16 @@ packages=/var/tmp/vf-deepseek-harness/packages
 export PATH="/var/tmp/vf-node/bin:$PATH"
 
 if ! command -v python3 >/dev/null || ! command -v make >/dev/null || ! command -v c++ >/dev/null; then
-    if ! command -v apt-get >/dev/null; then
+    if command -v apt-get >/dev/null; then
+        apt-get update -qq
+        DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends python3 make g++ >/dev/null
+        rm -rf /var/lib/apt/lists/*
+    elif command -v apk >/dev/null; then
+        apk add --no-cache python3 make g++ >/dev/null
+    else
         echo "DeepSeek Harness requires Python, make, and a C++ compiler to build node-pty" >&2
         exit 1
     fi
-    apt-get update -qq
-    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends python3 make g++ >/dev/null
-    rm -rf /var/lib/apt/lists/*
 fi
 
 versions="$VF_DEEPSEEK_HARNESS_VERSION:$VF_NODE_ADDON_VERSION"
@@ -59,7 +62,7 @@ fi
 
 
 class DeepSeekHarnessConfig(HarnessConfig):
-    version: str = Field(default="0.1.0-rc.6", pattern=r"^[A-Za-z0-9._+-]+$")
+    version: str = Field(default="0.1.0-rc.7", pattern=r"^[A-Za-z0-9._+-]+$")
     """DeepSeek Harness release to install, pinned for reproducibility."""
     transport: Literal["chat_completions", "responses", "anthropic_messages"] = (
         "chat_completions"
@@ -115,6 +118,7 @@ class DeepSeekHarness(ACPHarness[DeepSeekHarnessConfig]):
 
         adapter_path = f"{run_dir}/adapter.mjs"
         await runtime.write(adapter_path, ADAPTER_SOURCE)
+        bare_tool_prefixes = []
         composition = [
             {
                 "id": "llm-verifiers",
@@ -125,6 +129,7 @@ class DeepSeekHarness(ACPHarness[DeepSeekHarnessConfig]):
                     "model": ctx.model,
                     "contextWindow": DEFAULT_CONTEXT_WINDOW,
                     "maxTokens": ctx.sampling.max_tokens or DEFAULT_MAX_TOKENS,
+                    "bareToolPrefixes": bare_tool_prefixes,
                 },
             },
             {
@@ -156,6 +161,8 @@ class DeepSeekHarness(ACPHarness[DeepSeekHarnessConfig]):
             if server_name != name or len(server_name) > 32:
                 digest = hashlib.sha1(name.encode()).hexdigest()[:8]
                 server_name = f"{server_name[:23]}_{digest}"
+            if not name:
+                bare_tool_prefixes.append(f"mcp__{server_name}__")
             composition.append(
                 {
                     "id": f"mcp-{index}",


### PR DESCRIPTION
## Overview

Adds DeepSeek Harness as a native Verifiers v1 ACP harness, with model calls routed directly through Verifiers interception instead of an upstream provider plugin.

## Details

- installs pinned DeepSeek Harness ACP, LLM, bash, subprocess, and MCP packages inside the selected runtime
- generates an isolated Cordis composition for each rollout, including local execution tools and configured MCP servers
- supports Chat Completions, Responses, and Anthropic Messages while preserving provider-native replay state
- adapts MCP to Cordis plugins because the DeepSeek ACP server does not accept per-session ACP MCP declarations
- registers the harness publicly and adds Docker coverage for normal agent execution and ACP resume paths

## Impact

DeepSeek Harness can now run through the same Verifiers runtime, interception, tool, skill, and trace abstractions as the existing native harnesses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New harness path touches rollout install, Cordis composition, and multi-transport interception wiring; misconfiguration (e.g. missing `DSH_INTERCEPT_KEY`, `anthropic_messages` without `max_tokens`) fails at runtime rather than in CI unit tests alone.
> 
> **Overview**
> Adds **DeepSeek Harness** as a native Verifiers v1 **ACP harness** so rollouts run through the same interception, MCP, skills, and trace path as other agent CLIs.
> 
> Each rollout **installs pinned `@deepseek-ai/dsh-*` packages** in the runtime, writes a per-trace **Cordis** composition (Verifiers LLM adapter, bash/subprocess tools, MCP client plugins), and starts **`dsh-acp-demo`** with **`mcp_urls` cleared** because the ACP server does not accept per-session MCP. The new **`adapter.mjs`** registers an `llm-verifiers` adapter that POSTs to the interception endpoint for **`chat_completions`**, **`responses`**, or **`anthropic_messages`**, including tool-name mapping and provider-native replay state.
> 
> **`DeepSeekHarness`** is exported from the harness registry; pytest adds the **`deepseek_harness`** mark and Docker e2e rows for agentic shell work and ACP resume with tools. The ACP resume fixture prompt is generalized so it does not name a specific MCP server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee2a239c9e05f14ef3993886acd2ccb364fc187c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add DeepSeek Harness ACP integration with multi-transport LLM adapter
> - Adds a new `DeepSeekHarness` ACP harness in [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2377/files#diff-f44489395da8da9aa732db4045e912cbc8d5da50409cc6ab344cd6069e6638ef) that installs DeepSeek Harness packages, writes a Cordis config, and launches `dsh-acp-demo` as a subprocess with MCP server support.
> - Adds [adapter.mjs](https://github.com/PrimeIntellect-ai/verifiers/pull/2377/files#diff-dd08ab1cd8ae18a564dc61bb04501b422a693cecf169cfb4f1db782bdbf5963a), a DSH LLM adapter (`llm-verifiers`) that proxies LLM calls to the Verifiers interception server across three transports: `chat_completions`, `responses`, and `anthropic_messages`.
> - Registers `deepseek_harness` as a pytest marker and adds `dsh-agent-in-docker` and `dsh-acp-in-docker` placement pairs to the e2e test matrix.
> - The `anthropic_messages` transport requires `max_tokens` to be set; `disabled_tools` is unsupported and raises an error.
> - Risk: the adapter requires `DSH_INTERCEPT_KEY` to be present in the environment; missing key raises `LlmError` at request time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee2a239.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->