### PR TITLE
fix(v1): pin nano-rlm to 83ef01f

### DIFF
--- a/configs/gsm8k_rlm.toml
+++ b/configs/gsm8k_rlm.toml
@@ -14,7 +14,6 @@ id = "gsm8k"
 
 [env.agent.harness]
 id = "rlm"
-version = "main"
 
 [env.agent.runtime]
 type = "docker"

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -28,7 +28,9 @@ RLM_STATE_DIR = ".vf-rlm"
 
 
 class RLMHarnessConfig(HarnessConfig):
-    version: str = Field(default="main", min_length=1)
+    version: str = Field(
+        default="83ef01f7a6c97328919387343bd30cf4edaac20d", min_length=1
+    )
     """Git ref (branch, tag, or commit) of nano-rlm to install."""
     max_depth: int = 0
     """Recursion depth rlm may spawn sub-harnesses to (RLM_MAX_DEPTH)."""


### PR DESCRIPTION
Pin the rlm harness default `version` to nano-rlm `83ef01f` instead of tracking `main`, and drop the `version = "main"` override from `configs/gsm8k_rlm.toml` so the example uses it. An explicit `version` still selects any branch, tag, or commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
