### PR TITLE
Retry interaction episodes in live tests

### DIFF
--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -154,6 +154,8 @@ def _eval_config(
         runtime_cfg = dict(runtime)
         _configure_prime_runtimes(runtime_cfg)
         env_cfg.setdefault("agent", {})["runtime"] = runtime_cfg
+    retries = {"max_retries": 2, "include": ["ProviderError", "HarnessError"]}
+    env_cfg.setdefault("retries", retries)
     # Per-run caps live on the seats: resolve the env's declared roles and cap
     # each one (a test's own seat dict wins over the shared defaults).
     config_cls = vf.env_config_type(taskset, env_cfg.get("id", ""))
@@ -167,11 +169,8 @@ def _eval_config(
         seat_cfg.setdefault("max_turns", max_turns)
         seat_cfg.setdefault("max_output_tokens", max_tokens)
         seat_cfg.setdefault("timeout", {"rollout": rollout_timeout, "scoring": 60})
-        # Flake resilience: retries are per-agent now (flat RetryConfig).
-        seat_cfg.setdefault(
-            "retries",
-            {"max_retries": 2, "include": ["ProviderError", "HarnessError"]},
-        )
+        # Agent runs retry locally; interactions retry with their whole episode.
+        seat_cfg.setdefault("retries", retries)
     return EvalConfig(
         env={
             "taskset": taskset_cfg,

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -19,7 +19,6 @@ from verifiers.v1.clients import (
     ModelContext,
 )
 from verifiers.v1.configs.agent import AgentConfig, TimeoutConfig
-from verifiers.v1.configs.retries import RetryConfig
 from verifiers.v1.configs.runtime import NetworkPolicyConfig
 from verifiers.v1.dialects import parse_message
 from verifiers.v1.harness import Harness
@@ -150,22 +149,9 @@ class Interaction:
     rewards after close. Leaving the `interaction()` context closes the exchange
     as `user_closed` and finishes the rollout — hooks and scoring included."""
 
-    def __init__(
-        self,
-        run: "Rollout",
-        make_run: Callable[[], "Rollout"],
-        retry: RetryConfig,
-        gate: asyncio.Semaphore | None = None,
-        borrowed: bool = False,
-    ) -> None:
+    def __init__(self, run: "Rollout", gate: asyncio.Semaphore | None = None) -> None:
         self._run = run
         self._gate = gate
-        self._make_run = make_run
-        self._retry = retry
-        self._borrowed = borrowed
-        self._attempt = 0
-        self._history: list = []
-        self._delivered = False
         self._over = False  # a terminated segment was already delivered
         self._started = False  # a segment has run (the exchange is under way)
         self._lock = asyncio.Lock()
@@ -173,53 +159,6 @@ class Interaction:
     @property
     def trace(self) -> Trace:
         return self._run.trace
-
-    async def _finish(self, *, include_history: bool) -> Trace:
-        trace = await self._run.close()
-        if trace.agent.runtime is not None:
-            trace.agent.runtime.borrowed = self._borrowed
-        if include_history and self._history:
-            trace.errors[:0] = self._history
-            self._history.clear()
-        return trace
-
-    async def _retry_failed(self) -> bool:
-        retry = self._retry
-        if (
-            self._delivered
-            or self._attempt >= retry.max_retries
-            or not trace_should_retry(self.trace, retry)
-        ):
-            return False
-        if self._borrowed:
-            logger.warning(
-                "not retrying the interaction on a borrowed box (its state is no "
-                "longer the task's start state); the error stands"
-            )
-            return False
-        trace = await self._finish(include_history=False)
-        self._history.extend(trace.errors)
-        delay = backoff(self._attempt)
-        logger.warning(
-            "retrying agent interaction (retry %d/%d) in %.1fs after error: %s",
-            self._attempt + 1,
-            retry.max_retries,
-            delay,
-            trace.last_error.type if trace.last_error else "?",
-        )
-        await asyncio.sleep(delay)
-        self._attempt += 1
-        self._run = self._make_run()
-        self._started = False
-        self._over = False
-        return True
-
-    async def _open(self) -> bool:
-        while True:
-            if await self._run.open():
-                return True
-            if not await self._retry_failed():
-                return False
 
     async def turn(self, message: str | Messages | None = None) -> Segment:
         """Send one user turn (a string, or full `Messages` for multimodal /
@@ -256,28 +195,24 @@ class Interaction:
             # A turn's messages may arrive typed or as wire dicts (env code naturally
             # writes `{"role": "user", ...}`); the trace speaks typed, so normalize.
             messages = [parse_message(m) if isinstance(m, dict) else m for m in message]
-        while True:
-            self._started = True
-            turns_before = self.trace.num_turns
-            nodes_before = len(self.trace.nodes)
-            await self._run.step(messages)
-            if self.trace.num_turns > turns_before:
-                # The segment answered — even if a limit or @stop then ended the
-                # exchange, that surfaces as the NEXT turn's terminated segment.
-                segment_messages: Messages = []
-                saw_assistant = False
-                for node in self.trace.nodes[nodes_before:]:
-                    if node.sampled:
-                        segment_messages.append(node.message)
-                        saw_assistant = True
-                    elif saw_assistant and isinstance(node.message, ToolMessage):
-                        segment_messages.append(node.message)
-                self._delivered = True
-                return Segment(messages=segment_messages)
-            if await self._retry_failed() and await self._open():
-                continue
-            self._over = True
-            return Segment(messages=[], terminated=True)
+        self._started = True
+        turns_before = self.trace.num_turns
+        nodes_before = len(self.trace.nodes)
+        await self._run.step(messages)
+        if self.trace.num_turns > turns_before:
+            # The segment answered — even if a limit or @stop then ended the
+            # exchange, that surfaces as the NEXT turn's terminated segment.
+            segment_messages: Messages = []
+            saw_assistant = False
+            for node in self.trace.nodes[nodes_before:]:
+                if node.sampled:
+                    segment_messages.append(node.message)
+                    saw_assistant = True
+                elif saw_assistant and isinstance(node.message, ToolMessage):
+                    segment_messages.append(node.message)
+            return Segment(messages=segment_messages)
+        self._over = True
+        return Segment(messages=[], terminated=True)
 
     async def close(self) -> Trace:
         """End the exchange and finish the rollout (idempotent): scoring and hooks
@@ -285,7 +220,7 @@ class Interaction:
         async with self._lock, self._gate or nullcontext():
             if not self._run.closed and self._run.ok:
                 self.trace.stop("user_closed")
-            return await self._finish(include_history=True)
+            return await self._run.close()
 
 
 class Agent:
@@ -515,45 +450,38 @@ class Agent:
         exchange (`user_closed`) and finishes the rollout, hooks and scoring
         included. A failure while opening the rollout raises before the context
         is entered (the failed trace is still completed and reported through
-        `on_trace`). `config.retries` applies while no segment has been returned
-        to the caller: setup and the opening turn can restart on a fresh runtime.
-        Once caller-visible output exists, the exchange cannot be replayed without
-        also rewinding caller state, so later failures conclude the interaction."""
+        `on_trace`). An exchange is caller-driven, so `config.retries` does not
+        apply here."""
         if self._closed:
             raise RuntimeError("Agent is closed; create a new agent")
         self._check_resume_support()
         params = self._rollout_params(task, runtime, dict(tools or {}))
-
-        def make_run() -> Rollout:
-            return Rollout(
-                task=task,
-                has_user=True,
-                on_trace=on_trace,
-                **params,
-            )
-
-        interaction = Interaction(
-            make_run(),
-            make_run=make_run,
-            retry=self.config.retries,
-            gate=self._gate,
-            borrowed=runtime is not None,
+        run = Rollout(
+            task=task,
+            has_user=True,
+            on_trace=on_trace,
+            **params,
         )
+        interaction = Interaction(run, gate=self._gate)
         async with self._gate or nullcontext():
-            opened = await interaction._open()
-            if not opened and (failure := interaction._run.failure) is not None:
-                await interaction._finish(include_history=True)
+            opened = await run.open()
+            if not opened and (failure := run.failure) is not None:
+                trace = await run.close()
+                if trace.agent.runtime is not None:
+                    trace.agent.runtime.borrowed = runtime is not None
                 raise failure
         try:
             yield interaction
         except Exception as e:
-            interaction._run.fail(e)
+            run.fail(e)
             raise
         except BaseException:
-            await interaction._run.abort()
+            await run.abort()
             raise
         finally:
-            await interaction.close()
+            trace = run.trace if run.closed else await interaction.close()
+            if trace.agent.runtime is not None:
+                trace.agent.runtime.borrowed = runtime is not None
 
     def _rollout_params(
         self, task: Task, runtime: Runtime | None, shared_tools: dict

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -19,6 +19,7 @@ from verifiers.v1.clients import (
     ModelContext,
 )
 from verifiers.v1.configs.agent import AgentConfig, TimeoutConfig
+from verifiers.v1.configs.retries import RetryConfig
 from verifiers.v1.configs.runtime import NetworkPolicyConfig
 from verifiers.v1.dialects import parse_message
 from verifiers.v1.harness import Harness
@@ -149,9 +150,22 @@ class Interaction:
     rewards after close. Leaving the `interaction()` context closes the exchange
     as `user_closed` and finishes the rollout — hooks and scoring included."""
 
-    def __init__(self, run: "Rollout", gate: asyncio.Semaphore | None = None) -> None:
+    def __init__(
+        self,
+        run: "Rollout",
+        make_run: Callable[[], "Rollout"],
+        retry: RetryConfig,
+        gate: asyncio.Semaphore | None = None,
+        borrowed: bool = False,
+    ) -> None:
         self._run = run
         self._gate = gate
+        self._make_run = make_run
+        self._retry = retry
+        self._borrowed = borrowed
+        self._attempt = 0
+        self._history: list = []
+        self._delivered = False
         self._over = False  # a terminated segment was already delivered
         self._started = False  # a segment has run (the exchange is under way)
         self._lock = asyncio.Lock()
@@ -159,6 +173,53 @@ class Interaction:
     @property
     def trace(self) -> Trace:
         return self._run.trace
+
+    async def _finish(self, *, include_history: bool) -> Trace:
+        trace = await self._run.close()
+        if trace.agent.runtime is not None:
+            trace.agent.runtime.borrowed = self._borrowed
+        if include_history and self._history:
+            trace.errors[:0] = self._history
+            self._history.clear()
+        return trace
+
+    async def _retry_failed(self) -> bool:
+        retry = self._retry
+        if (
+            self._delivered
+            or self._attempt >= retry.max_retries
+            or not trace_should_retry(self.trace, retry)
+        ):
+            return False
+        if self._borrowed:
+            logger.warning(
+                "not retrying the interaction on a borrowed box (its state is no "
+                "longer the task's start state); the error stands"
+            )
+            return False
+        trace = await self._finish(include_history=False)
+        self._history.extend(trace.errors)
+        delay = backoff(self._attempt)
+        logger.warning(
+            "retrying agent interaction (retry %d/%d) in %.1fs after error: %s",
+            self._attempt + 1,
+            retry.max_retries,
+            delay,
+            trace.last_error.type if trace.last_error else "?",
+        )
+        await asyncio.sleep(delay)
+        self._attempt += 1
+        self._run = self._make_run()
+        self._started = False
+        self._over = False
+        return True
+
+    async def _open(self) -> bool:
+        while True:
+            if await self._run.open():
+                return True
+            if not await self._retry_failed():
+                return False
 
     async def turn(self, message: str | Messages | None = None) -> Segment:
         """Send one user turn (a string, or full `Messages` for multimodal /
@@ -195,24 +256,28 @@ class Interaction:
             # A turn's messages may arrive typed or as wire dicts (env code naturally
             # writes `{"role": "user", ...}`); the trace speaks typed, so normalize.
             messages = [parse_message(m) if isinstance(m, dict) else m for m in message]
-        self._started = True
-        turns_before = self.trace.num_turns
-        nodes_before = len(self.trace.nodes)
-        await self._run.step(messages)
-        if self.trace.num_turns > turns_before:
-            # The segment answered — even if a limit or @stop then ended the
-            # exchange, that surfaces as the NEXT turn's terminated segment.
-            segment_messages: Messages = []
-            saw_assistant = False
-            for node in self.trace.nodes[nodes_before:]:
-                if node.sampled:
-                    segment_messages.append(node.message)
-                    saw_assistant = True
-                elif saw_assistant and isinstance(node.message, ToolMessage):
-                    segment_messages.append(node.message)
-            return Segment(messages=segment_messages)
-        self._over = True
-        return Segment(messages=[], terminated=True)
+        while True:
+            self._started = True
+            turns_before = self.trace.num_turns
+            nodes_before = len(self.trace.nodes)
+            await self._run.step(messages)
+            if self.trace.num_turns > turns_before:
+                # The segment answered — even if a limit or @stop then ended the
+                # exchange, that surfaces as the NEXT turn's terminated segment.
+                segment_messages: Messages = []
+                saw_assistant = False
+                for node in self.trace.nodes[nodes_before:]:
+                    if node.sampled:
+                        segment_messages.append(node.message)
+                        saw_assistant = True
+                    elif saw_assistant and isinstance(node.message, ToolMessage):
+                        segment_messages.append(node.message)
+                self._delivered = True
+                return Segment(messages=segment_messages)
+            if await self._retry_failed() and await self._open():
+                continue
+            self._over = True
+            return Segment(messages=[], terminated=True)
 
     async def close(self) -> Trace:
         """End the exchange and finish the rollout (idempotent): scoring and hooks
@@ -220,7 +285,7 @@ class Interaction:
         async with self._lock, self._gate or nullcontext():
             if not self._run.closed and self._run.ok:
                 self.trace.stop("user_closed")
-            return await self._run.close()
+            return await self._finish(include_history=True)
 
 
 class Agent:
@@ -450,38 +515,45 @@ class Agent:
         exchange (`user_closed`) and finishes the rollout, hooks and scoring
         included. A failure while opening the rollout raises before the context
         is entered (the failed trace is still completed and reported through
-        `on_trace`). An exchange is caller-driven, so `config.retries` does not
-        apply here."""
+        `on_trace`). `config.retries` applies while no segment has been returned
+        to the caller: setup and the opening turn can restart on a fresh runtime.
+        Once caller-visible output exists, the exchange cannot be replayed without
+        also rewinding caller state, so later failures conclude the interaction."""
         if self._closed:
             raise RuntimeError("Agent is closed; create a new agent")
         self._check_resume_support()
         params = self._rollout_params(task, runtime, dict(tools or {}))
-        run = Rollout(
-            task=task,
-            has_user=True,
-            on_trace=on_trace,
-            **params,
+
+        def make_run() -> Rollout:
+            return Rollout(
+                task=task,
+                has_user=True,
+                on_trace=on_trace,
+                **params,
+            )
+
+        interaction = Interaction(
+            make_run(),
+            make_run=make_run,
+            retry=self.config.retries,
+            gate=self._gate,
+            borrowed=runtime is not None,
         )
-        interaction = Interaction(run, gate=self._gate)
         async with self._gate or nullcontext():
-            opened = await run.open()
-            if not opened and (failure := run.failure) is not None:
-                trace = await run.close()
-                if trace.agent.runtime is not None:
-                    trace.agent.runtime.borrowed = runtime is not None
+            opened = await interaction._open()
+            if not opened and (failure := interaction._run.failure) is not None:
+                await interaction._finish(include_history=True)
                 raise failure
         try:
             yield interaction
         except Exception as e:
-            run.fail(e)
+            interaction._run.fail(e)
             raise
         except BaseException:
-            await run.abort()
+            await interaction._run.abort()
             raise
         finally:
-            trace = run.trace if run.closed else await interaction.close()
-            if trace.agent.runtime is not None:
-                trace.agent.runtime.borrowed = runtime is not None
+            await interaction.close()
 
     def _rollout_params(
         self, task: Task, runtime: Runtime | None, shared_tools: dict


### PR DESCRIPTION
## Overview

Apply the live test retry policy at the episode boundary so caller-driven interactions can be retried safely.

## Details

- share one retry policy between direct agent runs and episode retries
- restart the whole episode when an interaction ends with a transient provider or harness error
- leave the production interaction lifecycle unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b19b5b0df536436711697fb114a6ed923fb12522. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add env-level retry defaults to live test interaction episodes
> Sets a default `retries` config (`{"max_retries": 2, "include": ["ProviderError", "HarnessError"]}`) at the env level in `_eval_config` in [conftest.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2399/files#diff-bc28790d38dc6e7e4f2c44639d40bc33dea724d6c73149abf7ba82b37d14f40b) when no retries are specified. Previously, retries were only defaulted at the seat level; now both env and seat configs share the same defaults via `setdefault`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b19b5b0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->