### PR TITLE
fix: address DeepSeek Harness review feedback

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,9 @@ def pytest_configure(config) -> None:
     config.addinivalue_line(
         "markers", "hermes_agent: v1 e2e cases on the hermes-agent harness"
     )
+    config.addinivalue_line(
+        "markers", "deepseek_harness: v1 e2e cases on the deepseek-harness harness"
+    )
 
 
 @pytest.fixture

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -25,7 +25,7 @@ Every combination carries its axes' pytest marks, so subsets select with `-m`:
 
 Marks: runtimes `subprocess` / `docker` / `prime` / `modal`, placement `colocated`,
 harnesses `null` / `bash` / `rlm` / `kimi_code` / `pi` / `pool` / `openclaw` / `codex` /
-`claude_code` / `hermes_agent`.
+`claude_code` / `hermes_agent` / `deepseek_harness`.
 A mark is applied per axis, so it selects every case touching that value on ANY axis; for one exact
 combination use `-k` on the test id (e.g. `-k "harness-in-docker-with-tool-in-subprocess"`).
 prime/modal provision real remote sandboxes (slow, infra-flaky, need setup), so they're local-only.
@@ -71,8 +71,8 @@ def tool_runtime(request) -> dict:
 
 
 # Built-in harnesses are bundled in the `harnesses` package; the agent CLIs (`rlm` /
-# `kimi-code` / `openclaw` / `codex` / `claude-code` / `hermes-agent`) install their
-# dependencies at rollout.
+# `kimi-code` / `openclaw` / `codex` / `claude-code` / `hermes-agent` /
+# `deepseek-harness`) install their dependencies at rollout.
 # `compact` (an example harness) and `terminus-2` (drives the host tmux) are excluded from e2e.
 @pytest.fixture
 def harness(request) -> HarnessConfig:

--- a/tests/v1/test_deepseek_harness.py
+++ b/tests/v1/test_deepseek_harness.py
@@ -1,0 +1,23 @@
+from verifiers.v1.harnesses.deepseek_harness.harness import (
+    INSTALL,
+    _dsh_server_name,
+)
+
+
+def test_install_script_supports_alpine_build_dependencies():
+    assert "command -v apk" in INSTALL
+    assert "apk add --no-cache python3 make g++" in INSTALL
+
+
+def test_dsh_server_name_preserves_bare_tool_namespace():
+    assert _dsh_server_name("") == ""
+
+
+def test_dsh_server_name_hashes_sanitized_or_long_names():
+    assert _dsh_server_name("server.with.dots").startswith("server_with_dots_")
+
+    long_name = "a" * 40
+    normalized = _dsh_server_name(long_name)
+
+    assert normalized.startswith("a" * 23)
+    assert len(normalized) == 32

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -48,6 +48,7 @@ AGENTIC_PLACEMENTS = [
     pair("codex", "docker", "codex-harness-in-docker"),
     pair("claude-code", "docker", "claude-code-harness-in-docker"),
     pair("hermes-agent", "docker", "hermes-agent-harness-in-docker"),
+    pair("deepseek-harness", "docker", "dsh-agent-in-docker"),
     pair("bash", "prime", "bash-harness-in-prime"),
     pair("bash", "modal", "bash-harness-in-modal"),
 ]
@@ -83,6 +84,7 @@ ACP_RESUME_PLACEMENTS = [
     ),
     pair("pool", "docker", "pool-acp-in-docker"),
     pair("openclaw", "docker", "openclaw-acp-in-docker"),
+    pair("deepseek-harness", "docker", "dsh-acp-in-docker"),
     pair("pool", "prime", "pool-acp-in-prime"),
     pair("rlm", "prime", "rlm-acp-in-prime-vm"),
 ]

--- a/verifiers/v1/harnesses/__init__.py
+++ b/verifiers/v1/harnesses/__init__.py
@@ -8,6 +8,10 @@ from verifiers.v1.harnesses.claude_code import (
     ClaudeCodeHarnessConfig,
 )
 from verifiers.v1.harnesses.codex import CodexHarness, CodexHarnessConfig
+from verifiers.v1.harnesses.deepseek_harness import (
+    DeepSeekHarness,
+    DeepSeekHarnessConfig,
+)
 from verifiers.v1.harnesses.hermes_agent import (
     HermesAgentHarness,
     HermesAgentHarnessConfig,
@@ -33,6 +37,8 @@ __all__ = [
     "ClaudeCodeHarnessConfig",
     "CodexHarness",
     "CodexHarnessConfig",
+    "DeepSeekHarness",
+    "DeepSeekHarnessConfig",
     "HermesAgentHarness",
     "HermesAgentHarnessConfig",
     "KimiCodeHarness",

--- a/verifiers/v1/harnesses/deepseek_harness/__init__.py
+++ b/verifiers/v1/harnesses/deepseek_harness/__init__.py
@@ -1,0 +1,6 @@
+from verifiers.v1.harnesses.deepseek_harness.harness import (
+    DeepSeekHarness,
+    DeepSeekHarnessConfig,
+)
+
+__all__ = ["DeepSeekHarness", "DeepSeekHarnessConfig"]

--- a/verifiers/v1/harnesses/deepseek_harness/adapter.mjs
+++ b/verifiers/v1/harnesses/deepseek_harness/adapter.mjs
@@ -232,8 +232,8 @@ function responsesResponse(raw) {
       reasoning.push(...(item.content || []).map((part) => part?.text || ""));
     } else if (item.type === "message") {
       text += (item.content || [])
-        .filter((part) => part?.type === "output_text")
-        .map((part) => part.text || "")
+        .filter((part) => part?.type === "output_text" || part?.type === "refusal")
+        .map((part) => part.text || part.refusal || "")
         .join("");
     } else if (item.type === "function_call" || item.type === "custom_tool_call") {
       blocks.push({
@@ -250,9 +250,7 @@ function responsesResponse(raw) {
   return {
     blocks,
     usage: responsesUsage(raw.usage),
-    reason: raw.status === "incomplete"
-      ? { kind: "max-tokens" }
-      : finishReason(undefined, blocks),
+    reason: responsesFinishReason(raw, blocks),
     replayState: {
       transport: "responses",
       data: output,
@@ -280,7 +278,10 @@ function anthropicRequest(options) {
       for (const call of toolCallsOf(message.content)) {
         let input = {};
         try {
-          input = JSON.parse(call.arguments);
+          const parsed = JSON.parse(call.arguments);
+          if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            input = parsed;
+          }
         } catch {
           // Anthropic requires an object; malformed provider arguments stay executable as {}.
         }
@@ -398,6 +399,14 @@ function finishReason(raw, blocks) {
     return { kind: "tool-calls" };
   }
   return { kind: "stop" };
+}
+
+function responsesFinishReason(raw, blocks) {
+  if (raw.status !== "incomplete") return finishReason(undefined, blocks);
+  if (raw.incomplete_details?.reason === "content_filter") {
+    return { kind: "content-filter" };
+  }
+  return { kind: "max-tokens" };
 }
 
 function errorCode(status) {

--- a/verifiers/v1/harnesses/deepseek_harness/adapter.mjs
+++ b/verifiers/v1/harnesses/deepseek_harness/adapter.mjs
@@ -1,0 +1,531 @@
+/** DSH LLM adapter that talks directly to a Verifiers interception server. */
+
+import {
+  attributionHeaders,
+  CallId,
+  contentHasImage,
+  LlmAdapter,
+  LlmError,
+} from "@deepseek-ai/dsh-llm";
+
+function textOf(blocks) {
+  return blocks
+    .map((block) => {
+      if (block.type === "text") return block.text;
+      if (block.type === "tool-result") return textOf(block.content);
+      return "";
+    })
+    .join("");
+}
+
+function reasoningOf(blocks) {
+  return blocks
+    .filter((block) => block.type === "reasoning")
+    .map((block) => block.text)
+    .join("");
+}
+
+function toolCallsOf(blocks) {
+  return blocks.filter((block) => block.type === "tool-call");
+}
+
+function replayOf(message, transport) {
+  const source = message.source.kind === "model" ? message.source : undefined;
+  const state = source?.replayState;
+  return state?.transport === transport ? state.data : undefined;
+}
+
+const TOOL_ENCODERS = {
+  chat_completions: (tool) => ({
+    type: "function",
+    function: {
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.parameters,
+    },
+  }),
+  responses: (tool) => ({ type: "function", ...tool }),
+  anthropic_messages: (tool) => ({
+    name: tool.name,
+    description: tool.description,
+    input_schema: tool.parameters,
+  }),
+};
+
+function toolsOf(options, transport) {
+  return options.tools?.length
+    ? { tools: options.tools.map(TOOL_ENCODERS[transport]) }
+    : {};
+}
+
+function chatRequest(options) {
+  const messages = [];
+  if (options.system !== undefined) messages.push({ role: "system", content: options.system });
+
+  for (const message of options.messages) {
+    if (message.role === "system") {
+      messages.push({ role: "system", content: textOf(message.content) });
+      continue;
+    }
+    if (message.role === "assistant") {
+      const text = textOf(message.content);
+      const reasoning = reasoningOf(message.content);
+      const calls = toolCallsOf(message.content);
+      const replay = replayOf(message, "chat_completions");
+      messages.push({
+        role: "assistant",
+        content: text || (calls.length > 0 ? null : ""),
+        ...(Array.isArray(replay)
+          ? { reasoning_details: replay }
+          : reasoning
+            ? { reasoning_content: reasoning }
+            : {}),
+        ...(calls.length === 0
+          ? {}
+          : {
+              tool_calls: calls.map((call) => ({
+                id: call.id,
+                type: "function",
+                function: { name: call.name, arguments: call.arguments },
+              })),
+            }),
+      });
+      continue;
+    }
+
+    const results = message.content.filter((block) => block.type === "tool-result");
+    const text = textOf(message.content.filter((block) => block.type !== "tool-result"));
+    if (text || results.length === 0) messages.push({ role: "user", content: text });
+    for (const result of results) {
+      messages.push({
+        role: "tool",
+        tool_call_id: result.toolCallId,
+        content: textOf(result.content) || "(no output)",
+      });
+    }
+  }
+
+  return {
+    model: options.model,
+    messages,
+    stream: false,
+    ...(options.temperature === undefined ? {} : { temperature: options.temperature }),
+    ...(options.stop === undefined ? {} : { stop: options.stop }),
+    ...(options.maxTokens === undefined ? {} : { max_tokens: options.maxTokens }),
+    ...toolsOf(options, "chat_completions"),
+  };
+}
+
+function reasoningText(message) {
+  for (const field of ["reasoning", "reasoning_content"]) {
+    if (typeof message[field] === "string" && message[field]) return message[field];
+  }
+  if (!Array.isArray(message.reasoning_details)) return "";
+  return message.reasoning_details
+    .map((detail) => detail?.text || detail?.summary || "")
+    .filter(Boolean)
+    .join("\n");
+}
+
+function chatResponse(raw) {
+  const choice = raw.choices?.[0];
+  const message = choice?.message;
+  if (message === undefined) {
+    throw new LlmError("Chat Completions response has no assistant message.", "MALFORMED_RESPONSE");
+  }
+  const blocks = [];
+  const reasoning = reasoningText(message);
+  if (reasoning) blocks.push({ type: "reasoning", text: reasoning });
+  const text = typeof message.content === "string"
+    ? message.content
+    : Array.isArray(message.content)
+      ? message.content.map((part) => part?.text || "").join("")
+      : "";
+  if (text) blocks.push({ type: "text", text });
+  for (const call of message.tool_calls || []) {
+    blocks.push({
+      type: "tool-call",
+      id: String(call.id || ""),
+      name: String(call.function?.name || ""),
+      arguments: String(call.function?.arguments || ""),
+    });
+  }
+  return {
+    blocks,
+    usage: openAiUsage(raw.usage),
+    reason: finishReason(choice?.finish_reason, blocks),
+    replayState: {
+      transport: "chat_completions",
+      data: Array.isArray(message.reasoning_details)
+        ? message.reasoning_details
+        : null,
+    },
+  };
+}
+
+function responsesRequest(options) {
+  const input = [];
+  for (const message of options.messages) {
+    if (message.role === "assistant") {
+      const replay = replayOf(message, "responses");
+      if (Array.isArray(replay)) {
+        input.push(...replay);
+        continue;
+      }
+      const text = textOf(message.content);
+      if (text) {
+        input.push({
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text }],
+        });
+      }
+      for (const call of toolCallsOf(message.content)) {
+        input.push({
+          type: "function_call",
+          call_id: call.id,
+          name: call.name,
+          arguments: call.arguments,
+        });
+      }
+      continue;
+    }
+    if (message.role === "system") {
+      input.push({ role: "system", content: textOf(message.content) });
+      continue;
+    }
+    const results = message.content.filter((block) => block.type === "tool-result");
+    const text = textOf(message.content.filter((block) => block.type !== "tool-result"));
+    if (text || results.length === 0) input.push({ role: "user", content: text });
+    for (const result of results) {
+      input.push({
+        type: "function_call_output",
+        call_id: result.toolCallId,
+        output: textOf(result.content) || "(no output)",
+      });
+    }
+  }
+
+  return {
+    model: options.model,
+    input,
+    stream: false,
+    ...(options.system === undefined ? {} : { instructions: options.system }),
+    include: ["reasoning.encrypted_content"],
+    ...(options.temperature === undefined ? {} : { temperature: options.temperature }),
+    ...(options.maxTokens === undefined ? {} : { max_output_tokens: options.maxTokens }),
+    ...toolsOf(options, "responses"),
+  };
+}
+
+function responsesResponse(raw) {
+  const output = raw.output;
+  if (!Array.isArray(output)) {
+    throw new LlmError("Responses response has no output array.", "MALFORMED_RESPONSE");
+  }
+  const blocks = [];
+  const reasoning = [];
+  let text = "";
+  for (const item of output) {
+    if (item.type === "reasoning") {
+      reasoning.push(...(item.summary || []).map((part) => part?.text || ""));
+      reasoning.push(...(item.content || []).map((part) => part?.text || ""));
+    } else if (item.type === "message") {
+      text += (item.content || [])
+        .filter((part) => part?.type === "output_text")
+        .map((part) => part.text || "")
+        .join("");
+    } else if (item.type === "function_call" || item.type === "custom_tool_call") {
+      blocks.push({
+        type: "tool-call",
+        id: String(item.call_id || ""),
+        name: String(item.name || ""),
+        arguments: String(item.arguments ?? item.input ?? ""),
+      });
+    }
+  }
+  const reasoningText = reasoning.filter(Boolean).join("\n");
+  if (reasoningText) blocks.unshift({ type: "reasoning", text: reasoningText });
+  if (text) blocks.splice(reasoningText ? 1 : 0, 0, { type: "text", text });
+  return {
+    blocks,
+    usage: responsesUsage(raw.usage),
+    reason: raw.status === "incomplete"
+      ? { kind: "max-tokens" }
+      : finishReason(undefined, blocks),
+    replayState: {
+      transport: "responses",
+      data: output,
+    },
+  };
+}
+
+function anthropicRequest(options) {
+  const messages = [];
+  const system = options.system === undefined ? [] : [options.system];
+  for (const message of options.messages) {
+    if (message.role === "system") {
+      system.push(textOf(message.content));
+      continue;
+    }
+    if (message.role === "assistant") {
+      const replay = replayOf(message, "anthropic_messages");
+      if (Array.isArray(replay)) {
+        messages.push({ role: "assistant", content: replay });
+        continue;
+      }
+      const content = [];
+      const text = textOf(message.content);
+      if (text) content.push({ type: "text", text });
+      for (const call of toolCallsOf(message.content)) {
+        let input = {};
+        try {
+          input = JSON.parse(call.arguments);
+        } catch {
+          // Anthropic requires an object; malformed provider arguments stay executable as {}.
+        }
+        content.push({ type: "tool_use", id: call.id, name: call.name, input });
+      }
+      messages.push({ role: "assistant", content });
+      continue;
+    }
+    const content = [];
+    const text = textOf(message.content.filter((block) => block.type !== "tool-result"));
+    if (text) content.push({ type: "text", text });
+    for (const result of message.content.filter((block) => block.type === "tool-result")) {
+      content.push({
+        type: "tool_result",
+        tool_use_id: result.toolCallId,
+        content: textOf(result.content) || "(no output)",
+        ...(result.isError === undefined ? {} : { is_error: result.isError }),
+      });
+    }
+    if (content.length === 0) content.push({ type: "text", text: "" });
+    messages.push({ role: "user", content });
+  }
+
+  return {
+    model: options.model,
+    messages,
+    stream: false,
+    max_tokens: options.maxTokens,
+    ...(system.length === 0 ? {} : { system: system.join("\n\n") }),
+    ...(options.temperature === undefined ? {} : { temperature: options.temperature }),
+    ...(options.stop === undefined ? {} : { stop_sequences: options.stop }),
+    ...toolsOf(options, "anthropic_messages"),
+  };
+}
+
+function anthropicResponse(raw) {
+  if (!Array.isArray(raw.content)) {
+    throw new LlmError("Anthropic response has no content array.", "MALFORMED_RESPONSE");
+  }
+  const blocks = [];
+  const reasoning = raw.content
+    .filter((block) => block.type === "thinking")
+    .map((block) => block.thinking || "")
+    .join("");
+  if (reasoning) blocks.push({ type: "reasoning", text: reasoning });
+  const text = raw.content
+    .filter((block) => block.type === "text")
+    .map((block) => block.text || "")
+    .join("");
+  if (text) blocks.push({ type: "text", text });
+  for (const call of raw.content.filter((block) => block.type === "tool_use")) {
+    blocks.push({
+      type: "tool-call",
+      id: String(call.id || ""),
+      name: String(call.name || ""),
+      arguments: JSON.stringify(call.input || {}),
+    });
+  }
+  const stopReasons = {
+    end_turn: "stop",
+    stop_sequence: "stop",
+    max_tokens: "max-tokens",
+    tool_use: "tool-calls",
+  };
+  const kind = stopReasons[raw.stop_reason] || finishReason(undefined, blocks).kind;
+  return {
+    blocks,
+    usage: anthropicUsage(raw.usage),
+    reason: { kind },
+    replayState: {
+      transport: "anthropic_messages",
+      data: raw.content,
+    },
+  };
+}
+
+function openAiUsage(usage = {}) {
+  const cached = usage.prompt_tokens_details?.cached_tokens || 0;
+  const reasoning = usage.completion_tokens_details?.reasoning_tokens;
+  return {
+    inputTokens: Math.max(0, (usage.prompt_tokens || 0) - cached),
+    outputTokens: usage.completion_tokens || 0,
+    ...(cached ? { cacheReadTokens: cached } : {}),
+    ...(reasoning ? { reasoningTokens: reasoning } : {}),
+  };
+}
+
+function responsesUsage(usage = {}) {
+  const cached = usage.input_tokens_details?.cached_tokens || 0;
+  const reasoning = usage.output_tokens_details?.reasoning_tokens;
+  return {
+    inputTokens: Math.max(0, (usage.input_tokens || 0) - cached),
+    outputTokens: usage.output_tokens || 0,
+    ...(cached ? { cacheReadTokens: cached } : {}),
+    ...(reasoning ? { reasoningTokens: reasoning } : {}),
+  };
+}
+
+function anthropicUsage(usage = {}) {
+  const read = usage.cache_read_input_tokens || 0;
+  const write = usage.cache_creation_input_tokens || 0;
+  const reasoning = usage.output_tokens_details?.thinking_tokens;
+  return {
+    inputTokens: usage.input_tokens || 0,
+    outputTokens: usage.output_tokens || 0,
+    ...(read ? { cacheReadTokens: read } : {}),
+    ...(write ? { cacheWriteTokens: write } : {}),
+    ...(reasoning ? { reasoningTokens: reasoning } : {}),
+  };
+}
+
+function finishReason(raw, blocks) {
+  if (raw === "length") return { kind: "max-tokens" };
+  if (raw === "tool_calls" || blocks.some((block) => block.type === "tool-call")) {
+    return { kind: "tool-calls" };
+  }
+  return { kind: "stop" };
+}
+
+function errorCode(status) {
+  if (status === 401 || status === 403) return "AUTH";
+  if (status === 429) return "RATE_LIMIT";
+  if (status === 400) return "INVALID_REQUEST";
+  if (status >= 500) return "SERVER";
+  return `HTTP_${status}`;
+}
+
+async function postJson(url, apiKey, transport, body, signal) {
+  const headers = {
+    "content-type": "application/json",
+    ...attributionHeaders(),
+    ...(transport === "anthropic_messages"
+      ? { "x-api-key": apiKey, "anthropic-version": "2023-06-01" }
+      : { authorization: `Bearer ${apiKey}` }),
+  };
+  let response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal,
+    });
+  } catch (error) {
+    if (signal?.aborted) throw new LlmError("Verifiers request aborted.", "ABORTED", { cause: error });
+    throw new LlmError(`Verifiers request to ${url} failed.`, "TRANSPORT", { cause: error });
+  }
+  const raw = await response.json().catch(() => undefined);
+  if (!response.ok) {
+    const detail = raw?.error?.message || raw?.error?.type || response.statusText;
+    throw new LlmError(`Verifiers request failed (${response.status}): ${detail}`, errorCode(response.status));
+  }
+  if (raw === undefined || raw === null || typeof raw !== "object") {
+    throw new LlmError("Verifiers returned malformed JSON.", "MALFORMED_RESPONSE");
+  }
+  return raw;
+}
+
+const CODECS = {
+  chat_completions: {
+    path: "chat/completions",
+    request: chatRequest,
+    response: chatResponse,
+  },
+  responses: {
+    path: "responses",
+    request: responsesRequest,
+    response: responsesResponse,
+  },
+  anthropic_messages: {
+    path: "messages",
+    request: anthropicRequest,
+    response: anthropicResponse,
+  },
+};
+
+class VerifiersAdapter extends LlmAdapter {
+  constructor(config) {
+    super();
+    this.config = config;
+  }
+
+  resolveModel(provider, model) {
+    return Promise.resolve({
+      provider,
+      id: model,
+      name: model,
+      inputModalities: ["text"],
+      context: { contextWindow: this.config.contextWindow },
+      defaultMaxTokens: this.config.maxTokens,
+    });
+  }
+
+  async *stream(options) {
+    if (options.messages.some((message) => contentHasImage(message.content))) {
+      throw new LlmError(
+        "The Verifiers DSH adapter does not support image content.",
+        "UNSUPPORTED_CONTENT",
+      );
+    }
+    const codec = CODECS[this.config.transport];
+    const apiKey = process.env.DSH_INTERCEPT_KEY;
+    if (!apiKey) throw new LlmError("Missing DSH_INTERCEPT_KEY.", "MISSING_CREDENTIAL");
+    const body = codec.request(options);
+    const url = `${this.config.endpoint.replace(/\/$/, "")}/${codec.path}`;
+    const raw = await postJson(
+      url,
+      apiKey,
+      this.config.transport,
+      body,
+      options.signal,
+    );
+    const result = codec.response(raw);
+    if (result.blocks.length === 0) {
+      throw new LlmError(`Model ${options.model} returned no content.`, "EMPTY_RESPONSE");
+    }
+    for (const [index, block] of result.blocks.entries()) {
+      yield { type: "block-start", index, blockType: block.type };
+      if (block.type === "text") {
+        yield { type: "text-delta", index, text: block.text };
+      } else if (block.type === "reasoning") {
+        yield { type: "reasoning-delta", index, text: block.text };
+      } else {
+        yield {
+          type: "tool-call-delta",
+          index,
+          id: CallId(block.id),
+          name: block.name,
+          argumentsDelta: block.arguments,
+        };
+      }
+      yield {
+        type: "block-end",
+        index,
+        block: block.type === "tool-call" ? { ...block, id: CallId(block.id) } : block,
+      };
+    }
+    yield { type: "usage", usage: result.usage };
+    yield { type: "finish", reason: result.reason, replayState: result.replayState };
+  }
+}
+
+export const name = "llm-verifiers";
+export const inject = ["llm"];
+
+export function apply(ctx, config) {
+  ctx.llm.registerAdapter(["verifiers"], new VerifiersAdapter(config));
+}

--- a/verifiers/v1/harnesses/deepseek_harness/harness.py
+++ b/verifiers/v1/harnesses/deepseek_harness/harness.py
@@ -35,13 +35,16 @@ packages=/var/tmp/vf-deepseek-harness/packages
 export PATH="/var/tmp/vf-node/bin:$PATH"
 
 if ! command -v python3 >/dev/null || ! command -v make >/dev/null || ! command -v c++ >/dev/null; then
-    if ! command -v apt-get >/dev/null; then
+    if command -v apk >/dev/null; then
+        apk add --no-cache python3 make g++ >/dev/null
+    elif command -v apt-get >/dev/null; then
+        apt-get update -qq
+        DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends python3 make g++ >/dev/null
+        rm -rf /var/lib/apt/lists/*
+    else
         echo "DeepSeek Harness requires Python, make, and a C++ compiler to build node-pty" >&2
         exit 1
     fi
-    apt-get update -qq
-    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends python3 make g++ >/dev/null
-    rm -rf /var/lib/apt/lists/*
 fi
 
 versions="$VF_DEEPSEEK_HARNESS_VERSION:$VF_NODE_ADDON_VERSION"
@@ -152,10 +155,7 @@ class DeepSeekHarness(ACPHarness[DeepSeekHarnessConfig]):
         ]
 
         for index, (name, url) in enumerate(mcp_urls.items()):
-            server_name = re.sub(r"[^A-Za-z0-9_-]", "_", name) or "server"
-            if server_name != name or len(server_name) > 32:
-                digest = hashlib.sha1(name.encode()).hexdigest()[:8]
-                server_name = f"{server_name[:23]}_{digest}"
+            server_name = _dsh_server_name(name)
             composition.append(
                 {
                     "id": f"mcp-{index}",
@@ -202,3 +202,11 @@ class DeepSeekHarness(ACPHarness[DeepSeekHarnessConfig]):
         # Keeping the config below the npm prefix lets Cordis resolve its bare
         # plugin specifiers while the trace id isolates concurrent rollouts.
         return f"{PACKAGES_DIR}/runs/{trace.id}"
+
+
+def _dsh_server_name(name: str) -> str:
+    server_name = re.sub(r"[^A-Za-z0-9_-]", "_", name)
+    if server_name != name or len(server_name) > 32:
+        digest = hashlib.sha1(name.encode()).hexdigest()[:8]
+        server_name = f"{server_name[:23]}_{digest}"
+    return server_name

--- a/verifiers/v1/harnesses/deepseek_harness/harness.py
+++ b/verifiers/v1/harnesses/deepseek_harness/harness.py
@@ -1,0 +1,204 @@
+"""Run DeepSeek Harness against interception through its ACP server."""
+
+import hashlib
+import json
+import logging
+import re
+import shlex
+from pathlib import Path
+from typing import Literal
+
+from pydantic import Field
+
+from verifiers.v1.acp import ACPConfig, ACPHarness
+from verifiers.v1.clients import ModelContext
+from verifiers.v1.configs.harness import HarnessConfig
+from verifiers.v1.harnesses.node import NODE_BIN_DIR, ensure_node
+from verifiers.v1.runtimes import Runtime
+from verifiers.v1.task import TaskData
+from verifiers.v1.trace import Trace
+
+logger = logging.getLogger(__name__)
+
+KEY_VAR = "DSH_INTERCEPT_KEY"
+DSH_DIR = "/var/tmp/vf-deepseek-harness"
+PACKAGES_DIR = f"{DSH_DIR}/packages"
+DSH_BIN = f"{PACKAGES_DIR}/node_modules/.bin/dsh-acp-demo"
+NODE_ADDON_VERSION = "0.1.4"
+DEFAULT_CONTEXT_WINDOW = 262_144
+DEFAULT_MAX_TOKENS = 32_768
+ADAPTER_SOURCE = (Path(__file__).resolve().parent / "adapter.mjs").read_bytes()
+
+INSTALL = r"""
+set -e
+packages=/var/tmp/vf-deepseek-harness/packages
+export PATH="/var/tmp/vf-node/bin:$PATH"
+
+if ! command -v python3 >/dev/null || ! command -v make >/dev/null || ! command -v c++ >/dev/null; then
+    if ! command -v apt-get >/dev/null; then
+        echo "DeepSeek Harness requires Python, make, and a C++ compiler to build node-pty" >&2
+        exit 1
+    fi
+    apt-get update -qq
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends python3 make g++ >/dev/null
+    rm -rf /var/lib/apt/lists/*
+fi
+
+versions="$VF_DEEPSEEK_HARNESS_VERSION:$VF_NODE_ADDON_VERSION"
+if [ "$(cat "$packages/.versions" 2>/dev/null)" != "$versions" ]; then
+    npm install --prefix "$packages" --no-audit --no-fund --omit=dev \
+        "node-addon-require-builtin@$VF_NODE_ADDON_VERSION" \
+        "@deepseek-ai/dsh-acp-demo@$VF_DEEPSEEK_HARNESS_VERSION" \
+        "@deepseek-ai/dsh-bash-local@$VF_DEEPSEEK_HARNESS_VERSION" \
+        "@deepseek-ai/dsh-llm@$VF_DEEPSEEK_HARNESS_VERSION" \
+        "@deepseek-ai/dsh-mcp-client@$VF_DEEPSEEK_HARNESS_VERSION" \
+        "@deepseek-ai/dsh-subprocess-local@$VF_DEEPSEEK_HARNESS_VERSION" >/dev/null
+    printf %s "$versions" > "$packages/.versions"
+fi
+"""
+
+
+class DeepSeekHarnessConfig(HarnessConfig):
+    version: str = Field(default="0.1.0-rc.6", pattern=r"^[A-Za-z0-9._+-]+$")
+    """DeepSeek Harness release to install, pinned for reproducibility."""
+    transport: Literal["chat_completions", "responses", "anthropic_messages"] = (
+        "chat_completions"
+    )
+    """Model API transport."""
+
+
+class DeepSeekHarness(ACPHarness[DeepSeekHarnessConfig]):
+    APPENDS_SYSTEM_PROMPT = True
+    SUPPORTS_MCP = True
+    SUPPORTS_SKILLS = True
+
+    async def setup(self, runtime: Runtime) -> None:
+        await ensure_node(runtime)
+        logger.info(
+            "deepseek-harness: ensuring DeepSeek Harness %s is installed",
+            self.config.version,
+        )
+        guarded = (
+            f"mkdir -p {DSH_DIR} && "
+            f'"$(command -v flock || command -v lockf)" {DSH_DIR}/install.lock '
+            f"sh -c {shlex.quote(INSTALL)}"
+        )
+        install = await runtime.run(
+            ["sh", "-c", guarded],
+            {
+                "VF_DEEPSEEK_HARNESS_VERSION": self.config.version,
+                "VF_NODE_ADDON_VERSION": NODE_ADDON_VERSION,
+            },
+        )
+        if install.exit_code != 0:
+            detail = (install.stderr or install.stdout).strip()[-500:]
+            raise RuntimeError(f"DeepSeek Harness install failed: {detail}")
+        await super().setup(runtime)
+
+    async def prepare_acp(
+        self,
+        ctx: ModelContext,
+        trace: Trace,
+        runtime: Runtime,
+        endpoint: str,
+        secret: str,
+        mcp_urls: dict[str, str],
+        data: TaskData,
+    ) -> ACPConfig:
+        if self.config.disabled_tools:
+            raise ValueError("DeepSeek Harness ACP does not support disabling tools")
+
+        system_prompt, prompt = self.resolve_prompt(data)
+        run_dir = self.run_dir(trace)
+        dsh_home = f"{run_dir}/dsh"
+        await self.install_skills(runtime, f"{dsh_home}/skills")
+
+        adapter_path = f"{run_dir}/adapter.mjs"
+        await runtime.write(adapter_path, ADAPTER_SOURCE)
+        composition = [
+            {
+                "id": "llm-verifiers",
+                "name": "./adapter.mjs",
+                "config": {
+                    "endpoint": endpoint,
+                    "transport": self.config.transport,
+                    "model": ctx.model,
+                    "contextWindow": DEFAULT_CONTEXT_WINDOW,
+                    "maxTokens": ctx.sampling.max_tokens or DEFAULT_MAX_TOKENS,
+                },
+            },
+            {
+                "id": "subprocess",
+                "name": "@deepseek-ai/dsh-subprocess-local",
+            },
+            {"id": "bash", "name": "@deepseek-ai/dsh-bash-local"},
+            {
+                "id": "acp-agent",
+                "name": "@deepseek-ai/dsh-acp-demo",
+                "config": {
+                    "provider": "verifiers",
+                    "model": ctx.model,
+                    "dshHome": dsh_home,
+                    "persistenceRoot": f"{run_dir}/sessions",
+                    "persistenceCompression": "none",
+                    "persona": system_prompt or "",
+                    "workspaceContext": {"maxBytes": 65536},
+                    "skills": {"filesystem": {"watch": False}},
+                    "toolBash": {"enableRunInBackground": False},
+                    "toolJobs": False,
+                    "goals": False,
+                },
+            },
+        ]
+
+        for index, (name, url) in enumerate(mcp_urls.items()):
+            server_name = re.sub(r"[^A-Za-z0-9_-]", "_", name) or "server"
+            if server_name != name or len(server_name) > 32:
+                digest = hashlib.sha1(name.encode()).hexdigest()[:8]
+                server_name = f"{server_name[:23]}_{digest}"
+            composition.append(
+                {
+                    "id": f"mcp-{index}",
+                    "name": "@deepseek-ai/dsh-mcp-client",
+                    "config": {
+                        "serverName": server_name,
+                        "transport": "streamable-http",
+                        "url": url,
+                        "toolCallTimeoutMs": int(self.config.tool_timeout * 1000),
+                        "failOnStartupError": True,
+                    },
+                }
+            )
+
+        config_path = f"{run_dir}/cordis.yml"
+        await runtime.write(
+            config_path, json.dumps(composition, ensure_ascii=False).encode()
+        )
+        return ACPConfig(
+            env={
+                **self.config.resolved_env,
+                KEY_VAR: secret,
+                "DSH_HOME": dsh_home,
+                "DSH_AGENTS_HOME": f"{run_dir}/agents",
+                "NO_COLOR": "1",
+            },
+            command=[f"{NODE_BIN_DIR}/node", DSH_BIN, "--config", config_path],
+            prompt=prompt,
+            # DeepSeek's ACP server rejects per-session MCP declarations. Its
+            # Cordis MCP plugins above own the equivalent rollout-scoped tools.
+            mcp_urls={},
+        )
+
+    async def cleanup(self, trace: Trace, runtime: Runtime) -> None:
+        result = await runtime.run(["rm", "-rf", self.run_dir(trace)], {})
+        if result.exit_code != 0:
+            raise RuntimeError(
+                f"failed to clean up DeepSeek Harness state: "
+                f"{result.stderr.strip()[-500:]}"
+            )
+
+    @staticmethod
+    def run_dir(trace: Trace) -> str:
+        # Keeping the config below the npm prefix lets Cordis resolve its bare
+        # plugin specifiers while the trace id isolates concurrent rollouts.
+        return f"{PACKAGES_DIR}/runs/{trace.id}"


### PR DESCRIPTION
Stacked on #2377.

This addresses the actionable DeepSeek Harness review feedback:

- preserve Responses API refusal text blocks instead of returning an empty response
- map Responses `incomplete_details.reason == "content_filter"` to a content-filter finish reason instead of max-tokens
- keep Anthropic tool input as `{}` unless parsed arguments are a non-array object
- support Alpine `apk add --no-cache python3 make g++` for node-pty build dependencies
- preserve empty MCP server names for `TOOL_PREFIX = None` bare tools

Validation:

- `uv run pytest tests/v1/test_deepseek_harness.py`
- `uv run ruff check verifiers/v1/harnesses/deepseek_harness/harness.py tests/v1/test_deepseek_harness.py`
- `uv run ty check verifiers/v1/harnesses/deepseek_harness/harness.py tests/v1/test_deepseek_harness.py`
- `node --check verifiers/v1/harnesses/deepseek_harness/adapter.mjs`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix DeepSeek harness Alpine support, server name handling, and adapter finish reasons
> - [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2383/files#diff-f44489395da8da9aa732db4045e912cbc8d5da50409cc6ab344cd6069e6638ef) adds Alpine (`apk`) support to the install script and extracts a `_dsh_server_name` helper that allows empty names to remain empty and hashes/truncates names that are sanitized or exceed 32 characters
> - [adapter.mjs](https://github.com/PrimeIntellect-ai/verifiers/pull/2383/files#diff-dd08ab1cd8ae18a564dc61bb04501b422a693cecf169cfb4f1db782bdbf5963a) adds a `responsesFinishReason` helper that returns `content-filter` when `incomplete_details.reason` is `content_filter`, `max-tokens` for other incomplete responses, and delegates to `finishReason` for complete ones
> - Refusal parts are now included in text aggregation and tool call arguments that parse to non-object values (arrays, strings, null) now produce `{}` instead of passing the raw value through
> - Tests are added for Alpine dependency installation, empty server names, and name hashing/truncation behavior
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 647f965.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->