### PR TITLE
chore: bump prime-pydantic-config to >=0.4.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "setproctitle>=1.3.0",
     "httpx>=0.27.0",
     "aiohttp>=3.9.0",
-    "prime-pydantic-config[toml]>=0.4.2",
+    "prime-pydantic-config[toml]>=0.4.3",
     "uvloop>=0.21.0; sys_platform != 'win32' and sys_platform != 'cygwin' and platform_python_implementation != 'PyPy'",
     "loguru>=0.7.0",
     "tomli-w>=1.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3316,14 +3316,14 @@ wheels = [
 
 [[package]]
 name = "prime-pydantic-config"
-version = "0.4.2"
+version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3c/37/e240dd598e687af74523f4497acb122b6d484975dac35e38932b58733753/prime_pydantic_config-0.4.2.tar.gz", hash = "sha256:7e85ac624c63edc1995ef512398fa5cd4610724b48a65c595f7742b7514153a4", size = 75997, upload-time = "2026-07-20T19:39:54.631Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/eb/9c00634759016565e6359376f76817987c13ea25bb121aab638268c64e28/prime_pydantic_config-0.4.3.tar.gz", hash = "sha256:1f0a6bd78c69e21da389bbd0e1177ca5440888488708a625e355d98712d4374d", size = 76884, upload-time = "2026-08-18T00:24:31.744Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/f7/12d3b54d0db5812d4fb9e8b9df987f805e687df2f0d11359c2d066df513c/prime_pydantic_config-0.4.2-py3-none-any.whl", hash = "sha256:092f7da638f625747a136983b579f5c929ead1b243df22f69fad6cf16b044ab0", size = 27414, upload-time = "2026-07-20T19:39:53.716Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ec/1d43ce0cd6b981a9381457e3b8f136cc8c7527fe13b3cb45c3b874a7cd49/prime_pydantic_config-0.4.3-py3-none-any.whl", hash = "sha256:13e8a0c39d0f88c3f75eb1df74a56198d1e907670e63e4918558a2e852b4e015", size = 27869, upload-time = "2026-08-18T00:24:30.681Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Floor `prime-pydantic-config` at 0.4.3 and refresh the lock.
- 0.4.3 fixes `validation_alias` normalization for fields inside discriminated-union variants and `Optional` models (PrimeIntellect-ai/pydantic-config#23): mixed alias/canonical spellings across config layers now collapse onto one canonical key with CLI-over-file precedence instead of erroring or silently keeping the file value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `prime-pydantic-config` minimum version to 0.4.3
> Raises the version floor for `prime-pydantic-config[toml]` in [pyproject.toml](https://github.com/PrimeIntellect-ai/verifiers/pull/2391/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) from `>=0.4.2` to `>=0.4.3` and updates the lockfile accordingly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 45cbf2d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile and minimum-version bump only; risk is limited to config merge/precedence behavior for affected Pydantic field layouts at runtime.
> 
> **Overview**
> **Dependency-only change:** `pyproject.toml` now requires `prime-pydantic-config[toml]>=0.4.3` (was `>=0.4.2`), and `uv.lock` pins the new release.
> 
> Verifiers already routes eval, validate, GEPA, and related CLIs through **prime-pydantic-config** for layered TOML/CLI config. **0.4.3** fixes `validation_alias` handling inside discriminated-union variants and `Optional` models so mixed alias vs canonical keys across layers resolve to one canonical key with CLI-over-file precedence, instead of failing or keeping a stale file value.
> 
> No changes under `verifiers/` in this PR—behavior shifts come from the upgraded library when configs use those field shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45cbf2d8fd7410874446df49ebb028f6f0d23c66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->