### PR TITLE
fix: use upstream ACP notification ordering

### DIFF
--- a/verifiers/v1/acp/runner.py
+++ b/verifiers/v1/acp/runner.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.10,<3.15"
-# dependencies = ["agent-client-protocol==0.11.0"]
+# dependencies = ["agent-client-protocol==0.12.1"]
 # ///
 """Run harness segments through an ACP agent."""
 
@@ -35,7 +35,6 @@ from acp.schema import (
 )
 
 MAX_PACKET_BYTES = 128 * 1024 * 1024
-LATE_UPDATE_GRACE_SECONDS = 1.0
 
 
 class VerifiersACPClient(Client):
@@ -43,7 +42,6 @@ class VerifiersACPClient(Client):
         self.visible_reply = ""
         self.message_id: str | None = None
         self.tool_calls: dict[str, str] = {}
-        self.output_changed = asyncio.Condition()
 
     def reset(self) -> None:
         self.visible_reply = ""
@@ -51,23 +49,19 @@ class VerifiersACPClient(Client):
         self.tool_calls = {}
 
     async def session_update(self, session_id: str, update: Any, **kwargs: Any) -> None:
-        async with self.output_changed:
-            if isinstance(update, ToolCall):
-                self.tool_calls[update.tool_call_id] = update.status or "pending"
-            elif isinstance(update, ToolCallUpdate):
-                if update.status:
-                    self.tool_calls[update.tool_call_id] = update.status
-            elif isinstance(update, AgentMessageChunk) and isinstance(
-                update.content, TextContentBlock
-            ):
-                message_id = getattr(update, "message_id", None)
-                if message_id is not None and message_id != self.message_id:
-                    self.visible_reply = ""
-                    self.message_id = message_id
-                self.visible_reply += update.content.text
-            else:
-                return
-            self.output_changed.notify_all()
+        if isinstance(update, ToolCall):
+            self.tool_calls[update.tool_call_id] = update.status or "pending"
+        elif isinstance(update, ToolCallUpdate):
+            if update.status:
+                self.tool_calls[update.tool_call_id] = update.status
+        elif isinstance(update, AgentMessageChunk) and isinstance(
+            update.content, TextContentBlock
+        ):
+            message_id = getattr(update, "message_id", None)
+            if message_id is not None and message_id != self.message_id:
+                self.visible_reply = ""
+                self.message_id = message_id
+            self.visible_reply += update.content.text
 
     async def request_permission(
         self,
@@ -148,24 +142,6 @@ async def prompt(
         detail = error.data.get("details") if isinstance(error.data, dict) else None
         raise RuntimeError(detail or str(error)) from error
 
-    # ACP 0.11 dispatches notifications in background tasks but resolves a request
-    # response directly in its receive loop. An agent that sends its final
-    # session/update immediately before session/prompt returns can therefore wake
-    # this coroutine before the update handler has run. Wait specifically for text:
-    # a completed tool update may also arrive first and must not hide a later reply.
-    def has_visible_reply() -> bool:
-        return bool(client.visible_reply.strip())
-
-    if not has_visible_reply():
-        async with client.output_changed:
-            try:
-                await asyncio.wait_for(
-                    client.output_changed.wait_for(has_visible_reply),
-                    timeout=LATE_UPDATE_GRACE_SECONDS,
-                )
-            except asyncio.TimeoutError:  # noqa: UP041 - Python 3.10 compatibility
-                pass
-
     tool_statuses = list(client.tool_calls.values())
     completed_tool_turn = (
         config.get("allow_empty_tool_reply", False)
@@ -173,7 +149,7 @@ async def prompt(
         and bool(tool_statuses)
         and all(status in ("completed", "failed") for status in tool_statuses)
     )
-    if not has_visible_reply() and not completed_tool_turn:
+    if not client.visible_reply.strip() and not completed_tool_turn:
         raise RuntimeError(
             "ACP agent produced no visible reply "
             f"(stop_reason={response.stop_reason}, tool_statuses={tool_statuses})"


### PR DESCRIPTION
## What changed

- bump the standalone ACP runner from `agent-client-protocol==0.11.0` to `0.12.1`
- remove Verifiers' one-second late-update grace timer and its `asyncio.Condition`
- retain the existing tool-only completion and empty visible reply validation

## Why

ACP Python SDK [#129](https://github.com/agentclientprotocol/python-sdk/pull/129), released in [0.12.1](https://github.com/agentclientprotocol/python-sdk/releases/tag/0.12.1), makes `ClientSideConnection.prompt()` wait for preceding `session/update` handlers on both success and error responses. That is the ordering race the Verifiers workaround compensated for, so keeping the downstream timer adds latency and redundant state.

The separate 10-second graceful process shutdown bound is unchanged.

## Validation

- `uv run pytest tests/v1 -m 'not e2e' -q`
- live `test_acp_resume_with_tool[rlm-acp-in-docker]` (`1 passed`)
- live `test_acp_resume_with_tool[rlm-acp-in-prime-vm]` (`1 passed`); confirmed zero active `vf-ci` sandboxes afterward
- Ruff check and format
- pre-push Ruff, format, and Ty

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency bump and removal of redundant timing logic in the ACP harness runner; no auth, data, or broader API surface changes.
> 
> **Overview**
> Bumps the standalone ACP runner dependency from **`agent-client-protocol==0.11.0`** to **`0.12.1`**, which upstream now orders **`session/update`** handling before **`prompt()`** returns.
> 
> Removes the Verifiers workaround: the **`LATE_UPDATE_GRACE_SECONDS`** timer, **`asyncio.Condition`** on **`VerifiersACPClient`**, and the post-**`prompt`** wait for visible text. **`session_update`** still accumulates tool status and reply text; empty-reply checks and tool-only completion validation are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cf5b561571c8dfd5f81ee15a8ed9d93a814f4f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove late-update grace period from ACP notification ordering in `prompt`
> - Upgrades the `agent-client-protocol` dependency from `0.11.0` to `0.12.1` to use upstream notification ordering, which makes late-update waiting unnecessary.
> - Removes the `output_changed` asyncio `Condition` from `VerifiersACPClient` and the corresponding notify/wait logic in `session_update` and `prompt`.
> - Behavioral Change: `prompt` no longer waits up to 1 second for a late visible text reply; it checks `client.visible_reply` immediately and raises `RuntimeError` if no reply is present on a non-tool turn.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1cf5b56.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->