### PR TITLE
chore: bump prime-sandboxes to 0.2.37

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "openai>=2.9.0",
     "openai-agents>=0.8.2",
     "prime-tunnel>=0.1.8",
-    "prime-sandboxes>=0.2.36",
+    "prime-sandboxes>=0.2.37",
     "pydantic>=2.12.3",
     "requests",
     "rich>=11.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3333,7 +3333,7 @@ toml = [
 
 [[package]]
 name = "prime-sandboxes"
-version = "0.2.36"
+version = "0.2.37"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -3345,9 +3345,9 @@ dependencies = [
     { name = "pyqwest" },
     { name = "tenacity" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/c8/ca5261ff5d5c2e944e198866ead91b09bc88eb0390a905925bb6d7f9cd28/prime_sandboxes-0.2.36.tar.gz", hash = "sha256:3a5c8a7912b1ea0fb775674650835f7f86aac1a05aa8566c2db129b9a622fe55", size = 88415, upload-time = "2026-08-12T23:30:15.214Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/18/837603f47eae2cc86bd6652dbbebe955caaca8c0f987dfc7cb947e4c993b/prime_sandboxes-0.2.37.tar.gz", hash = "sha256:44a7cb4bc97ee04bbef824b7ccf185da78cffa90c3f0345ef69fbfbd75ca6bce", size = 89684, upload-time = "2026-08-17T17:07:18.985Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/26/081296fc8e6d8ce962f2aee0e47ac843982094dedb34a1fad22d10086f37/prime_sandboxes-0.2.36-py3-none-any.whl", hash = "sha256:a5db92d927cf4a3dd37ce230027a9d83dbf21804d4f6ed2255d276c1962fa8f2", size = 49316, upload-time = "2026-08-12T23:30:14.047Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/4c/346abc72f6891267f490abfbe9de867c3ba2ed64ae8a4f964ffc4065492a/prime_sandboxes-0.2.37-py3-none-any.whl", hash = "sha256:9687e1b698c183798138b5e2ca116554773e3e300307a599beb7fbe8ed65e783", size = 49587, upload-time = "2026-08-17T17:07:17.403Z" },
 ]
 
 [[package]]

--- a/verifiers/legacy/envs/integrations/browser_env/modes/cua_mode.py
+++ b/verifiers/legacy/envs/integrations/browser_env/modes/cua_mode.py
@@ -195,6 +195,7 @@ class CUAMode:
                 self._sandbox_request = CreateSandboxRequest(
                     name="cua-server",
                     docker_image=prebuilt_image,
+                    vm=False,
                     start_command="./cua-server-linux-x64",
                     cpu_cores=cpu_cores,
                     memory_gb=memory_gb,
@@ -207,6 +208,7 @@ class CUAMode:
                 self._sandbox_request = CreateSandboxRequest(
                     name="cua-server",
                     docker_image=docker_image,
+                    vm=False,
                     start_command="tail -f /dev/null",
                     cpu_cores=cpu_cores,
                     memory_gb=memory_gb,

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -160,11 +160,10 @@ class PrimeRuntime(Runtime):
         # GB). gpu_type/region are only sent when set (else provider-chosen).
         gpu_type, gpu_count = parse_gpu(self.config.gpu)
         # prime's idle timeout is in whole minutes; convert from the seconds config surface
-        # (floored to the SDK's 1-minute minimum). VM sandboxes don't support an idle timeout
-        # (the API 422s on it), so it's dropped there rather than failing every VM rollout.
+        # (floored to the SDK's 1-minute minimum).
         idle_minutes = (
             max(1, math.ceil(self.config.idle_timeout / 60))
-            if self.config.idle_timeout is not None and not self.config.vm
+            if self.config.idle_timeout is not None
             else None
         )
         options = {


### PR DESCRIPTION
## Summary
- Bump `prime-sandboxes` to `>=0.2.37` (latest on PyPI, released 2026-08-17) and relock `uv.lock`.
- 0.2.37 picks up VM idle-timeout support (PrimeIntellect-ai/prime#841) and the re-landed VM opt-out validation (PrimeIntellect-ai/prime#834).
- Adapt to the 0.2.37 validation split: string `start_command` values are now container-only. Add `vm=False` to both CUA `CreateSandboxRequest`s in `verifiers/legacy/envs/integrations/browser_env/modes/cua_mode.py` — they are docker container workloads.
- Send `idle_timeout` for VM sandboxes too (`PrimeRuntime.start`): the SDK/API restriction that forced dropping it for `vm=true` is lifted, so the `idle_timeout` config (default 3600s) now reaches every sandbox.

## Verification
- `tests/test_browser_env.py` failed on 0.2.37 with `Value error, String start_command values are container-only. Pass vm=False ...`; after the `vm=False` fix: `uv run pytest tests/test_browser_env.py -q` — 18 passed.
- Live idle-timeout semantics (1-task probe taskset, prime VM runtime, `idle_timeout=60`):
  - "Idle" means no sandbox API operations AND no attached live process. Status reads (`get`) do not count as activity.
  - Bare SDK probe (one exec, then nothing): platform terminated it at t+107s.
  - bash-harness rollout running `sleep 300`: never idle-killed — `run_program` goes through `run_background_job(poll_interval=1)`, and the 1 Hz job poll counts as activity. Completed the full sleep, reward 1.0.
  - rlm-harness rollout running `sleep 300`: never idle-killed — the held ACP live-process stream counts as activity (confirmed separately with a silent `open_process` stream surviving 6+ minutes). Completed, reward 1.0.
  - Orphaned rollout (eval SIGKILLed mid-sleep so vf cleanup cannot run): the platform terminated the sandbox 67–85s after the kill, verified on both paths — bash (poll stops) and rlm (ACP stream drops).
- Net: the idle timeout never kills a live rollout (polling or held stream keeps the sandbox active) and reliably self-cleans orphaned sandboxes once the owning process dies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
