### PR TITLE
fix(mcp): use runtime Python for readiness probe

### DIFF
--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -303,7 +303,7 @@ async def serve_in_runtime(
         except ToolsetError as e:
             raise ToolsetError(f"{e}: {await log_tail(runtime, log)}") from e
     probe = await runtime.run(
-        ["python3", "-c", _PROBE, f"http://127.0.0.1:{port}/mcp"], {}
+        [python, "-c", _PROBE, f"http://127.0.0.1:{port}/mcp"], {}
     )
     if probe.exit_code != 0:
         raise ToolsetError(


### PR DESCRIPTION
## Summary

- use the already selected runtime Python interpreter for MCP readiness probes
- preserve existing subprocess, sandbox-install, and prebuilt-image behavior

## Problem

#2395 lets server classes declare `RUNTIME_PYTHON`, but `serve_in_runtime()` launches the server with that path and still runs its readiness probe with bare `python3`. A prebuilt image without a global `python3` command therefore fails with `ToolsetError` after the server launches successfully.

## Validation

- exact fake-runtime reproduction with only `/opt/server/.venv/bin/python` available
- `UV_NO_SYNC=1 uv run pytest tests/v1 -m "not e2e" -q`
- `UV_NO_SYNC=1 uv run pytest tests/ -q`
- `UV_NO_SYNC=1 uv run ruff check --fix .`
- `UV_NO_SYNC=1 uv run ruff format --check .`
- `UV_NO_SYNC=1 uv run ty check verifiers`
- touched-file pre-commit and pre-push hooks

All-files pre-commit remains blocked only by 321 pre-existing `MD033` violations in `verifiers/legacy/envs/experimental/composable/tasksets/swe/README.md`; Ruff and formatting hooks pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d045177e2ade547fa75d5ab152e807f1dfbe897f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix readiness probe in `serve_in_runtime` to use runtime Python interpreter
> Replaces the hardcoded `"python3"` string with the `python` variable in the readiness probe argument list in [launch.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2398/files#diff-989d87123d40d48511f9e1df74594d2e30776e9a99c11eca49d9cc20bf9e2230). This ensures the probe runs under the same interpreter as the rest of the runtime, rather than whatever `python3` resolves to on the host.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d045177.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->