### PR TITLE
feat(v1): add MiniMax Code harness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -294,6 +294,7 @@ markers = [
     "pi: v1 e2e cases on the pi harness",
     "pool: v1 e2e cases on the pool harness",
     "codex: v1 e2e cases on the codex harness",
+    "mcode: v1 e2e cases on the mcode harness",
     "unit: marks tests as unit tests",
     "asyncio: marks tests as async tests",
     "parsers: marks tests for parser components",

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -25,7 +25,7 @@ Every combination carries its axes' pytest marks, so subsets select with `-m`:
 
 Marks: runtimes `subprocess` / `docker` / `prime` / `modal`, placement `colocated`,
 harnesses `null` / `bash` / `rlm` / `kimi_code` / `pi` / `pool` / `openclaw` / `codex` /
-`claude_code` / `hermes_agent`.
+`claude_code` / `hermes_agent` / `mcode`.
 A mark is applied per axis, so it selects every case touching that value on ANY axis; for one exact
 combination use `-k` on the test id (e.g. `-k "harness-in-docker-with-tool-in-subprocess"`).
 prime/modal provision real remote sandboxes (slow, infra-flaky, need setup), so they're local-only.
@@ -71,7 +71,7 @@ def tool_runtime(request) -> dict:
 
 
 # Built-in harnesses are bundled in the `harnesses` package; the agent CLIs (`rlm` /
-# `kimi-code` / `openclaw` / `codex` / `claude-code` / `hermes-agent`) install their
+# `kimi-code` / `openclaw` / `codex` / `claude-code` / `hermes-agent` / `mcode`) install their
 # dependencies at rollout.
 # `compact` (an example harness) and `terminus-2` (drives the host tmux) are excluded from e2e.
 @pytest.fixture

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -48,6 +48,7 @@ AGENTIC_PLACEMENTS = [
     pair("codex", "docker", "codex-harness-in-docker"),
     pair("claude-code", "docker", "claude-code-harness-in-docker"),
     pair("hermes-agent", "docker", "hermes-agent-harness-in-docker"),
+    pair("mcode", "docker", "mcode-harness-in-docker"),
     pair("bash", "prime", "bash-harness-in-prime"),
     pair("bash", "modal", "bash-harness-in-modal"),
 ]

--- a/verifiers/v1/harnesses/__init__.py
+++ b/verifiers/v1/harnesses/__init__.py
@@ -13,6 +13,7 @@ from verifiers.v1.harnesses.hermes_agent import (
     HermesAgentHarnessConfig,
 )
 from verifiers.v1.harnesses.kimi_code import KimiCodeHarness, KimiCodeHarnessConfig
+from verifiers.v1.harnesses.mcode import MCodeHarness, MCodeHarnessConfig
 from verifiers.v1.harnesses.mini_swe_agent import (
     MiniSWEAgentHarness,
     MiniSWEAgentHarnessConfig,
@@ -37,6 +38,8 @@ __all__ = [
     "HermesAgentHarnessConfig",
     "KimiCodeHarness",
     "KimiCodeHarnessConfig",
+    "MCodeHarness",
+    "MCodeHarnessConfig",
     "MiniSWEAgentHarness",
     "MiniSWEAgentHarnessConfig",
     "NullHarness",

--- a/verifiers/v1/harnesses/mcode/__init__.py
+++ b/verifiers/v1/harnesses/mcode/__init__.py
@@ -1,0 +1,3 @@
+from verifiers.v1.harnesses.mcode.harness import MCodeHarness, MCodeHarnessConfig
+
+__all__ = ["MCodeHarness", "MCodeHarnessConfig"]

--- a/verifiers/v1/harnesses/mcode/harness.py
+++ b/verifiers/v1/harnesses/mcode/harness.py
@@ -1,0 +1,331 @@
+"""Run MiniMax Code's headless CLI as a v1 harness."""
+
+import json
+import logging
+import shlex
+
+from pydantic import Field
+
+from verifiers.v1.clients import ModelContext
+from verifiers.v1.configs.harness import HarnessConfig
+from verifiers.v1.harness import Harness
+from verifiers.v1.harnesses.node import NODE_BIN_DIR, ensure_node
+from verifiers.v1.runtimes import ProgramResult, Runtime
+from verifiers.v1.task import TaskData
+from verifiers.v1.trace import Trace
+from verifiers.v1.types import Messages, content_text
+
+logger = logging.getLogger(__name__)
+
+MCODE_DIR = "/var/tmp/vf-mcode-{version}"
+PACKAGES_DIR = f"{MCODE_DIR}/packages"
+MCODE_BIN = f"{PACKAGES_DIR}/node_modules/.bin/mcode"
+MCODE_VERSION = "0.1.4"
+
+INSTALL = r"""
+set -e
+export PATH="/var/tmp/vf-node/bin:$PATH"
+rm -f {ready}
+npm install --prefix {packages} --no-audit --no-fund --omit=dev \
+    "@minimax-ai/code@$VF_MCODE_VERSION" >/dev/null
+touch {ready}
+"""
+
+# MiniMax Code 0.1.4 requires a literal custom-provider key in config. Keep only a
+# harmless placeholder there, then replace its request header from a Node preload.
+# The preload consumes and unlinks a one-use credential file before the CLI module
+# loads, and removes its control variables before any model-directed tool can run.
+PRELOAD = r"""
+import fs from "node:fs";
+
+const secretPath = process.env.VF_MCODE_SECRET_FILE;
+const endpointValue = process.env.VF_MCODE_ENDPOINT;
+if (!secretPath || !endpointValue) {
+  throw new Error("missing mcode interception preload configuration");
+}
+const secret = fs.readFileSync(secretPath, "utf8");
+fs.unlinkSync(secretPath);
+delete process.env.VF_MCODE_SECRET_FILE;
+delete process.env.VF_MCODE_ENDPOINT;
+delete process.env.NODE_OPTIONS;
+
+const endpoint = new URL(endpointValue);
+const endpointPath = endpoint.pathname.replace(/\/$/, "");
+const metricsHosts = new Set(["agent.minimaxi.com", "agent.minimax.io"]);
+const metricsPath = "/matrix/api/v1/metrics/batch";
+const originalFetch = globalThis.fetch;
+
+globalThis.fetch = function interceptedFetch(input, init = undefined) {
+  const request = input instanceof Request ? input : undefined;
+  const url = new URL(request?.url ?? String(input));
+  if (metricsHosts.has(url.hostname) && url.pathname === metricsPath) {
+    return Promise.resolve(new Response(null, { status: 204 }));
+  }
+  const inScope =
+    url.origin === endpoint.origin &&
+    (url.pathname === endpointPath || url.pathname.startsWith(`${endpointPath}/`));
+  if (!inScope) {
+    return originalFetch(input, init);
+  }
+
+  const headers = new Headers(
+    init && Object.hasOwn(init, "headers") ? init.headers : request?.headers,
+  );
+  headers.set("authorization", `Bearer ${secret}`);
+  if (request) {
+    return originalFetch(new Request(request, { ...init, headers }));
+  }
+  return originalFetch(input, { ...init, headers });
+};
+"""
+
+BUILTIN_TOOLS = ("read", "write", "edit", "bash", "grep", "glob")
+
+
+class MCodeHarnessConfig(HarnessConfig):
+    version: str = Field(default=MCODE_VERSION, pattern=r"^[A-Za-z0-9._+-]+$")
+    """MiniMax Code release to install, pinned for reproducibility."""
+
+
+class MCodeHarness(Harness[MCodeHarnessConfig]):
+    """Harness backed by MiniMax Code's non-interactive ``exec`` command."""
+
+    SUPPORTS_MCP = False
+
+    def _tools(self) -> list[str]:
+        disabled = set(self.config.disabled_tools or ())
+        unsupported = disabled - set(BUILTIN_TOOLS)
+        if unsupported:
+            raise ValueError(
+                "MiniMax Code does not recognize disabled tools: "
+                + ", ".join(sorted(unsupported))
+            )
+        return [tool for tool in BUILTIN_TOOLS if tool not in disabled]
+
+    async def setup(self, runtime: Runtime) -> None:
+        await ensure_node(runtime)
+        versions = {"version": self.config.version}
+        directory = MCODE_DIR.format(**versions)
+        packages = PACKAGES_DIR.format(**versions)
+        mcode_bin = MCODE_BIN.format(**versions)
+        ready = f"{directory}/.ready"
+        script = INSTALL.replace("{packages}", packages).replace("{ready}", ready)
+        ensure = shlex.quote(f"[ -f {ready} ] && [ -x {mcode_bin} ] || ({script})")
+        lock = f"{directory}/install.lock"
+        guarded = (
+            f"mkdir -p {directory} && "
+            f'until ln -s "$$" {lock} 2>/dev/null; do '
+            f"owner=$(readlink {lock}); "
+            f'if ! kill -0 "$owner" 2>/dev/null; then '
+            f'[ "$(readlink {lock})" != "$owner" ] || rm -f {lock}; fi; '
+            f"sleep 0.1; done; "
+            f'trap \'[ "$(readlink {lock})" != "$$" ] || rm -f {lock}\' EXIT; '
+            f"sh -c {ensure}"
+        )
+        logger.info("mcode: ensuring MiniMax Code %s is installed", self.config.version)
+        result = await runtime.run(
+            ["sh", "-c", guarded], {"VF_MCODE_VERSION": self.config.version}
+        )
+        if result.exit_code != 0:
+            detail = (result.stderr or result.stdout).strip()[-500:]
+            raise RuntimeError(f"MiniMax Code install failed: {detail}")
+
+    @staticmethod
+    def _home(trace: Trace) -> str:
+        return f".vf-mcode/{trace.id}"
+
+    async def _write_config(
+        self,
+        ctx: ModelContext,
+        trace: Trace,
+        runtime: Runtime,
+        endpoint: str,
+    ) -> tuple[str, str, str]:
+        home = self._home(trace)
+        data_dir = f"{home}/data"
+        config_path = f"{home}/config.yaml"
+        preload_path = f"{home}/interception-preload.mjs"
+        tools = self._tools()
+        config = {
+            "logLevel": "warn",
+            "agents": {
+                "default": {
+                    "persona": {"enabled": False},
+                    "tools": tools,
+                    "builtinTools": [],
+                    "skills": [],
+                    "features": {
+                        "mavis": False,
+                        "delegation": False,
+                        "webSearch": False,
+                    },
+                }
+            },
+            "memory": {"enabled": False, "proactive": False},
+            "askUser": {"enabled": False},
+            "skills": {"external": {"enabled": False}},
+            "skillEvolve": {"enabled": False},
+            "beta": {
+                "autoMemory": False,
+                "skillEvolve": False,
+                "skillEvolveBuiltinMr": False,
+                "skillProposal": False,
+                "browserBridge": False,
+                "filePanelBrowser": False,
+                "filePanelBrowserMultiTab": False,
+                "browserUseTooling": False,
+                "browserAgentCursor": False,
+                "desktopPlanMode": False,
+                "peek": False,
+                "keepAlive": False,
+                "promptOverride": False,
+                "cuMode": False,
+                "asr": False,
+                "teamPlanWorkspaceCard": False,
+                "teamPlanDrilldown": False,
+                "taskHistoryProjectGrouping": False,
+                "threadGoal": False,
+                "mcodeTools": False,
+                "codexOAuth": False,
+            },
+            "custom_provider": {
+                "verifiers": {
+                    "name": "verifiers",
+                    "kind": "custom",
+                    "enabled": True,
+                    "api": "openai-completions",
+                    "options": {
+                        "apiKey": "verifiers-interception",
+                        "baseURL": endpoint,
+                        "authMode": "api-key",
+                    },
+                    "models": {
+                        ctx.model: {"reasoning": False, "tool_call": bool(tools)}
+                    },
+                }
+            },
+            "defaultModel": f"custom_provider:verifiers/{ctx.model}",
+        }
+        created = await runtime.run(["mkdir", "-m", "700", "-p", home, data_dir], {})
+        if created.exit_code != 0:
+            raise RuntimeError(f"failed to create mcode home: {created.stderr.strip()}")
+        await runtime.write(config_path, json.dumps(config).encode())
+        await runtime.write(preload_path, PRELOAD.encode())
+        secured = await runtime.run(["chmod", "600", config_path, preload_path], {})
+        if secured.exit_code != 0:
+            raise RuntimeError(f"failed to secure mcode config: {secured.stderr.strip()}")
+        return data_dir, config_path, preload_path
+
+    async def _write_secret(self, trace: Trace, runtime: Runtime, secret: str) -> str:
+        path = f"{self._home(trace)}/interception-secret"
+        await runtime.write(path, secret.encode())
+        secured = await runtime.run(["chmod", "600", path], {})
+        if secured.exit_code != 0:
+            raise RuntimeError(
+                f"failed to secure mcode interception secret: {secured.stderr.strip()}"
+            )
+        return path
+
+    @staticmethod
+    def _prompt_text(prompt: str | Messages | None) -> str:
+        if isinstance(prompt, str):
+            if not prompt:
+                raise ValueError("mcode exec requires a non-empty prompt")
+            return prompt
+        if prompt is None:
+            raise ValueError("mcode exec requires a prompt")
+        parts = []
+        for message in prompt:
+            text = content_text(message.content)
+            if text:
+                parts.append(f"[{message.role}]\n{text}")
+        if not parts:
+            raise ValueError("mcode exec requires a non-empty prompt")
+        return "\n\n".join(parts)
+
+    async def _exec(
+        self,
+        ctx: ModelContext,
+        trace: Trace,
+        runtime: Runtime,
+        endpoint: str,
+        secret: str,
+        data: TaskData,
+        mcp_urls: dict[str, str],
+    ) -> ProgramResult:
+        if mcp_urls:
+            raise ValueError("mcode headless harness does not support MCP URLs yet")
+        _, prompt = self.resolve_prompt(data)
+        prompt_text = self._prompt_text(prompt)
+        data_dir, config_path, preload_path = await self._write_config(
+            ctx, trace, runtime, endpoint
+        )
+        secret_path = await self._write_secret(trace, runtime, secret)
+        versions = {"version": self.config.version}
+        argv = [
+            NODE_BIN_DIR + "/node",
+            MCODE_BIN.format(**versions),
+            "exec",
+            "--config",
+            config_path,
+            "--permission",
+            "off",
+            "--max-steps",
+            "1000",
+            "--output-format",
+            "json",
+        ]
+        argv.append(prompt_text)
+        result = await runtime.run_program(
+            argv,
+            {
+                **self.config.resolved_env,
+                "MINIMAX_DATA_DIR": data_dir,
+                "NO_COLOR": "1",
+                "NODE_OPTIONS": f"--import=./{preload_path}",
+                "VF_MCODE_ENDPOINT": endpoint,
+                "VF_MCODE_SECRET_FILE": secret_path,
+            },
+        )
+        if result.exit_code != 0:
+            return result
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError as error:
+            raise RuntimeError(
+                "MiniMax Code returned non-JSON output: "
+                + result.stdout.strip()[-500:]
+            ) from error
+        if payload.get("status") != "succeeded":
+            raise RuntimeError(
+                "MiniMax Code run failed: "
+                + str(payload.get("error") or payload.get("status") or "unknown error")
+            )
+        return result
+
+    async def launch(
+        self,
+        ctx: ModelContext,
+        trace: Trace,
+        runtime: Runtime,
+        endpoint: str,
+        secret: str,
+        mcp_urls: dict[str, str],
+        data: TaskData,
+    ) -> ProgramResult:
+        return await self._exec(
+            ctx,
+            trace,
+            runtime,
+            endpoint,
+            secret,
+            data,
+            mcp_urls,
+        )
+
+    async def cleanup(self, trace: Trace, runtime: Runtime) -> None:
+        result = await runtime.run(["rm", "-rf", self._home(trace)], {})
+        if result.exit_code != 0:
+            raise RuntimeError(
+                f"failed to clean up MiniMax Code data: {result.stderr.strip()[-500:]}"
+            )


### PR DESCRIPTION
## Summary

- add a built-in v1 `mcode` harness backed by `mcode exec`
- pin `@minimax-ai/code` to `0.1.4` and reuse the shared Node.js installer
- expose MiniMax Code's built-in `read`, `write`, `edit`, `bash`, `grep`, and `glob` tools in an isolated per-rollout data directory
- register one agentic Docker E2E placement

## Interception and isolation

MiniMax Code 0.1.4 requires a literal custom-provider key in its config. The harness keeps only a harmless placeholder there and uses a Node preload to:

- read and immediately unlink a mode-`0600` one-use interception credential before the CLI module loads
- remove the credential path, endpoint, and `NODE_OPTIONS` from the process environment before model-directed tools can run
- inject the bearer only for the exact verifiers interception origin/path
- suppress MiniMax Code's metrics batch requests locally so rollout metadata is not sent outside the eval

The harness also uses a rollout-local `MINIMAX_DATA_DIR` and disables persona, memory, external skills, delegation, web search, and other unrelated product features.

## Scope

This integration intentionally uses headless `mcode exec` rather than ACP because the current ACP server performs an additional conversation-title model call. MCP URLs and cross-segment resume are not advertised by this harness.

## Validation

- `uv run --frozen ruff check verifiers/v1/harnesses/mcode verifiers/v1/harnesses/__init__.py tests/v1/conftest.py tests/v1/test_e2e.py`
- `uv run --frozen pytest --collect-only -q tests/v1/test_e2e.py -m mcode`
- `uv run --frozen pytest -q tests/v1 -m 'not e2e'` (70 passed)
- loader/config assertions for the built-in `mcode` harness
- black-box mcode 0.1.4 regression against a mock OpenAI-compatible endpoint, including a real `bash` tool call
- verified the interception endpoint received the real bearer while the model-controlled shell saw the secret file absent and `VF_MCODE_*` / `NODE_OPTIONS` unset
- audited effective fetch destinations: only the local interception endpoint was reached; metrics requests were handled locally

The live model-backed Docker E2E was not run locally because `PRIME_API_KEY` is not configured.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add MiniMax Code harness for headless agent execution
> - Adds `MCodeHarness` and `MCodeHarnessConfig` in [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2393/files#diff-8248c12598b6e4132de875d8b943061e81cdc5f9ad3700871a460b362025e096), implementing the `Harness` interface for running MiniMax Code CLI in headless mode against a custom OpenAI-compatible endpoint with bearer auth.
> - Installs the `@minimax-ai/code` npm package at a pinned version (0.1.4) on first use, guarded by a lockfile; subsequent runs reuse the installation.
> - Injects auth headers and suppresses telemetry via a Node.js preload module that intercepts `fetch`, reads a one-use on-disk secret, and scrubs related env vars.
> - Adds an `mcode` pytest marker and a docker-based e2e parameterization entry in `AGENTIC_PLACEMENTS`.
> - Risk: requires Node.js present in the execution environment; MCP URLs are explicitly rejected and will fail fast.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bcf6f24.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->