### PR TITLE
Auto-wire declared task Toolsets

### DIFF
--- a/environments/deepwiki/deepwiki/taskset.py
+++ b/environments/deepwiki/deepwiki/taskset.py
@@ -26,9 +26,7 @@ class DeepWikiTaskData(vf.TaskData):
 
 
 class DeepWikiTask(vf.Task[DeepWikiTaskData, vf.State, DeepWikiTaskConfig]):
-    @classmethod
-    def toolsets(cls, config: DeepWikiTaskConfig) -> list[vf.Toolset]:
-        return [DeepWikiToolset(config.tools)]
+    tools = (DeepWikiToolset,)
 
     @vf.reward(weight=1.0)
     async def answered(self, trace: vf.Trace) -> float:

--- a/environments/glossary/glossary/taskset.py
+++ b/environments/glossary/glossary/taskset.py
@@ -19,9 +19,7 @@ class GlossaryTaskData(vf.TaskData):
 
 
 class GlossaryTask(vf.Task[GlossaryTaskData, vf.State, GlossaryTaskConfig]):
-    @classmethod
-    def toolsets(cls, config: GlossaryTaskConfig) -> list[vf.Toolset]:
-        return [GlossaryToolset(config.tools)]
+    tools = (GlossaryToolset,)
 
     @vf.reward(weight=1.0)
     async def looked_up(self, trace: vf.Trace) -> float:

--- a/tests/v1/fixtures/counter_tool_v1.py
+++ b/tests/v1/fixtures/counter_tool_v1.py
@@ -24,9 +24,7 @@ class CounterTaskConfig(vf.TaskConfig):
 
 
 class CounterTask(vf.Task[vf.TaskData, CounterState, CounterTaskConfig]):
-    @classmethod
-    def toolsets(cls, config: CounterTaskConfig) -> list[vf.Toolset]:
-        return [CounterToolset(config.tools)]
+    tools = (CounterToolset,)
 
     @vf.reward(weight=1.0)
     async def counted(self, trace: vf.Trace) -> float:

--- a/tests/v1/fixtures/echo_acp_resume_v1.py
+++ b/tests/v1/fixtures/echo_acp_resume_v1.py
@@ -28,9 +28,7 @@ class ACPResumeConfig(vf.TasksetConfig):
 
 
 class ACPResumeTask(vf.Task[vf.TaskData, vf.State, ACPResumeTaskConfig]):
-    @classmethod
-    def toolsets(cls, config: ACPResumeTaskConfig) -> list[vf.Toolset]:
-        return [ResumeToolset(config.tools)]
+    tools = (ResumeToolset,)
 
     @vf.reward(weight=1.0)
     async def resumed(self, trace: vf.Trace) -> float:

--- a/tests/v1/fixtures/echo_tool_v1.py
+++ b/tests/v1/fixtures/echo_tool_v1.py
@@ -1,7 +1,7 @@
 """echo (v1, MCP tool): retrieve a stamped echo from a `vf.Toolset`, then report it.
 
-The v1 tool fixture for the e2e matrix. The task constructs an `EchoToolset`
-(`vf.Toolset`) in `Task.toolsets`, with one `@vf.tool` method whose placement is
+The v1 tool fixture for the e2e matrix. The task declares an `EchoToolset`
+(`vf.Toolset`), with one `@vf.tool` method whose placement is
 CLI-tunable (`--taskset.task.tools.colocated`, `--taskset.task.tools.runtime.type`):
 it runs colocated in the harness's runtime or in its own runtime, and the harness
 must reach it wherever it lives. The tool stamps its output with a token the prompt
@@ -31,9 +31,7 @@ class EchoToolTaskConfig(vf.TaskConfig):
 
 
 class EchoToolTask(vf.Task[vf.TaskData, vf.State, EchoToolTaskConfig]):
-    @classmethod
-    def toolsets(cls, config: EchoToolTaskConfig) -> list[vf.Toolset]:
-        return [EchoToolset(config.tools)]
+    tools = (EchoToolset,)
 
     @vf.reward(weight=1.0)
     async def echoed(self, trace: vf.Trace) -> float:

--- a/tests/v1/fixtures/tool_response_image_v1.py
+++ b/tests/v1/fixtures/tool_response_image_v1.py
@@ -33,9 +33,7 @@ class ToolResponseImageTaskConfig(vf.TaskConfig):
 class ToolResponseImageTask(
     vf.Task[vf.TaskData, vf.State, ToolResponseImageTaskConfig]
 ):
-    @classmethod
-    def toolsets(cls, config: ToolResponseImageTaskConfig) -> list[vf.Toolset]:
-        return [VisionToolset(config.tools)]
+    tools = (VisionToolset,)
 
     @vf.reward(weight=1.0)
     async def preserved_image_tool_result(self, trace: vf.Trace) -> float:

--- a/verifiers/v1/cli/init.py
+++ b/verifiers/v1/cli/init.py
@@ -71,12 +71,7 @@ def _taskset_py(pkg: str, prefix: str, *, add_tool: bool) -> str:
     if add_tool:
         local_imports.append(f"from {pkg}.servers.tool import {prefix}Toolset")
         task_config_fields += "\n    tools: vf.ToolsetConfig = vf.ToolsetConfig()"
-        task_decls += (
-            "\n\n    @classmethod"
-            f"\n    def toolsets(cls, config: {prefix}TaskConfig) -> list[vf.Toolset]:"
-            f"\n        return [{prefix}Toolset(config.tools)]"
-            "\n"
-        )
+        task_decls += f"\n    tools = ({prefix}Toolset,)\n"
     if local_imports:
         imports += "\n\n" + "\n".join(local_imports)
     methods_block = ""
@@ -183,7 +178,7 @@ def _readme(dash: str, pkg: str, *, add_tool: bool, add_harness: bool) -> str:
     ]
     if add_tool:
         layout.append(
-            f"- `{pkg}/servers/tool.py` — a `vf.Toolset` tool server, constructed in `Task.toolsets`."
+            f"- `{pkg}/servers/tool.py` — a `vf.Toolset` declared by the task."
         )
     if add_harness:
         layout.append(

--- a/verifiers/v1/task.py
+++ b/verifiers/v1/task.py
@@ -15,7 +15,7 @@ import inspect
 import json
 import logging
 from collections.abc import Callable, Mapping
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, Self
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, Self, cast
 
 from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import TypeVar
@@ -137,6 +137,8 @@ ConfigT = TypeVar("ConfigT", bound=TaskConfig, default=TaskConfig)
 class Task(Generic[DataT, StateT, ConfigT]):
     NEEDS_CONTAINER: ClassVar[bool] = False
     """Whether the task needs a containerized environment (isolated filesystem, ...)."""
+    tools: ClassVar[tuple[type[Toolset], ...]] = ()
+    """Per-rollout Toolsets, each constructed from ``config.tools``."""
 
     def __init__(self, data: DataT, config: ConfigT | None = None) -> None:
         self.data = data
@@ -277,16 +279,15 @@ class Task(Generic[DataT, StateT, ConfigT]):
 
     @classmethod
     def toolsets(cls, config: ConfigT) -> list[Toolset]:
-        """Tool servers launched per rollout, each constructed with its config off
-        `config` — override and wire explicitly:
+        """Build the Toolsets declared by ``tools`` for one rollout.
 
-            @classmethod
-            def toolsets(cls, config: MyTaskConfig) -> list[vf.Toolset]:
-                return [SearchToolset(config.tools)]
-
-        A classmethod so consumers can size placement (tunnels) off the class
-        before any task instance exists."""
-        return []
+        Override this for dynamic Toolsets or Toolsets with distinct configs. A
+        classmethod lets consumers size placement before a task instance exists.
+        """
+        if not cls.tools:
+            return []
+        tool_config = cast(Any, config).tools
+        return [toolset(tool_config) for toolset in cls.tools]
 
 
 TaskT = TypeVar("TaskT", bound=Task)


### PR DESCRIPTION
## Overview

Lets task-scoped Toolsets use a declarative `Task.tools` tuple instead of repeating a `toolsets()` factory in every task.

## Details

- Adds `Task.tools` as the common per-rollout declaration and has the base `Task.toolsets(config)` construct fresh Toolset instances from `config.tools`.
- Preserves `Task.toolsets(config)` overrides for dynamic Toolsets or Toolsets that require distinct configuration fields.
- Updates the v1 `init -T` scaffold to emit the declarative form.
- Migrates the task-scoped Glossary and DeepWiki examples and the existing Toolset end-to-end fixtures to exercise the common path.

## Impact

Task authors can expose a configured per-rollout Toolset with `tools = (MyToolset,)`; Verifiers continues to own server startup, routing, state channels, and teardown.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API with preserved `toolsets()` override; rollout/agent code still calls the same classmethod, with the new default assuming shared `config.tools` for all entries in `tools`.
> 
> **Overview**
> **Introduces declarative per-rollout Toolset wiring** via a `Task.tools` class tuple. The default `Task.toolsets(config)` now instantiates each declared Toolset with `config.tools`, so authors no longer need a repetitive `toolsets()` override for the common single-config case.
> 
> **`Task.toolsets(config)` remains overridable** for dynamic Toolsets or when different servers need distinct config fields; behavior for tasks with empty `tools` is unchanged (no servers).
> 
> **Scaffold and examples** are updated: `init -T` emits `tools = (…Toolset,)`, and Glossary, DeepWiki, and v1 tool e2e fixtures migrate off manual `toolsets()` factories. Docs in the init README and echo fixture comment now describe declaration instead of construction in `toolsets`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e21c89764702877a0eb364580e320859fe56176b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Auto-wire declared task Toolsets via a `tools` class attribute on `Task`
> - Adds a `tools: tuple[type[Toolset], ...]` class attribute to [`Task`](https://github.com/PrimeIntellect-ai/verifiers/pull/2381/files#diff-a1b4a5d6915beae41831864087ea497ed41f0b67b9091ad1ee614834cbfd9399), replacing the need for subclasses to override the `toolsets()` classmethod manually.
> - `Task.toolsets()` now auto-instantiates each declared `Toolset` type using `config.tools`, returning an empty list when `tools` is unset.
> - All existing task subclasses (in environments and test fixtures) are updated to use the new `tools = (SomeToolset,)` declaration.
> - The `init` CLI scaffold is updated to emit `tools = (<Prefix>Toolset,)` instead of generating a `toolsets()` classmethod.
> - Behavioral Change: subclasses that previously returned an empty list from the default `toolsets()` now also return an empty list, but subclasses that declared toolsets via the classmethod must migrate to the class attribute or override `toolsets()` explicitly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e21c897.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->