### PR TITLE
Propagate network policy to provider capabilities

### DIFF
--- a/docs/v1/harbor.md
+++ b/docs/v1/harbor.md
@@ -99,9 +99,11 @@ allowlists retain their shared entries, while blocklists combine; framework-only
 either side takes precedence, and concrete allowlists cannot be combined with blocklists.
 Docker framework routes take precedence over deny rules, while ordinary Prime deny rules
 are applied unchanged and may block a matching route. Restricted Harbor tasks require
-Docker or a Prime VM; Prime accepts host-level entries. Provider-resolved remote resources
-and hosted tools are disabled under every restricted policy; allowlists govern runtime
-egress only.
+Docker or a Prime VM; Prime accepts host-level entries. Provider-resolved URLs are retained
+when their initial destination matches the effective policy. OpenAI Responses web search and
+Anthropic web search/fetch receive wildcard host allowlists translated to provider domains;
+policies that cannot be translated without widening still disable them. Every other hosted
+tool and provider-held resource remains disabled.
 
 ## Artifacts and collect hooks
 

--- a/verifiers/v1/dialects/anthropic.py
+++ b/verifiers/v1/dialects/anthropic.py
@@ -16,12 +16,14 @@ from anthropic.types import Message as AnthropicMessage
 from anthropic.types import MessageCreateParams
 from anthropic.types import Usage as AnthropicUsage
 
+from verifiers.v1.configs.runtime import NetworkPolicyConfig
 from verifiers.v1.dialects.base import (
     Dialect,
     StreamParser,
     append_user_notice,
     blocked_url,
     parse_sse_event,
+    provider_allowed_domains,
 )
 from verifiers.v1.types import (
     AssistantMessage,
@@ -56,6 +58,7 @@ THINKING = ("redacted_thinking", "thinking")
 # at the provider. Anchoring the pattern keeps new versions client-side without treating an
 # arbitrary dated provider tool as safe.
 _CLIENT_TOOL_TYPE = re.compile(r"(?:bash|text_editor|computer|memory)_\d{8}").fullmatch
+_WEB_TOOL_TYPE = re.compile(r"web_(?:search|fetch)_\d{8}").fullmatch
 _CONTENT_WRAPPERS = (
     "tool_result",
     "code_execution_tool_result",
@@ -126,10 +129,10 @@ def parse_content(content) -> str | list[ContentPart]:
     return parts
 
 
-def blocked_content_path(value, path: str) -> str | None:
+def blocked_content_path(value, path: str, policy: NetworkPolicyConfig) -> str | None:
     if isinstance(value, list):
         for index, item in enumerate(value):
-            if blocked := blocked_content_path(item, f"{path}[{index}]"):
+            if blocked := blocked_content_path(item, f"{path}[{index}]", policy):
                 return blocked
         return None
     if not isinstance(value, dict):
@@ -148,10 +151,12 @@ def blocked_content_path(value, path: str) -> str | None:
             return source_path
         source_kind = source.get("type")
         if source_kind == "content":
-            return blocked_content_path(source.get("content"), f"{source_path}.content")
+            return blocked_content_path(
+                source.get("content"), f"{source_path}.content", policy
+            )
         if source_kind == "url":
             url = source.get("url")
-            if not isinstance(url, str) or blocked_url(url):
+            if not isinstance(url, str) or blocked_url(url, policy):
                 return f"{source_path}.url"
         if source_kind == "file":
             return (
@@ -169,13 +174,13 @@ def blocked_content_path(value, path: str) -> str | None:
     ) and value.get("file_id"):
         return f"{path}.file_id"
     if kind in _CONTENT_WRAPPERS:
-        return blocked_content_path(value.get("content"), f"{path}.content")
+        return blocked_content_path(value.get("content"), f"{path}.content", policy)
     return None if kind in _SAFE_CONTENT_TYPES else f"{path}.type"
 
 
-def mediate_content(value, path: str):
+def mediate_content(value, path: str, policy: NetworkPolicyConfig):
     if not isinstance(value, list):
-        blocked = blocked_content_path(value, path)
+        blocked = blocked_content_path(value, path, policy)
         return ("", [blocked]) if blocked else (value, [])
 
     mediated = []
@@ -183,16 +188,18 @@ def mediate_content(value, path: str):
     for index, block in enumerate(value):
         item_path = f"{path}[{index}]"
         if isinstance(block, dict) and block.get("type") in _CONTENT_WRAPPERS:
-            if blocked := blocked_content_path({**block, "content": []}, item_path):
+            if blocked := blocked_content_path(
+                {**block, "content": []}, item_path, policy
+            ):
                 capabilities.append(blocked)
                 continue
             content, removed = mediate_content(
-                block.get("content"), f"{item_path}.content"
+                block.get("content"), f"{item_path}.content", policy
             )
             if removed:
                 block["content"] = content or ""
                 capabilities.extend(removed)
-        elif blocked := blocked_content_path(block, item_path):
+        elif blocked := blocked_content_path(block, item_path, policy):
             capabilities.append(blocked)
             continue
         mediated.append(block)
@@ -448,7 +455,7 @@ class AnthropicDialect(Dialect[MessageCreateParams, AnthropicMessage]):
     response_type = ModdedAnthropicMessage
 
     def mediate_external_capabilities(
-        self, body: MessageCreateParams
+        self, body: MessageCreateParams, policy: NetworkPolicyConfig
     ) -> tuple[MessageCreateParams, list[str]]:
         mediated = body
         capabilities: list[str] = []
@@ -457,7 +464,7 @@ class AnthropicDialect(Dialect[MessageCreateParams, AnthropicMessage]):
             if mediated.pop(key, None):
                 capabilities.append(key)
 
-        system, removed = mediate_content(mediated.get("system"), "system")
+        system, removed = mediate_content(mediated.get("system"), "system", policy)
         capabilities.extend(removed)
         if removed:
             if system:
@@ -469,7 +476,9 @@ class AnthropicDialect(Dialect[MessageCreateParams, AnthropicMessage]):
             if not isinstance(message, dict):
                 continue
             content, removed = mediate_content(
-                message.get("content"), f"messages[{message_index}].content"
+                message.get("content"),
+                f"messages[{message_index}].content",
+                policy,
             )
             capabilities.extend(removed)
             if removed:
@@ -482,6 +491,33 @@ class AnthropicDialect(Dialect[MessageCreateParams, AnthropicMessage]):
         tools = []
         for index, tool in enumerate(tool_items):
             kind = tool.get("type") if isinstance(tool, dict) else None
+            if (
+                isinstance(tool, dict)
+                and isinstance(kind, str)
+                and _WEB_TOOL_TYPE(kind)
+            ):
+                callers = tool.get("allowed_callers")
+                domains = (
+                    provider_allowed_domains(policy, tool.get("allowed_domains"))
+                    if tool.get("blocked_domains") in (None, [])
+                    and (
+                        callers is None
+                        or isinstance(callers, list)
+                        and "direct" in callers
+                    )
+                    else []
+                )
+                if domains:
+                    web_tool = {
+                        **tool,
+                        "allowed_domains": domains,
+                        "allowed_callers": ["direct"],
+                    }
+                    web_tool.pop("blocked_domains", None)
+                    tools.append(web_tool)
+                    continue
+                capabilities.append(f"tools[{index}].type")
+                continue
             if isinstance(tool, dict) and (
                 (isinstance(kind, str) and _CLIENT_TOOL_TYPE(kind))
                 or (kind in (None, "custom") and "input_schema" in tool)

--- a/verifiers/v1/dialects/base.py
+++ b/verifiers/v1/dialects/base.py
@@ -16,16 +16,19 @@ import logging
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterator, Mapping
 from typing import ClassVar, Generic, TypeVar
+from urllib.parse import urlsplit
 
-from pydantic import BaseModel
+from pydantic import AnyHttpUrl, BaseModel, TypeAdapter, ValidationError
 from pydantic_core import from_json
 
+from verifiers.v1.configs.runtime import NetworkPolicyConfig, network_rule_matches
 from verifiers.v1.types import Request, Response, Sampling, SamplingConfig
 
 ReqT = TypeVar("ReqT")
 RespT = TypeVar("RespT", bound=BaseModel)
 
 logger = logging.getLogger(__name__)
+HTTP_URL_ADAPTER = TypeAdapter(AnyHttpUrl)
 
 PROVIDER_CAPABILITY_POLICY_CODE = "provider_capability_unavailable"
 CAPABILITY_NOTICE = (
@@ -35,9 +38,83 @@ CAPABILITY_NOTICE = (
 )
 
 
-def blocked_url(value: str) -> bool:
-    """Whether a provider-resolved resource is not inline data."""
-    return not value.lower().startswith("data:")
+def blocked_url(value: str, policy: NetworkPolicyConfig) -> bool:
+    """Whether a provider-resolved resource is neither inline nor policy-permitted."""
+    if value.lower().startswith("data:"):
+        return False
+    try:
+        url = HTTP_URL_ADAPTER.validate_python(value)
+    except ValidationError:
+        return True
+    host = url.host.lower().rstrip(".").strip("[]")
+    return any(
+        network_rule_matches(rule, url.scheme, host, url.port) for rule in policy.block
+    ) or not any(
+        network_rule_matches(rule, url.scheme, host, url.port) for rule in policy.allow
+    )
+
+
+def provider_allowed_domains(
+    policy: NetworkPolicyConfig, requested: object = None
+) -> list[str]:
+    """Translate a network policy to provider domain-filter semantics without widening it."""
+    if policy.block or not policy.allow or "*" in policy.allow:
+        return []
+    domains = []
+    for rule in policy.allow:
+        try:
+            url = urlsplit(rule if "://" in rule else f"//{rule}")
+            port = url.port
+        except ValueError:
+            return []
+        host = (url.hostname or "").lower().rstrip(".")
+        domain = host.removeprefix("*.")
+        if (
+            url.scheme
+            or port is not None
+            or not host.startswith("*.")
+            or not domain
+            or "*" in domain
+            or not domain.isascii()
+        ):
+            return []
+        domains.append(domain)
+    domains = list(dict.fromkeys(domains))
+    if requested is None:
+        return domains
+    if not isinstance(requested, list):
+        return []
+    requested_domains = []
+    for domain in requested:
+        if not isinstance(domain, str):
+            return []
+        try:
+            url = urlsplit(domain if "://" in domain else f"//{domain}")
+            port = url.port
+        except ValueError:
+            return []
+        host = (url.hostname or "").lower().rstrip(".")
+        if (
+            url.scheme
+            or port is not None
+            or url.username is not None
+            or url.path
+            or url.query
+            or url.fragment
+            or not host
+            or "*" in host
+            or not host.isascii()
+        ):
+            return []
+        requested_domains.append(host)
+    intersection = []
+    for allowed in domains:
+        for requested_domain in requested_domains:
+            if allowed == requested_domain or allowed.endswith(f".{requested_domain}"):
+                intersection.append(allowed)
+            elif requested_domain.endswith(f".{allowed}"):
+                intersection.append(requested_domain)
+    return list(dict.fromkeys(intersection))
 
 
 def append_user_notice(
@@ -187,7 +264,9 @@ class Dialect(ABC, Generic[ReqT, RespT]):
         return {"error": {"message": message, "type": "invalid_request_error"}}
 
     @abstractmethod
-    def mediate_external_capabilities(self, body: ReqT) -> tuple[ReqT, list[str]]:
+    def mediate_external_capabilities(
+        self, body: ReqT, policy: NetworkPolicyConfig
+    ) -> tuple[ReqT, list[str]]:
         """Remove provider-side capabilities during restricted execution. Implementations add
         the same policy context on every call because the agent does not retain injected request
         content. Returned paths never contain request values."""

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -17,6 +17,7 @@ from urllib.parse import urlsplit
 from openai.types.chat import ChatCompletion
 from openai.types.chat.completion_create_params import CompletionCreateParams
 
+from verifiers.v1.configs.runtime import NetworkPolicyConfig
 from verifiers.v1.dialects.base import (
     Dialect,
     StreamParser,
@@ -356,7 +357,7 @@ class ChatDialect(Dialect[CompletionCreateParams, ChatCompletion]):
     response_type = ModdedChatCompletion
 
     def mediate_external_capabilities(
-        self, body: CompletionCreateParams
+        self, body: CompletionCreateParams, policy: NetworkPolicyConfig
     ) -> tuple[CompletionCreateParams, list[str]]:
         mediated = body
         capabilities: list[str] = []
@@ -446,7 +447,7 @@ class ChatDialect(Dialect[CompletionCreateParams, ChatCompletion]):
                 elif kind == "image_url":
                     image = part.get("image_url") or {}
                     url = image.get("url") if isinstance(image, dict) else image
-                    if not isinstance(url, str) or blocked_url(url):
+                    if not isinstance(url, str) or blocked_url(url, policy):
                         capability = f"{path}.image_url.url"
                 elif kind == "file":
                     file = part.get("file")
@@ -465,7 +466,7 @@ class ChatDialect(Dialect[CompletionCreateParams, ChatCompletion]):
                                 capability = f"{path}.file.file_data"
                             else:
                                 if (parsed.scheme or parsed.netloc) and blocked_url(
-                                    file_data
+                                    file_data, policy
                                 ):
                                     capability = f"{path}.file.file_data"
                 if capability is None:

--- a/verifiers/v1/dialects/responses.py
+++ b/verifiers/v1/dialects/responses.py
@@ -8,6 +8,7 @@ parsing reads the `output` items. Relay-only: the eval client forwards the progr
 """
 
 import json
+import re
 from collections import deque
 from typing import cast
 
@@ -17,12 +18,14 @@ from openai.types.responses import (
 from openai.types.responses.response_create_params import ResponseCreateParams
 from pydantic import BaseModel, ConfigDict
 
+from verifiers.v1.configs.runtime import NetworkPolicyConfig
 from verifiers.v1.dialects.base import (
     Dialect,
     StreamParser,
     append_user_notice,
     blocked_url,
     iter_sse_reverse,
+    provider_allowed_domains,
 )
 from verifiers.v1.errors import OverlongPromptError, model_error
 from verifiers.v1.types import (
@@ -65,6 +68,7 @@ _CLIENT_TOOL_TYPES = (
     "computer_use_preview",
 )
 _CLIENT_TOOL_CHOICES = (*_CLIENT_TOOL_TYPES, "namespace", "tool_search", "shell")
+_WEB_SEARCH_TOOL_TYPE = re.compile(r"web_search(?:_\d{4}_\d{2}_\d{2})?").fullmatch
 _SAFE_INPUT_TYPES = (
     "input_text",
     "input_file",
@@ -142,7 +146,9 @@ def parse_content(content) -> str | list[ContentPart]:
     return parts
 
 
-def mediate_tools(tools, path: str) -> tuple[list[dict], list[str]]:
+def mediate_tools(
+    tools, path: str, policy: NetworkPolicyConfig
+) -> tuple[list[dict], list[str]]:
     if tools is not None and not isinstance(tools, list):
         return [], [path]
     mediated = []
@@ -153,11 +159,27 @@ def mediate_tools(tools, path: str) -> tuple[list[dict], list[str]]:
             capabilities.append(item_path)
             continue
         kind = tool.get("type")
+        if isinstance(kind, str) and _WEB_SEARCH_TOOL_TYPE(kind):
+            raw_filters = tool.get("filters")
+            if raw_filters is None or isinstance(raw_filters, dict):
+                requested = raw_filters.get("allowed_domains") if raw_filters else None
+                domains = provider_allowed_domains(policy, requested)
+            else:
+                domains = []
+            if domains:
+                filters = dict(raw_filters) if isinstance(raw_filters, dict) else {}
+                filters["allowed_domains"] = domains
+                mediated.append({**tool, "filters": filters})
+                continue
+            capabilities.append(f"{item_path}.type")
+            continue
         if kind in _CLIENT_TOOL_TYPES:
             mediated.append(tool)
             continue
         if kind == "namespace":
-            nested, removed = mediate_tools(tool.get("tools"), f"{item_path}.tools")
+            nested, removed = mediate_tools(
+                tool.get("tools"), f"{item_path}.tools", policy
+            )
             capabilities.extend(removed)
             if nested:
                 mediated.append({**tool, "tools": nested})
@@ -177,10 +199,10 @@ def mediate_tools(tools, path: str) -> tuple[list[dict], list[str]]:
     return mediated, capabilities
 
 
-def blocked_content_path(value, path: str) -> str | None:
+def blocked_content_path(value, path: str, policy: NetworkPolicyConfig) -> str | None:
     if isinstance(value, list):
         for index, item in enumerate(value):
-            if blocked := blocked_content_path(item, f"{path}[{index}]"):
+            if blocked := blocked_content_path(item, f"{path}[{index}]", policy):
                 return blocked
         return None
     if not isinstance(value, dict):
@@ -196,7 +218,9 @@ def blocked_content_path(value, path: str) -> str | None:
         if value.get("file_id"):
             return f"{path}.file_id"
         if "file_url" in value:
-            if not isinstance(value["file_url"], str) or blocked_url(value["file_url"]):
+            if not isinstance(value["file_url"], str) or blocked_url(
+                value["file_url"], policy
+            ):
                 return f"{path}.file_url"
         elif not isinstance(value.get("file_data"), str):
             return f"{path}.file_data"
@@ -204,7 +228,7 @@ def blocked_content_path(value, path: str) -> str | None:
         if value.get("file_id"):
             return f"{path}.file_id"
         if not isinstance(value.get("image_url"), str) or blocked_url(
-            value["image_url"]
+            value["image_url"], policy
         ):
             return f"{path}.image_url"
 
@@ -222,7 +246,7 @@ def blocked_content_path(value, path: str) -> str | None:
     if kind in ("additional_tools", "tool_search_output"):
         if kind == "tool_search_output" and value.get("execution") != "client":
             return f"{path}.execution"
-        _, removed = mediate_tools(value.get("tools"), f"{path}.tools")
+        _, removed = mediate_tools(value.get("tools"), f"{path}.tools", policy)
         return removed[0] if removed else None
 
     if kind in (
@@ -230,21 +254,21 @@ def blocked_content_path(value, path: str) -> str | None:
         "function_call_output",
         "custom_tool_call_output",
     ):
-        return blocked_content_path(value.get("output"), f"{path}.output")
+        return blocked_content_path(value.get("output"), f"{path}.output", policy)
     if kind in (None, "message") and "role" in value and "content" in value:
-        return blocked_content_path(value["content"], f"{path}.content")
+        return blocked_content_path(value["content"], f"{path}.content", policy)
     return None if kind in _SAFE_INPUT_TYPES else f"{path}.type"
 
 
-def mediate_content(value, path: str):
+def mediate_content(value, path: str, policy: NetworkPolicyConfig):
     if not isinstance(value, list):
-        blocked = blocked_content_path(value, path)
+        blocked = blocked_content_path(value, path, policy)
         return ("", [blocked]) if blocked else (value, [])
 
     mediated = []
     capabilities = []
     for index, part in enumerate(value):
-        if blocked := blocked_content_path(part, f"{path}[{index}]"):
+        if blocked := blocked_content_path(part, f"{path}[{index}]", policy):
             capabilities.append(blocked)
             continue
         mediated.append(part)
@@ -415,7 +439,7 @@ class ResponsesDialect(Dialect[ResponseCreateParams, OpenAIResponse]):
     response_type = OpenAIResponse
 
     def mediate_external_capabilities(
-        self, body: ResponseCreateParams
+        self, body: ResponseCreateParams, policy: NetworkPolicyConfig
     ) -> tuple[ResponseCreateParams, list[str]]:
         mediated = body
         capabilities: list[str] = []
@@ -440,12 +464,12 @@ class ResponsesDialect(Dialect[ResponseCreateParams, OpenAIResponse]):
                 kind = item.get("type")
                 if kind in ("additional_tools", "tool_search_output"):
                     if blocked := blocked_content_path(
-                        {**item, "tools": []}, item_path
+                        {**item, "tools": []}, item_path, policy
                     ):
                         capabilities.append(blocked)
                         continue
                     item["tools"], removed = mediate_tools(
-                        item.get("tools"), f"{item_path}.tools"
+                        item.get("tools"), f"{item_path}.tools", policy
                     )
                     capabilities.extend(removed)
                     if kind == "tool_search_output" or item["tools"]:
@@ -459,14 +483,16 @@ class ResponsesDialect(Dialect[ResponseCreateParams, OpenAIResponse]):
 
                 if content_field:
                     content, removed = mediate_content(
-                        item.get(content_field), f"{item_path}.{content_field}"
+                        item.get(content_field),
+                        f"{item_path}.{content_field}",
+                        policy,
                     )
                     capabilities.extend(removed)
                     if removed:
                         item[content_field] = content or ""
 
                 scan = {**item, content_field: []} if content_field else item
-                blocked = blocked_content_path(scan, item_path)
+                blocked = blocked_content_path(scan, item_path, policy)
                 if blocked is None:
                     safe_input.append(item)
                 else:
@@ -480,11 +506,11 @@ class ResponsesDialect(Dialect[ResponseCreateParams, OpenAIResponse]):
                         }
                         safe_input.append(item)
             mediated["input"] = safe_input
-        elif blocked := blocked_content_path(raw_input, "input"):
+        elif blocked := blocked_content_path(raw_input, "input", policy):
             capabilities.append(blocked)
             mediated["input"] = []
 
-        tools, tool_capabilities = mediate_tools(mediated.get("tools"), "tools")
+        tools, tool_capabilities = mediate_tools(mediated.get("tools"), "tools", policy)
         capabilities.extend(tool_capabilities)
         if "tools" in mediated:
             mediated["tools"] = tools
@@ -497,14 +523,18 @@ class ResponsesDialect(Dialect[ResponseCreateParams, OpenAIResponse]):
         )
         if isinstance(choice, dict):
             kind = choice.get("type")
-            valid_choice = kind in _CLIENT_TOOL_CHOICES and any(
+            valid_choice = (
+                kind in _CLIENT_TOOL_CHOICES
+                or isinstance(kind, str)
+                and _WEB_SEARCH_TOOL_TYPE(kind)
+            ) and any(
                 tool.get("type") == kind
                 and ("name" not in choice or tool.get("name") == choice["name"])
                 for tool in tools
             )
             if kind == "allowed_tools":
                 choice_tools, choice_capabilities = mediate_tools(
-                    choice.get("tools"), "tool_choice.tools"
+                    choice.get("tools"), "tool_choice.tools", policy
                 )
                 valid_choice = not choice_capabilities
                 mediated["tool_choice"] = {**choice, "tools": choice_tools}

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -280,7 +280,9 @@ class InterceptionServer(Interception):
     ) -> tuple[dict, list[str]]:
         if not session.network_policy.network_restricted:
             return body, []
-        mediated, capabilities = dialect.mediate_external_capabilities(body)
+        mediated, capabilities = dialect.mediate_external_capabilities(
+            body, session.network_policy
+        )
         capabilities = list(dict.fromkeys(capabilities))
         if capabilities:
             logger.warning(


### PR DESCRIPTION
## Overview

Align provider-resolved URLs and hosted browsing capabilities with the effective runtime network policy across Chat Completions, OpenAI Responses, and Anthropic Messages.

## Details

- Thread the effective network policy through dialect capability mediation.
- Retain direct media and file URLs when their HTTP(S) destination matches the configured allow and block rules, while preserving inline data.
- Translate compatible wildcard host rules into OpenAI web-search and Anthropic web-search/web-fetch domain filters.
- Intersect existing provider domain and caller restrictions so mediation never widens the original request.
- Continue removing provider capabilities when their restrictions cannot represent the runtime policy safely.
- Document how restricted runtime policies apply to provider-resolved resources and hosted tools.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 6ac210a831421bd275a0bd4b013b7d43657c76d7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Propagate session network policy into provider capability mediation for web search and fetch tools
> - `mediate_external_capabilities` in the Anthropic, Chat, and Responses dialects now accepts a `NetworkPolicyConfig` and enforces it during capability mediation; the session policy is passed in from [`server.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/2401/files#diff-84e2f8d027d609e8760ef6d533535ec9d99dfc6384d5ddb6111b4001b2010f35).
> - `blocked_url` in [`base.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/2401/files#diff-10ccce5f7f0d991c33492a01e73014e10883deb74f7006253f1c690422d841bd) now evaluates HTTP(S) URLs against the session's allow/block rules instead of only rejecting non-`data:` URLs.
> - A new `provider_allowed_domains` helper translates a policy allowlist to provider-safe domain filters; it returns empty when translation would widen access (e.g. block rules present, wildcard `*`, or non-wildcard hostnames).
> - Web search/fetch tools (`web_search_YYYYMMDD`, `web_fetch_YYYYMMDD`) are rewritten with derived `allowed_domains` when the policy can be safely translated; otherwise they are removed entirely.
> - Risk: tools that were previously passed through are now removed when the session policy cannot be safely expressed as provider domain filters.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ac210a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->