### PR TITLE
feat: preserve RLM call lineage across retries

### DIFF
--- a/tests/v1/test_rlm_lineage.py
+++ b/tests/v1/test_rlm_lineage.py
@@ -8,17 +8,18 @@ import verifiers.v1 as vf
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.client import EvalClientConfig
 from verifiers.v1.errors import ProviderError
-from verifiers.v1.interception.server import (
+from verifiers.v1.harnesses.rlm.protocol import (
     RLM_LINEAGE_METADATA_KEY,
-    InterceptionServer,
-    _rlm_lineage,
+    RLM_LINEAGE_RESOLVER,
 )
+from verifiers.v1.interception.server import InterceptionServer
 from verifiers.v1.session import RolloutSession
 from verifiers.v1.types import AssistantMessage, Response, Usage
 
 
 def _trace() -> vf.Trace:
     return vf.Trace(
+        id="trace-1",
         agent=vf.AgentInfo(config=vf.AgentConfig()),
         task=vf.TraceTask(
             type="Task",
@@ -44,6 +45,14 @@ def _lineage_headers(call_id: str = "call-1") -> dict[str, str]:
         "X-RLM-Depth": "0",
         "X-RLM-Call-Kind": "turn",
     }
+
+
+def _session(trace: vf.Trace) -> RolloutSession:
+    return RolloutSession(
+        ctx=_context(),
+        trace=trace,
+        logical_call_resolver=RLM_LINEAGE_RESOLVER,
+    )
 
 
 class _BlockingClient:
@@ -91,7 +100,7 @@ class _FailOnceClient(_BlockingClient):
         return await super().get_response(dialect, body, sampling, **kwargs)
 
 
-def test_rlm_lineage_parser_handles_parents_compaction_and_future_versions():
+def test_rlm_lineage_parser_handles_parents_compaction_and_rejects_bad_context():
     headers = httpx.Headers(
         {
             **_lineage_headers(),
@@ -102,9 +111,11 @@ def test_rlm_lineage_parser_handles_parents_compaction_and_future_versions():
         }
     )
 
-    call_id, metadata = _rlm_lineage(headers)
+    resolved = RLM_LINEAGE_RESOLVER.resolve(headers, session_id="trace-1")
+    assert resolved.call is not None
+    metadata = resolved.call.metadata
 
-    assert call_id == "call-1"
+    assert resolved.call.key == "call-1"
     assert metadata[RLM_LINEAGE_METADATA_KEY]["parent_invocation_id"] == (
         "parent-invocation"
     )
@@ -112,16 +123,26 @@ def test_rlm_lineage_parser_handles_parents_compaction_and_future_versions():
     assert metadata[RLM_LINEAGE_METADATA_KEY]["depth"] == 2
     assert metadata[RLM_LINEAGE_METADATA_KEY]["call_kind"] == "compaction"
     future = httpx.Headers({**_lineage_headers(), "X-RLM-Lineage-Version": "2"})
-    assert _rlm_lineage(future) == (None, {})
+    with pytest.raises(ValueError, match="unsupported"):
+        RLM_LINEAGE_RESOLVER.resolve(future, session_id="trace-1")
     invalid = httpx.Headers({**_lineage_headers(), "X-RLM-Depth": "not-an-int"})
     with pytest.raises(ValueError, match="depth"):
-        _rlm_lineage(invalid)
+        RLM_LINEAGE_RESOLVER.resolve(invalid, session_id="trace-1")
+    with pytest.raises(ValueError, match="does not match"):
+        RLM_LINEAGE_RESOLVER.resolve(headers, session_id="another-trace")
+
+    legacy = RLM_LINEAGE_RESOLVER.resolve(
+        httpx.Headers({"X-RLM-Depth": "2", "X-Public": "yes"}),
+        session_id="trace-1",
+    )
+    assert legacy.call is None
+    assert legacy.forward_headers == {"x-public": "yes"}
 
 
 @pytest.mark.asyncio
 async def test_rlm_call_identity_coalesces_and_records_lineage_without_forwarding_it():
     trace = _trace()
-    session = RolloutSession(ctx=_context(), trace=trace)
+    session = _session(trace)
     client = _BlockingClient()
     session.client = client
     body = {"model": "ignored", "messages": [{"role": "user", "content": "hi"}]}
@@ -153,10 +174,16 @@ async def test_rlm_call_identity_coalesces_and_records_lineage_without_forwardin
                 json={**body, "temperature": 0.5},
                 headers=headers,
             )
+            changed_metadata = await http.post(
+                f"{server.base_url}/v1/chat/completions",
+                json=body,
+                headers={**headers, "X-RLM-Depth": "1"},
+            )
 
     assert first_response.status_code == second_response.status_code == 200
     assert replay.status_code == 200
     assert reused.status_code == 400
+    assert changed_metadata.status_code == 400
     assert client.calls == 1
     assert all(not name.lower().startswith("x-rlm-") for name in client.headers)
     assert len(trace.calls) == 1
@@ -177,7 +204,7 @@ async def test_rlm_call_identity_coalesces_and_records_lineage_without_forwardin
 @pytest.mark.asyncio
 async def test_distinct_rlm_call_ids_with_identical_bodies_both_sample():
     trace = _trace()
-    session = RolloutSession(ctx=_context(), trace=trace)
+    session = _session(trace)
     client = _BlockingClient()
     client.release.set()
     session.client = client
@@ -205,9 +232,34 @@ async def test_distinct_rlm_call_ids_with_identical_bodies_both_sample():
 
 
 @pytest.mark.asyncio
-async def test_failed_rlm_call_can_retry_with_the_same_identity():
+async def test_rlm_headers_do_not_enable_identity_without_the_rlm_resolver():
     trace = _trace()
     session = RolloutSession(ctx=_context(), trace=trace)
+    client = _BlockingClient()
+    client.release.set()
+    session.client = client
+    body = {"model": "ignored", "messages": [{"role": "user", "content": "hi"}]}
+
+    async with InterceptionServer() as server:
+        secret = "rollout-secret"
+        server.sessions[secret] = session
+        headers = {"Authorization": f"Bearer {secret}", **_lineage_headers()}
+        async with httpx.AsyncClient() as http:
+            first = await http.post(
+                f"{server.base_url}/v1/chat/completions", json=body, headers=headers
+            )
+            second = await http.post(
+                f"{server.base_url}/v1/chat/completions", json=body, headers=headers
+            )
+
+    assert first.status_code == second.status_code == 200
+    assert client.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_failed_rlm_call_can_retry_with_the_same_identity():
+    trace = _trace()
+    session = _session(trace)
     client = _FailOnceClient()
     client.release.set()
     session.client = client

--- a/tests/v1/test_rlm_lineage.py
+++ b/tests/v1/test_rlm_lineage.py
@@ -1,0 +1,233 @@
+import asyncio
+import time
+
+import httpx
+import pytest
+
+import verifiers.v1 as vf
+from verifiers.v1.clients import ModelContext
+from verifiers.v1.configs.client import EvalClientConfig
+from verifiers.v1.errors import ProviderError
+from verifiers.v1.interception.server import (
+    RLM_LINEAGE_METADATA_KEY,
+    InterceptionServer,
+    _rlm_lineage,
+)
+from verifiers.v1.session import RolloutSession
+from verifiers.v1.types import AssistantMessage, Response, Usage
+
+
+def _trace() -> vf.Trace:
+    return vf.Trace(
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
+        task=vf.TraceTask(
+            type="Task",
+            data=vf.TaskData(idx=7, prompt="solve it"),
+        ),
+    )
+
+
+def _context() -> ModelContext:
+    return ModelContext(
+        model="test-model",
+        client=EvalClientConfig(base_url="http://unused.invalid", api_key_var="NONE"),
+    )
+
+
+def _lineage_headers(call_id: str = "call-1") -> dict[str, str]:
+    return {
+        "X-RLM-Lineage-Version": "1",
+        "X-RLM-Session-ID": "trace-1",
+        "X-RLM-Invocation-ID": "invocation-1",
+        "X-RLM-Segment-ID": "segment-1",
+        "X-RLM-Call-ID": call_id,
+        "X-RLM-Depth": "0",
+        "X-RLM-Call-Kind": "turn",
+    }
+
+
+class _BlockingClient:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.headers: dict[str, str] = {}
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def get_response(self, dialect, body, sampling, **kwargs) -> Response:
+        self.calls += 1
+        self.headers = dict(kwargs["headers"])
+        self.started.set()
+        await self.release.wait()
+        raw = {
+            "id": "completion-1",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "test-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "done"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 2, "completion_tokens": 1},
+        }
+        return Response(
+            id="completion-1",
+            created=int(time.time()),
+            model="test-model",
+            message=AssistantMessage(content="done"),
+            finish_reason="stop",
+            usage=Usage(prompt_tokens=2, completion_tokens=1),
+            raw=raw,
+        )
+
+
+class _FailOnceClient(_BlockingClient):
+    async def get_response(self, dialect, body, sampling, **kwargs) -> Response:
+        if self.calls == 0:
+            self.calls += 1
+            raise ProviderError("transient", status_code=503)
+        return await super().get_response(dialect, body, sampling, **kwargs)
+
+
+def test_rlm_lineage_parser_handles_parents_compaction_and_future_versions():
+    headers = httpx.Headers(
+        {
+            **_lineage_headers(),
+            "X-RLM-Parent-Invocation-ID": "parent-invocation",
+            "X-RLM-Parent-Call-ID": "parent-call",
+            "X-RLM-Depth": "2",
+            "X-RLM-Call-Kind": "compaction",
+        }
+    )
+
+    call_id, metadata = _rlm_lineage(headers)
+
+    assert call_id == "call-1"
+    assert metadata[RLM_LINEAGE_METADATA_KEY]["parent_invocation_id"] == (
+        "parent-invocation"
+    )
+    assert metadata[RLM_LINEAGE_METADATA_KEY]["parent_call_id"] == "parent-call"
+    assert metadata[RLM_LINEAGE_METADATA_KEY]["depth"] == 2
+    assert metadata[RLM_LINEAGE_METADATA_KEY]["call_kind"] == "compaction"
+    future = httpx.Headers({**_lineage_headers(), "X-RLM-Lineage-Version": "2"})
+    assert _rlm_lineage(future) == (None, {})
+    invalid = httpx.Headers({**_lineage_headers(), "X-RLM-Depth": "not-an-int"})
+    with pytest.raises(ValueError, match="depth"):
+        _rlm_lineage(invalid)
+
+
+@pytest.mark.asyncio
+async def test_rlm_call_identity_coalesces_and_records_lineage_without_forwarding_it():
+    trace = _trace()
+    session = RolloutSession(ctx=_context(), trace=trace)
+    client = _BlockingClient()
+    session.client = client
+    body = {"model": "ignored", "messages": [{"role": "user", "content": "hi"}]}
+
+    async with InterceptionServer() as server:
+        secret = "rollout-secret"
+        server.sessions[secret] = session
+        headers = {"Authorization": f"Bearer {secret}", **_lineage_headers()}
+        async with httpx.AsyncClient() as http:
+            first = asyncio.create_task(
+                http.post(
+                    f"{server.base_url}/v1/chat/completions", json=body, headers=headers
+                )
+            )
+            await client.started.wait()
+            second = asyncio.create_task(
+                http.post(
+                    f"{server.base_url}/v1/chat/completions", json=body, headers=headers
+                )
+            )
+            await asyncio.sleep(0)
+            client.release.set()
+            first_response, second_response = await asyncio.gather(first, second)
+            replay = await http.post(
+                f"{server.base_url}/v1/chat/completions", json=body, headers=headers
+            )
+            reused = await http.post(
+                f"{server.base_url}/v1/chat/completions",
+                json={**body, "temperature": 0.5},
+                headers=headers,
+            )
+
+    assert first_response.status_code == second_response.status_code == 200
+    assert replay.status_code == 200
+    assert reused.status_code == 400
+    assert client.calls == 1
+    assert all(not name.lower().startswith("x-rlm-") for name in client.headers)
+    assert len(trace.calls) == 1
+    assert trace.calls[0].metadata[RLM_LINEAGE_METADATA_KEY] == {
+        "version": 1,
+        "session_id": "trace-1",
+        "invocation_id": "invocation-1",
+        "parent_invocation_id": None,
+        "segment_id": "segment-1",
+        "call_id": "call-1",
+        "parent_call_id": None,
+        "depth": 0,
+        "call_kind": "turn",
+    }
+    assert trace.num_branches == 1
+
+
+@pytest.mark.asyncio
+async def test_distinct_rlm_call_ids_with_identical_bodies_both_sample():
+    trace = _trace()
+    session = RolloutSession(ctx=_context(), trace=trace)
+    client = _BlockingClient()
+    client.release.set()
+    session.client = client
+    body = {"model": "ignored", "messages": [{"role": "user", "content": "hi"}]}
+
+    async with InterceptionServer() as server:
+        secret = "rollout-secret"
+        server.sessions[secret] = session
+        async with httpx.AsyncClient() as http:
+            for call_id in ("call-1", "call-2"):
+                response = await http.post(
+                    f"{server.base_url}/v1/chat/completions",
+                    json=body,
+                    headers={
+                        "Authorization": f"Bearer {secret}",
+                        **_lineage_headers(call_id),
+                    },
+                )
+                assert response.status_code == 200
+
+    assert client.calls == 2
+    assert [
+        call.metadata[RLM_LINEAGE_METADATA_KEY]["call_id"] for call in trace.calls
+    ] == ["call-1", "call-2"]
+
+
+@pytest.mark.asyncio
+async def test_failed_rlm_call_can_retry_with_the_same_identity():
+    trace = _trace()
+    session = RolloutSession(ctx=_context(), trace=trace)
+    client = _FailOnceClient()
+    client.release.set()
+    session.client = client
+    body = {"model": "ignored", "messages": [{"role": "user", "content": "hi"}]}
+
+    async with InterceptionServer() as server:
+        secret = "rollout-secret"
+        server.sessions[secret] = session
+        headers = {"Authorization": f"Bearer {secret}", **_lineage_headers()}
+        async with httpx.AsyncClient() as http:
+            failed = await http.post(
+                f"{server.base_url}/v1/chat/completions", json=body, headers=headers
+            )
+            succeeded = await http.post(
+                f"{server.base_url}/v1/chat/completions", json=body, headers=headers
+            )
+
+    assert failed.status_code == 503
+    assert succeeded.status_code == 200
+    assert client.calls == 2
+    assert len(trace.calls) == 2
+    assert trace.calls[0].error is not None
+    assert trace.calls[1].node is not None

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -104,3 +104,16 @@ def test_wire_trace_round_trip():
 
     # the env-server wire form (a plain model_dump) loads too
     assert vf.WireTrace.model_validate(tr.model_dump()).num_branches == 2
+
+
+def test_model_call_metadata_round_trips_without_affecting_branches():
+    trace = vf.Trace(
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
+        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="q")),
+        calls=[vf.ModelCall(metadata={"example/lineage-v1": {"call_id": "call-1"}})],
+    )
+
+    restored = vf.WireTrace.model_validate(trace.model_dump())
+
+    assert restored.calls[0].metadata == {"example/lineage-v1": {"call_id": "call-1"}}
+    assert restored.num_branches == trace.num_branches == 0

--- a/verifiers/v1/clients/eval.py
+++ b/verifiers/v1/clients/eval.py
@@ -111,9 +111,6 @@ class EvalClient(Client):
             map(str.strip, connection.lower().split(","))
         ):
             headers.pop(name, None)
-        for name in list(headers):
-            if name.lower().startswith("x-rlm-"):
-                headers.pop(name, None)
         headers.update(self.headers)
         if session_id:
             headers[SESSION_ID_HEADER] = session_id

--- a/verifiers/v1/clients/eval.py
+++ b/verifiers/v1/clients/eval.py
@@ -111,6 +111,9 @@ class EvalClient(Client):
             map(str.strip, connection.lower().split(","))
         ):
             headers.pop(name, None)
+        for name in list(headers):
+            if name.lower().startswith("x-rlm-"):
+                headers.pop(name, None)
         headers.update(self.headers)
         if session_id:
             headers[SESSION_ID_HEADER] = session_id

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.errors import HarnessError, SandboxError, boundary
+from verifiers.v1.logical_calls import LogicalCallResolver
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.types import Messages
@@ -52,6 +53,8 @@ class Harness(ABC, Generic[ConfigT]):
     that installs and drives a third-party program — on the host (subprocess) it
     leaks host state (auth, config, processes) both ways. Only the minimal
     in-house loops (`bash`, `null`) override to False."""
+    LOGICAL_CALL_RESOLVER: ClassVar[LogicalCallResolver | None] = None
+    """Optional harness protocol for stable model-call identity and private headers."""
 
     def __init__(self, config: ConfigT) -> None:
         self.config = config

--- a/verifiers/v1/harnesses/rlm/__init__.py
+++ b/verifiers/v1/harnesses/rlm/__init__.py
@@ -1,3 +1,4 @@
 from verifiers.v1.harnesses.rlm.harness import RLMHarness, RLMHarnessConfig
+from verifiers.v1.harnesses.rlm.protocol import RLM_LINEAGE_METADATA_KEY
 
-__all__ = ["RLMHarness", "RLMHarnessConfig"]
+__all__ = ["RLM_LINEAGE_METADATA_KEY", "RLMHarness", "RLMHarnessConfig"]

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -11,6 +11,7 @@ from pydantic import Field, PositiveInt, model_validator
 from verifiers.v1.acp import ACPConfig, ACPHarness
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
+from verifiers.v1.harnesses.rlm.protocol import RLM_LINEAGE_RESOLVER
 from verifiers.v1.runtimes import Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
@@ -65,6 +66,7 @@ class RLMHarness(ACPHarness[RLMHarnessConfig]):
     APPENDS_SYSTEM_PROMPT = True
     SUPPORTS_MCP = True
     SUPPORTS_SKILLS = True
+    LOGICAL_CALL_RESOLVER = RLM_LINEAGE_RESOLVER
 
     async def setup(self, runtime: Runtime) -> None:
         # Before the installer: install.sh packages the skills it finds.

--- a/verifiers/v1/harnesses/rlm/protocol.py
+++ b/verifiers/v1/harnesses/rlm/protocol.py
@@ -1,0 +1,83 @@
+"""RLM extensions at ACP and model-interception boundaries."""
+
+import re
+from collections.abc import Mapping
+from typing import Any
+
+from verifiers.v1.logical_calls import LogicalCall, ResolvedCallHeaders
+
+RLM_LINEAGE_VERSION_HEADER = "x-rlm-lineage-version"
+RLM_LINEAGE_METADATA_KEY = "ai.prime.rlm/lineage-v1"
+RLM_LINEAGE_HEADERS = {
+    "session_id": "x-rlm-session-id",
+    "invocation_id": "x-rlm-invocation-id",
+    "parent_invocation_id": "x-rlm-parent-invocation-id",
+    "segment_id": "x-rlm-segment-id",
+    "call_id": "x-rlm-call-id",
+    "parent_call_id": "x-rlm-parent-call-id",
+    "depth": "x-rlm-depth",
+    "call_kind": "x-rlm-call-kind",
+}
+_LINEAGE_ID_RE = re.compile(r"[A-Za-z0-9._:-]{1,128}")
+
+
+class RLMLineageResolver:
+    def resolve(
+        self, headers: Mapping[str, str], *, session_id: str
+    ) -> ResolvedCallHeaders:
+        forwarded = {
+            name: value
+            for name, value in headers.items()
+            if not name.lower().startswith("x-rlm-")
+        }
+        version = headers.get(RLM_LINEAGE_VERSION_HEADER)
+        if version is None:
+            return ResolvedCallHeaders(call=None, forward_headers=forwarded)
+        if version != "1":
+            raise ValueError(f"unsupported RLM lineage version {version!r}")
+        values = {
+            name: headers.get(header) for name, header in RLM_LINEAGE_HEADERS.items()
+        }
+        required = (
+            "session_id",
+            "invocation_id",
+            "segment_id",
+            "call_id",
+            "depth",
+            "call_kind",
+        )
+        missing = [name for name in required if values[name] is None]
+        if missing:
+            raise ValueError(f"RLM lineage is missing fields: {missing}")
+        for name in (
+            "session_id",
+            "invocation_id",
+            "parent_invocation_id",
+            "segment_id",
+            "call_id",
+            "parent_call_id",
+        ):
+            value = values[name]
+            if value is not None and _LINEAGE_ID_RE.fullmatch(value) is None:
+                raise ValueError(f"RLM lineage field {name!r} is invalid")
+        if values["session_id"] != session_id:
+            raise ValueError("RLM lineage session ID does not match the rollout")
+        try:
+            depth = int(values["depth"])
+        except (TypeError, ValueError) as error:
+            raise ValueError("RLM lineage depth is invalid") from error
+        if depth < 0:
+            raise ValueError("RLM lineage depth is invalid")
+        if values["call_kind"] not in ("turn", "compaction"):
+            raise ValueError("RLM lineage call kind is invalid")
+        lineage: dict[str, Any] = {"version": 1, **values, "depth": depth}
+        return ResolvedCallHeaders(
+            call=LogicalCall(
+                key=values["call_id"],
+                metadata={RLM_LINEAGE_METADATA_KEY: lineage},
+            ),
+            forward_headers=forwarded,
+        )
+
+
+RLM_LINEAGE_RESOLVER = RLMLineageResolver()

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -24,7 +24,6 @@ import contextlib
 import hashlib
 import json
 import logging
-import re
 import secrets
 import time
 import traceback
@@ -59,7 +58,7 @@ from verifiers.v1.interception.tunnel import (
     TunnelConfig,
     make_tunnel,
 )
-from verifiers.v1.session import RolloutSession
+from verifiers.v1.session import LogicalCallReplay, RolloutSession
 from verifiers.v1.trace import Error, ModelCall, PolicyEvent, TimeSpan
 from verifiers.v1.types import FinishReason, Request, Response, Usage
 
@@ -81,20 +80,6 @@ HASH_INLINE_MAX = 1024**2  # 1 MiB
 # Attempt counter the stainless-generated SDKs (OpenAI, Anthropic) send on every request:
 # 0 on the first attempt, incremented on each retry of the same request.
 RETRY_COUNT_HEADER = "x-stainless-retry-count"
-RLM_LINEAGE_VERSION_HEADER = "x-rlm-lineage-version"
-RLM_CALL_ID_HEADER = "x-rlm-call-id"
-RLM_LINEAGE_METADATA_KEY = "ai.prime.rlm/lineage-v1"
-RLM_LINEAGE_HEADERS = {
-    "session_id": "x-rlm-session-id",
-    "invocation_id": "x-rlm-invocation-id",
-    "parent_invocation_id": "x-rlm-parent-invocation-id",
-    "segment_id": "x-rlm-segment-id",
-    "call_id": RLM_CALL_ID_HEADER,
-    "parent_call_id": "x-rlm-parent-call-id",
-    "depth": "x-rlm-depth",
-    "call_kind": "x-rlm-call-kind",
-}
-_RLM_LINEAGE_ID_RE = re.compile(r"[A-Za-z0-9._:-]{1,128}")
 
 
 def is_retried_request(headers: Mapping[str, str]) -> bool:
@@ -102,57 +87,6 @@ def is_retried_request(headers: Mapping[str, str]) -> bool:
         return int(headers.get(RETRY_COUNT_HEADER, 0)) > 0
     except ValueError:
         return False
-
-
-def _rlm_lineage(headers: Mapping[str, str]) -> tuple[str | None, dict[str, Any]]:
-    version = headers.get(RLM_LINEAGE_VERSION_HEADER)
-    if version is None:
-        return None, {}
-    if version != "1":
-        logger.warning("ignoring unsupported RLM lineage version %r", version)
-        return None, {}
-    values = {name: headers.get(header) for name, header in RLM_LINEAGE_HEADERS.items()}
-    required = (
-        "session_id",
-        "invocation_id",
-        "segment_id",
-        "call_id",
-        "depth",
-        "call_kind",
-    )
-    missing = [name for name in required if values[name] is None]
-    if missing:
-        raise ValueError(f"RLM lineage is missing fields: {missing}")
-    for name in (
-        "session_id",
-        "invocation_id",
-        "parent_invocation_id",
-        "segment_id",
-        "call_id",
-        "parent_call_id",
-    ):
-        value = values[name]
-        if value is not None and _RLM_LINEAGE_ID_RE.fullmatch(value) is None:
-            raise ValueError(f"RLM lineage field {name!r} is invalid")
-    try:
-        depth = int(values["depth"])
-    except (TypeError, ValueError) as error:
-        raise ValueError("RLM lineage depth is invalid") from error
-    if depth < 0:
-        raise ValueError("RLM lineage depth is invalid")
-    if values["call_kind"] not in ("turn", "compaction"):
-        raise ValueError("RLM lineage call kind is invalid")
-    lineage = {"version": 1, **values, "depth": depth}
-    return values["call_id"], {RLM_LINEAGE_METADATA_KEY: lineage}
-
-
-def _upstream_headers(headers: Mapping[str, str]) -> dict[str, str]:
-    """Drop Verifiers-authenticated RLM control headers before the provider boundary."""
-    return {
-        name: value
-        for name, value in headers.items()
-        if not name.lower().startswith("x-rlm-")
-    }
 
 
 def _body_digest(raw: bytes) -> bytes:
@@ -462,11 +396,17 @@ class InterceptionServer(Interception):
         del raw
         body = dialect.apply_overrides(body, session.ctx.model, session.ctx.sampling)
         streaming = dialect.streaming(body)
+        logical_call = None
+        upstream_headers = dict(request.headers)
         try:
-            rlm_call_id, call_metadata = _rlm_lineage(request.headers)
+            if session.logical_call_resolver is not None:
+                resolved = session.logical_call_resolver.resolve(
+                    request.headers, session_id=session.trace.id
+                )
+                logical_call = resolved.call
+                upstream_headers = resolved.forward_headers
         except ValueError as error:
             return web.json_response(dialect.error_body(str(error)), status=400)
-        upstream_headers = _upstream_headers(request.headers)
         logger.debug(
             "intercept %s: id=%s stream=%s",
             request.path,
@@ -479,28 +419,53 @@ class InterceptionServer(Interception):
         # alone is no proof of a retry (compaction can legitimately regenerate an identical
         # request), and a stale replay would loop the rollout.
         retried = is_retried_request(request.headers)
-        if rlm_call_id:
-            prior_digest = session.rlm_request_digests.get(rlm_call_id)
-            if prior_digest is not None and prior_digest != req_hash:
+        logical_replay: LogicalCallReplay | None = None
+        if logical_call is not None:
+            if streaming:
                 return web.json_response(
                     dialect.error_body(
-                        "RLM call ID was reused with a different request"
+                        "logical call identity is not supported for streaming requests"
                     ),
                     status=400,
                 )
-            session.rlm_request_digests.setdefault(rlm_call_id, req_hash)
-        if rlm_call_id and rlm_call_id in session.rlm_responses:
-            logger.debug("intercept replay: id=%s (RLM call retry)", session.trace.id)
-            return _completion_response(session.rlm_responses[rlm_call_id])
+            metadata_digest = _body_digest(
+                json.dumps(
+                    logical_call.metadata,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ).encode()
+            )
+            binding = (
+                f"{type(dialect).__module__}.{type(dialect).__qualname__}:{request.path}",
+                req_hash,
+                metadata_digest,
+            )
+            logical_replay = session.logical_calls.get(logical_call.key)
+            if logical_replay is not None and logical_replay.binding != binding:
+                return web.json_response(
+                    dialect.error_body(
+                        "logical call ID was reused with a different request context"
+                    ),
+                    status=400,
+                )
+            if logical_replay is None:
+                logical_replay = LogicalCallReplay(binding=binding)
+                session.logical_calls[logical_call.key] = logical_replay
+            if logical_replay.response is not None:
+                logger.debug(
+                    "intercept replay: id=%s (logical call retry)", session.trace.id
+                )
+                return _completion_response(logical_replay.response)
         if (
-            not rlm_call_id
+            logical_call is None
             and retried
             and session.last_request == req_hash
             and session.last_response is not None
         ):
             logger.debug("intercept replay: id=%s (retried request)", session.trace.id)
             return _completion_response(session.last_response)
-        if not rlm_call_id and session.last_request == req_hash:
+        if logical_call is None and session.last_request == req_hash:
             # A fresh attempt supersedes the recorded response for the same body: drop it
             # so this attempt's own retries coalesce or re-run instead of replaying the
             # previous turn.
@@ -534,29 +499,26 @@ class InterceptionServer(Interception):
 
         fut: asyncio.Future[dict | None] | None = None
         if not streaming:
+            if logical_replay is not None and logical_replay.inflight is not None:
+                return await coalesced(logical_replay.inflight)
             if (
-                rlm_call_id
-                and (inflight := session.rlm_inflight.get(rlm_call_id)) is not None
-            ):
-                return await coalesced(inflight)
-            if (
-                not rlm_call_id
+                logical_call is None
                 and retried
                 and (inflight := session.inflight.get(req_hash)) is not None
             ):
                 return await coalesced(inflight)
             fut = asyncio.get_running_loop().create_future()
-            if rlm_call_id:
-                session.rlm_inflight[rlm_call_id] = fut
+            if logical_replay is not None:
+                logical_replay.inflight = fut
             else:
                 session.inflight[req_hash] = fut
 
         def finish_inflight(completion: dict | None = None) -> None:
             if fut is None:
                 return
-            if rlm_call_id and session.rlm_inflight.get(rlm_call_id) is fut:
-                session.rlm_inflight.pop(rlm_call_id, None)
-            elif not rlm_call_id and session.inflight.get(req_hash) is fut:
+            if logical_replay is not None and logical_replay.inflight is fut:
+                logical_replay.inflight = None
+            elif logical_call is None and session.inflight.get(req_hash) is fut:
                 session.inflight.pop(req_hash, None)
             if not fut.done():
                 fut.set_result(completion)
@@ -624,7 +586,7 @@ class InterceptionServer(Interception):
                 inspect_response=inspect_response,
                 policy_paths=policy_paths,
                 upstream_headers=upstream_headers,
-                call_metadata=call_metadata,
+                call_metadata=logical_call.metadata if logical_call else None,
             )
 
         def serve(response: Response) -> web.Response:
@@ -632,8 +594,8 @@ class InterceptionServer(Interception):
             # byte-identical request replays instead of re-sampling and forking the graph.
             # `Response.raw` is the full native provider object (or the renderer's synthesized
             # completion) that the server serializes back to the program.
-            if rlm_call_id:
-                session.rlm_responses[rlm_call_id] = response.raw
+            if logical_replay is not None:
+                logical_replay.response = response.raw
             else:
                 session.last_request = req_hash
                 session.last_response = response.raw
@@ -756,7 +718,7 @@ class InterceptionServer(Interception):
                     usage=call_response.usage if call_response else None,
                     error=error,
                     policy_paths=policy_paths,
-                    metadata=call_metadata,
+                    metadata=logical_call.metadata if logical_call else None,
                 )
             return serve(call_response)
         finally:

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -24,13 +24,14 @@ import contextlib
 import hashlib
 import json
 import logging
+import re
 import secrets
 import time
 import traceback
 from collections.abc import AsyncIterator, Collection, Mapping
 from contextlib import asynccontextmanager
 from tempfile import SpooledTemporaryFile
-from typing import Literal
+from typing import Any, Literal
 
 from aiohttp import web
 from pydantic import ValidationError
@@ -80,6 +81,20 @@ HASH_INLINE_MAX = 1024**2  # 1 MiB
 # Attempt counter the stainless-generated SDKs (OpenAI, Anthropic) send on every request:
 # 0 on the first attempt, incremented on each retry of the same request.
 RETRY_COUNT_HEADER = "x-stainless-retry-count"
+RLM_LINEAGE_VERSION_HEADER = "x-rlm-lineage-version"
+RLM_CALL_ID_HEADER = "x-rlm-call-id"
+RLM_LINEAGE_METADATA_KEY = "ai.prime.rlm/lineage-v1"
+RLM_LINEAGE_HEADERS = {
+    "session_id": "x-rlm-session-id",
+    "invocation_id": "x-rlm-invocation-id",
+    "parent_invocation_id": "x-rlm-parent-invocation-id",
+    "segment_id": "x-rlm-segment-id",
+    "call_id": RLM_CALL_ID_HEADER,
+    "parent_call_id": "x-rlm-parent-call-id",
+    "depth": "x-rlm-depth",
+    "call_kind": "x-rlm-call-kind",
+}
+_RLM_LINEAGE_ID_RE = re.compile(r"[A-Za-z0-9._:-]{1,128}")
 
 
 def is_retried_request(headers: Mapping[str, str]) -> bool:
@@ -87,6 +102,57 @@ def is_retried_request(headers: Mapping[str, str]) -> bool:
         return int(headers.get(RETRY_COUNT_HEADER, 0)) > 0
     except ValueError:
         return False
+
+
+def _rlm_lineage(headers: Mapping[str, str]) -> tuple[str | None, dict[str, Any]]:
+    version = headers.get(RLM_LINEAGE_VERSION_HEADER)
+    if version is None:
+        return None, {}
+    if version != "1":
+        logger.warning("ignoring unsupported RLM lineage version %r", version)
+        return None, {}
+    values = {name: headers.get(header) for name, header in RLM_LINEAGE_HEADERS.items()}
+    required = (
+        "session_id",
+        "invocation_id",
+        "segment_id",
+        "call_id",
+        "depth",
+        "call_kind",
+    )
+    missing = [name for name in required if values[name] is None]
+    if missing:
+        raise ValueError(f"RLM lineage is missing fields: {missing}")
+    for name in (
+        "session_id",
+        "invocation_id",
+        "parent_invocation_id",
+        "segment_id",
+        "call_id",
+        "parent_call_id",
+    ):
+        value = values[name]
+        if value is not None and _RLM_LINEAGE_ID_RE.fullmatch(value) is None:
+            raise ValueError(f"RLM lineage field {name!r} is invalid")
+    try:
+        depth = int(values["depth"])
+    except (TypeError, ValueError) as error:
+        raise ValueError("RLM lineage depth is invalid") from error
+    if depth < 0:
+        raise ValueError("RLM lineage depth is invalid")
+    if values["call_kind"] not in ("turn", "compaction"):
+        raise ValueError("RLM lineage call kind is invalid")
+    lineage = {"version": 1, **values, "depth": depth}
+    return values["call_id"], {RLM_LINEAGE_METADATA_KEY: lineage}
+
+
+def _upstream_headers(headers: Mapping[str, str]) -> dict[str, str]:
+    """Drop Verifiers-authenticated RLM control headers before the provider boundary."""
+    return {
+        name: value
+        for name, value in headers.items()
+        if not name.lower().startswith("x-rlm-")
+    }
 
 
 def _body_digest(raw: bytes) -> bytes:
@@ -324,6 +390,7 @@ class InterceptionServer(Interception):
         usage: "Usage | None" = None,
         error: BaseException | None = None,
         policy_paths: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> None:
         """Append one provider exchange to the trace's per-call records (`Trace.calls`):
         the model + effective settings that went upstream, timing, and — when the call
@@ -371,6 +438,7 @@ class InterceptionServer(Interception):
                 )
                 if policy_paths
                 else None,
+                metadata=metadata or {},
             )
         )
 
@@ -394,6 +462,11 @@ class InterceptionServer(Interception):
         del raw
         body = dialect.apply_overrides(body, session.ctx.model, session.ctx.sampling)
         streaming = dialect.streaming(body)
+        try:
+            rlm_call_id, call_metadata = _rlm_lineage(request.headers)
+        except ValueError as error:
+            return web.json_response(dialect.error_body(str(error)), status=400)
+        upstream_headers = _upstream_headers(request.headers)
         logger.debug(
             "intercept %s: id=%s stream=%s",
             request.path,
@@ -406,14 +479,28 @@ class InterceptionServer(Interception):
         # alone is no proof of a retry (compaction can legitimately regenerate an identical
         # request), and a stale replay would loop the rollout.
         retried = is_retried_request(request.headers)
+        if rlm_call_id:
+            prior_digest = session.rlm_request_digests.get(rlm_call_id)
+            if prior_digest is not None and prior_digest != req_hash:
+                return web.json_response(
+                    dialect.error_body(
+                        "RLM call ID was reused with a different request"
+                    ),
+                    status=400,
+                )
+            session.rlm_request_digests.setdefault(rlm_call_id, req_hash)
+        if rlm_call_id and rlm_call_id in session.rlm_responses:
+            logger.debug("intercept replay: id=%s (RLM call retry)", session.trace.id)
+            return _completion_response(session.rlm_responses[rlm_call_id])
         if (
-            retried
+            not rlm_call_id
+            and retried
             and session.last_request == req_hash
             and session.last_response is not None
         ):
             logger.debug("intercept replay: id=%s (retried request)", session.trace.id)
             return _completion_response(session.last_response)
-        if session.last_request == req_hash:
+        if not rlm_call_id and session.last_request == req_hash:
             # A fresh attempt supersedes the recorded response for the same body: drop it
             # so this attempt's own retries coalesce or re-run instead of replaying the
             # previous turn.
@@ -447,15 +534,29 @@ class InterceptionServer(Interception):
 
         fut: asyncio.Future[dict | None] | None = None
         if not streaming:
-            if retried and (inflight := session.inflight.get(req_hash)) is not None:
+            if (
+                rlm_call_id
+                and (inflight := session.rlm_inflight.get(rlm_call_id)) is not None
+            ):
+                return await coalesced(inflight)
+            if (
+                not rlm_call_id
+                and retried
+                and (inflight := session.inflight.get(req_hash)) is not None
+            ):
                 return await coalesced(inflight)
             fut = asyncio.get_running_loop().create_future()
-            session.inflight[req_hash] = fut
+            if rlm_call_id:
+                session.rlm_inflight[rlm_call_id] = fut
+            else:
+                session.inflight[req_hash] = fut
 
         def finish_inflight(completion: dict | None = None) -> None:
             if fut is None:
                 return
-            if session.inflight.get(req_hash) is fut:
+            if rlm_call_id and session.rlm_inflight.get(rlm_call_id) is fut:
+                session.rlm_inflight.pop(rlm_call_id, None)
+            elif not rlm_call_id and session.inflight.get(req_hash) is fut:
                 session.inflight.pop(req_hash, None)
             if not fut.done():
                 fut.set_result(completion)
@@ -522,6 +623,8 @@ class InterceptionServer(Interception):
                 turn=turn,
                 inspect_response=inspect_response,
                 policy_paths=policy_paths,
+                upstream_headers=upstream_headers,
+                call_metadata=call_metadata,
             )
 
         def serve(response: Response) -> web.Response:
@@ -529,8 +632,11 @@ class InterceptionServer(Interception):
             # byte-identical request replays instead of re-sampling and forking the graph.
             # `Response.raw` is the full native provider object (or the renderer's synthesized
             # completion) that the server serializes back to the program.
-            session.last_request = req_hash
-            session.last_response = response.raw
+            if rlm_call_id:
+                session.rlm_responses[rlm_call_id] = response.raw
+            else:
+                session.last_request = req_hash
+                session.last_response = response.raw
             finish_inflight(response.raw)
             return _completion_response(response.raw)
 
@@ -548,7 +654,7 @@ class InterceptionServer(Interception):
                         dialect,
                         body,
                         session.ctx.sampling,
-                        headers=request.headers,
+                        headers=upstream_headers,
                         session_id=session.trace.id,
                         turn=turn,
                     )
@@ -650,6 +756,7 @@ class InterceptionServer(Interception):
                     usage=call_response.usage if call_response else None,
                     error=error,
                     policy_paths=policy_paths,
+                    metadata=call_metadata,
                 )
             return serve(call_response)
         finally:
@@ -668,6 +775,8 @@ class InterceptionServer(Interception):
         turn: graph.PendingTurn,
         inspect_response: bool,
         policy_paths: list[str] | None = None,
+        upstream_headers: Mapping[str, str] | None = None,
+        call_metadata: dict[str, Any] | None = None,
     ) -> web.StreamResponse:
         """A streamed (SSE) model turn: relay the provider's stream through to the program,
         incrementally assembling the response to record on the trace (the only client that
@@ -683,7 +792,7 @@ class InterceptionServer(Interception):
                 reply = await session.client.relay(
                     dialect,
                     body,
-                    headers=request.headers,
+                    headers=upstream_headers,
                     session_id=session.trace.id,
                 )
             except OverlongPromptError as e:
@@ -926,6 +1035,7 @@ class InterceptionServer(Interception):
                 usage=response.usage if response is not None else None,
                 error=error,
                 policy_paths=policy_paths,
+                metadata=call_metadata,
             )
 
     async def handle_aux(

--- a/verifiers/v1/logical_calls.py
+++ b/verifiers/v1/logical_calls.py
@@ -1,0 +1,27 @@
+"""Harness-owned request identity at the model interception boundary."""
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+
+@dataclass(frozen=True)
+class LogicalCall:
+    """One stable model call that may cross several transport attempts."""
+
+    key: str
+    metadata: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ResolvedCallHeaders:
+    """Logical identity plus the request headers safe to forward upstream."""
+
+    call: LogicalCall | None
+    forward_headers: dict[str, str]
+
+
+class LogicalCallResolver(Protocol):
+    def resolve(
+        self, headers: Mapping[str, str], *, session_id: str
+    ) -> ResolvedCallHeaders: ...

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -103,6 +103,7 @@ class Rollout:
         self._session = RolloutSession(
             ctx=ctx,
             trace=self.trace,
+            logical_call_resolver=harness.LOGICAL_CALL_RESOLVER,
             network_policy=(
                 runtime_config
                 if isinstance(runtime_config, NetworkPolicyConfig)

--- a/verifiers/v1/session.py
+++ b/verifiers/v1/session.py
@@ -124,6 +124,12 @@ class RolloutSession:
     """The response returned for `last_request`, replayed verbatim on a retry."""
     inflight: dict[bytes, "asyncio.Future[dict | None]"] = field(default_factory=dict)
     """Body digest -> the response currently computing, used to coalesce an in-flight retry."""
+    rlm_request_digests: dict[str, bytes] = field(default_factory=dict)
+    """Stable RLM call ID -> body digest, used to reject identity reuse with new content."""
+    rlm_responses: dict[str, dict] = field(default_factory=dict)
+    """Completed non-streaming RLM calls, replayed across SDK and outer transport retries."""
+    rlm_inflight: dict[str, "asyncio.Future[dict | None]"] = field(default_factory=dict)
+    """Stable RLM call ID -> the response currently computing."""
     released: bool = False
     """Set when the rollout unregisters the session: the trace is sealed (its conclusion is
     what scored and persisted), so a handler still in flight must not commit turns, record

--- a/verifiers/v1/session.py
+++ b/verifiers/v1/session.py
@@ -22,6 +22,7 @@ from verifiers.v1 import graph
 from verifiers.v1.clients import Client, ModelContext
 from verifiers.v1.configs.runtime import NetworkPolicyConfig
 from verifiers.v1.errors import RolloutError, TaskError
+from verifiers.v1.logical_calls import LogicalCallResolver
 from verifiers.v1.trace import InterceptRecord, Trace
 from verifiers.v1.types import (
     AssistantMessage,
@@ -95,9 +96,17 @@ class RolloutLimits:
 
 
 @dataclass
+class LogicalCallReplay:
+    binding: tuple[str, bytes, bytes]
+    response: dict | None = None
+    inflight: "asyncio.Future[dict | None] | None" = None
+
+
+@dataclass
 class RolloutSession:
     ctx: ModelContext
     trace: Trace
+    logical_call_resolver: LogicalCallResolver | None = None
     network_policy: NetworkPolicyConfig = field(default_factory=NetworkPolicyConfig)
     """The resolved execution policy, including task-level restrictions."""
     trace_stops: list[Callable[..., Awaitable[bool] | bool]] = field(
@@ -124,12 +133,8 @@ class RolloutSession:
     """The response returned for `last_request`, replayed verbatim on a retry."""
     inflight: dict[bytes, "asyncio.Future[dict | None]"] = field(default_factory=dict)
     """Body digest -> the response currently computing, used to coalesce an in-flight retry."""
-    rlm_request_digests: dict[str, bytes] = field(default_factory=dict)
-    """Stable RLM call ID -> body digest, used to reject identity reuse with new content."""
-    rlm_responses: dict[str, dict] = field(default_factory=dict)
-    """Completed non-streaming RLM calls, replayed across SDK and outer transport retries."""
-    rlm_inflight: dict[str, "asyncio.Future[dict | None]"] = field(default_factory=dict)
-    """Stable RLM call ID -> the response currently computing."""
+    logical_calls: dict[str, LogicalCallReplay] = field(default_factory=dict)
+    """Stable harness call identity -> request binding and replay state."""
     released: bool = False
     """Set when the rollout unregisters the session: the trace is sealed (its conclusion is
     what scored and persisted), so a handler still in flight must not commit turns, record

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -203,6 +203,9 @@ class ModelCall(BaseModel):
     """The failure that ended this call, coupled to the exchange that caused it."""
     policy: PolicyEvent | None = None
     """Policy mediation applied to the request before this call."""
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    """Namespaced boundary metadata for this exchange. It is descriptive only; message
+    ancestry in `Trace.nodes` remains authoritative for branch construction."""
 
 
 def min_new_input_tokens(calls: Iterable[ModelCall]) -> Iterator[tuple[ModelCall, int]]:


### PR DESCRIPTION
## Summary

- add a generic, harness-bound logical-call resolver for stable identity, private request headers, and namespaced `ModelCall.metadata`
- replay completed non-streaming calls and coalesce concurrent attempts by opaque logical ID while preserving the existing Stainless retry fallback
- bind every logical ID to route, request bytes, and stable metadata so changed bodies or lineage cannot receive a stale replay
- move every `X-RLM-*` constant, parser, schema rule, and stripping decision into the RLM harness protocol module
- keep `Trace.nodes` authoritative for training branches; runtime lineage remains descriptive call metadata

Unrelated harnesses cannot activate RLM behavior merely by sending `X-RLM-*` headers.

Depends on #2384.

## Validation

- `uv run pytest tests/v1/test_rlm_lineage.py tests/v1/test_trace.py -q`
- complete deterministic v1 suite passed as part of the stack
- Ruff, format, and Ty passed locally and in CI
