### PR TITLE
fix: enable Qwen3-Max prompt caching for hosted evals

### DIFF
--- a/tests/test_client_multimodal_types.py
+++ b/tests/test_client_multimodal_types.py
@@ -1,8 +1,13 @@
+from copy import deepcopy
 from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 
 from verifiers.clients.openai_chat_completions_client import OpenAIChatCompletionsClient
+from verifiers.legacy.clients import (
+    openai_chat_completions_client as openai_chat_completions_module,
+)
 from verifiers.types import (
     AssistantMessage,
     ImageUrlContentPart,
@@ -22,6 +27,46 @@ from verifiers.utils.response_utils import parse_response_message
 class _OpenAIMessage(SimpleNamespace):
     def model_dump(self):
         return self.__dict__
+
+
+async def _capture_chat_request_body(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    base_url: str,
+    model: str,
+    prompt: Any,
+    tools: Any = None,
+    sampling_args: Any = None,
+) -> dict[str, Any]:
+    captured_body: dict[str, Any] = {}
+    sentinel = cast(Any, object())
+
+    async def fake_post_chat_completion(
+        _client: object,
+        path: str,
+        *,
+        body: dict[str, Any],
+        extra_headers: Any = None,
+    ) -> Any:
+        assert path == "/chat/completions"
+        assert extra_headers is None
+        captured_body.update(body)
+        return sentinel
+
+    monkeypatch.setattr(
+        openai_chat_completions_module,
+        "post_chat_completion_with_routed_experts_sidecar",
+        fake_post_chat_completion,
+    )
+    client = OpenAIChatCompletionsClient(SimpleNamespace(base_url=base_url))
+    response = await client.get_native_response(
+        prompt=prompt,
+        model=model,
+        sampling_args=sampling_args or {},
+        tools=tools,
+    )
+    assert response is sentinel
+    return captured_body
 
 
 @pytest.mark.asyncio
@@ -56,6 +101,159 @@ async def test_openai_to_native_prompt_with_typed_multimodal_content_parts():
             "input_audio": {"data": "ZHVtbXk=", "format": "wav"},
         },
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "base_url",
+    ["https://openrouter.ai/api/v1", "https://api.pinference.ai/api/v1"],
+)
+async def test_qwen3_max_gateway_marks_only_static_prompt_cache_boundaries(
+    monkeypatch: pytest.MonkeyPatch,
+    base_url: str,
+):
+    prompt = cast(
+        Any,
+        [
+            {"role": "system", "content": "first static instruction"},
+            {
+                "role": "developer",
+                "content": [
+                    {"type": "text", "text": "end of static instructions"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/static.png"},
+                    },
+                ],
+            },
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "dynamic rollout turn"}],
+            },
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "call_1", "type": "function"}],
+            },
+        ],
+    )
+    tools = cast(
+        Any,
+        [
+            {
+                "type": "function",
+                "function": {"name": "first", "parameters": {}},
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "last",
+                    "parameters": {"properties": {"cache_control": {"type": "string"}}},
+                },
+            },
+        ],
+    )
+    original_prompt = deepcopy(prompt)
+    original_tools = deepcopy(tools)
+
+    body = await _capture_chat_request_body(
+        monkeypatch,
+        base_url=base_url,
+        model="qwen/qwen3-max",
+        prompt=prompt,
+        tools=tools,
+    )
+
+    assert prompt == original_prompt
+    assert tools == original_tools
+    assert body["messages"][0] == original_prompt[0]
+    assert body["messages"][1]["content"][0] == {
+        "type": "text",
+        "text": "end of static instructions",
+        "cache_control": {"type": "ephemeral"},
+    }
+    assert body["messages"][1]["content"][1] == original_prompt[1]["content"][1]
+    assert body["messages"][2:] == original_prompt[2:]
+    assert body["tools"][0] == original_tools[0]
+    assert body["tools"][1]["cache_control"] == {"type": "ephemeral"}
+    assert set(body["messages"][1]["content"][0]["cache_control"]) == {"type"}
+    assert set(body["tools"][1]["cache_control"]) == {"type"}
+
+
+@pytest.mark.parametrize(
+    ("prompt", "tools", "extra_body"),
+    [
+        ([{"role": "system", "content": "static", "cache_control": {}}], None, {}),
+        (
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "dynamic",
+                            "prompt_cache_breakpoint": True,
+                        }
+                    ],
+                }
+            ],
+            None,
+            {},
+        ),
+        ([], [{"type": "function", "cache_control": {}}], {}),
+        ([], None, {"prompt_cache_breakpoint": True}),
+    ],
+)
+def test_qwen3_max_prompt_cache_recognizes_caller_intent(
+    prompt: Any,
+    tools: Any,
+    extra_body: dict[str, Any],
+):
+    assert openai_chat_completions_module._has_caller_prompt_cache_intent(
+        prompt, tools, extra_body
+    )
+
+
+@pytest.mark.asyncio
+async def test_qwen3_max_top_level_prompt_cache_intent_suppresses_auto_markers(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    prompt = cast(Any, [{"role": "system", "content": "stable instruction"}])
+    tools = cast(Any, [{"type": "function", "function": {"name": "lookup"}}])
+    caller_marker = {"source": "caller"}
+
+    body = await _capture_chat_request_body(
+        monkeypatch,
+        base_url="https://openrouter.ai/api/v1",
+        model="qwen/qwen3-max",
+        prompt=prompt,
+        tools=tools,
+        sampling_args={"extra_body": {"prompt_cache_breakpoint": caller_marker}},
+    )
+
+    assert body["messages"] is prompt
+    assert body["tools"] is tools
+    assert body["prompt_cache_breakpoint"] is caller_marker
+
+
+@pytest.mark.parametrize(
+    ("model", "base_url"),
+    [
+        ("qwen/qwen3-max", "https://api.openai.com/v1"),
+        ("qwen/qwen3-max-turbo", "https://openrouter.ai/api/v1"),
+        ("QWEN/QWEN3-MAX", "https://openrouter.ai/api/v1"),
+        ("qwen/qwen3-max", "https://api.openrouter.ai/v1"),
+        ("qwen/qwen3-max", "https://foo.pinference.ai/v1"),
+        ("qwen/qwen3-max", "https://notopenrouter.ai/v1"),
+    ],
+)
+def test_qwen3_max_prompt_cache_is_exactly_scoped(
+    model: str,
+    base_url: str,
+):
+    assert not openai_chat_completions_module._uses_qwen3_max_explicit_prompt_cache(
+        model, base_url
+    )
 
 
 @pytest.mark.asyncio

--- a/verifiers/legacy/clients/openai_chat_completions_client.py
+++ b/verifiers/legacy/clients/openai_chat_completions_client.py
@@ -3,6 +3,7 @@
 import functools
 from collections.abc import Iterable, Mapping
 from typing import Any, TypeAlias, cast
+from urllib.parse import urlsplit
 
 from openai import (
     AsyncOpenAI,
@@ -171,6 +172,131 @@ OpenAIChatMessages: TypeAlias = list[OpenAIChatMessage]
 OpenAIChatResponse: TypeAlias = ChatCompletion
 OpenAITool: TypeAlias = ChatCompletionToolParam
 
+_QWEN3_MAX_MODEL = "qwen/qwen3-max"
+_EXPLICIT_PROMPT_CACHE_HOSTS = frozenset({"openrouter.ai", "api.pinference.ai"})
+_PROMPT_CACHE_MARKERS = frozenset({"cache_control", "prompt_cache_breakpoint"})
+
+
+def _ephemeral_cache_control() -> dict[str, str]:
+    return {"type": "ephemeral"}
+
+
+def _uses_qwen3_max_explicit_prompt_cache(model: str, api_base_url: str | None) -> bool:
+    if model != _QWEN3_MAX_MODEL or not api_base_url:
+        return False
+
+    hostname = urlsplit(api_base_url).hostname
+    if hostname is None:
+        return False
+    return hostname.casefold() in _EXPLICIT_PROMPT_CACHE_HOSTS
+
+
+def _has_prompt_cache_marker(value: Mapping[str, Any]) -> bool:
+    return not _PROMPT_CACHE_MARKERS.isdisjoint(value)
+
+
+def _has_caller_prompt_cache_intent(
+    prompt: OpenAIChatMessages,
+    tools: list[OpenAITool] | None,
+    extra_body: Mapping[str, Any],
+) -> bool:
+    if _has_prompt_cache_marker(extra_body):
+        return True
+    for message in prompt:
+        if not isinstance(message, Mapping):
+            continue
+        if _has_prompt_cache_marker(message):
+            return True
+        content = message.get("content")
+        if isinstance(content, list) and any(
+            isinstance(part, Mapping) and _has_prompt_cache_marker(part)
+            for part in content
+        ):
+            return True
+    return bool(
+        tools
+        and any(
+            isinstance(tool, Mapping) and _has_prompt_cache_marker(tool)
+            for tool in tools
+        )
+    )
+
+
+def _with_cache_control_on_last_text(
+    message: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    content = message.get("content")
+    if isinstance(content, str):
+        if not content:
+            return None
+        updated_message = dict(message)
+        updated_message["content"] = [
+            {
+                "type": "text",
+                "text": content,
+                "cache_control": _ephemeral_cache_control(),
+            }
+        ]
+        return updated_message
+
+    if not isinstance(content, list):
+        return None
+    for part_index in range(len(content) - 1, -1, -1):
+        part = content[part_index]
+        if (
+            not isinstance(part, Mapping)
+            or part.get("type") != "text"
+            or not isinstance(part.get("text"), str)
+            or not part["text"]
+        ):
+            continue
+        updated_part = dict(part)
+        updated_part["cache_control"] = _ephemeral_cache_control()
+        updated_content = list(content)
+        updated_content[part_index] = updated_part
+        updated_message = dict(message)
+        updated_message["content"] = updated_content
+        return updated_message
+    return None
+
+
+def _with_cache_control_on_instruction_prefix(
+    prompt: OpenAIChatMessages,
+) -> OpenAIChatMessages:
+    instruction_prefix: list[tuple[int, Mapping[str, Any]]] = []
+    for message_index, message in enumerate(prompt):
+        if not isinstance(message, Mapping) or message.get("role") not in {
+            "system",
+            "developer",
+        }:
+            break
+        instruction_prefix.append((message_index, message))
+
+    for message_index, message in reversed(instruction_prefix):
+        updated_message = _with_cache_control_on_last_text(message)
+        if updated_message is None:
+            continue
+        updated_prompt = list(prompt)
+        updated_prompt[message_index] = cast(OpenAIChatMessage, updated_message)
+        return updated_prompt
+    return prompt
+
+
+def _with_cache_control_on_last_tool(
+    tools: list[OpenAITool] | None,
+) -> list[OpenAITool] | None:
+    if not tools:
+        return tools
+    last_tool = tools[-1]
+    if not isinstance(last_tool, Mapping) or last_tool.get("type") != "function":
+        return tools
+
+    updated_tool = dict(last_tool)
+    updated_tool["cache_control"] = _ephemeral_cache_control()
+    updated_tools = list(tools)
+    updated_tools[-1] = cast(OpenAITool, updated_tool)
+    return updated_tools
+
 
 class OpenAIChatCompletionsClient(
     Client[
@@ -278,13 +404,14 @@ class OpenAIChatCompletionsClient(
         tools: list[OpenAITool] | None = None,
         **kwargs,
     ) -> OpenAIChatResponse:
+        api_base_url = None
+        if hasattr(self.client, "base_url"):
+            api_base_url = str(self.client.base_url)
+        elif self._config is not None:
+            api_base_url = self._config.api_base_url
+
         def normalize_sampling_args(sampling_args: SamplingArgs):
             sampling_args = dict(sampling_args)
-            api_base_url = None
-            if hasattr(self.client, "base_url"):
-                api_base_url = str(self.client.base_url)
-            elif self._config is not None:
-                api_base_url = self._config.api_base_url
             reasoning_effort = sampling_args.pop("reasoning_effort", None)
             model_id = model.lower().split("/")[-1].replace(".", "-").replace("_", "-")
             is_anthropic_route = (
@@ -332,6 +459,14 @@ class OpenAIChatCompletionsClient(
         extra_headers = kwargs.pop("extra_headers", None)
         request_args = normalize_sampling_args(sampling_args)
         extra_body = request_args.pop("extra_body", {})
+
+        if _uses_qwen3_max_explicit_prompt_cache(
+            model, api_base_url
+        ) and not _has_caller_prompt_cache_intent(prompt, tools, extra_body):
+            # Alibaba's Qwen endpoint uses explicit Anthropic-style breakpoints.
+            # Only mark the reusable instruction/tool prefix; rollout turns are dynamic.
+            prompt = _with_cache_control_on_instruction_prefix(prompt)
+            tools = _with_cache_control_on_last_tool(tools)
 
         body: dict[str, Any] = {
             "model": model,


### PR DESCRIPTION
## Why this change is needed

Hosted Evals launches `prime eval run`, whose default inference path builds a non-streaming Chat Completions request in `OpenAIChatCompletionsClient`. Alibaba's `qwen/qwen3-max` endpoint does not create an explicit prompt cache from provider pinning alone: the request must contain block-level `cache_control: {"type": "ephemeral"}` breakpoints. See the [OpenRouter Alibaba Qwen caching contract](https://openrouter.ai/docs/guides/best-practices/prompt-caching#alibaba-qwen).

The inference gateway already preserves caller-authored markers. It should not infer stable prompt boundaries for heterogeneous clients. This client is the narrowest layer where the resolved model, destination API, final structured messages, and ordered tool definitions coexist immediately before the request is sent.

## What changes

For the exact `qwen/qwen3-max` model on the exact `openrouter.ai` or `api.pinference.ai` hosts, the default Chat Completions client now adds explicit cache breakpoints to:

- the final cacheable text block in the leading system/developer prefix;
- the final function tool, preserving tool order.

The transformation is copy-on-write. It does not mutate the rollout prompt or tool definitions, and it never marks the changing user/assistant rollout tail. This limits Alibaba's 1.25x cache-write premium to content expected to be reused across examples, parallel rollouts, and tool turns.

The generated marker is exactly `{"type": "ephemeral"}`. No `ttl` is sent because Alibaba supports a fixed five-minute cache, not Anthropic's optional one-hour retention.

Caller intent always wins: if `cache_control` or `prompt_cache_breakpoint` is already present at the request, message, direct content-block, or tool level, this client leaves the entire request unchanged. Tool parameter schemas containing a property named `cache_control` are not mistaken for cache directives.

## Scope and related changes

- [PrimeIntellect-ai/inference-iac#157](https://github.com/PrimeIntellect-ai/inference-iac/pull/157) controls provider locality and pins Qwen3-Max to Alibaba.
- [PrimeIntellect-ai/platform#4450](https://github.com/PrimeIntellect-ai/platform/pull/4450) locks the gateway passthrough contract for caller-authored Qwen markers.
- [PrimeIntellect-ai/platform#4447](https://github.com/PrimeIntellect-ai/platform/pull/4447) was closed because gateway-side breakpoint inference and `_pi_prompt_cache` route metadata put prompt policy at the wrong layer.

This PR intentionally covers the default Hosted Evals Chat Completions path. Explicit Responses, Anthropic Messages, renderer, native v1 proxy, and direct-SDK harness paths are separate request producers and are unchanged.

## Validation

- focused client tests: 22 passed;
- offline test suite: 926 passed, 75 API/e2e tests deselected;
- Ruff: passed;
- Python 3.13 type check: passed;
- all pre-commit hooks relevant to the changed Python files passed. The all-files run still reports 321 pre-existing MD033 inline-HTML findings in the untouched legacy SWE README.

No paid inference APIs were called.

## Rollout

After merge, publish a `verifiers` release and ensure Hosted Evals resolves that release. The hosted runner currently installs an upgraded version satisfying the environment's `verifiers` requirement; exact older pins are intentionally preserved and will not receive this behavior. Post-deploy, verify two back-to-back requests with an identical marked static prefix and require the second response to report nonzero cached prompt tokens.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 93a9b8a239375f86353248a245c9cf4a59ba7994. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add automatic prompt cache markers for `qwen/qwen3-max` on hosted eval gateways
> - When the model is `qwen/qwen3-max` and the API base URL is `openrouter.ai` or `api.pinference.ai`, `OpenAIChatCompletionsClient.get_native_response` now auto-inserts `cache_control={'type': 'ephemeral'}` on the last text segment of the final leading system/developer message and on the last function tool.
> - Auto-insertion is skipped if the caller has already supplied any `cache_control` or `prompt_cache_breakpoint` markers in the prompt, tools, or `extra_body`.
> - New utility helpers in [openai_chat_completions_client.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2404/files#diff-687c2124e93bc3b7a864e3fa533d29c4ff552e54e00ffb55f7056fbb13d0ae11) handle detection and mutation of cache markers without mutating caller-owned objects.
> - Behavioral Change: requests for `qwen/qwen3-max` on the listed hosts will now include prompt cache markers by default unless the caller opts out by providing their own markers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 93a9b8a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->