### PR TITLE
fix(cli): sanitize sensitive header values in config dumps and logs (#2345)

### DIFF
--- a/tests/v1/test_configs.py
+++ b/tests/v1/test_configs.py
@@ -24,3 +24,22 @@ CONFIGS = sorted(
 def test_eval_config_parses(path: Path) -> None:
     config = EvalConfig.model_validate(tomllib.load(path.open("rb")))
     assert config.env.taskset.id
+
+
+def test_write_config_sanitizes_headers(tmp_path: Path) -> None:
+    from verifiers.v1.cli.output import write_config
+    from verifiers.v1.configs.client import EvalClientConfig
+
+    config = EvalConfig(
+        client=EvalClientConfig(
+            headers={"X-Prime-Team-ID": "secret-team-123", "Authorization": "Bearer secret"}
+        )
+    )
+    written_path = write_config(config, tmp_path)
+    import json
+    data = json.loads(written_path.read_text())
+    assert data["client"]["headers"] == {
+        "X-Prime-Team-ID": "<redacted>",
+        "Authorization": "<redacted>",
+    }
+

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import contextlib
+import json
 import logging
 import time
 
@@ -11,6 +12,7 @@ from verifiers.v1.cli.output import (
     append_episode,
     output_path,
     save_config,
+    sanitize_dict,
 )
 from verifiers.v1.cli.resume import distribute
 from verifiers.v1.clients import ModelContext
@@ -23,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 async def run_eval(env: Env, config: EvalConfig) -> list[Episode]:
-    logger.info("eval config:\n%s", config.model_dump_json(indent=2))
+    logger.info("eval config:\n%s", json.dumps(sanitize_dict(config.model_dump(mode="json")), indent=2))
     taskset = env.taskset
     if config.num_tasks is None and taskset.INFINITE:
         raise ValueError(

--- a/verifiers/v1/cli/output.py
+++ b/verifiers/v1/cli/output.py
@@ -15,6 +15,7 @@ import hashlib
 import json
 from functools import cache
 from pathlib import Path
+from typing import Any
 
 from pydantic import BaseModel, TypeAdapter
 
@@ -61,6 +62,21 @@ def output_path(config: EvalConfig) -> Path:
     return config.output_dir / config.run.dir
 
 
+def sanitize_dict(data: Any) -> Any:
+    """Recursively sanitize a dictionary or list, masking sensitive fields like headers."""
+    if isinstance(data, dict):
+        sanitized = {}
+        for k, v in data.items():
+            if k == "headers" and isinstance(v, dict):
+                sanitized[k] = {hk: "<redacted>" for hk in v}
+            else:
+                sanitized[k] = sanitize_dict(v)
+        return sanitized
+    elif isinstance(data, list):
+        return [sanitize_dict(item) for item in data]
+    return data
+
+
 def write_config(
     config: BaseModel, results_dir: Path, filename: str = "eval.json"
 ) -> Path:
@@ -70,7 +86,8 @@ def write_config(
     config_dir = results_dir / CONFIG_DIR
     config_dir.mkdir(parents=True, exist_ok=True)
     config_path = config_dir / filename
-    config_path.write_text(json.dumps(config.model_dump(mode="json"), indent=2))
+    sanitized = sanitize_dict(config.model_dump(mode="json"))
+    config_path.write_text(json.dumps(sanitized, indent=2))
     return config_path
 
 


### PR DESCRIPTION
Fixes #2345

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sanitize sensitive header values in config dumps and logs
> - Adds `sanitize_dict` in [`output.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/2382/files#diff-07fce45dd0fa633f34d25e19962ab801b705a509774833de0d81bfe872787e8b), a recursive utility that replaces all values under any `headers` key with the literal string `<redacted>`.
> - `write_config` now passes the serialized config through `sanitize_dict` before writing to disk, so persisted JSON files never contain raw header values.
> - The eval runner in [`runner.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/2382/files#diff-65be4a576330571f2729a3bbcdbe92ac81bbcba450c313597c1bdca3a1c3f2e4) uses `sanitize_dict` + `json.dumps` instead of `model_dump_json` when logging the eval config.
> - A new test in [`test_configs.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/2382/files#diff-da1dfaa2b3c1eece16937ccf9dc4cfc035ca8f26fcbfd1d262b5427752600bc4) asserts that `write_config` redacts all header values in the output JSON.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ee7f0f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->