### PR TITLE
Share Prime sandbox clients across concurrent runtimes

### DIFF
--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -18,7 +18,7 @@ from typing import Any, ClassVar, Literal
 from urllib.parse import urlsplit
 
 from prime_sandboxes.models import validate_egress_lists
-from pydantic import BaseModel, Field, InstanceOf, model_validator
+from pydantic import BaseModel, Field, model_validator
 
 from verifiers.v1.configs.runtime import NetworkPolicyConfig
 from verifiers.v1.errors import SandboxError
@@ -44,7 +44,6 @@ BASE_LABELS: list[str] = []
 
 
 class PrimeClientPool(BaseModel):
-    loop: InstanceOf[asyncio.AbstractEventLoop]
     client: Any
     leases: int = 0
 
@@ -155,7 +154,6 @@ class PrimeRuntime(Runtime):
         self.config = config
         self.info = PrimeRuntimeInfo(**config.model_dump())
         self._client = None
-        self.client_pool: PrimeClientPool | None = None
 
     @property
     def supports_live_processes(self) -> bool:
@@ -169,13 +167,11 @@ class PrimeRuntime(Runtime):
         from prime_sandboxes import AsyncSandboxClient, CreateSandboxRequest
 
         loop = asyncio.get_running_loop()
-        client_pool = client_pools.get(loop)
-        if client_pool is None:
-            client_pool = PrimeClientPool(loop=loop, client=AsyncSandboxClient())
-            client_pools[loop] = client_pool
-        client_pool.leases += 1
-        self.client_pool = client_pool
-        self._client = client_pool.client
+        pool = client_pools.get(loop)
+        if pool is None:
+            pool = client_pools[loop] = PrimeClientPool(client=AsyncSandboxClient())
+        pool.leases += 1
+        self._client = pool.client
         # Map the resources onto prime's API (minutes, split GPU; memory/disk are already
         # GB). gpu_type/region are only sent when set (else provider-chosen).
         gpu_type, gpu_count = parse_gpu(self.config.gpu)
@@ -415,21 +411,18 @@ class PrimeRuntime(Runtime):
         # Best-effort, idempotent teardown: delete the sandbox (the costly resource). Runs via
         # `stop`, shielded from cancellation, so it fires on success, error, and Ctrl-C.
         client, self._client = self._client, None  # `_client` is the idempotency guard
-        client_pool, self.client_pool = self.client_pool, None
         if client is None:
             return
-        assert client_pool is not None
+        loop = asyncio.get_running_loop()
+        pool = client_pools[loop]
         try:
             if self.info.id is not None:  # keep info.id available after teardown
-                try:
-                    await client.delete(self.info.id)
-                except Exception as e:  # noqa: BLE001 - provider teardown is best-effort
-                    logger.warning(
-                        "prime: failed to delete sandbox %s: %s", self.info.id, e
-                    )
+                await client.delete(self.info.id)
+        except Exception as e:  # noqa: BLE001 - provider teardown is best-effort
+            logger.warning("prime: failed to delete sandbox %s: %s", self.info.id, e)
         finally:
-            client_pool.leases -= 1
-            if client_pool.leases == 0:
-                del client_pools[client_pool.loop]
+            pool.leases -= 1
+            if not pool.leases:
+                del client_pools[loop]
                 with contextlib.suppress(Exception):
                     await client.aclose()

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -46,12 +46,12 @@ BASE_LABELS: list[str] = []
 class PrimeClientPool(BaseModel):
     loop: InstanceOf[asyncio.AbstractEventLoop]
     client: Any
-    users: int = 0
+    leases: int = 0
 
 
 # The SDK batches concurrent status polls per client. One client per event loop lets
 # every runtime share that batcher while keeping the client's tasks on their owning loop.
-clientPools: dict[asyncio.AbstractEventLoop, PrimeClientPool] = {}
+client_pools: dict[asyncio.AbstractEventLoop, PrimeClientPool] = {}
 
 
 def set_base_sandbox_labels(labels: list[str]) -> None:
@@ -155,7 +155,7 @@ class PrimeRuntime(Runtime):
         self.config = config
         self.info = PrimeRuntimeInfo(**config.model_dump())
         self._client = None
-        self.clientPool: PrimeClientPool | None = None
+        self.client_pool: PrimeClientPool | None = None
 
     @property
     def supports_live_processes(self) -> bool:
@@ -169,13 +169,13 @@ class PrimeRuntime(Runtime):
         from prime_sandboxes import AsyncSandboxClient, CreateSandboxRequest
 
         loop = asyncio.get_running_loop()
-        clientPool = clientPools.get(loop)
-        if clientPool is None:
-            clientPool = PrimeClientPool(loop=loop, client=AsyncSandboxClient())
-            clientPools[loop] = clientPool
-        clientPool.users += 1
-        self.clientPool = clientPool
-        self._client = clientPool.client
+        client_pool = client_pools.get(loop)
+        if client_pool is None:
+            client_pool = PrimeClientPool(loop=loop, client=AsyncSandboxClient())
+            client_pools[loop] = client_pool
+        client_pool.leases += 1
+        self.client_pool = client_pool
+        self._client = client_pool.client
         # Map the resources onto prime's API (minutes, split GPU; memory/disk are already
         # GB). gpu_type/region are only sent when set (else provider-chosen).
         gpu_type, gpu_count = parse_gpu(self.config.gpu)
@@ -415,10 +415,10 @@ class PrimeRuntime(Runtime):
         # Best-effort, idempotent teardown: delete the sandbox (the costly resource). Runs via
         # `stop`, shielded from cancellation, so it fires on success, error, and Ctrl-C.
         client, self._client = self._client, None  # `_client` is the idempotency guard
-        clientPool, self.clientPool = self.clientPool, None
+        client_pool, self.client_pool = self.client_pool, None
         if client is None:
             return
-        assert clientPool is not None
+        assert client_pool is not None
         try:
             if self.info.id is not None:  # keep info.id available after teardown
                 try:
@@ -428,8 +428,8 @@ class PrimeRuntime(Runtime):
                         "prime: failed to delete sandbox %s: %s", self.info.id, e
                     )
         finally:
-            clientPool.users -= 1
-            if clientPool.users == 0:
-                del clientPools[clientPool.loop]
+            client_pool.leases -= 1
+            if client_pool.leases == 0:
+                del client_pools[client_pool.loop]
                 with contextlib.suppress(Exception):
                     await client.aclose()

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -14,11 +14,11 @@ import shlex
 import tempfile
 from collections.abc import AsyncIterator
 from pathlib import Path, PurePosixPath
-from typing import ClassVar, Literal
+from typing import Any, ClassVar, Literal
 from urllib.parse import urlsplit
 
 from prime_sandboxes.models import validate_egress_lists
-from pydantic import Field, model_validator
+from pydantic import BaseModel, Field, InstanceOf, model_validator
 
 from verifiers.v1.configs.runtime import NetworkPolicyConfig
 from verifiers.v1.errors import SandboxError
@@ -41,6 +41,17 @@ MAX_LIFETIME = 24 * 60 * 60
 
 
 BASE_LABELS: list[str] = []
+
+
+class PrimeClientPool(BaseModel):
+    loop: InstanceOf[asyncio.AbstractEventLoop]
+    client: Any
+    users: int = 0
+
+
+# The SDK batches concurrent status polls per client. One client per event loop lets
+# every runtime share that batcher while keeping the client's tasks on their owning loop.
+clientPools: dict[asyncio.AbstractEventLoop, PrimeClientPool] = {}
 
 
 def set_base_sandbox_labels(labels: list[str]) -> None:
@@ -144,6 +155,7 @@ class PrimeRuntime(Runtime):
         self.config = config
         self.info = PrimeRuntimeInfo(**config.model_dump())
         self._client = None
+        self.clientPool: PrimeClientPool | None = None
 
     @property
     def supports_live_processes(self) -> bool:
@@ -156,7 +168,14 @@ class PrimeRuntime(Runtime):
     async def start(self) -> None:
         from prime_sandboxes import AsyncSandboxClient, CreateSandboxRequest
 
-        self._client = AsyncSandboxClient()
+        loop = asyncio.get_running_loop()
+        clientPool = clientPools.get(loop)
+        if clientPool is None:
+            clientPool = PrimeClientPool(loop=loop, client=AsyncSandboxClient())
+            clientPools[loop] = clientPool
+        clientPool.users += 1
+        self.clientPool = clientPool
+        self._client = clientPool.client
         # Map the resources onto prime's API (minutes, split GPU; memory/disk are already
         # GB). gpu_type/region are only sent when set (else provider-chosen).
         gpu_type, gpu_count = parse_gpu(self.config.gpu)
@@ -396,14 +415,21 @@ class PrimeRuntime(Runtime):
         # Best-effort, idempotent teardown: delete the sandbox (the costly resource). Runs via
         # `stop`, shielded from cancellation, so it fires on success, error, and Ctrl-C.
         client, self._client = self._client, None  # `_client` is the idempotency guard
+        clientPool, self.clientPool = self.clientPool, None
         if client is None:
             return
-        if self.info.id is not None:  # keep info.id available after teardown
-            try:
-                await client.delete(self.info.id)
-            except Exception as e:  # noqa: BLE001 - provider teardown is best-effort
-                logger.warning(
-                    "prime: failed to delete sandbox %s: %s", self.info.id, e
-                )
-        with contextlib.suppress(Exception):
-            await client.aclose()
+        assert clientPool is not None
+        try:
+            if self.info.id is not None:  # keep info.id available after teardown
+                try:
+                    await client.delete(self.info.id)
+                except Exception as e:  # noqa: BLE001 - provider teardown is best-effort
+                    logger.warning(
+                        "prime: failed to delete sandbox %s: %s", self.info.id, e
+                    )
+        finally:
+            clientPool.users -= 1
+            if clientPool.users == 0:
+                del clientPools[clientPool.loop]
+                with contextlib.suppress(Exception):
+                    await client.aclose()


### PR DESCRIPTION
## Overview

Share one Prime Sandboxes async client across active Prime runtimes on the same event loop. This lets the SDK coalesce concurrent sandbox and background-job status polls into its bounded batch requests.

## Details

- Add an event-loop-scoped, reference-counted `PrimeClientPool`.
- Lease the shared client during runtime startup while preserving each sandbox's independent lifecycle.
- Release the lease during teardown and close the client when the final runtime exits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared client lifecycle and teardown for remote sandboxes. Incorrect lease counting or loop-keyed global state could close a client too early or leak it.
> 
> **Overview**
> Shares one Prime `AsyncSandboxClient` across concurrent `PrimeRuntime`s on the same event loop so the SDK can batch status polls.
> 
> Adds a reference-counted `PrimeClientPool`. `start` leases the loop’s client instead of creating a new one; `teardown` still deletes each sandbox independently, then drops the lease and `aclose`s only when the last runtime on that loop exits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7661ba728db7c34ac1df9ce5956d4b5ce2c31100. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Share `AsyncSandboxClient` across `PrimeRuntime` instances per event loop
> - Introduces `PrimeClientPool` and a `client_pools` dict mapping `asyncio` event loops to shared `AsyncSandboxClient` instances and lease counts.
> - `PrimeRuntime.start` now reuses an existing client for the current event loop or creates a new one, incrementing the pool's lease counter.
> - `PrimeRuntime.teardown` decrements the lease counter and only calls `client.aclose()` when the last runtime on that loop tears down.
> - Risk: `PrimeRuntime.teardown` no longer unconditionally closes the client; incorrect lease tracking could leak or prematurely close `AsyncSandboxClient` instances.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7661ba7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->