### PR TITLE
Increase default connect timeout to 30 seconds

### DIFF
--- a/verifiers/v1/clients/base.py
+++ b/verifiers/v1/clients/base.py
@@ -9,7 +9,7 @@ from verifiers.v1.configs.client import BaseClientConfig, resolve_api_key
 
 # No read timeout: agentic completions are slow and the rollout timeout is the real
 # backstop. The connect bound stays so an unreachable endpoint still fails fast.
-DEFAULT_TIMEOUT = httpx.Timeout(connect=5.0, read=None, write=None, pool=None)
+DEFAULT_TIMEOUT = httpx.Timeout(connect=30.0, read=None, write=None, pool=None)
 DEFAULT_LIMITS = httpx.Limits(max_connections=1000, max_keepalive_connections=100)
 MAX_RETRIES = 0
 """No client-side retries: failures surface to the harness SDK and the trace instead of


### PR DESCRIPTION
## What changed

- Increase the default HTTP client connection timeout from 5 seconds to 30 seconds.

## Why

A 5-second connection timeout is too aggressive when connection establishment is temporarily slow. The longer default allows transient connection delays to recover without changing the existing overall request timeout.

## Impact

HTTP clients now wait up to 30 seconds to establish a connection by default. Explicitly configured connection timeouts continue to override the default.

## Validation

- Ruff and formatting checks passed.
- Type checks passed.
- Verified the runtime default resolves to 30 seconds.
