### PR TITLE
feat: support RLM training over ACP

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,7 @@ jobs:
       PRIME_API_KEY: ${{ secrets.PRIME_API_KEY }}
       PRIME_TEAM_ID: ${{ secrets.PRIME_TEAM_ID }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      NANO_RLM_E2E_VERSION: 7a26d3c2cd2f38e11807ef7b88ce4ea197552ea8
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,7 @@ jobs:
       PRIME_API_KEY: ${{ secrets.PRIME_API_KEY }}
       PRIME_TEAM_ID: ${{ secrets.PRIME_TEAM_ID }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
-      NANO_RLM_E2E_VERSION: 7a26d3c2cd2f38e11807ef7b88ce4ea197552ea8
+      NANO_RLM_E2E_VERSION: 9f67cd7483f6c41fcacf66e5287503aab0b43374
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,6 @@ jobs:
       PRIME_API_KEY: ${{ secrets.PRIME_API_KEY }}
       PRIME_TEAM_ID: ${{ secrets.PRIME_TEAM_ID }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
-      NANO_RLM_E2E_VERSION: c27f8ea151061e31497a5831fda4c168de6d0587
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,7 @@ jobs:
       PRIME_API_KEY: ${{ secrets.PRIME_API_KEY }}
       PRIME_TEAM_ID: ${{ secrets.PRIME_TEAM_ID }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
-      NANO_RLM_E2E_VERSION: 9f67cd7483f6c41fcacf66e5287503aab0b43374
+      NANO_RLM_E2E_VERSION: c27f8ea151061e31497a5831fda4c168de6d0587
 
     steps:
       - uses: actions/checkout@v7

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -77,6 +77,8 @@ def tool_runtime(request) -> dict:
 @pytest.fixture
 def harness(request) -> HarnessConfig:
     config = {"id": request.param} if isinstance(request.param, str) else request.param
+    if config["id"] == "rlm" and (version := os.environ.get("NANO_RLM_E2E_VERSION")):
+        config.setdefault("version", version)
     return harness_config_type(config["id"]).model_validate(config)
 
 

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -257,6 +257,7 @@ async def test_acp_resume_with_tool(run_v1, harness, harness_runtime, tmp_path):
     assert len(segments) == 2
     assert segments[0]["terminated"] is False
     assert segments[1]["terminated"] is False
+    assert trace.primary_reply == segments[1]["last_reply"]
     # Kimi Code is broken upstream: its Responses adapter drops message `phase` on replay.
     if harness.id != "kimi-code":
         assert trace.num_branches == 1

--- a/tests/v1/test_idempotency.py
+++ b/tests/v1/test_idempotency.py
@@ -1,0 +1,126 @@
+import asyncio
+import time
+
+import httpx
+import pytest
+
+import verifiers.v1 as vf
+from verifiers.v1.clients import ModelContext
+from verifiers.v1.configs.client import EvalClientConfig
+from verifiers.v1.interception.server import InterceptionServer
+from verifiers.v1.session import RolloutSession
+from verifiers.v1.types import AssistantMessage, Response, Usage
+
+
+class _BlockingClient:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.headers: dict[str, str] = {}
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def get_response(self, dialect, body, sampling, **kwargs) -> Response:
+        self.calls += 1
+        self.headers = dict(kwargs["headers"])
+        self.started.set()
+        await self.release.wait()
+        raw = {
+            "id": f"completion-{self.calls}",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "test-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "done"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 2, "completion_tokens": 1},
+        }
+        return Response(
+            id=raw["id"],
+            created=int(time.time()),
+            model="test-model",
+            message=AssistantMessage(content="done"),
+            finish_reason="stop",
+            usage=Usage(prompt_tokens=2, completion_tokens=1),
+            raw=raw,
+        )
+
+
+@pytest.mark.asyncio
+async def test_idempotency_key_coalesces_and_replays_one_model_call():
+    trace = vf.Trace(
+        id="trace-1",
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
+        task=vf.TraceTask(
+            type="Task",
+            data=vf.TaskData(idx=7, prompt="solve it"),
+        ),
+    )
+    session = RolloutSession(
+        ctx=ModelContext(
+            model="test-model",
+            client=EvalClientConfig(
+                base_url="http://unused.invalid", api_key_var="NONE"
+            ),
+        ),
+        trace=trace,
+    )
+    client = _BlockingClient()
+    session.client = client
+    body = {"model": "ignored", "messages": [{"role": "user", "content": "hi"}]}
+
+    async with InterceptionServer() as server:
+        secret = "rollout-secret"
+        server.sessions[secret] = session
+        headers = {
+            "Authorization": f"Bearer {secret}",
+            "idempotency-key": "call-1",
+        }
+        async with httpx.AsyncClient() as http:
+            first = asyncio.create_task(
+                http.post(
+                    f"{server.base_url}/v1/chat/completions", json=body, headers=headers
+                )
+            )
+            await client.started.wait()
+            concurrent_retry = asyncio.create_task(
+                http.post(
+                    f"{server.base_url}/v1/chat/completions", json=body, headers=headers
+                )
+            )
+            await asyncio.sleep(0)
+            client.release.set()
+            first_response, concurrent_response = await asyncio.gather(
+                first, concurrent_retry
+            )
+            completed_retry = await http.post(
+                f"{server.base_url}/v1/chat/completions", json=body, headers=headers
+            )
+            conflicting_retry = await http.post(
+                f"{server.base_url}/v1/chat/completions",
+                json={**body, "temperature": 0.5},
+                headers=headers,
+            )
+            distinct_call = await http.post(
+                f"{server.base_url}/v1/chat/completions",
+                json=body,
+                headers={**headers, "idempotency-key": "call-2"},
+            )
+
+    assert first_response.status_code == 200
+    assert concurrent_response.json() == first_response.json()
+    assert completed_retry.json() == first_response.json()
+    assert conflicting_retry.status_code == 400
+    assert distinct_call.status_code == 200
+    assert client.calls == 2
+    provider_keys = [
+        value
+        for name, value in client.headers.items()
+        if name.lower() == "idempotency-key"
+    ]
+    assert len(provider_keys) == 1
+    assert provider_keys[0] != "call-2"
+    assert len(trace.calls) == 2

--- a/tests/v1/test_idempotency.py
+++ b/tests/v1/test_idempotency.py
@@ -172,7 +172,9 @@ async def test_idempotency_key_coalesces_original_error_without_caching_it():
                     f"{server.base_url}/v1/chat/completions", json=body, headers=headers
                 )
             )
-            while len(session.tasks) < 2:
+            while (
+                request := session.idempotent_requests.get("call-error")
+            ) is None or request.inflight_waiters < 1:
                 await asyncio.sleep(0)
             client.release.set()
             first_response, concurrent_response = await asyncio.gather(

--- a/tests/v1/test_idempotency.py
+++ b/tests/v1/test_idempotency.py
@@ -7,6 +7,8 @@ import pytest
 import verifiers.v1 as vf
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.client import EvalClientConfig
+from verifiers.v1.errors import ProviderError
+from verifiers.v1.interception import server as interception_server
 from verifiers.v1.interception.server import InterceptionServer
 from verifiers.v1.session import RolloutSession
 from verifiers.v1.types import AssistantMessage, Response, Usage
@@ -49,8 +51,20 @@ class _BlockingClient:
         )
 
 
-@pytest.mark.asyncio
-async def test_idempotency_key_coalesces_and_replays_one_model_call():
+class _FailingBlockingClient:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def get_response(self, dialect, body, sampling, **kwargs) -> Response:
+        self.calls += 1
+        self.started.set()
+        await self.release.wait()
+        raise ProviderError("rate limited", status_code=429)
+
+
+def _session() -> tuple[vf.Trace, RolloutSession]:
     trace = vf.Trace(
         id="trace-1",
         agent=vf.AgentInfo(config=vf.AgentConfig()),
@@ -68,6 +82,12 @@ async def test_idempotency_key_coalesces_and_replays_one_model_call():
         ),
         trace=trace,
     )
+    return trace, session
+
+
+@pytest.mark.asyncio
+async def test_idempotency_key_coalesces_and_replays_one_model_call():
+    trace, session = _session()
     client = _BlockingClient()
     session.client = client
     body = {"model": "ignored", "messages": [{"role": "user", "content": "hi"}]}
@@ -124,3 +144,84 @@ async def test_idempotency_key_coalesces_and_replays_one_model_call():
     assert len(provider_keys) == 1
     assert provider_keys[0] != "call-2"
     assert len(trace.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_idempotency_key_coalesces_original_error_without_caching_it():
+    _, session = _session()
+    client = _FailingBlockingClient()
+    session.client = client
+    body = {"model": "ignored", "messages": [{"role": "user", "content": "hi"}]}
+
+    async with InterceptionServer() as server:
+        secret = "rollout-secret"
+        server.sessions[secret] = session
+        headers = {
+            "Authorization": f"Bearer {secret}",
+            "idempotency-key": "call-error",
+        }
+        async with httpx.AsyncClient() as http:
+            first = asyncio.create_task(
+                http.post(
+                    f"{server.base_url}/v1/chat/completions", json=body, headers=headers
+                )
+            )
+            await client.started.wait()
+            concurrent_retry = asyncio.create_task(
+                http.post(
+                    f"{server.base_url}/v1/chat/completions", json=body, headers=headers
+                )
+            )
+            while len(session.tasks) < 2:
+                await asyncio.sleep(0)
+            client.release.set()
+            first_response, concurrent_response = await asyncio.gather(
+                first, concurrent_retry
+            )
+            assert client.calls == 1
+            later_retry = await http.post(
+                f"{server.base_url}/v1/chat/completions", json=body, headers=headers
+            )
+
+    assert first_response.status_code == 429
+    assert concurrent_response.status_code == 429
+    assert concurrent_response.content == first_response.content
+    assert later_retry.status_code == 429
+    assert client.calls == 2
+    assert "call-error" not in session.idempotent_requests
+
+
+@pytest.mark.asyncio
+async def test_idempotency_cache_bounds_completed_responses(monkeypatch):
+    monkeypatch.setattr(interception_server, "IDEMPOTENCY_CACHE_MAX_COMPLETED", 1)
+    _, session = _session()
+    client = _BlockingClient()
+    client.release.set()
+    session.client = client
+    body = {"model": "ignored", "messages": [{"role": "user", "content": "hi"}]}
+
+    async with InterceptionServer() as server:
+        secret = "rollout-secret"
+        server.sessions[secret] = session
+        headers = {"Authorization": f"Bearer {secret}"}
+        async with httpx.AsyncClient() as http:
+            first = await http.post(
+                f"{server.base_url}/v1/chat/completions",
+                json=body,
+                headers={**headers, "idempotency-key": "call-1"},
+            )
+            await http.post(
+                f"{server.base_url}/v1/chat/completions",
+                json=body,
+                headers={**headers, "idempotency-key": "call-2"},
+            )
+            assert set(session.idempotent_requests) == {"call-2"}
+            evicted_retry = await http.post(
+                f"{server.base_url}/v1/chat/completions",
+                json=body,
+                headers={**headers, "idempotency-key": "call-1"},
+            )
+
+    assert evicted_retry.json() != first.json()
+    assert client.calls == 3
+    assert set(session.idempotent_requests) == {"call-1"}

--- a/tests/v1/test_rlm_prime_contract.py
+++ b/tests/v1/test_rlm_prime_contract.py
@@ -109,10 +109,13 @@ def _completion(body: dict[str, Any], sequence: int) -> tuple[dict[str, Any], st
 @pytest.mark.prime
 async def test_rlm_training_contract_in_prime_vm(run_v1, tmp_path, monkeypatch):
     calls: list[str] = []
+    children_started = 0
+    both_children_started = asyncio.Event()
 
     async def handle(
         reader: asyncio.StreamReader, writer: asyncio.StreamWriter
     ) -> None:
+        nonlocal children_started
         try:
             head = await reader.readuntil(b"\r\n\r\n")
             headers = {
@@ -126,6 +129,11 @@ async def test_rlm_training_contract_in_prime_vm(run_v1, tmp_path, monkeypatch):
             )
             response, label = _completion(body, len(calls))
             calls.append(label)
+            if label in {"child-one", "child-two"}:
+                children_started += 1
+                if children_started == 2:
+                    both_children_started.set()
+                await asyncio.wait_for(both_children_started.wait(), timeout=30)
             payload = json.dumps(response, separators=(",", ":")).encode()
             writer.write(
                 b"HTTP/1.1 200 OK\r\n"
@@ -180,6 +188,13 @@ async def test_rlm_training_contract_in_prime_vm(run_v1, tmp_path, monkeypatch):
 
     assert trace.ok, trace.errors
     assert trace.rewards["resumed"].score == 1.0
+    assert trace.primary_reply == f"{CODEWORD} [{TOOL_STAMP}]"
+    assert trace.num_branches == 3
+    assert {branch.last_reply for branch in trace.branches} == {
+        "CHILD-ONE",
+        "CHILD-TWO",
+        f"{CODEWORD} [{TOOL_STAMP}]",
+    }
     assert set(calls) == {
         "root-ready",
         "root-tool",

--- a/tests/v1/test_rlm_prime_contract.py
+++ b/tests/v1/test_rlm_prime_contract.py
@@ -27,6 +27,13 @@ def _message_text(message: dict[str, Any]) -> str:
     return str(content)
 
 
+def _branch_reply(branch: Any) -> str:
+    for node in reversed(branch.nodes):
+        if node.sampled and node.message.role == "assistant":
+            return str(node.message.content or "")
+    return ""
+
+
 def _completion(body: dict[str, Any], sequence: int) -> tuple[dict[str, Any], str]:
     messages = body["messages"]
     users = [
@@ -190,7 +197,7 @@ async def test_rlm_training_contract_in_prime_vm(run_v1, tmp_path, monkeypatch):
     assert trace.rewards["resumed"].score == 1.0
     assert trace.primary_reply == f"{CODEWORD} [{TOOL_STAMP}]"
     assert trace.num_branches == 3
-    assert {branch.last_reply for branch in trace.branches} == {
+    assert {_branch_reply(branch) for branch in trace.branches} == {
         "CHILD-ONE",
         "CHILD-TWO",
         f"{CODEWORD} [{TOOL_STAMP}]",

--- a/tests/v1/test_rlm_prime_contract.py
+++ b/tests/v1/test_rlm_prime_contract.py
@@ -1,0 +1,191 @@
+"""Deterministic RLM training-contract E2E in a Prime VM."""
+
+import asyncio
+import json
+import os
+import time
+from typing import Any
+
+import pytest
+
+from verifiers.v1.harnesses.rlm import RLMHarnessConfig
+
+CODEWORD = "violet-cascade-731"
+TOOL_STAMP = "resume-ok-9d2"
+FAKE_API_KEY_VAR = "RLM_CONTRACT_E2E_API_KEY"
+
+
+def _message_text(message: dict[str, Any]) -> str:
+    content = message.get("content", "")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "\n".join(
+            str(item.get("text", "")) if isinstance(item, dict) else str(item)
+            for item in content
+        )
+    return str(content)
+
+
+def _completion(body: dict[str, Any], sequence: int) -> tuple[dict[str, Any], str]:
+    messages = body["messages"]
+    users = [
+        _message_text(message) for message in messages if message["role"] == "user"
+    ]
+    last_role = messages[-1]["role"]
+
+    if any(text == "child-one" for text in users):
+        message, label = {"role": "assistant", "content": "CHILD-ONE"}, "child-one"
+    elif any(text == "child-two" for text in users):
+        message, label = {"role": "assistant", "content": "CHILD-TWO"}, "child-two"
+    elif last_role == "tool":
+        message, label = (
+            {"role": "assistant", "content": f"{CODEWORD} [{TOOL_STAMP}]"},
+            "root-final",
+        )
+    elif any("Call the `recall` tool" in text for text in users):
+        code = (
+            "import asyncio\n"
+            "import os\n"
+            "import subprocess\n"
+            "assert os.environ.get('TASK_VISIBLE') == 'yes'\n"
+            "assert os.environ.get('EXPLICIT_TASK') == 'also-yes'\n"
+            "private = ('RLM_API_KEY', 'SERPER_API_KEY')\n"
+            "assert all(name not in os.environ for name in private)\n"
+            "child_env = subprocess.check_output(['env'], text=True)\n"
+            "assert all(f'{name}=' not in child_env for name in private)\n"
+            "tool_result, children = await asyncio.gather(\n"
+            f"    resume_recall.run(codeword={CODEWORD!r}),\n"
+            "    asyncio.gather(rlm('child-one'), rlm('child-two')),\n"
+            ")\n"
+            "print(tool_result)\n"
+            "print([child.answer for child in children])"
+        )
+        message, label = (
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call-contract-ipython",
+                        "type": "function",
+                        "function": {
+                            "name": "ipython",
+                            "arguments": json.dumps({"code": code, "timeout": 120}),
+                        },
+                    }
+                ],
+            },
+            "root-tool",
+        )
+    else:
+        message, label = {"role": "assistant", "content": "READY"}, "root-ready"
+
+    finish_reason = "tool_calls" if "tool_calls" in message else "stop"
+    return (
+        {
+            "id": f"chatcmpl-contract-{sequence}",
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "model": body.get("model", "contract-model"),
+            "choices": [
+                {
+                    "index": 0,
+                    "message": message,
+                    "finish_reason": finish_reason,
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+            },
+        },
+        label,
+    )
+
+
+@pytest.mark.e2e
+@pytest.mark.prime
+async def test_rlm_training_contract_in_prime_vm(run_v1, tmp_path, monkeypatch):
+    calls: list[str] = []
+
+    async def handle(
+        reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        try:
+            head = await reader.readuntil(b"\r\n\r\n")
+            headers = {
+                name.strip().lower(): value.strip()
+                for line in head.decode("latin-1").split("\r\n")[1:]
+                if line and (name_value := line.split(":", 1))
+                for name, value in [name_value]
+            }
+            body = json.loads(
+                await reader.readexactly(int(headers.get("content-length", "0")))
+            )
+            response, label = _completion(body, len(calls))
+            calls.append(label)
+            payload = json.dumps(response, separators=(",", ":")).encode()
+            writer.write(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: application/json\r\n"
+                + f"Content-Length: {len(payload)}\r\n".encode()
+                + b"Connection: close\r\n\r\n"
+                + payload
+            )
+            await writer.drain()
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    server = await asyncio.start_server(handle, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    monkeypatch.setenv(FAKE_API_KEY_VAR, "contract-secret")
+    harness = RLMHarnessConfig(
+        id="rlm",
+        version=os.environ.get("NANO_RLM_E2E_VERSION", "main"),
+        max_depth=1,
+        max_concurrent_subagents=2,
+        max_subagent_calls=2,
+        kernel_env={"TASK_VISIBLE": "yes", "EXPLICIT_TASK": "also-yes"},
+        env={
+            "RLM_API_KEY": "ambient-provider-secret",
+            "SERPER_API_KEY": "search-secret",
+        },
+    )
+
+    try:
+        (trace,) = await run_v1(
+            "echo-acp-resume-v1",
+            harness=harness,
+            runtime={"type": "prime", "vm": True},
+            env={
+                "agent": {
+                    "client": {
+                        "type": "eval",
+                        "base_url": f"http://127.0.0.1:{port}/v1",
+                        "api_key_var": FAKE_API_KEY_VAR,
+                    }
+                }
+            },
+            output_dir=tmp_path,
+            max_turns=8,
+            max_tokens=8192,
+            rollout_timeout=600,
+        )
+    finally:
+        server.close()
+        await server.wait_closed()
+
+    assert trace.ok, trace.errors
+    assert trace.rewards["resumed"].score == 1.0
+    assert set(calls) == {
+        "root-ready",
+        "root-tool",
+        "root-final",
+        "child-one",
+        "child-two",
+    }
+    assert trace.metrics["sub_rlm_num_calls"] == 2
+    assert trace.metrics["has_sub_rlm"] == 1

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -80,6 +80,7 @@ def test_wire_trace_round_trip():
     tr.rewards.setdefault("solved", None)  # seeded: expected but never scored
     tr.metrics.setdefault("acc", None)
     tr.info = {"build": "ok"}
+    tr.primary_reply = "primary answer"
     tr.stop("done")
 
     # the dump is plain pydantic — derived values are properties, so they're not serialized
@@ -95,6 +96,11 @@ def test_wire_trace_round_trip():
     assert rt.rewards["solved"] is None
     assert rt.stop_condition == "done"
     assert rt.info == {"build": "ok"}
+    assert rt.primary_reply == "primary answer"
+    assert rt.last_reply == "primary answer"
+    # An intentionally empty primary reply must not leak a child response.
+    rt.primary_reply = ""
+    assert rt.last_reply == ""
     assert (
         rt.tools == tr.tools
     )  # the advertised tools persist (tool-use SFT reads them)

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -49,6 +49,7 @@ from verifiers.v1.episode import (
 from verifiers.v1.errors import (
     EnvError,
     HarnessError,
+    HarnessFinalizationError,
     InterceptionError,
     ProviderError,
     RolloutError,
@@ -256,6 +257,7 @@ __all__ = [  # noqa: RUF022 - grouped by public API area
     "EnvError",
     "ProviderError",
     "HarnessError",
+    "HarnessFinalizationError",
     "ToolsetError",
     "SandboxError",
     "TaskError",

--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -262,6 +262,8 @@ class ACPHarnessSession(HarnessSession):
             return
         finalization_error: HarnessFinalizationError | None = None
         finalization_cause: BaseException | None = None
+        shutdown_error: BaseException | None = None
+        shutdown_detail: str | None = None
         try:
             metadata: JsonObject = {}
             if graceful and reader is not None:
@@ -274,13 +276,12 @@ class ACPHarnessSession(HarnessSession):
                         )
                 except BaseException as error:
                     logger.warning("ACP session shutdown failed", exc_info=True)
-                    detail = f"{type(error).__name__}: {error}"
+                    shutdown_error = error
+                    shutdown_detail = f"{type(error).__name__}: {error}"
                     if stderr := self._stderr():
-                        detail = f"{detail}\n\nACP process stderr:\n{stderr}"
-                    finalization_error = HarnessFinalizationError(
-                        f"ACP session shutdown failed: {detail}"
-                    )
-                    finalization_cause = error
+                        shutdown_detail = (
+                            f"{shutdown_detail}\n\nACP process stderr:\n{stderr}"
+                        )
                 else:
                     value = response.get("metadata", {})
                     if isinstance(value, dict):
@@ -295,10 +296,18 @@ class ACPHarnessSession(HarnessSession):
                         self.harness.acp_close_metrics(self.trace, metadata)
                     )
                 except Exception as error:  # noqa: BLE001 - type artifact failures
-                    finalization_error = HarnessFinalizationError(
-                        "ACP session finalization failed: "
-                        f"{type(error).__name__}: {error}"
-                    )
+                    if shutdown_error is not None:
+                        finalization_error = HarnessFinalizationError(
+                            "ACP session shutdown failed and required finalization "
+                            f"could not complete: {shutdown_detail}; "
+                            f"{type(error).__name__}: {error}"
+                        )
+                        finalization_cause = shutdown_error
+                    else:
+                        finalization_error = HarnessFinalizationError(
+                            "ACP session finalization failed: "
+                            f"{type(error).__name__}: {error}"
+                        )
             for timeout, stop in (
                 (10 if graceful else 0.1, None),
                 (5, process.terminate),

--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -3,8 +3,9 @@
 import asyncio
 import contextlib
 import json
+import logging
 from abc import abstractmethod
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TypeAlias, TypeVar
@@ -21,6 +22,7 @@ from verifiers.v1.utils.aio import run_shielded
 
 ACP_SOURCE = (Path(__file__).resolve().parent / "runner.py").read_text()
 MAX_PACKET_BYTES = 128 * 1024 * 1024
+logger = logging.getLogger(__name__)
 
 __all__ = ["ACPConfig", "ACPHarness"]
 
@@ -50,6 +52,12 @@ class ACPHarness(Harness[ConfigT]):
         await runtime.prepare_uv_script(
             ACP_SOURCE, {**self.config.resolved_env, "UV_FROZEN": "false"}
         )
+
+    def acp_close_metrics(
+        self, trace: Trace, metadata: JsonObject
+    ) -> Mapping[str, float]:
+        """Extract harness metrics from a successful ACP session/close response."""
+        return {}
 
     @abstractmethod
     async def prepare_acp(
@@ -253,9 +261,21 @@ class ACPHarnessSession(HarnessSession):
             return
         try:
             if graceful and reader is not None:
-                with contextlib.suppress(BaseException):
+                try:
                     await process.write(_packet({"operation": "shutdown"}))
-                    await asyncio.wait_for(reader.read(), timeout=10)
+                    response = await asyncio.wait_for(reader.read(), timeout=10)
+                    if not response.get("ok"):
+                        raise RuntimeError(
+                            response.get("error") or "ACP session shutdown failed"
+                        )
+                    metadata = response.get("metadata", {})
+                    if not isinstance(metadata, dict):
+                        raise TypeError("ACP close metadata must be an object")
+                    self.trace.record_metrics(
+                        self.harness.acp_close_metrics(self.trace, metadata)
+                    )
+                except BaseException:
+                    logger.warning("ACP session shutdown failed", exc_info=True)
             for timeout, stop in (
                 (10 if graceful else 0.1, None),
                 (5, process.terminate),

--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -12,7 +12,7 @@ from typing import TypeAlias, TypeVar
 
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
-from verifiers.v1.errors import HarnessError
+from verifiers.v1.errors import HarnessError, HarnessFinalizationError
 from verifiers.v1.harness import Harness, HarnessSession
 from verifiers.v1.runtimes import ProgramResult, Runtime, RuntimeProcess
 from verifiers.v1.task import TaskData
@@ -260,7 +260,9 @@ class ACPHarnessSession(HarnessSession):
         stderr_task, self._stderr_task = self._stderr_task, None
         if process is None:
             return
+        finalization_error: HarnessFinalizationError | None = None
         try:
+            metadata: JsonObject = {}
             if graceful and reader is not None:
                 try:
                     await process.write(_packet({"operation": "shutdown"}))
@@ -269,14 +271,26 @@ class ACPHarnessSession(HarnessSession):
                         raise RuntimeError(
                             response.get("error") or "ACP session shutdown failed"
                         )
-                    metadata = response.get("metadata", {})
-                    if not isinstance(metadata, dict):
-                        raise TypeError("ACP close metadata must be an object")
+                except BaseException:
+                    logger.warning("ACP session shutdown failed", exc_info=True)
+                else:
+                    value = response.get("metadata", {})
+                    if isinstance(value, dict):
+                        metadata = value
+                    else:
+                        finalization_error = HarnessFinalizationError(
+                            "ACP close metadata must be an object"
+                        )
+            if graceful and finalization_error is None:
+                try:
                     self.trace.record_metrics(
                         self.harness.acp_close_metrics(self.trace, metadata)
                     )
-                except BaseException:
-                    logger.warning("ACP session shutdown failed", exc_info=True)
+                except Exception as error:  # noqa: BLE001 - type artifact failures
+                    finalization_error = HarnessFinalizationError(
+                        "ACP session finalization failed: "
+                        f"{type(error).__name__}: {error}"
+                    )
             for timeout, stop in (
                 (10 if graceful else 0.1, None),
                 (5, process.terminate),
@@ -290,6 +304,8 @@ class ACPHarnessSession(HarnessSession):
                     break
                 except TimeoutError:
                     continue
+            if finalization_error is not None:
+                raise finalization_error
         finally:
             if stderr_task is not None:
                 if not stderr_task.done():

--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -251,6 +251,7 @@ class ACPHarnessSession(HarnessSession):
             raise TypeError("ACP session reply must be a string")
         result = ProgramResult(exit_code=0, stdout=reply, stderr="")
         _require_model_turn(self.trace, calls_before, result)
+        self.trace.primary_reply = reply
         return result
 
     async def _stop(self, *, graceful: bool) -> None:

--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -261,6 +261,7 @@ class ACPHarnessSession(HarnessSession):
         if process is None:
             return
         finalization_error: HarnessFinalizationError | None = None
+        finalization_cause: BaseException | None = None
         try:
             metadata: JsonObject = {}
             if graceful and reader is not None:
@@ -271,8 +272,15 @@ class ACPHarnessSession(HarnessSession):
                         raise RuntimeError(
                             response.get("error") or "ACP session shutdown failed"
                         )
-                except BaseException:
+                except BaseException as error:
                     logger.warning("ACP session shutdown failed", exc_info=True)
+                    detail = f"{type(error).__name__}: {error}"
+                    if stderr := self._stderr():
+                        detail = f"{detail}\n\nACP process stderr:\n{stderr}"
+                    finalization_error = HarnessFinalizationError(
+                        f"ACP session shutdown failed: {detail}"
+                    )
+                    finalization_cause = error
                 else:
                     value = response.get("metadata", {})
                     if isinstance(value, dict):
@@ -305,7 +313,7 @@ class ACPHarnessSession(HarnessSession):
                 except TimeoutError:
                     continue
             if finalization_error is not None:
-                raise finalization_error
+                raise finalization_error from finalization_cause
         finally:
             if stderr_task is not None:
                 if not stderr_task.done():

--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -251,7 +251,7 @@ class ACPHarnessSession(HarnessSession):
             raise TypeError("ACP session reply must be a string")
         result = ProgramResult(exit_code=0, stdout=reply, stderr="")
         _require_model_turn(self.trace, calls_before, result)
-        self.trace.primary_reply = reply
+        self.trace.primary_reply = reply.strip()
         return result
 
     async def _stop(self, *, graceful: bool) -> None:

--- a/verifiers/v1/acp/runner.py
+++ b/verifiers/v1/acp/runner.py
@@ -195,18 +195,25 @@ class ACPSession:
         self.is_new = False
         return reply
 
-    async def close(self) -> None:
+    async def close(self) -> dict:
+        metadata: dict = {}
         try:
             if self.connection is not None and self.session_id is not None:
                 session_capabilities = (
                     self.capabilities and self.capabilities.session_capabilities
                 )
                 if session_capabilities and session_capabilities.close is not None:
-                    with suppress(Exception):
-                        await self.connection.close_session(session_id=self.session_id)
-            await self.stack.aclose()
+                    response = await self.connection.close_session(
+                        session_id=self.session_id
+                    )
+                    if response is not None:
+                        metadata = dict(response.field_meta or {})
         finally:
-            self._reset()
+            try:
+                await self.stack.aclose()
+            finally:
+                self._reset()
+        return metadata
 
 
 async def read_packet(stream: asyncio.StreamReader) -> dict | None:
@@ -252,9 +259,9 @@ async def serve_stream() -> None:
                         "reply": await session.run(request["config"]),
                     }
                 elif operation == "shutdown":
-                    await session.close()
                     stop = True
-                    response = {"ok": True}
+                    metadata = await session.close()
+                    response = {"ok": True, "metadata": metadata}
                 else:
                     raise ValueError(f"unknown ACP session operation: {operation!r}")
             except Exception as error:  # noqa: BLE001 - serialize protocol failures

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -116,19 +116,23 @@ class Segment:
     """One harness segment's agent/tool output, as `Interaction.turn` returns it.
 
     `messages` carries every model-sampled assistant message and intervening tool
-    result produced by the segment, in order; `last_reply` is quick sugar for its
-    final assistant text. `terminated` marks the exchange over — the run ended (a
+    result produced by the segment, in order; `primary_reply` carries a
+    harness-declared user-visible response when graph order cannot identify one,
+    and `last_reply` resolves between the two. `terminated` marks the exchange over — the run ended (a
     limit, a `@stop`, or the harness finishing) instead of producing another
     segment; a terminated `Segment` carries no messages (the last real segment was
     already delivered), and the interaction's `trace` holds the full exchange.
     """
 
     messages: Messages
+    primary_reply: str | None = None
     terminated: bool = False
 
     @property
     def last_reply(self) -> str:
-        """The final assistant message's text, matching `Trace.last_reply`."""
+        """The segment's primary or final assistant text."""
+        if self.primary_reply is not None:
+            return self.primary_reply.strip()
         for message in reversed(self.messages):
             if isinstance(message, AssistantMessage):
                 return (message.content or "").strip()
@@ -210,7 +214,10 @@ class Interaction:
                     saw_assistant = True
                 elif saw_assistant and isinstance(node.message, ToolMessage):
                     segment_messages.append(node.message)
-            return Segment(messages=segment_messages)
+            return Segment(
+                messages=segment_messages,
+                primary_reply=self.trace.primary_reply,
+            )
         self._over = True
         return Segment(messages=[], terminated=True)
 

--- a/verifiers/v1/errors.py
+++ b/verifiers/v1/errors.py
@@ -56,6 +56,14 @@ class HarnessError(RolloutError):
     """The harness failed to install or launch, or its agent process exited unsuccessfully."""
 
 
+class HarnessFinalizationError(HarnessError):
+    """A harness failed to publish required terminal artifacts during session close.
+
+    Unlike an ordinary teardown failure, losing these artifacts changes the meaning of
+    the rollout (for example, dropping trainer metrics), so the rollout must fail.
+    """
+
+
 class ToolsetError(RolloutError):
     """A task's `Toolset` could not be built or served."""
 

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -1,20 +1,26 @@
 """RLM over ACP, with MCP tools exposed as pre-imported IPython skills."""
 
-import json
 import logging
 import random
 import shlex
 from typing import Literal
 
-from pydantic import Field, PositiveInt, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    NonNegativeInt,
+    PositiveInt,
+    field_validator,
+    model_validator,
+)
 
-from verifiers.v1.acp import ACPConfig, ACPHarness
+from verifiers.v1.acp import ACPConfig, ACPHarness, JsonObject
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.runtimes import Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
-from verifiers.v1.utils.decorators import metric
 
 logger = logging.getLogger(__name__)
 
@@ -25,13 +31,72 @@ RLM_DIR = "/tmp/vf-rlm"
 RLM_BIN = f"{RLM_DIR}/bin/rlm"
 SKILLS_DIR = "/task/rlm-skills"
 RLM_STATE_DIR = ".vf-rlm"
+RLM_RUNTIME_METADATA_KEY = "ai.prime.rlm/runtime-v1"
+RLM_SESSION_METADATA_KEY = "ai.prime.rlm/session-v1"
+
+
+class _ContractModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+
+class _UsageSnapshot(_ContractModel):
+    prompt_tokens: int = Field(ge=0)
+    completion_tokens: int = Field(ge=0)
+    total_tokens: int = Field(ge=0)
+
+
+class _ProgrammaticToolCallSnapshot(_ContractModel):
+    python_total: int = Field(ge=0)
+    bash_total: int = Field(ge=0)
+    by_tool_python: dict[str, int]
+    by_tool_bash: dict[str, int]
+
+
+class _SupervisorSnapshot(_ContractModel):
+    subagent_calls: int = Field(ge=0)
+    active_subagent_calls: int = Field(ge=0)
+
+
+class _LimitsSnapshot(_ContractModel):
+    max_depth: int = Field(ge=0)
+    max_concurrent_subagents: int = Field(gt=0)
+    max_subagent_calls: int = Field(gt=0)
+    max_tokens: int | None = Field(default=None, gt=0)
+    summarize_at_tokens: int | None = Field(default=None, gt=0)
+    max_compactions: int | None = Field(default=None, gt=0)
+    max_tool_output_chars: int | None = Field(default=None, gt=0)
+    allow_git: bool
+
+
+class _SessionSnapshot(_ContractModel):
+    session_id: str = Field(pattern=r"^[A-Za-z0-9._:-]{1,128}$")
+    last_stop_reason: str | None
+    model: str = Field(min_length=1)
+    turns: int = Field(ge=0)
+    usage: _UsageSnapshot
+    metrics: dict[str, int | float]
+    programmatic_tool_call_stats: _ProgrammaticToolCallSnapshot
+    supervisor: _SupervisorSnapshot
+    limits: _LimitsSnapshot
 
 
 class RLMHarnessConfig(HarnessConfig):
     version: str = Field(default="main", min_length=1)
     """Git ref (branch, tag, or commit) of nano-rlm to install."""
-    max_depth: int = 0
-    """Recursion depth rlm may spawn sub-harnesses to (RLM_MAX_DEPTH)."""
+    max_depth: NonNegativeInt = 0
+    """Recursion depth RLM may spawn sub-harnesses to."""
+    exec_timeout: PositiveInt = 300
+    max_output: int = -1
+    max_tokens: PositiveInt | None = None
+    max_compactions: PositiveInt | None = None
+    max_concurrent_subagents: PositiveInt | None = None
+    max_subagent_calls: PositiveInt = 64
+    max_tool_output_chars: PositiveInt | None = None
+    allow_git: bool = False
+    sdk_max_retries: NonNegativeInt = 5
+    system_prompt_path: str | None = None
+    kernel_env: dict[str, str] = Field(default_factory=dict)
+    """Task variables intentionally visible to model-controlled kernel code."""
     builtin_skills: list[BuiltinSkill] = Field(default_factory=list)
     """Built-in rlm skills to enable (RLM_SKILLS), e.g. `["edit"]`; empty enables none.
     The tool set is fixed (ipython); the base `skills` field takes SKILL.md paths."""
@@ -48,6 +113,22 @@ class RLMHarnessConfig(HarnessConfig):
             raise ValueError(
                 "`summarize_at_tokens` range must be (lo, hi) with lo <= hi."
             )
+        return self
+
+    @field_validator("max_output")
+    @classmethod
+    def validate_max_output(cls, value: int) -> int:
+        if value == 0 or value < -1:
+            raise ValueError("must be positive, or -1 to disable truncation")
+        return value
+
+    @model_validator(mode="after")
+    def validate_concurrency(self) -> "RLMHarnessConfig":
+        if (
+            self.max_concurrent_subagents is not None
+            and self.max_concurrent_subagents < self.max_depth
+        ):
+            raise ValueError("max_concurrent_subagents must be at least max_depth")
         return self
 
     @model_validator(mode="after")
@@ -89,19 +170,17 @@ class RLMHarness(ACPHarness[RLMHarnessConfig]):
             raise RuntimeError(f"rlm install failed: {result.stderr.strip()[-500:]}")
         await super().setup(runtime)
 
-    def summarize_threshold(self, task_idx: int | None) -> str:
-        """The `RLM_SUMMARIZE_AT_TOKENS` value: a range draws per-group (seeded by task index —
-        0 when unset — so a task's rollouts share one threshold). Always set — "" when disabled —
-        so the typed field, not a host var the subprocess runtime would inherit, wins."""
+    def summarize_threshold(self, task_idx: int | None) -> int | None:
+        """Resolve a fixed or per-task compaction threshold."""
         value = self.config.summarize_at_tokens
         if value is None:
-            return ""
+            return None
         if isinstance(value, tuple):
             lo, hi = value
-            return str(random.Random(task_idx or 0).randint(lo, hi))
-        return str(value)
+            return random.Random(task_idx or 0).randint(lo, hi)
+        return value
 
-    def _env(
+    def _runtime_metadata(
         self,
         ctx: ModelContext,
         trace: Trace,
@@ -109,21 +188,38 @@ class RLMHarness(ACPHarness[RLMHarnessConfig]):
         secret: str,
         data: TaskData,
         system_prompt: str | None,
-    ) -> dict[str, str]:
-        env = {
-            **self.config.resolved_env,
-            "RLM_BASE_URL": endpoint,
-            "RLM_API_KEY": secret,
-            "RLM_MODEL": ctx.model,
-            "RLM_MAX_DEPTH": str(self.config.max_depth),
-            "RLM_HOME": self._home(trace),
-            "RLM_SUMMARIZE_AT_TOKENS": self.summarize_threshold(data.idx),
+    ) -> JsonObject:
+        max_concurrent = self.config.max_concurrent_subagents or max(
+            4, self.config.max_depth
+        )
+        payload = {
+            "session_id": trace.id,
+            "model": ctx.model,
+            "provider": {
+                "base_url": endpoint,
+                "api_key": secret,
+                "headers": {},
+                "max_retries": self.config.sdk_max_retries,
+            },
+            "policy": {
+                "max_depth": self.config.max_depth,
+                "exec_timeout": self.config.exec_timeout,
+                "max_output": self.config.max_output,
+                "max_tokens": self.config.max_tokens,
+                "summarize_at_tokens": self.summarize_threshold(data.idx),
+                "max_compactions": self.config.max_compactions,
+                "max_concurrent_subagents": max_concurrent,
+                "max_subagent_calls": self.config.max_subagent_calls,
+                "max_tool_output_chars": self.config.max_tool_output_chars,
+                "allow_git": self.config.allow_git,
+            },
+            "system_prompt_path": self.config.system_prompt_path,
+            "append_to_system_prompt": system_prompt,
+            "skills": list(self.config.builtin_skills),
+            "kernel_env": self.config.kernel_env,
+            "search_api_key": self.config.resolved_env.get("SERPER_API_KEY"),
         }
-        if system_prompt is not None:
-            env["RLM_APPEND_TO_SYSTEM_PROMPT"] = system_prompt
-        if self.config.builtin_skills:
-            env["RLM_SKILLS"] = ",".join(self.config.builtin_skills)
-        return env
+        return {RLM_RUNTIME_METADATA_KEY: payload}
 
     async def prepare_acp(
         self,
@@ -137,29 +233,21 @@ class RLMHarness(ACPHarness[RLMHarnessConfig]):
     ) -> ACPConfig:
         system_prompt, prompt = self.resolve_prompt(data)
         return ACPConfig(
-            env=self._env(ctx, trace, endpoint, secret, data, system_prompt),
+            env={**self.config.resolved_env, "RLM_HOME": self._home(trace)},
             command=[RLM_BIN, "--acp"],
             prompt=prompt,
+            session_meta=self._runtime_metadata(
+                ctx, trace, endpoint, secret, data, system_prompt
+            ),
         )
 
-    @metric
-    async def rlm(self, trace: Trace, runtime: Runtime) -> dict[str, float]:
-        # RolloutRun closes the harness session before metrics, which finalizes
-        # RLM's meta.json while leaving the harness-owned state available here.
-        home = shlex.quote(self._home(trace))
-        latest = f'cat "$(ls -t {home}/sessions/*/meta.json | head -1)"'
-        result = await runtime.run(["sh", "-c", latest], {})
-        if result.exit_code != 0 or not result.stdout.strip():
-            return {}
-        try:
-            meta = json.loads(result.stdout)
-        except json.JSONDecodeError:
-            return {}
-        return {
-            key: float(value)
-            for key, value in meta.get("metrics", {}).items()
-            if isinstance(value, (int, float)) and not isinstance(value, bool)
-        }
+    def acp_close_metrics(self, trace: Trace, metadata: JsonObject) -> dict[str, float]:
+        snapshot = _SessionSnapshot.model_validate(
+            metadata.get(RLM_SESSION_METADATA_KEY)
+        )
+        if snapshot.session_id != trace.id:
+            raise ValueError("RLM session snapshot does not match the rollout")
+        return {name: float(value) for name, value in snapshot.metrics.items()}
 
     async def cleanup(self, trace: Trace, runtime: Runtime) -> None:
         await runtime.run(["rm", "-rf", f"{RLM_STATE_DIR}/{trace.id}"], {})

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -542,7 +542,13 @@ class InterceptionServer(Interception):
             logger.debug(
                 "intercept coalesce: id=%s (retry of in-flight turn)", session.trace.id
             )
-            response = await asyncio.shield(inflight)
+            if idempotent is not None:
+                idempotent.inflight_waiters += 1
+            try:
+                response = await asyncio.shield(inflight)
+            finally:
+                if idempotent is not None:
+                    idempotent.inflight_waiters -= 1
             if response is None:
                 return web.json_response(
                     dialect.error_body("upstream attempt failed"), status=503

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -58,7 +58,7 @@ from verifiers.v1.interception.tunnel import (
     TunnelConfig,
     make_tunnel,
 )
-from verifiers.v1.session import IdempotentRequest, RolloutSession
+from verifiers.v1.session import IdempotentRequest, ReplayResponse, RolloutSession
 from verifiers.v1.trace import Error, ModelCall, PolicyEvent, TimeSpan
 from verifiers.v1.types import FinishReason, Request, Response, Usage
 
@@ -81,6 +81,10 @@ HASH_INLINE_MAX = 1024**2  # 1 MiB
 # 0 on the first attempt, incremented on each retry of the same request.
 RETRY_COUNT_HEADER = "x-stainless-retry-count"
 IDEMPOTENCY_KEY_HEADER = "Idempotency-Key"
+# nano-RLM retries for up to 315 seconds. Keep successful results beyond that
+# window, while bounding long-horizon rollout memory independently of turn limits.
+IDEMPOTENCY_CACHE_TTL_SECONDS = 600
+IDEMPOTENCY_CACHE_MAX_COMPLETED = 1024
 
 
 def is_retried_request(headers: Mapping[str, str]) -> bool:
@@ -115,6 +119,56 @@ def _completion_response(completion: dict | None) -> web.Response:
     except PydanticSerializationError:
         return web.json_response(completion)
     return web.Response(body=body, content_type="application/json", charset="utf-8")
+
+
+def _capture_response(response: web.Response) -> ReplayResponse:
+    body = response.body
+    if body is None:
+        data = b""
+    elif isinstance(body, bytes):
+        data = body
+    elif isinstance(body, bytearray):
+        data = bytes(body)
+    else:
+        raise TypeError("coalesced interception responses must have a byte body")
+    return ReplayResponse(status=response.status, body=data)
+
+
+def _replay_response(response: ReplayResponse) -> web.Response:
+    return web.Response(
+        body=response.body,
+        status=response.status,
+        content_type="application/json",
+        charset="utf-8",
+    )
+
+
+def _prune_idempotent_requests(session: RolloutSession, now: float) -> None:
+    """Expire and cap completed replays; active attempts are never evicted."""
+    completed = [
+        (key, request)
+        for key, request in session.idempotent_requests.items()
+        if request.response is not None and request.inflight is None
+    ]
+    for key, request in completed:
+        completed_at = request.completed_at or 0.0
+        if (
+            now - completed_at >= IDEMPOTENCY_CACHE_TTL_SECONDS
+            and session.idempotent_requests.get(key) is request
+        ):
+            session.idempotent_requests.pop(key)
+    completed = [
+        (key, request)
+        for key, request in completed
+        if session.idempotent_requests.get(key) is request
+    ]
+    excess = len(completed) - IDEMPOTENCY_CACHE_MAX_COMPLETED
+    if excess > 0:
+        for key, request in sorted(
+            completed, key=lambda item: item[1].completed_at or 0.0
+        )[:excess]:
+            if session.idempotent_requests.get(key) is request:
+                session.idempotent_requests.pop(key)
 
 
 async def _queue_chunks(
@@ -416,7 +470,8 @@ class InterceptionServer(Interception):
         # request), and a stale replay would loop the rollout.
         retried = is_retried_request(request.headers)
         idempotent: IdempotentRequest | None = None
-        if idempotency_key := request.headers.get(IDEMPOTENCY_KEY_HEADER):
+        idempotency_key = request.headers.get(IDEMPOTENCY_KEY_HEADER)
+        if idempotency_key:
             if streaming:
                 return web.json_response(
                     dialect.error_body(
@@ -424,6 +479,8 @@ class InterceptionServer(Interception):
                     ),
                     status=400,
                 )
+            now = time.monotonic()
+            _prune_idempotent_requests(session, now)
             binding = (request.path, req_hash)
             idempotent = session.idempotent_requests.get(idempotency_key)
             if idempotent is not None and idempotent.binding != binding:
@@ -433,13 +490,11 @@ class InterceptionServer(Interception):
                     ),
                     status=400,
                 )
-            if idempotent is None:
-                idempotent = IdempotentRequest(binding=binding)
-                session.idempotent_requests[idempotency_key] = idempotent
-            if idempotent.response is not None:
+            if idempotent is not None and idempotent.response is not None:
                 logger.debug(
                     "intercept replay: id=%s (idempotent request)", session.trace.id
                 )
+                idempotent.completed_at = now
                 return _completion_response(idempotent.response)
             upstream_headers = {
                 name: value
@@ -477,19 +532,24 @@ class InterceptionServer(Interception):
                 dialect.error_body(f"rollout stopped: {session.trace.stop_condition}"),
                 status=400,
             )
+        if idempotency_key and idempotent is None:
+            idempotent = IdempotentRequest(binding=(request.path, req_hash))
+            session.idempotent_requests[idempotency_key] = idempotent
 
-        async def coalesced(inflight: "asyncio.Future[dict | None]") -> web.Response:
+        async def coalesced(
+            inflight: "asyncio.Future[ReplayResponse | None]",
+        ) -> web.Response:
             logger.debug(
                 "intercept coalesce: id=%s (retry of in-flight turn)", session.trace.id
             )
-            completion = await asyncio.shield(inflight)
-            if completion is None:
+            response = await asyncio.shield(inflight)
+            if response is None:
                 return web.json_response(
                     dialect.error_body("upstream attempt failed"), status=503
                 )
-            return _completion_response(completion)
+            return _replay_response(response)
 
-        fut: asyncio.Future[dict | None] | None = None
+        fut: asyncio.Future[ReplayResponse | None] | None = None
         if not streaming:
             if idempotent is not None and idempotent.inflight is not None:
                 return await coalesced(idempotent.inflight)
@@ -505,22 +565,33 @@ class InterceptionServer(Interception):
             else:
                 session.inflight[req_hash] = fut
 
-        def finish_inflight(completion: dict | None = None) -> None:
+        def finish_inflight(response: ReplayResponse | None = None) -> None:
             if fut is None:
                 return
             if idempotent is not None and idempotent.inflight is fut:
                 idempotent.inflight = None
+                if (
+                    idempotent.response is None
+                    and idempotency_key
+                    and session.idempotent_requests.get(idempotency_key) is idempotent
+                ):
+                    session.idempotent_requests.pop(idempotency_key)
             elif session.inflight.get(req_hash) is fut:
                 session.inflight.pop(req_hash, None)
             if not fut.done():
-                fut.set_result(completion)
+                fut.set_result(response)
+
+        def finish_response(response: web.Response) -> web.Response:
+            finish_inflight(_capture_response(response))
+            return response
 
         try:
             refused = await session.refused()
             if refused is not None:
-                finish_inflight()
-                return web.json_response(
-                    dialect.error_body(f"rollout stopped: {refused}"), status=400
+                return finish_response(
+                    web.json_response(
+                        dialect.error_body(f"rollout stopped: {refused}"), status=400
+                    )
                 )
             original_request = model_request
             model_request, request_rewrites, stopped = await session.rewrite_request(
@@ -531,15 +602,15 @@ class InterceptionServer(Interception):
                 if stopped is None:
                     dialect.rewrite_request(body, original_request, model_request)
         except RolloutError as error:
-            finish_inflight()
-            return self._fail(session, dialect, error)
+            return finish_response(self._fail(session, dialect, error))
         except Exception as error:  # noqa: BLE001 - surface task hook failures
-            finish_inflight()
-            return self._fail(
-                session,
-                dialect,
-                TaskError(
-                    f"model boundary hook failed: {type(error).__name__}: {error}"
+            return finish_response(
+                self._fail(
+                    session,
+                    dialect,
+                    TaskError(
+                        f"model boundary hook failed: {type(error).__name__}: {error}"
+                    ),
                 ),
             )
         except BaseException:
@@ -549,10 +620,11 @@ class InterceptionServer(Interception):
             turn = graph.prepare_turn(session.trace, model_request.messages)
             turn.commit_prompt(model_request.tools)
             session.trace.stop(stopped)
-            finish_inflight()
-            return web.json_response(
-                dialect.error_body(f"rollout stopped: {stopped}"),
-                status=400,
+            return finish_response(
+                web.json_response(
+                    dialect.error_body(f"rollout stopped: {stopped}"),
+                    status=400,
+                )
             )
 
         try:
@@ -560,11 +632,11 @@ class InterceptionServer(Interception):
             model_request = dialect.parse_request(body)
             turn = graph.prepare_turn(session.trace, model_request.messages)
         except ValueError as error:
-            finish_inflight()
-            return web.json_response(dialect.error_body(str(error)), status=400)
+            return finish_response(
+                web.json_response(dialect.error_body(str(error)), status=400)
+            )
         except RolloutError as error:
-            finish_inflight()
-            return self._fail(session, dialect, error)
+            return finish_response(self._fail(session, dialect, error))
 
         inspect_response = bool(session.response_interceptors or session.response_stops)
         if streaming:
@@ -586,11 +658,15 @@ class InterceptionServer(Interception):
             # completion) that the server serializes back to the program.
             if idempotent is not None:
                 idempotent.response = response.raw
+                idempotent.completed_at = time.monotonic()
             else:
                 session.last_request = req_hash
                 session.last_response = response.raw
-            finish_inflight(response.raw)
-            return _completion_response(response.raw)
+            served = _completion_response(response.raw)
+            finish_inflight(_capture_response(served))
+            if idempotent is not None:
+                _prune_idempotent_requests(session, time.monotonic())
+            return served
 
         try:
             session.error = None
@@ -616,8 +692,10 @@ class InterceptionServer(Interception):
                         len(call_response.message.tool_calls or []),
                     )
                     if session.released:  # concluded while sampling — seal holds
-                        return web.json_response(
-                            dialect.error_body("rollout concluded"), status=409
+                        return finish_response(
+                            web.json_response(
+                                dialect.error_body("rollout concluded"), status=409
+                            )
                         )
                     response_rewrites = []
                     stopped = None
@@ -638,20 +716,24 @@ class InterceptionServer(Interception):
                             )
                             call_response.raw = raw_response
                     if session.stopped:
-                        return web.json_response(
-                            dialect.error_body(
-                                f"rollout stopped: {session.trace.stop_condition}"
-                            ),
-                            status=400,
+                        return finish_response(
+                            web.json_response(
+                                dialect.error_body(
+                                    f"rollout stopped: {session.trace.stop_condition}"
+                                ),
+                                status=400,
+                            )
                         )
                     node = turn.commit(call_response, model_request.tools)
                     session.consume_prepared(turn.tail)
                     session.trace.response_rewrites.extend(response_rewrites)
                     if stopped is not None:
                         session.trace.stop(stopped)
-                        return web.json_response(
-                            dialect.error_body(f"rollout stopped: {stopped}"),
-                            status=400,
+                        return finish_response(
+                            web.json_response(
+                                dialect.error_body(f"rollout stopped: {stopped}"),
+                                status=400,
+                            )
                         )
                 except OverlongPromptError as e:
                     # An overlong prompt is a budget limit, not a crash: end the rollout
@@ -660,9 +742,11 @@ class InterceptionServer(Interception):
                     error = e
                     session.trace.stop("context_length")
                     logger.debug("prompt too long: id=%s", session.trace.id)
-                    return web.json_response(
-                        dialect.error_body("rollout stopped: context_length"),
-                        status=400,
+                    return finish_response(
+                        web.json_response(
+                            dialect.error_body("rollout stopped: context_length"),
+                            status=400,
+                        )
                     )
                 except RolloutError as e:
                     # Stash the real cause; the rollout re-raises it after the harness returns.
@@ -675,9 +759,11 @@ class InterceptionServer(Interception):
                         type(e).__name__,
                         e,
                     )
-                    return web.json_response(
-                        dialect.error_body(str(e)),
-                        status=getattr(e, "status_code", 502),
+                    return finish_response(
+                        web.json_response(
+                            dialect.error_body(str(e)),
+                            status=getattr(e, "status_code", 502),
+                        )
                     )
                 except Exception as e:  # noqa: BLE001 - surface as an API error
                     error = e
@@ -687,7 +773,9 @@ class InterceptionServer(Interception):
                         type(e).__name__,
                         e,
                     )
-                    return web.json_response(dialect.error_body(str(e)), status=502)
+                    return finish_response(
+                        web.json_response(dialect.error_body(str(e)), status=502)
+                    )
                 except BaseException as e:
                     # A cancelled exchange (harness disconnect, shutdown) is still
                     # recorded, coupled to its cancellation.
@@ -711,8 +799,8 @@ class InterceptionServer(Interception):
                 )
             return serve(call_response)
         finally:
-            # Free the in-flight slot and unblock any coalesced retry; None signals "no servable
-            # response" (an error/refuse return above), so the waiter surfaces a retryable error.
+            # Free the slot after cancellation or an otherwise unrendered failure. Every
+            # ordinary return above publishes its exact HTTP result first.
             finish_inflight()
 
     async def _stream(

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -58,7 +58,7 @@ from verifiers.v1.interception.tunnel import (
     TunnelConfig,
     make_tunnel,
 )
-from verifiers.v1.session import RolloutSession
+from verifiers.v1.session import IdempotentRequest, RolloutSession
 from verifiers.v1.trace import Error, ModelCall, PolicyEvent, TimeSpan
 from verifiers.v1.types import FinishReason, Request, Response, Usage
 
@@ -80,6 +80,7 @@ HASH_INLINE_MAX = 1024**2  # 1 MiB
 # Attempt counter the stainless-generated SDKs (OpenAI, Anthropic) send on every request:
 # 0 on the first attempt, incremented on each retry of the same request.
 RETRY_COUNT_HEADER = "x-stainless-retry-count"
+IDEMPOTENCY_KEY_HEADER = "Idempotency-Key"
 
 
 def is_retried_request(headers: Mapping[str, str]) -> bool:
@@ -91,6 +92,11 @@ def is_retried_request(headers: Mapping[str, str]) -> bool:
 
 def _body_digest(raw: bytes) -> bytes:
     return hashlib.blake2b(raw, digest_size=16).digest()
+
+
+def _provider_idempotency_key(session_id: str, key: str) -> str:
+    value = f"{session_id}\0{key}".encode()
+    return hashlib.blake2b(value, digest_size=16).hexdigest()
 
 
 async def _request_digest(raw: bytes) -> bytes:
@@ -396,6 +402,7 @@ class InterceptionServer(Interception):
         del raw
         body = dialect.apply_overrides(body, session.ctx.model, session.ctx.sampling)
         streaming = dialect.streaming(body)
+        upstream_headers = dict(request.headers)
         logger.debug(
             "intercept %s: id=%s stream=%s",
             request.path,
@@ -408,14 +415,49 @@ class InterceptionServer(Interception):
         # alone is no proof of a retry (compaction can legitimately regenerate an identical
         # request), and a stale replay would loop the rollout.
         retried = is_retried_request(request.headers)
+        idempotent: IdempotentRequest | None = None
+        if idempotency_key := request.headers.get(IDEMPOTENCY_KEY_HEADER):
+            if streaming:
+                return web.json_response(
+                    dialect.error_body(
+                        "Idempotency-Key is not supported for streaming requests"
+                    ),
+                    status=400,
+                )
+            binding = (request.path, req_hash)
+            idempotent = session.idempotent_requests.get(idempotency_key)
+            if idempotent is not None and idempotent.binding != binding:
+                return web.json_response(
+                    dialect.error_body(
+                        "Idempotency-Key was reused with a different request"
+                    ),
+                    status=400,
+                )
+            if idempotent is None:
+                idempotent = IdempotentRequest(binding=binding)
+                session.idempotent_requests[idempotency_key] = idempotent
+            if idempotent.response is not None:
+                logger.debug(
+                    "intercept replay: id=%s (idempotent request)", session.trace.id
+                )
+                return _completion_response(idempotent.response)
+            upstream_headers = {
+                name: value
+                for name, value in upstream_headers.items()
+                if name.lower() != IDEMPOTENCY_KEY_HEADER.lower()
+            }
+            upstream_headers[IDEMPOTENCY_KEY_HEADER] = _provider_idempotency_key(
+                session.trace.id, idempotency_key
+            )
         if (
-            retried
+            idempotent is None
+            and retried
             and session.last_request == req_hash
             and session.last_response is not None
         ):
             logger.debug("intercept replay: id=%s (retried request)", session.trace.id)
             return _completion_response(session.last_response)
-        if session.last_request == req_hash:
+        if idempotent is None and session.last_request == req_hash:
             # A fresh attempt supersedes the recorded response for the same body: drop it
             # so this attempt's own retries coalesce or re-run instead of replaying the
             # previous turn.
@@ -440,7 +482,7 @@ class InterceptionServer(Interception):
             logger.debug(
                 "intercept coalesce: id=%s (retry of in-flight turn)", session.trace.id
             )
-            completion = await inflight
+            completion = await asyncio.shield(inflight)
             if completion is None:
                 return web.json_response(
                     dialect.error_body("upstream attempt failed"), status=503
@@ -449,15 +491,26 @@ class InterceptionServer(Interception):
 
         fut: asyncio.Future[dict | None] | None = None
         if not streaming:
-            if retried and (inflight := session.inflight.get(req_hash)) is not None:
+            if idempotent is not None and idempotent.inflight is not None:
+                return await coalesced(idempotent.inflight)
+            if (
+                idempotent is None
+                and retried
+                and (inflight := session.inflight.get(req_hash)) is not None
+            ):
                 return await coalesced(inflight)
             fut = asyncio.get_running_loop().create_future()
-            session.inflight[req_hash] = fut
+            if idempotent is not None:
+                idempotent.inflight = fut
+            else:
+                session.inflight[req_hash] = fut
 
         def finish_inflight(completion: dict | None = None) -> None:
             if fut is None:
                 return
-            if session.inflight.get(req_hash) is fut:
+            if idempotent is not None and idempotent.inflight is fut:
+                idempotent.inflight = None
+            elif session.inflight.get(req_hash) is fut:
                 session.inflight.pop(req_hash, None)
             if not fut.done():
                 fut.set_result(completion)
@@ -531,8 +584,11 @@ class InterceptionServer(Interception):
             # byte-identical request replays instead of re-sampling and forking the graph.
             # `Response.raw` is the full native provider object (or the renderer's synthesized
             # completion) that the server serializes back to the program.
-            session.last_request = req_hash
-            session.last_response = response.raw
+            if idempotent is not None:
+                idempotent.response = response.raw
+            else:
+                session.last_request = req_hash
+                session.last_response = response.raw
             finish_inflight(response.raw)
             return _completion_response(response.raw)
 
@@ -550,7 +606,7 @@ class InterceptionServer(Interception):
                         dialect,
                         body,
                         session.ctx.sampling,
-                        headers=request.headers,
+                        headers=upstream_headers,
                         session_id=session.trace.id,
                         turn=turn,
                     )

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -13,6 +13,7 @@ from verifiers.v1.configs.agent import AgentConfig
 from verifiers.v1.configs.runtime import NetworkPolicyConfig
 from verifiers.v1.errors import (
     HarnessError,
+    HarnessFinalizationError,
     RolloutError,
     TaskError,
     ToolsetError,
@@ -456,6 +457,10 @@ class Rollout:
             if self._harness_session is not None:
                 try:
                     await self._harness_session.close()
+                except HarnessFinalizationError:
+                    # Required terminal artifacts are part of the rollout result,
+                    # rather than best-effort transport teardown.
+                    raise
                 except Exception:
                     # Generation already completed. A transport teardown failure
                     # must not discard its otherwise scoreable trajectory.

--- a/verifiers/v1/session.py
+++ b/verifiers/v1/session.py
@@ -100,7 +100,16 @@ class IdempotentRequest:
 
     binding: tuple[str, bytes]
     response: dict | None = None
-    inflight: "asyncio.Future[dict | None] | None" = None
+    completed_at: float | None = None
+    inflight: "asyncio.Future[ReplayResponse | None] | None" = None
+
+
+@dataclass(frozen=True)
+class ReplayResponse:
+    """The exact HTTP result handed to coalesced in-flight request attempts."""
+
+    status: int
+    body: bytes
 
 
 @dataclass
@@ -131,7 +140,9 @@ class RolloutSession:
     replays the common SDK retry of the latest completed exchange without re-sampling it."""
     last_response: dict | None = None
     """The response returned for `last_request`, replayed verbatim on a retry."""
-    inflight: dict[bytes, "asyncio.Future[dict | None]"] = field(default_factory=dict)
+    inflight: dict[bytes, "asyncio.Future[ReplayResponse | None]"] = field(
+        default_factory=dict
+    )
     """Body digest -> the response currently computing, used to coalesce an in-flight retry."""
     idempotent_requests: dict[str, IdempotentRequest] = field(default_factory=dict)
     """Explicit idempotency key -> request binding and replay state for this rollout."""

--- a/verifiers/v1/session.py
+++ b/verifiers/v1/session.py
@@ -102,6 +102,8 @@ class IdempotentRequest:
     response: dict | None = None
     completed_at: float | None = None
     inflight: "asyncio.Future[ReplayResponse | None] | None" = None
+    inflight_waiters: int = 0
+    """Concurrent attempts currently coalesced onto ``inflight``."""
 
 
 @dataclass(frozen=True)

--- a/verifiers/v1/session.py
+++ b/verifiers/v1/session.py
@@ -95,6 +95,15 @@ class RolloutLimits:
 
 
 @dataclass
+class IdempotentRequest:
+    """One non-streaming request shared by every attempt carrying the same key."""
+
+    binding: tuple[str, bytes]
+    response: dict | None = None
+    inflight: "asyncio.Future[dict | None] | None" = None
+
+
+@dataclass
 class RolloutSession:
     ctx: ModelContext
     trace: Trace
@@ -124,6 +133,8 @@ class RolloutSession:
     """The response returned for `last_request`, replayed verbatim on a retry."""
     inflight: dict[bytes, "asyncio.Future[dict | None]"] = field(default_factory=dict)
     """Body digest -> the response currently computing, used to coalesce an in-flight retry."""
+    idempotent_requests: dict[str, IdempotentRequest] = field(default_factory=dict)
+    """Explicit idempotency key -> request binding and replay state for this rollout."""
     released: bool = False
     """Set when the rollout unregisters the session: the trace is sealed (its conclusion is
     what scored and persisted), so a handler still in flight must not commit turns, record

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -390,6 +390,9 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
     """Unweighted, named metrics; `None` as in `rewards`."""
     info: dict[str, Any] = Field(default_factory=dict)
     """Scratch space for task-specific metadata."""
+    primary_reply: str | None = None
+    """The harness-declared user-visible reply when graph leaf order does not
+    identify the primary agent. Protocol-backed harnesses set this directly."""
     state: StateT = Field(default_factory=State, exclude=True)
     """Runtime (possibly, non-serializable) state shared across runtimes; excluded from serialization."""
 
@@ -520,7 +523,9 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
 
     @property
     def last_reply(self) -> str:
-        """The last recorded model response, in text format."""
+        """The primary user-visible reply, or the last recorded model response."""
+        if self.primary_reply is not None:
+            return self.primary_reply.strip()
         msgs = self.assistant_messages
         return (msgs[-1].content or "").strip() if msgs else ""
 


### PR DESCRIPTION
## Summary

- express the RLM runtime as typed harness configuration and send its strict `ai.prime.rlm/runtime-v1` payload through ACP `session/new`
- carry opaque ACP `session/close` metadata through the generic runner and let the RLM harness validate its final `ai.prime.rlm/session-v1` snapshot into training metrics
- preserve a canonical root ACP-visible reply independently from concurrently intercepted descendant branches
- honor standard non-streaming HTTP idempotency by coalescing in-flight retries, replaying bounded completed responses, and namespacing provider keys per rollout
- run live RLM E2Es directly against merged nano-rlm `main`

Verifiers does not model RLM lineage, compaction, subagents, or agent-specific ACP lifecycle artifacts. Those semantics stay inside nano-rlm. Verifiers transports standard ACP metadata and records every intercepted parent and descendant model call in the trace graph.

## Contract

This intentionally requires the nano-rlm contract merged in [PrimeIntellect-ai/nano-rlm#134](https://github.com/PrimeIntellect-ai/nano-rlm/pull/134). No compatibility path or temporary commit pin remains; the harness default and CI both use nano-rlm `main`.

## Validation

- unpinned deterministic Prime VM E2E against merged nano-rlm `main` (`c27f8ea`): 1 passed in 44.89s
- forces two recursive child requests to be in flight simultaneously
- asserts three retained trace branches: root, child one, and child two
- persisted trace: reward `1.0`, no errors, five sampled turns, `sub_rlm_num_calls = 2`, `has_sub_rlm = 1`
- asserts the parent resumes after both children and the canonical reply remains the root ACP reply
- validates MCP resume, kernel environment isolation, and strict terminal training metrics in the same rollout
- exact Hermes ACP resume/Docker case passes, including its leading presentation-whitespace edge
- full local Verifiers suite and focused trace, idempotency, and contract checks pass
- pre-push Markdown, Ruff, format, and Ty checks pass
- all commits are GitHub signature-verified

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add RLM training support over ACP with session metadata and close metrics
> - RLM harness now passes configuration to ACP via structured `session_meta` from `RLMHarness._runtime_metadata` instead of environment variables; `prepare_acp` only forwards resolved env and `RLM_HOME`.
> - `ACPSession.close` now returns a metadata dict from the close-session response, and `serve_stream` includes it in shutdown responses; `ACPHarnessSession._stop` records harness metrics on the trace via `acp_close_metrics` and raises `HarnessFinalizationError` on shutdown/finalization failures.
> - `Trace` and `Segment` gain a `primary_reply` field; `last_reply` prefers it so child responses do not leak as the primary reply.
> - Interception server adds explicit `Idempotency-Key` handling for non-streaming calls: coalesces concurrent attempts, replays cached responses, rejects key reuse with different body/path, and applies TTL/size eviction via `_prune_idempotent_requests`.
> - Adds `HarnessFinalizationError` to the public verifier API and new tests for idempotency and the RLM Prime contract.
> - Risk: `RLMHarness.summarize_threshold` now returns `int | None` instead of `str`; any consumer expecting a string threshold will need updating. `RLMHarnessConfig` adds new policy fields and validation (e.g. `max_output` disallows 0, `max_concurrent_subagents >= max_depth`) that may reject previously accepted configs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 762650a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the model interception path (idempotency coalescing) and RLM configuration transport; close-time metric finalization now fails rollouts when artifacts are missing.
> 
> **Overview**
> Adds **RLM training over ACP** by sending typed `ai.prime.rlm/runtime-v1` config through ACP `session_meta` instead of RLM env vars, and reading training metrics from validated `session/close` metadata (`ai.prime.rlm/session-v1`) rather than scraping `meta.json` on disk. **`RLMHarnessConfig`** grows policy fields (limits, kernel env, SDK retries, etc.); default nano-rlm ref is **`main`**, overridable in E2E via **`NANO_RLM_E2E_VERSION`**.
> 
> Introduces **`Trace.primary_reply`** (and **`Segment`/`last_reply`** behavior) so ACP harnesses can expose the canonical user-visible answer when subagent branches pollute graph leaf order; ACP prompts set it from the session reply.
> 
> **ACP shutdown** now returns close metadata to the host; harnesses implement **`acp_close_metrics`**. Failures to finalize required close artifacts raise **`HarnessFinalizationError`** and fail the rollout (not best-effort teardown).
> 
> The **interception server** honors non-streaming **`Idempotency-Key`**: coalesce in-flight duplicates, replay completed responses with TTL/size bounds, reject key/body mismatches, and rewrite upstream keys per rollout session.
> 
> New tests cover idempotency, wire **`primary_reply`**, ACP resume **`primary_reply`**, and a deterministic Prime VM RLM contract E2E.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 762650a52fa019647bac8a9a6196b4235e409b8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->