### PR TITLE
Normalize MCP tool names in traces

### DIFF
--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -288,11 +288,21 @@ async def test_tool(run_v1, harness_runtime, tool_runtime, tmp_path):
     assert trace.ok
     assert trace.num_turns >= 2  # tool call + answer
     assert trace.reward == 1.0
-    # The interception server captured the advertised tools onto the trace (for tool-use SFT):
-    # the null harness offered the task's MCP tool under the canonical name, schema included.
+    # The harness advertised the qualified MCP name, while the trace captured the tool exactly
+    # as the environment declared it (for tool-use SFT), schema included.
     assert trace.tools
-    (echo_tool,) = [t for t in trace.tools if t.name == "mcp__echo__back"]
+    (echo_tool,) = [t for t in trace.tools if t.name == "back"]
     assert "message" in echo_tool.parameters.get("properties", {})
+    assert {
+        call.name
+        for message in trace.assistant_messages
+        for call in message.tool_calls or []
+    } == {"back"}
+    assert {
+        message.name
+        for message in trace.messages
+        if message.role == "tool" and message.name is not None
+    } <= {"back"}
 
 
 @pytest.mark.e2e
@@ -599,9 +609,9 @@ async def test_env_id_user_sim_with_tools(run_v1, tmp_path):
     assert assistant.task.data.prompt is None  # the scenario stayed off the wire
     assert user.num_turns >= 1  # the modeled user actually drove the exchange
     assert assistant.rewards["echoed"].score == 1.0  # the tool ran, mid-conversation
-    # The tool was advertised to the masked chat exactly as to any run.
+    # The assistant trace keeps the environment-declared name after the MCP call ran.
     assert assistant.tools
-    assert any(tool.name == "mcp__echo__back" for tool in assistant.tools)
+    assert any(tool.name == "back" for tool in assistant.tools)
 
 
 @pytest.mark.e2e

--- a/tests/v1/test_graph.py
+++ b/tests/v1/test_graph.py
@@ -128,6 +128,54 @@ def test_tool_call_hash_matches_v0_content_and_arguments_normalization():
     assert graph.message_hash(left) == graph.message_hash(right)
 
 
+def test_mcp_tool_names_are_normalized_on_the_trace_without_changing_replay():
+    trace = vf.Trace(
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
+        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="use submit")),
+    )
+    user = vf.UserMessage(content="use submit")
+    qualified = "mcp__grader__submit"
+    call = vf.ToolCall(id="call_0", name=qualified, arguments="{}")
+    response = _response(
+        vf.AssistantMessage(
+            tool_calls=[call],
+            provider_state=[
+                {
+                    "type": "function_call",
+                    "call_id": call.id,
+                    "name": qualified,
+                    "arguments": call.arguments,
+                }
+            ],
+        )
+    )
+
+    graph.prepare_turn(trace, [user]).commit(
+        response,
+        tools=[vf.Tool(name=qualified, description="", parameters={})],
+    )
+
+    stored_call = trace.assistant_messages[0].tool_calls
+    assert stored_call is not None and stored_call[0].name == "submit"
+    assert trace.tools[0].name == "submit"
+    assert response.message.tool_calls == [call]
+    assert trace.nodes[-1].provider_message == response.message
+    dumped = trace.model_dump()
+    assert dumped["nodes"][-1]["message"]["tool_calls"][0]["name"] == "submit"
+    assert "provider_message" not in dumped["nodes"][-1]
+
+    result = vf.ToolMessage(content="accepted", tool_call_id=call.id, name=qualified)
+    graph.prepare_turn(trace, [user, response.message, result]).commit(
+        _response(vf.AssistantMessage(content="done"))
+    )
+
+    assert trace.num_branches == 1
+    recorded_result = trace.messages[-2]
+    assert isinstance(recorded_result, vf.ToolMessage)
+    assert recorded_result.name == "submit"
+    assert trace.nodes[-2].provider_message == result
+
+
 def test_reasoning_content_participates_in_graph_prefix_matching():
     task = vf.TaskData(idx=0, prompt="use a tool")
     trace = vf.Trace(

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -37,6 +37,7 @@ from verifiers.v1.types import (
     TextContentPart,
     Tool,
     ToolMessage,
+    declared_tool_name,
 )
 
 if TYPE_CHECKING:
@@ -70,6 +71,12 @@ class MessageNode(BaseModel):
     """Index into `Trace.nodes` of the predecessor message; None for a root."""
     message: Message
     """The message this node carries (system / user / assistant / tool)."""
+    provider_message: Message | None = Field(default=None, exclude=True, repr=False)
+    """The original provider-facing form when trace recording normalized an MCP tool name.
+
+    Retained only in memory so a stateless harness can replay its exact conversation on resume;
+    persisted traces contain only the environment-declared tool names in ``message``.
+    """
     sampled: bool = False
     """True iff a model call produced this message (the response passed to `commit`); False for
     every prompt-supplied message — including assistant/tool messages fabricated as context
@@ -214,6 +221,22 @@ def _canonical_tool_arguments(arguments: str) -> str:
         return json.dumps(json.loads(arguments), sort_keys=True, separators=(",", ":"))
     except (json.JSONDecodeError, ValueError):
         return arguments
+
+
+def _trace_message(message: Message) -> Message:
+    """Normalize provider-qualified MCP names to the environment's declared names."""
+    if isinstance(message, AssistantMessage) and message.tool_calls:
+        calls = [
+            call.model_copy(update={"name": declared_tool_name(call.name)})
+            for call in message.tool_calls
+        ]
+        if calls != message.tool_calls:
+            return message.model_copy(update={"tool_calls": calls})
+    elif isinstance(message, ToolMessage) and message.name:
+        name = declared_tool_name(message.name)
+        if name != message.name:
+            return message.model_copy(update={"name": name})
+    return message
 
 
 # Provider-specific fields not represented by typed messages but required on replay.
@@ -372,7 +395,10 @@ class PendingTurn:
         """Add this turn to the graph; returns the committed assistant node's id."""
         assistant_id = _commit_turn(self, response)
         if tools:
-            self.trace.tools = tools
+            self.trace.tools = [
+                tool.model_copy(update={"name": declared_tool_name(tool.name)})
+                for tool in tools
+            ]
         return assistant_id
 
     def commit_prompt(self, tools: list[Tool] | None = None) -> None:
@@ -380,12 +406,22 @@ class PendingTurn:
         parent = self.prefix_node_ids[-1] if self.prefix_node_ids else None
         index = _head_index(self.trace)
         for message in self.tail:
+            recorded = _trace_message(message)
             previous = parent
-            self.trace.nodes.append(MessageNode(parent=parent, message=message))
+            self.trace.nodes.append(
+                MessageNode(
+                    parent=parent,
+                    message=recorded,
+                    provider_message=message if recorded != message else None,
+                )
+            )
             parent = len(self.trace.nodes) - 1
-            index[(previous, message_hash(message))] = parent
+            index[(previous, message_hash(recorded))] = parent
         if tools:
-            self.trace.tools = tools
+            self.trace.tools = [
+                tool.model_copy(update={"name": declared_tool_name(tool.name)})
+                for tool in tools
+            ]
 
 
 def prepare_turn(trace: Trace, prompt: list[Message]) -> PendingTurn:
@@ -395,11 +431,12 @@ def prepare_turn(trace: Trace, prompt: list[Message]) -> PendingTurn:
     path_len = 0
     prefix_node_ids: list[int] = []
     for msg in prompt:
+        recorded = _trace_message(msg)
         existing = None
         if (
-            isinstance(msg.content, list)
+            isinstance(recorded.content, list)
             and len(idx) <= 10
-            and any(part.type == "image_url" for part in msg.content)
+            and any(part.type == "image_url" for part in recorded.content)
         ):
             children = [
                 node_id
@@ -408,10 +445,10 @@ def prepare_turn(trace: Trace, prompt: list[Message]) -> PendingTurn:
             ]
             # Repeated image URLs are cheaper to compare than to encode and hash again.
             # Only scan short, unambiguous parents; all other cases use the stable index.
-            if len(children) == 1 and trace.nodes[children[0]].message == msg:
+            if len(children) == 1 and trace.nodes[children[0]].message == recorded:
                 existing = children[0]
         if existing is None:
-            existing = idx.get((parent, message_hash(msg)))
+            existing = idx.get((parent, message_hash(recorded)))
         if existing is None:
             break
         prefix_node_ids.append(existing)
@@ -573,7 +610,8 @@ def _commit_turn(turn: PendingTurn, response: Response) -> int:
     if multi_modal_data is not None:
         mm_path = [(nid, prompt[i]) for i, nid in enumerate(prefix)]
     for i, msg in enumerate(prompt[num_reused:], start=num_reused):
-        key = (parent, message_hash(msg))
+        recorded = _trace_message(msg)
+        key = (parent, message_hash(recorded))
         start = path_len if cursor is None else cursor
         span = spans[i] if spans and i < len(spans) else None
         end = span[1] if span else start
@@ -583,7 +621,8 @@ def _commit_turn(turn: PendingTurn, response: Response) -> int:
             # potentially huge token slices a second time.
             MessageNode.model_construct(
                 parent=parent,
-                message=msg,
+                message=recorded,
+                provider_message=msg if recorded != msg else None,
                 token_ids=node_tokens,
                 mask=[False] * len(node_tokens),
                 is_content=is_content[start:end] if has_is_content else [],
@@ -593,17 +632,21 @@ def _commit_turn(turn: PendingTurn, response: Response) -> int:
         idx[key] = parent
         new_node_ids.append(parent)
         if mm_path is not None:
-            mm_path.append((parent, msg))
+            mm_path.append((parent, recorded))
         cursor = end
 
     # Assistant node: trailing scaffold (the generation prompt) + the sampled completion.
     comp_ids = tokens.completion_ids if tokens else []
     gen_start = path_len if cursor is None else cursor
     gen_prompt = prompt_ids[gen_start:]
+    recorded_response = _trace_message(response.message)
     trace.nodes.append(
         MessageNode.model_construct(
             parent=parent,
-            message=response.message,
+            message=recorded_response,
+            provider_message=response.message
+            if recorded_response != response.message
+            else None,
             sampled=True,
             token_ids=[*gen_prompt, *comp_ids],
             mask=[False] * len(gen_prompt) + [True] * len(comp_ids),
@@ -616,7 +659,7 @@ def _commit_turn(turn: PendingTurn, response: Response) -> int:
     )
     # Register the assistant so the next turn's prompt (which restates it) reuses this node.
     assistant_id = len(trace.nodes) - 1
-    idx[(parent, message_hash(response.message))] = assistant_id
+    idx[(parent, message_hash(recorded_response))] = assistant_id
     new_node_ids.append(assistant_id)
 
     # Attribute this turn's images onto the input nodes that introduced them (by content part).

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -231,7 +231,14 @@ class Harness(ABC, Generic[ConfigT]):
                 "overrides resume() nor supports a Messages prompt for the default "
                 "relaunch-on-the-conversation."
             )
-        branch = trace.branches[-1].messages if trace.branches else []
+        branches = trace.branches
+        # Trace messages use environment names; relaunch the program with the exact names
+        # that its provider-facing tool catalog used in the original exchange.
+        branch = (
+            [node.provider_message or node.message for node in branches[-1].nodes]
+            if branches
+            else []
+        )
         # `resolve_prompt` re-emits `data.system_prompt`; only de-duplicate those
         # system messages when it has something to re-emit. Explicit system
         # messages in a Messages prompt must survive a resumed segment.

--- a/verifiers/v1/tasksets/nemo_gym/response.py
+++ b/verifiers/v1/tasksets/nemo_gym/response.py
@@ -1,17 +1,15 @@
 """Convert Verifiers traces to NeMo Gym Responses objects."""
 
 import json
-from collections.abc import Collection
 from typing import Any
 
 from verifiers.v1.trace import Trace
-from verifiers.v1.types import AssistantMessage, ToolMessage
+from verifiers.v1.types import AssistantMessage, ToolMessage, declared_tool_name
 
 
 def trace_to_nemo_response(
     trace: Trace,
     responses_create_params: dict[str, Any],
-    tool_names: Collection[str],
 ) -> dict[str, Any]:
     """Convert the one completed V1 branch into a Gym Responses object."""
 
@@ -84,18 +82,11 @@ def trace_to_nemo_response(
                 }
             )
 
-    known_names = sorted(tool_names, key=len, reverse=True)
     for index, item in enumerate(output):
         name = item.get("name")
         if item.get("type") != "function_call" or not isinstance(name, str):
             continue
-        if name in tool_names:
-            continue
-        if name.startswith("mcp__"):
-            for tool_name in known_names:
-                if name.endswith(f"__{tool_name}"):
-                    output[index] = item | {"name": tool_name}
-                    break
+        output[index] = item | {"name": declared_tool_name(name)}
 
     return {
         "id": f"resp_{trace.id}",

--- a/verifiers/v1/tasksets/nemo_gym/taskset.py
+++ b/verifiers/v1/tasksets/nemo_gym/taskset.py
@@ -60,8 +60,6 @@ class NeMoGymTask(Task[NeMoGymData, NeMoGymState, NeMoGymTaskConfig]):
         state.direct_tools = {
             tool["name"]: tool for tool in tools if tool.get("type") == "function"
         }
-        state.tool_names = list(state.direct_tools)
-
         response = await state.post("seed_session", self.data.row)
         response.raise_for_status()
         state.cookies.update(response.cookies)
@@ -75,8 +73,7 @@ class NeMoGymTask(Task[NeMoGymData, NeMoGymState, NeMoGymTaskConfig]):
         params = self.data.row["responses_create_params"]
         response = await state.post(
             "verify",
-            self.data.row
-            | {"response": trace_to_nemo_response(trace, params, state.tool_names)},
+            self.data.row | {"response": trace_to_nemo_response(trace, params)},
         )
         response.raise_for_status()
         result = response.json()

--- a/verifiers/v1/tasksets/nemo_gym/toolset.py
+++ b/verifiers/v1/tasksets/nemo_gym/toolset.py
@@ -28,7 +28,6 @@ class NeMoGymState(State):
     mcp_url: str | None = None
     mcp_headers: dict[str, str] = Field(default_factory=dict)
     direct_tools: dict[str, dict[str, Any]] = Field(default_factory=dict)
-    tool_names: list[str] = Field(default_factory=list)
 
     async def post(self, path: str, body: dict[str, Any]) -> httpx.Response:
         """POST to Gym while carrying this rollout's cookie session forward."""
@@ -85,7 +84,6 @@ class NeMoGymToolset(Toolset[SharedToolsetConfig, NeMoGymState]):
                 )
                 for spec in self.state.direct_tools.values()
             ]
-        self.state.tool_names = [tool.name for tool in tools]
         return tools
 
     async def call_tool(self, name: str, arguments: dict[str, Any]) -> CallToolResult:

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -369,7 +369,7 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
     agent: AgentInfo[AgentConfigT]
     """The agent (harness x model x runtime) that produced this trace."""
     tools: list[Tool] = Field(default_factory=list)
-    """The tools advertised to the agent, automatically recorded from last intercepted turn."""
+    """The tools offered to the agent, recorded under their environment-declared names."""
 
     nodes: list[MessageNode] = Field(default_factory=list)
     """The message graph; branches are derived views and storage stays linear in turns."""

--- a/verifiers/v1/types.py
+++ b/verifiers/v1/types.py
@@ -63,6 +63,17 @@ class UserMessage(BaseModel):
     content: MessageContent
 
 
+def declared_tool_name(name: str) -> str:
+    """Recover the environment-declared name from a direct MCP tool name."""
+    original = name
+    server, separator, name = name.removeprefix("mcp__").partition("__")
+    return (
+        name
+        if original.startswith("mcp__") and server and separator and name
+        else original
+    )
+
+
 class ToolCall(BaseModel):
     id: str
     name: str


### PR DESCRIPTION
## Status

Superseded by #2378, which makes the MCP tool-use tests naming-agnostic without changing runtime naming or trace behavior.

This trace-normalization approach is intentionally not being pursued.