### PR TITLE
Keep the Modal sandbox handle when a create is interrupted

### DIFF
--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -155,7 +155,32 @@ class ModalRuntime(Runtime):
         except (
             Exception
         ) as e:  # provisioning failure is one rollout's problem, not the eval's
+            await self._adopt_orphan()
             raise SandboxError(f"modal sandbox provisioning failed: {e}") from e
+        except BaseException:  # cancellation, which is not an Exception
+            await self._adopt_orphan()
+            raise
+
+    async def _adopt_orphan(self) -> None:
+        """Reclaim a sandbox whose `create` did not live long enough to hand back a handle.
+
+        Modal commits the sandbox and schedules it before `Sandbox.create` responds, so a
+        create that does not return — Ctrl-C, a cancelled rollout, a connection dropped on
+        the reply — still boots and bills a sandbox, about a second after the caller stopped
+        waiting for it. `_sandbox` was never assigned, so neither `teardown` nor the atexit
+        backstop can see it and it runs to its 24h maximum lifetime. The name is ours and
+        unique per rollout, so the sandbox is still addressable: claim it here and the
+        owner's `stop` disposes of it like any other. Best effort — this runs while `start`
+        is already unwinding, usually from a cancellation, hence the shield.
+        """
+        if self._sandbox is not None:
+            return
+        import modal
+
+        with contextlib.suppress(Exception):
+            self._sandbox = await asyncio.shield(
+                modal.Sandbox.from_name.aio(_APP_NAME, self.name)
+            )
 
     async def expose(self, port: int) -> str | None:
         # Publish a server hosted IN the sandbox: Modal forwards `port` (named via

--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -27,6 +27,7 @@ from verifiers.v1.runtimes.base import (
     RuntimeProcess,
 )
 from verifiers.v1.runtimes.limiters import creation_limiter
+from verifiers.v1.utils.aio import run_shielded
 
 logger = logging.getLogger(__name__)
 
@@ -128,25 +129,7 @@ class ModalRuntime(Runtime):
                 creation_limiter(self.config.creates_per_sec, "modal-sandbox")
                 or contextlib.nullcontext()
             ):
-                self._sandbox = await modal.Sandbox.create.aio(
-                    "sleep",
-                    "infinity",  # keep-alive entrypoint; the harness runs via `exec`
-                    app=app,
-                    name=self.name,
-                    # Clear the image's ENTRYPOINT so `sleep infinity` runs as the command
-                    # rather than as args to it — otherwise an image with its own entrypoint
-                    # (e.g. SWE task images) never starts the keep-alive and the sandbox dies.
-                    image=modal.Image.from_registry(self.config.image).entrypoint([]),
-                    workdir=self.config.workdir,
-                    env=self.env,
-                    cpu=self.config.cpu,
-                    memory=int(self.config.memory * 1024),  # Modal memory is MB
-                    gpu=self.config.gpu,
-                    region=self.config.region,
-                    block_network=not self.config.network_access,
-                    timeout=24 * 60 * 60,  # Maximum lifetime of any sandbox.
-                    encrypted_ports=[SERVICE_PORT],
-                )
+                await run_shielded(self._create_sandbox(app))
             self.info.id = self._sandbox.object_id
             logger.info(
                 "modal: sandbox %s up (image=%s)", self.info.id, self.config.image
@@ -155,32 +138,38 @@ class ModalRuntime(Runtime):
         except (
             Exception
         ) as e:  # provisioning failure is one rollout's problem, not the eval's
-            await self._adopt_orphan()
             raise SandboxError(f"modal sandbox provisioning failed: {e}") from e
-        except BaseException:  # cancellation, which is not an Exception
-            await self._adopt_orphan()
-            raise
 
-    async def _adopt_orphan(self) -> None:
-        """Reclaim a sandbox whose `create` did not live long enough to hand back a handle.
+    async def _create_sandbox(self, app) -> None:
+        """Create the sandbox and take ownership of the handle, as one shielded step.
 
-        Modal commits the sandbox and schedules it before `Sandbox.create` responds, so a
-        create that does not return — Ctrl-C, a cancelled rollout, a connection dropped on
-        the reply — still boots and bills a sandbox, about a second after the caller stopped
-        waiting for it. `_sandbox` was never assigned, so neither `teardown` nor the atexit
-        backstop can see it and it runs to its 24h maximum lifetime. The name is ours and
-        unique per rollout, so the sandbox is still addressable: claim it here and the
-        owner's `stop` disposes of it like any other. Best effort — this runs while `start`
-        is already unwinding, usually from a cancellation, hence the shield.
+        Modal schedules the sandbox before `Sandbox.create` returns, so a cancellation
+        landing between those two points leaves a sandbox that boots and bills with
+        `_sandbox` still unset — invisible to both `teardown` and the atexit backstop, and
+        alive until its 24h maximum lifetime. Assigning inside the coroutine that
+        `run_shielded` owns keeps the cancellation pending until the handle is ours.
         """
-        if self._sandbox is not None:
-            return
         import modal
 
-        with contextlib.suppress(Exception):
-            self._sandbox = await asyncio.shield(
-                modal.Sandbox.from_name.aio(_APP_NAME, self.name)
-            )
+        self._sandbox = await modal.Sandbox.create.aio(
+            "sleep",
+            "infinity",  # keep-alive entrypoint; the harness runs via `exec`
+            app=app,
+            name=self.name,
+            # Clear the image's ENTRYPOINT so `sleep infinity` runs as the command rather
+            # than as args to it — otherwise an image with its own entrypoint (e.g. SWE
+            # task images) never starts the keep-alive and the sandbox dies.
+            image=modal.Image.from_registry(self.config.image).entrypoint([]),
+            workdir=self.config.workdir,
+            env=self.env,
+            cpu=self.config.cpu,
+            memory=int(self.config.memory * 1024),  # Modal memory is MB
+            gpu=self.config.gpu,
+            region=self.config.region,
+            block_network=not self.config.network_access,
+            timeout=24 * 60 * 60,  # Maximum lifetime of any sandbox.
+            encrypted_ports=[SERVICE_PORT],
+        )
 
     async def expose(self, port: int) -> str | None:
         # Publish a server hosted IN the sandbox: Modal forwards `port` (named via


### PR DESCRIPTION
## Symptom

Interrupt an eval that uses the Modal runtime while sandboxes are still being provisioned, and more sandboxes stay alive than the harness ever reports as up. They then run until their 24h `timeout` expires.

## Cause

Modal commits the sandbox and hands it to the scheduler **before** `Sandbox.create` returns, so a create interrupted in flight still leaves a running, billed sandbox. In `ModalRuntime.start` the handle is only assigned once the call returns:

```python
self._sandbox = await modal.Sandbox.create.aio(...)   # interrupted here
```

`_sandbox` stays `None`, and both cleanup paths key off exactly that attribute — `teardown` returns early and the `cleanup` atexit backstop no-ops. The sandbox is unreachable from the process that made it. `CancelledError` is not an `Exception`, so it also slips past `except Exception` in `start` and leaves no log line, which is why the "sandbox ... up" count doesn't match what is actually running.

## Fix

Move the create and the `self._sandbox` assignment into a coroutine owned by `run_shielded`. The handle is installed before the cancellation is re-raised, so teardown always has something to terminate.

A second Ctrl-C still exits immediately — `KeyboardInterrupt` leaves the event loop and no task-level shield can absorb it. That is deliberate: an interrupt repeated should not block on a network round-trip. The residue there is an `idle_timeout` question, not a shielding one.

## Verification

Real Modal sandboxes, 12 rollouts started concurrently, the batch cancelled mid-create, then every runtime stopped exactly as the owner's `finally` does. `LEAKED` is measured with `Sandbox.list` against the app, not inferred:

```
main    interrupted=12  no_handle=11  LEAKED=10
main    interrupted=12  no_handle=12  LEAKED=12

fix     interrupted=12  no_handle=0   LEAKED=0
fix     interrupted=12  no_handle=0   LEAKED=0
```

Cancelling outside the create window is unaffected. `uv run ruff check`, `uv run ruff format --check` and `uv run ty check verifiers` all pass. No tests added, per `AGENTS.md` — the check above was a temporary script.

## Two notes for maintainers, not changed here

- **`ModalConfig.creates_per_sec` defaults to 40.0.** Modal's default per-workspace sandbox creation limit is 5/s with a 150-token burst bucket, so this default is 8× over for a workspace that has not had its limit raised. Creates then retry with backoff, which keeps them in flight longer and widens the window this PR closes. Worth either lowering the default or documenting that the limit needs raising.
- **`Sandbox.create` accepts `idle_timeout`.** It is the only cleanup that survives losing the client entirely — a hard kill, or a second Ctrl-C. Currently only `timeout=24h` is set, so anything the process cannot clean up lives for a day.

Disclosure: I work at Modal. This came out of debugging a leak with a user running verifiers on us.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Shield `ModalRuntime.start` sandbox creation from cancellation
> Wraps the Modal `Sandbox.create` call in `run_shielded` via a new `_create_sandbox` helper, so the sandbox handle is stored on `self._sandbox` before any cancellation can propagate. This prevents scheduled sandboxes from being left without a handle that the teardown paths can terminate. All existing creation options (command, image, resources, networking, timeout, ports, env, name, working dir) are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bb662cd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->