### PR TITLE
chore: bump workflow actions to latest versions

### DIFF
--- a/.github/workflows/publish-verifiers.yml
+++ b/.github/workflows/publish-verifiers.yml
@@ -31,12 +31,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Build sdist and wheel
         run: uv build
@@ -45,7 +45,7 @@ jobs:
         run: ls -1 dist/
 
       - name: Upload dist artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: verifiers-dev-dist
           path: dist/
@@ -60,13 +60,13 @@ jobs:
       id-token: write
     steps:
       - name: Download dist artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: verifiers-dev-dist
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true
 
@@ -80,7 +80,7 @@ jobs:
       tag: ${{ steps.release.outputs.tag }}
     steps:
       - name: Checkout tagged release
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: refs/tags/${{ inputs.tag }}
@@ -100,13 +100,13 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Build sdist and wheel
         run: uv build
 
       - name: Upload dist artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: verifiers-dist
           path: dist/
@@ -121,13 +121,13 @@ jobs:
       id-token: write
     steps:
       - name: Download dist artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: verifiers-dist
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        uses: pypa/gh-action-pypi-publish@release/v1
 
   github-release-tag:
     needs: [build-tag, publish-tag]
@@ -136,18 +136,18 @@ jobs:
       contents: write
     steps:
       - name: Checkout tag
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: refs/tags/${{ needs.build-tag.outputs.tag }}
 
       - name: Download dist artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: verifiers-dist
           path: dist/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.build-tag.outputs.tag }}
           generate_release_notes: true

--- a/.github/workflows/publish-verifiers.yml
+++ b/.github/workflows/publish-verifiers.yml
@@ -66,7 +66,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           skip-existing: true
 
@@ -127,7 +127,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
   github-release-tag:
     needs: [build-tag, publish-tag]

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           submodules: true
       # Pin to the ruff uv.lock resolves, so CI and `uv run ruff` agree.
@@ -33,15 +33,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
       - name: Install dependencies
         run: uv sync
       - name: Run ty

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,20 +38,20 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Cache Hugging Face tokenizers
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${{ env.HF_HOME }}
           key: hf-tokenizers-${{ runner.os }}-${{ hashFiles('uv.lock', 'tests/test_renderer_client.py', 'tests/test_renderer_e2e.py') }}
@@ -83,20 +83,20 @@ jobs:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Cache Hugging Face tokenizers
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${{ env.HF_HOME }}
           key: hf-tokenizers-${{ runner.os }}-${{ hashFiles('uv.lock', 'tests/test_renderer_client.py', 'tests/test_renderer_e2e.py') }}


### PR DESCRIPTION
## Summary

- Bump all workflow actions to their latest majors: `actions/checkout` v5 → v7, `actions/setup-python` v6 → v7, `astral-sh/setup-uv` v7 → v10.0.1, `actions/cache` v4 → v6, `actions/upload-artifact` v5 → v7, `actions/download-artifact` v6 → v8, `softprops/action-gh-release` v2 → v3.
- `pypa/gh-action-pypi-publish` stays SHA-pinned at `dc37677` (v1.14.2, the latest release): the publish jobs hold `id-token: write` in the `pypi-prod` environment, so the action is kept on an immutable, reviewed commit rather than the mutable `release/v1` branch.
- `astral-sh/ruff-action@v4.1.0` (with ruff 0.16.0, matching `uv.lock`) and `peter-evans/repository-dispatch@v4` are already latest and stay as-is.

Notes on compatibility, checked against each major's release notes: the new majors run on node24 (all jobs here run on `ubuntu-latest`); `setup-uv` stopped publishing floating major tags with v8, so it is pinned to the exact release; `download-artifact` v8 turns digest mismatches into errors (desirable for the publish pipeline).

## Verification

- `actionlint` is clean on all edited workflows.
- Test (3.11/3.12/3.13), V1 live E2E, Ruff, and Ty all pass on this PR, covering checkout v7, setup-python v7, setup-uv v10.0.1, and cache v6.
- The publish path (upload/download-artifact, gh-release) only runs on pushes to `main`; the first post-merge publish run will confirm it end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1c52c38ed19232161b51f33c0d3921f284d34997. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump GitHub Actions versions across CI workflows
> Updates action versions in [publish-verifiers.yml](.github/workflows/publish-verifiers.yml), [style.yml](.github/workflows/style.yml), and [test.yml](.github/workflows/test.yml) to their latest releases. Affected actions include `actions/checkout` (v7), `actions/setup-python` (v7), `astral-sh/setup-uv` (v10.0.1), `actions/upload-artifact` (v7), `actions/download-artifact` (v8), `actions/cache` (v6), and `softprops/action-gh-release` (v3).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c52c38.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->