### PR TITLE
fix: accept empty ACP replies

### DIFF
--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -41,7 +41,6 @@ class ACPConfig:
     mcp_urls: dict[str, str] | None = None
     system_prompt: str | None = None
     session_meta: JsonObject | None = None
-    allow_empty_tool_reply: bool = False
 
 
 class ACPHarness(Harness[ConfigT]):
@@ -215,7 +214,6 @@ class ACPHarnessSession(HarnessSession):
             "mcp_urls": self.mcp_urls,
             "system_prompt": self.config.system_prompt or "",
             "session_meta": self.config.session_meta or {},
-            "allow_empty_tool_reply": self.config.allow_empty_tool_reply,
         }
         async with self._lock:
             if self._closed:

--- a/verifiers/v1/acp/runner.py
+++ b/verifiers/v1/acp/runner.py
@@ -30,8 +30,6 @@ from acp.schema import (
     PermissionOption,
     RequestPermissionResponse,
     TextContentBlock,
-    ToolCall,
-    ToolCallUpdate,
 )
 
 MAX_PACKET_BYTES = 128 * 1024 * 1024
@@ -41,20 +39,13 @@ class VerifiersACPClient(Client):
     def __init__(self) -> None:
         self.visible_reply = ""
         self.message_id: str | None = None
-        self.tool_calls: dict[str, str] = {}
 
     def reset(self) -> None:
         self.visible_reply = ""
         self.message_id = None
-        self.tool_calls = {}
 
     async def session_update(self, session_id: str, update: Any, **kwargs: Any) -> None:
-        if isinstance(update, ToolCall):
-            self.tool_calls[update.tool_call_id] = update.status or "pending"
-        elif isinstance(update, ToolCallUpdate):
-            if update.status:
-                self.tool_calls[update.tool_call_id] = update.status
-        elif isinstance(update, AgentMessageChunk) and isinstance(
+        if isinstance(update, AgentMessageChunk) and isinstance(
             update.content, TextContentBlock
         ):
             message_id = getattr(update, "message_id", None)
@@ -137,23 +128,10 @@ async def prompt(
         raise ValueError("ACP prompt has no content")
     client.reset()
     try:
-        response = await connection.prompt(session_id=session_id, prompt=blocks)
+        await connection.prompt(session_id=session_id, prompt=blocks)
     except RequestError as error:
         detail = error.data.get("details") if isinstance(error.data, dict) else None
         raise RuntimeError(detail or str(error)) from error
-
-    tool_statuses = list(client.tool_calls.values())
-    completed_tool_turn = (
-        config.get("allow_empty_tool_reply", False)
-        and response.stop_reason == "end_turn"
-        and bool(tool_statuses)
-        and all(status in ("completed", "failed") for status in tool_statuses)
-    )
-    if not client.visible_reply.strip() and not completed_tool_turn:
-        raise RuntimeError(
-            "ACP agent produced no visible reply "
-            f"(stop_reason={response.stop_reason}, tool_statuses={tool_statuses})"
-        )
     return client.visible_reply
 
 

--- a/verifiers/v1/harnesses/openclaw/harness.py
+++ b/verifiers/v1/harnesses/openclaw/harness.py
@@ -229,8 +229,6 @@ class OpenClawHarness(ACPHarness[OpenClawHarnessConfig]):
             prompt=prompt,
             mcp_urls={},
             system_prompt=system_prompt,
-            # OpenClaw can end after its final tool completes without a text message.
-            allow_empty_tool_reply=True,
         )
 
     async def cleanup(self, trace: Trace, runtime: Runtime) -> None:

--- a/verifiers/v1/harnesses/pi/harness.py
+++ b/verifiers/v1/harnesses/pi/harness.py
@@ -200,6 +200,4 @@ class PiHarness(ACPHarness[PiHarnessConfig]):
             prompt=prompt,
             # Pi's extension owns the task-scoped MCP configuration.
             mcp_urls={},
-            # Pi can end after its final tool completes without a text message.
-            allow_empty_tool_reply=True,
         )


### PR DESCRIPTION
## What changed

- Accept successful ACP prompts whose visible agent transcript is empty.
- Remove the `allow_empty_tool_reply` configuration escape hatch.
- Stop tracking ACP tool statuses solely to decide whether an empty reply is valid.

The change is four files and removes 29 net lines.

## Why

ACP does not require a successful prompt to emit non-empty text. A prompt may end normally with `stopReason=end_turn` while producing no visible agent message.

This occurs in real RLM rollouts when a provider returns a terminal assistant response containing reasoning but neither public content nor a tool call. Nano RLM faithfully converts the absent content to `answer=""`, emits an empty ACP text chunk, and returns `end_turn`. Verifiers currently turns that successful protocol response into a `HarnessError`:

```text
ACP agent produced no visible reply (stop_reason=end_turn, tool_statuses=[])
```

No visible transcript is not the same as no model activity. The intercepted model call, including its sampled reasoning tokens, has already been committed to the trace. Verifiers still requires a newly committed intercepted model turn after the harness returns, so removing the text-specific check does not allow an inert harness to pass. It lets the trajectory reach scoring, where an unhelpful empty answer can receive zero reward instead of being discarded as an infrastructure failure.

Actual ACP request, process, and no-model-turn failures continue to propagate.

## ScaleSWE reproduction

I ran a controlled main-versus-fixed experiment using:

- Verifiers main `c9da45779`
- Nano RLM `878f49807163e802d60cd90e853d80920580ed05`
- `deepseek/deepseek-v4-flash`
- the same deterministic selection of 32 ScaleSWE tasks
- 32 concurrent Prime VM rollouts
- zero episode retries, with every finalized trace persisted

The main run had diagnostic-only ACP update capture added without changing the empty-reply decision. Both runs were stopped after the target behavior was reproduced and the remaining long-running tail stopped making progress, so the finalized sample sizes differ:

| Run | Finalized traces | Valid | Empty-reply `HarnessError` | Unrelated provider 400s |
| --- | ---: | ---: | ---: | ---: |
| Main | 29 | 21 | **3** | 5 |
| Fixed | 27 | 18 | **0** | 9 |

The three main failures were terminal reasoning-only responses:

| ScaleSWE task | Calls | Final reasoning | Content | Tool calls | Provider finish |
| --- | ---: | ---: | --- | ---: | --- |
| `jupyter-server_jupyter-scheduler_pr513` | 16 | 3,868 chars | `null` | 0 | `stop` |
| `pysal_spopt_pr319` | 24 | 5,358 chars | `null` | 0 | `stop` |
| `google_flatbuffers_pr4153` | 32 | 3,887 chars | `null` | 0 | `stop` |

The instrumentation showed that ACP delivered exactly one empty `AgentMessageChunk` followed by a successful `PromptResponse(stopReason=end_turn)`. This rules out lost notification ordering.

The fixed run independently encountered the same formerly-fatal shape on `pypa_installer_pr239`: provider `finish_reason=stop`, 2,598 reasoning characters, `content=null`, and no tool calls. It completed normally with `stop=agent_completed`, preserved the full trace, and received reward `0.0`. That is the intended training behavior.

Provider `400 Invalid request` failures occurred on both sides and were preserved without trajectory retries. They are upstream request failures, not ACP empty-reply failures.

## Checks

- `uv run ruff check verifiers/v1/acp/__init__.py verifiers/v1/acp/runner.py verifiers/v1/harnesses/pi/harness.py verifiers/v1/harnesses/openclaw/harness.py`
- `uv run pytest tests/v1/test_configs.py -q` (12 passed)
- ACP 0.12.1 protocol smoke confirming a successful empty prompt returns `""`
- Prime VM ScaleSWE main-versus-fixed reproduction described above


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ACP `prompt()` to return empty string instead of raising on empty agent replies
> - Removes the `allow_empty_tool_reply` config field from `ACPConfig` and all call sites in `OpenClawHarness` and `PiHarness`.
> - Strips tool call tracking (`tool_calls` dict, `ToolCall`/`ToolCallUpdate` handling) from `VerifiersACPClient` in [runner.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2400/files#diff-d5f52739b5575f4d9a3006836e988d6527ccfd28d82a299aa1554eb0878b95ca).
> - `prompt()` now returns the accumulated `visible_reply` (possibly empty) instead of raising a `RuntimeError` when the agent produces no visible text.
> - Behavioral Change: callers that previously relied on the exception to detect empty replies must now check for an empty string return value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7cdccff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7cdccff3b5cd7bca75a973cabfd50504d7940126. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
