### PR TITLE
feat: add search_mixedbread web-search tool to bash harness

### DIFF
--- a/verifiers/v1/harnesses/bash/harness.py
+++ b/verifiers/v1/harnesses/bash/harness.py
@@ -26,6 +26,14 @@ SEARCH_PROMPT = (
     "use it to research, and use bash (e.g. curl) to read result pages in full when needed."
 )
 
+# Appended when search_mixedbread is enabled, so the model knows the extra tool exists.
+MIXEDBREAD_PROMPT = (
+    "You also have a search_mixedbread tool that searches the web via Mixedbread (mixedbread/web "
+    "web store) and returns title, URL, relevance score, and page content (a large chunk of each "
+    "page's text, often the whole page for short pages); use it to research, and use bash "
+    "(e.g. curl) to read result pages in full when needed."
+)
+
 
 class BashHarnessConfig(HarnessConfig):
     edit: bool = True
@@ -36,6 +44,11 @@ class BashHarnessConfig(HarnessConfig):
     """Offer a `search` tool (Google web results via serper.dev). Requires `SERPER_API_KEY` in the
     eval environment; the key is handed to the program over argv (like the interception secret) so
     the agent's `bash` subprocesses don't inherit it."""
+
+    search_mixedbread: bool = False
+    """Offer a `search_mixedbread` tool (Mixedbread Basic Web Search, web store `mixedbread/web`).
+    Requires `MIXEDBREAD_API_KEY` in the eval environment; the key is handed to the program over
+    argv (like the Serper key) so the agent's `bash` subprocesses don't inherit it."""
 
 
 class BashHarness(Harness[BashHarnessConfig]):
@@ -65,6 +78,8 @@ class BashHarness(Harness[BashHarnessConfig]):
             fragments.append(EDIT_SYSTEM_PROMPT)
         if self.config.search:
             fragments.append(SEARCH_PROMPT)
+        if self.config.search_mixedbread:
+            fragments.append(MIXEDBREAD_PROMPT)
         system_prompt = "\n\n".join(
             p for p in (" ".join(fragments), system_prompt) if p
         )
@@ -97,6 +112,19 @@ class BashHarness(Harness[BashHarnessConfig]):
                     "(the host env or the harness config's env)"
                 )
             args += ["--search", f"--serper-key={serper_key}"]
+        if self.config.search_mixedbread:
+            # Same secret hygiene as the Serper key above: the Mixedbread key is popped from the
+            # program env and handed over argv (--mixedbread-key) so the agent's `bash`
+            # subprocesses never inherit it via $MIXEDBREAD_API_KEY / /proc/self/environ.
+            mixedbread_key = env.pop("MIXEDBREAD_API_KEY", None)
+            if mixedbread_key is None:
+                mixedbread_key = os.environ.get("MIXEDBREAD_API_KEY")
+            if not mixedbread_key:
+                raise ValueError(
+                    "bash search_mixedbread=true requires MIXEDBREAD_API_KEY in the eval "
+                    "environment (the host env or the harness config's env)"
+                )
+            args += ["--mixedbread-search", f"--mixedbread-key={mixedbread_key}"]
         if mcp_urls:
             # The program connects to the tool servers over HTTP; hand it a standard
             # `mcpServers` URL config (the `mcp` client itself comes from the uv deps).

--- a/verifiers/v1/harnesses/bash/program.py
+++ b/verifiers/v1/harnesses/bash/program.py
@@ -16,6 +16,7 @@ from openai import AsyncOpenAI
 from tenacity import AsyncRetrying, stop_after_attempt, wait_exponential_jitter
 
 SERPER_URL = "https://google.serper.dev/search"
+MIXEDBREAD_URL = "https://api.mixedbread.com/v1/stores/search"
 
 MCP_CALL_ATTEMPTS = 6
 MCP_TIMEOUT = 600.0
@@ -86,6 +87,33 @@ SEARCH_TOOL = {
 }
 
 
+SEARCH_MIXEDBREAD_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "search_mixedbread",
+        "description": (
+            "Run a web search via Mixedbread's web store (store identifier \"mixedbread/web\", "
+            "Basic Web Search) and return the top results as title, URL, relevance score, and "
+            "page content (a large chunk of each page's text, often the whole page for short "
+            "pages). Results are always reranked for relevance. Issue focused queries and call it "
+            "several times to cover different angles; each query returns the most relevant chunk "
+            "of a page, so re-query to see other parts of a long page."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "The search query."},
+                "num_results": {
+                    "type": "integer",
+                    "description": "Number of results to return (default 5, maps to top_k).",
+                },
+            },
+            "required": ["query"],
+        },
+    },
+}
+
+
 def format_results(results, query: str) -> str:
     """Format Serper organic results as title/URL/snippet blocks."""
     sections = []
@@ -131,6 +159,61 @@ def run_search(query: str, api_key: str, num_results: int = 5) -> str:
         return format_results(organic[:num_results], query)
     except Exception as e:  # noqa: BLE001 - tool failures are returned to the model
         return f"search failed ({e}). Try again or rephrase the query."
+
+
+def format_mixedbread_results(chunks, query: str) -> str:
+    """Format Mixedbread web-store chunks as title/URL/score/content blocks."""
+    sections = []
+    for i, chunk in enumerate(chunks, 1):
+        if not isinstance(chunk, dict):
+            continue
+        metadata = chunk.get("metadata") or {}
+        title = (metadata.get("title") or "").strip() or "Untitled"
+        url = (metadata.get("url") or chunk.get("filename") or "").strip()
+        lines = [f"Result {i}: {title}"]
+        if url:
+            lines.append(f"URL: {url}")
+        score = chunk.get("score")
+        if score is not None:
+            lines.append(f"Score: {score}")
+        text = (chunk.get("text") or "").strip()
+        if text:
+            lines.append(f"Content: {text}")
+        sections.append("\n".join(lines))
+    if not sections:
+        return f"No results returned for query: {query}"
+    return "\n\n---\n\n".join(sections)
+
+
+def run_mixedbread_search(query: str, api_key: str, num_results: int = 5) -> str:
+    """Mixedbread Basic Web Search (store identifier `mixedbread/web`) -> formatted chunks.
+
+    The key arrives as an argument (handed in by the harness over argv, like the Serper key and
+    the interception secret) instead of from `$MIXEDBREAD_API_KEY`, so the agent's `bash`
+    subprocesses never inherit it. The whole call is wrapped so a bad query or malformed payload
+    becomes a tool error rather than raising out of the chat loop and killing the rollout."""
+    if not api_key:
+        return "Error: no Mixedbread API key (MIXEDBREAD_API_KEY was not set in the eval environment)"
+    try:
+        num_results = max(1, int(num_results))
+    except (TypeError, ValueError):
+        num_results = 5
+    try:
+        response = httpx.post(
+            MIXEDBREAD_URL,
+            json={
+                "query": query,
+                "store_identifiers": ["mixedbread/web"],
+                "top_k": num_results,
+            },
+            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+            timeout=45,
+        )
+        response.raise_for_status()
+        chunks = response.json().get("data") or []
+        return format_mixedbread_results(chunks[:num_results], query)
+    except Exception as e:  # noqa: BLE001 - tool failures are returned to the model
+        return f"search_mixedbread failed ({e}). Try again or rephrase the query."
 
 
 def run_bash(command: str) -> str:
@@ -331,6 +414,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--edit", action="store_true")
     parser.add_argument("--search", action="store_true")
     parser.add_argument("--serper-key", default="")
+    parser.add_argument("--mixedbread-search", action="store_true")
+    parser.add_argument("--mixedbread-key", default="")
     return parser.parse_args()
 
 
@@ -357,6 +442,9 @@ async def main() -> None:
     if args.search:
         tools.append(SEARCH_TOOL)
         reserved.add("search")
+    if args.mixedbread_search:
+        tools.append(SEARCH_MIXEDBREAD_TOOL)
+        reserved.add("search_mixedbread")
     mcp_tools, dispatch, servers = (
         await connect_mcp(config, reserved)
         if config.get("mcpServers")
@@ -423,6 +511,13 @@ async def main() -> None:
                         run_search,
                         tool_args.get("query", ""),
                         args.serper_key,
+                        tool_args.get("num_results", 5),
+                    )
+                elif name == "search_mixedbread" and args.mixedbread_search:
+                    content = await asyncio.to_thread(
+                        run_mixedbread_search,
+                        tool_args.get("query", ""),
+                        args.mixedbread_key,
                         tool_args.get("num_results", 5),
                     )
                 else:


### PR DESCRIPTION
## Summary

Adds a `search_mixedbread` web-search tool to the bash harness, alongside the existing Serper `search` tool. It performs **Mixedbread Basic Web Search** (`POST https://api.mixedbread.com/v1/stores/search` with `store_identifiers: ["mixedbread/web"]`) and returns each result as title, URL, relevance score, and the **page-content chunk text** (a large chunk of the page — often the whole page for short pages — not just a snippet).

## Changes

- `verifiers/v1/harnesses/bash/program.py`:
  - `SEARCH_MIXEDBREAD_TOOL` schema (name: `search_mixedbread`, params: `query`, `num_results` → `top_k`)
  - `run_mixedbread_search()` — POSTs to Mixedbread with `Authorization: Bearer`, wraps failures as tool errors
  - `format_mixedbread_results()` — title / URL / score / full content text per result
  - `--mixedbread-search` / `--mixedbread-key` argv plumbing + dispatch
- `verifiers/v1/harnesses/bash/harness.py`:
  - New `search_mixedbread: bool = False` config flag
  - `MIXEDBREAD_PROMPT` system-prompt fragment
  - Key resolution: `MIXEDBREAD_API_KEY` is popped from the program env and handed over argv (same secret hygiene as the Serper key), so the agent's `bash` subprocesses never inherit it

## Enable

```
--harness.search_mixedbread true   # + MIXEDBREAD_API_KEY in the eval environment
```

## Verified

- Live-tested against the real API with a key: returns title/URL/score/full content (e.g. a Wikipedia page returned ~5.6K chars of page content; a Substack article ~6K chars)
- Follow-up "full content" endpoints (`list-chunks`, `files.retrieve`, `grep`) return 404 for the web store — the search response's `text` field is the full content surface
- `ruff` clean; harness config tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 03208599a5fcae81ab05442df23d714866a2ebc9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `search_mixedbread` web-search tool to `BashHarness`
> - Adds a `search_mixedbread: bool` flag to `BashHarnessConfig` that enables a Mixedbread Basic Web Search tool, requiring `MIXEDBREAD_API_KEY` in the program environment.
> - Implements the tool in [program.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2407/files#diff-d4cd8c8ecce1607fa0d58ad9d6be1b24a81ace7b7dd85521910d4082319a2400): `run_mixedbread_search` calls the Mixedbread API via `httpx.post`, formats results with `format_mixedbread_results`, and returns error strings instead of raising.
> - Passes `--mixedbread-search` and `--mixedbread-key` to the program and appends `MIXEDBREAD_PROMPT` to the system prompt when the flag is enabled, mirroring the existing Serper search pattern.
> - Behavioral Change: when `search_mixedbread` is enabled but `MIXEDBREAD_API_KEY` is missing, the harness raises `ValueError` at program launch; without the flag the tool is entirely unavailable.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 0320859. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->