### PR TITLE
Reset terminal signals for Prime runtime processes

### DIFF
--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -38,8 +38,8 @@ logger = logging.getLogger(__name__)
 MAX_LIFETIME = 24 * 60 * 60
 """Prime's fixed cap (seconds) on any sandbox's total lifetime."""
 
-# Prime launchers can ignore terminal signals; reset them for every user process.
-DEFAULT_SIGNAL_ARGV = ("env", "--default-signal=INT,QUIT")
+# GNU env can restore terminal signals ignored by Prime's process launcher.
+DEFAULT_SIGNAL_ARGV = ("env", "--default-signal=INT,QUIT", "--")
 
 
 BASE_LABELS: list[str] = []
@@ -146,6 +146,7 @@ class PrimeRuntime(Runtime):
         self.config = config
         self.info = PrimeRuntimeInfo(**config.model_dump())
         self._client = None
+        self._signal_argv: tuple[str, ...] = ()
 
     @property
     def supports_live_processes(self) -> bool:
@@ -218,6 +219,18 @@ class PrimeRuntime(Runtime):
             await self._client.execute_command(
                 self.info.id, f"mkdir -p {shlex.quote(self.config.workdir)}"
             )
+            signal_probe = await self._client.execute_command(
+                self.info.id, shlex.join([*DEFAULT_SIGNAL_ARGV, "true"])
+            )
+            self._signal_argv = (
+                DEFAULT_SIGNAL_ARGV if signal_probe.exit_code == 0 else ()
+            )
+            if not self._signal_argv:
+                logger.warning(
+                    "prime: image %s lacks GNU env signal reset; child processes may "
+                    "inherit ignored SIGINT/SIGQUIT",
+                    self.config.image,
+                )
         except (
             Exception
         ) as e:  # provisioning failure is one rollout's problem, not the eval's
@@ -270,7 +283,7 @@ class PrimeRuntime(Runtime):
         try:
             result = await self._client.run_background_job(
                 self.info.id,
-                shlex.join([*DEFAULT_SIGNAL_ARGV, *argv]),
+                shlex.join([*self._signal_argv, *argv]),
                 timeout=MAX_LIFETIME,
                 working_dir=self.config.workdir,
                 env=self.process_env(env),
@@ -297,7 +310,7 @@ class PrimeRuntime(Runtime):
         try:
             process = await self._client.open_process(
                 self.info.id,
-                shlex.join([*DEFAULT_SIGNAL_ARGV, *argv]),
+                shlex.join([*self._signal_argv, *argv]),
                 working_dir=self.config.workdir,
                 env=self.process_env(env),
             )
@@ -325,7 +338,9 @@ class PrimeRuntime(Runtime):
     async def run_background(
         self, argv: list[str], env: dict[str, str], log: str
     ) -> None:
-        command = f"exec {shlex.join([*DEFAULT_SIGNAL_ARGV, *argv])} > {shlex.quote(log)} 2>&1"
+        command = (
+            f"exec {shlex.join([*self._signal_argv, *argv])} > {shlex.quote(log)} 2>&1"
+        )
         try:
             await self._client.start_background_job(
                 self.info.id,

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -38,6 +38,9 @@ logger = logging.getLogger(__name__)
 MAX_LIFETIME = 24 * 60 * 60
 """Prime's fixed cap (seconds) on any sandbox's total lifetime."""
 
+# Prime launchers can ignore terminal signals; reset them for every user process.
+_DEFAULT_SIGNAL_ARGV = ("env", "--default-signal=INT,QUIT")
+
 
 BASE_LABELS: list[str] = []
 
@@ -267,7 +270,7 @@ class PrimeRuntime(Runtime):
         try:
             result = await self._client.run_background_job(
                 self.info.id,
-                shlex.join(argv),
+                shlex.join([*_DEFAULT_SIGNAL_ARGV, *argv]),
                 timeout=MAX_LIFETIME,
                 working_dir=self.config.workdir,
                 env=self.process_env(env),
@@ -294,7 +297,7 @@ class PrimeRuntime(Runtime):
         try:
             process = await self._client.open_process(
                 self.info.id,
-                shlex.join(argv),
+                shlex.join([*_DEFAULT_SIGNAL_ARGV, *argv]),
                 working_dir=self.config.workdir,
                 env=self.process_env(env),
             )
@@ -322,7 +325,7 @@ class PrimeRuntime(Runtime):
     async def run_background(
         self, argv: list[str], env: dict[str, str], log: str
     ) -> None:
-        command = f"exec {shlex.join(argv)} > {shlex.quote(log)} 2>&1"
+        command = f"exec {shlex.join([*_DEFAULT_SIGNAL_ARGV, *argv])} > {shlex.quote(log)} 2>&1"
         try:
             await self._client.start_background_job(
                 self.info.id,

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -39,7 +39,7 @@ MAX_LIFETIME = 24 * 60 * 60
 """Prime's fixed cap (seconds) on any sandbox's total lifetime."""
 
 # Prime launchers can ignore terminal signals; reset them for every user process.
-_DEFAULT_SIGNAL_ARGV = ("env", "--default-signal=INT,QUIT")
+DEFAULT_SIGNAL_ARGV = ("env", "--default-signal=INT,QUIT")
 
 
 BASE_LABELS: list[str] = []
@@ -270,7 +270,7 @@ class PrimeRuntime(Runtime):
         try:
             result = await self._client.run_background_job(
                 self.info.id,
-                shlex.join([*_DEFAULT_SIGNAL_ARGV, *argv]),
+                shlex.join([*DEFAULT_SIGNAL_ARGV, *argv]),
                 timeout=MAX_LIFETIME,
                 working_dir=self.config.workdir,
                 env=self.process_env(env),
@@ -297,7 +297,7 @@ class PrimeRuntime(Runtime):
         try:
             process = await self._client.open_process(
                 self.info.id,
-                shlex.join([*_DEFAULT_SIGNAL_ARGV, *argv]),
+                shlex.join([*DEFAULT_SIGNAL_ARGV, *argv]),
                 working_dir=self.config.workdir,
                 env=self.process_env(env),
             )
@@ -325,7 +325,7 @@ class PrimeRuntime(Runtime):
     async def run_background(
         self, argv: list[str], env: dict[str, str], log: str
     ) -> None:
-        command = f"exec {shlex.join([*_DEFAULT_SIGNAL_ARGV, *argv])} > {shlex.quote(log)} 2>&1"
+        command = f"exec {shlex.join([*DEFAULT_SIGNAL_ARGV, *argv])} > {shlex.quote(log)} 2>&1"
         try:
             await self._client.start_background_job(
                 self.info.id,


### PR DESCRIPTION
## Overview

Ensure processes launched through the Prime runtime begin with normal terminal signal dispositions when the image supports GNU `env`, without breaking images that use BusyBox or another `env` implementation.

## Details

Prime launchers may pass ignored `SIGINT` and `SIGQUIT` dispositions into child process trees, preventing ordinary cancellation behavior. During sandbox startup, the runtime probes whether the image supports `env --default-signal=INT,QUIT` and selects that prefix when available.

The selected behavior applies consistently to synchronous commands, live processes, and background processes. A `--` delimiter keeps dash-prefixed executable names separate from `env` options, and unsupported images retain their existing command launch behavior.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reset SIGINT/SIGQUIT signal handling for Prime runtime child processes
> - Child processes in `PrimeRuntime` can inherit ignored signals from the parent, causing them to be unresponsive to INT/QUIT. This adds a GNU `env`-based signal reset prefix to fix that.
> - On startup, [`prime.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/2397/files#diff-d22d61279ff7587a2b14c72ab1a0fc9d3f805a735338a70f8efc7fe19aaa8502) probes the sandbox image for GNU `env --default-signal` support; if available, the prefix is stored and applied to all foreground, live, and background process launches.
> - If the probe fails, the runtime logs a warning and continues without the prefix, preserving existing behavior.
> - Behavioral Change: processes in images with GNU `env` support will now receive default SIGINT/SIGQUIT disposition instead of inheriting the parent's ignored disposition.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f822c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->