### PR TITLE
fix: bump pypi-publish action to v1.14.2

### DIFF
--- a/.github/workflows/publish-verifiers.yml
+++ b/.github/workflows/publish-verifiers.yml
@@ -66,7 +66,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           skip-existing: true
 
@@ -127,7 +127,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
   github-release-tag:
     needs: [build-tag, publish-tag]


### PR DESCRIPTION
## Summary

- Bump `pypa/gh-action-pypi-publish` from v1.14.0 to v1.14.2 in both publish jobs.

## Verification

- Before: every push to `main` since 2026-08-18 fails `publish-dev` with `InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version` ([example run](https://github.com/PrimeIntellect-ai/verifiers/actions/runs/32278301116)). Cause: hatchling 1.32.0 bumped the default core metadata version to 2.5, and v1.14.0 bundles twine 6.1.0 + packaging 25.0, which only accept up to 2.4.
- After: v1.14.2 bundles twine 7.0.0 + packaging 26.2; verified `packaging` 26.2 lists `2.5` as a valid metadata version. No dev release has published since `0.3.1.dev50` — merging this resumes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit becfb38f21eb0b29d2405945a61b0ae86f20bcc2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `pypa/gh-action-pypi-publish` to v1.14.2 in publish workflow
> Updates the pinned commit hash for `pypa/gh-action-pypi-publish` from `cef2210` (v1.14.0) to `dc37677` (v1.14.2) in both the dev and tagged release publish steps of [publish-verifiers.yml](.github/workflows/publish-verifiers.yml).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized becfb38.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->