### PR TITLE
feat: default prime sandboxes to no lifetime timeout

### DIFF
--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -36,10 +36,6 @@ from verifiers.v1.utils.prime import ensure_prime_auth
 
 logger = logging.getLogger(__name__)
 
-MAX_LIFETIME = 24 * 60 * 60
-"""Prime's fixed cap (seconds) on any sandbox's total lifetime."""
-
-
 BASE_LABELS: list[str] = []
 
 
@@ -77,6 +73,9 @@ class PrimeConfig(NetworkPolicyConfig):
     """GPU spec, e.g. "A100" or "A100:2" (a bare count = provider-chosen type)."""
     disk: float = 5.0
     """Disk in GB."""
+    timeout: float | None = None
+    """Seconds until the sandbox is deleted regardless of activity (None disables;
+    only VM sandboxes support running without a lifetime limit)."""
     idle_timeout: float | None = 3600
     """Seconds of inactivity before the sandbox self-deletes (None disables)."""
     creates_per_min: int | None = None
@@ -101,11 +100,20 @@ class PrimeConfig(NetworkPolicyConfig):
         return self
 
     @model_validator(mode="after")
-    def _validate_idle_timeout(self) -> "PrimeConfig":
-        if self.idle_timeout is not None and self.idle_timeout > MAX_LIFETIME:
+    def _validate_timeouts(self) -> "PrimeConfig":
+        if self.timeout is None and not self.vm:
+            raise ValueError(
+                "container sandboxes (vm=false) require a lifetime timeout - "
+                "running without one is only supported for VM sandboxes"
+            )
+        if (
+            self.timeout is not None
+            and self.idle_timeout is not None
+            and self.idle_timeout > self.timeout
+        ):
             raise ValueError(
                 f"idle_timeout ({self.idle_timeout}s) must not exceed the "
-                f"{MAX_LIFETIME}s ({MAX_LIFETIME // 3600}h) max sandbox lifetime"
+                f"sandbox lifetime timeout ({self.timeout}s)"
             )
         return self
 
@@ -160,8 +168,13 @@ class PrimeRuntime(Runtime):
         # Map the resources onto prime's API (minutes, split GPU; memory/disk are already
         # GB). gpu_type/region are only sent when set (else provider-chosen).
         gpu_type, gpu_count = parse_gpu(self.config.gpu)
-        # prime's idle timeout is in whole minutes; convert from the seconds config surface
-        # (floored to the SDK's 1-minute minimum).
+        # prime's timeouts are in whole minutes; convert from the seconds config surface
+        # (raised to the SDK's 1-minute minimum). A negative lifetime means no limit.
+        lifetime_minutes = (
+            max(1, math.ceil(self.config.timeout / 60))
+            if self.config.timeout is not None
+            else -1
+        )
         idle_minutes = (
             max(1, math.ceil(self.config.idle_timeout / 60))
             if self.config.idle_timeout is not None
@@ -172,7 +185,7 @@ class PrimeRuntime(Runtime):
             "memory_gb": self.config.memory,
             "disk_size_gb": self.config.disk,
             "gpu_count": gpu_count,
-            "timeout_minutes": MAX_LIFETIME // 60,
+            "timeout_minutes": lifetime_minutes,
             "idle_timeout_minutes": idle_minutes,
             "gpu_type": gpu_type,
             "region": self.config.region,
@@ -278,7 +291,13 @@ class PrimeRuntime(Runtime):
             result = await self._client.run_background_job(
                 self.info.id,
                 shlex.join(argv),
-                timeout=MAX_LIFETIME,
+                # the SDK poll needs a finite deadline: the sandbox lifetime when
+                # capped, else effectively unbounded
+                timeout=(
+                    int(self.config.timeout)
+                    if self.config.timeout is not None
+                    else 365 * 24 * 60 * 60
+                ),
                 working_dir=self.config.workdir,
                 env=self.process_env(env),
                 poll_interval=1,

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -36,6 +36,11 @@ from verifiers.v1.utils.prime import ensure_prime_auth
 
 logger = logging.getLogger(__name__)
 
+CONTAINER_LIFETIME = 24 * 60 * 60
+"""Fixed lifetime (seconds) of container sandboxes; only VM sandboxes support an
+unbounded lifetime."""
+
+
 BASE_LABELS: list[str] = []
 
 
@@ -73,9 +78,6 @@ class PrimeConfig(NetworkPolicyConfig):
     """GPU spec, e.g. "A100" or "A100:2" (a bare count = provider-chosen type)."""
     disk: float = 5.0
     """Disk in GB."""
-    timeout: float | None = Field(default=None, gt=0)
-    """Seconds until the sandbox is deleted regardless of activity (None disables;
-    only VM sandboxes support running without a lifetime limit)."""
     idle_timeout: float | None = 3600
     """Seconds of inactivity before the sandbox self-deletes (None disables)."""
     creates_per_min: int | None = None
@@ -100,20 +102,16 @@ class PrimeConfig(NetworkPolicyConfig):
         return self
 
     @model_validator(mode="after")
-    def _validate_timeouts(self) -> "PrimeConfig":
-        if self.timeout is None and not self.vm:
-            raise ValueError(
-                "container sandboxes (vm=false) require a lifetime timeout - "
-                "running without one is only supported for VM sandboxes"
-            )
+    def _validate_idle_timeout(self) -> "PrimeConfig":
         if (
-            self.timeout is not None
+            not self.vm
             and self.idle_timeout is not None
-            and self.idle_timeout > self.timeout
+            and self.idle_timeout > CONTAINER_LIFETIME
         ):
             raise ValueError(
                 f"idle_timeout ({self.idle_timeout}s) must not exceed the "
-                f"sandbox lifetime timeout ({self.timeout}s)"
+                f"{CONTAINER_LIFETIME}s ({CONTAINER_LIFETIME // 3600}h) container "
+                "sandbox lifetime"
             )
         return self
 
@@ -168,13 +166,8 @@ class PrimeRuntime(Runtime):
         # Map the resources onto prime's API (minutes, split GPU; memory/disk are already
         # GB). gpu_type/region are only sent when set (else provider-chosen).
         gpu_type, gpu_count = parse_gpu(self.config.gpu)
-        # prime's timeouts are in whole minutes; convert from the seconds config surface
-        # (raised to the SDK's 1-minute minimum). A negative lifetime means no limit.
-        lifetime_minutes = (
-            max(1, math.ceil(self.config.timeout / 60))
-            if self.config.timeout is not None
-            else -1
-        )
+        # prime's idle timeout is in whole minutes; convert from the seconds config surface
+        # (raised to the SDK's 1-minute minimum).
         idle_minutes = (
             max(1, math.ceil(self.config.idle_timeout / 60))
             if self.config.idle_timeout is not None
@@ -185,7 +178,8 @@ class PrimeRuntime(Runtime):
             "memory_gb": self.config.memory,
             "disk_size_gb": self.config.disk,
             "gpu_count": gpu_count,
-            "timeout_minutes": lifetime_minutes,
+            # -1 is prime's convention for no lifetime limit (VM-only)
+            "timeout_minutes": -1 if self.config.vm else CONTAINER_LIFETIME // 60,
             "idle_timeout_minutes": idle_minutes,
             "gpu_type": gpu_type,
             "region": self.config.region,
@@ -291,13 +285,9 @@ class PrimeRuntime(Runtime):
             result = await self._client.run_background_job(
                 self.info.id,
                 shlex.join(argv),
-                # the SDK poll needs a finite deadline: the sandbox lifetime when
-                # capped, else effectively unbounded
-                timeout=(
-                    int(self.config.timeout)
-                    if self.config.timeout is not None
-                    else 365 * 24 * 60 * 60
-                ),
+                # the SDK poll needs a finite deadline: the container lifetime, or
+                # effectively unbounded for VM sandboxes
+                timeout=365 * 24 * 60 * 60 if self.config.vm else CONTAINER_LIFETIME,
                 working_dir=self.config.workdir,
                 env=self.process_env(env),
                 poll_interval=1,

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -73,7 +73,7 @@ class PrimeConfig(NetworkPolicyConfig):
     """GPU spec, e.g. "A100" or "A100:2" (a bare count = provider-chosen type)."""
     disk: float = 5.0
     """Disk in GB."""
-    timeout: float | None = None
+    timeout: float | None = Field(default=None, gt=0)
     """Seconds until the sandbox is deleted regardless of activity (None disables;
     only VM sandboxes support running without a lifetime limit)."""
     idle_timeout: float | None = 3600

--- a/verifiers/v1/utils/compile.py
+++ b/verifiers/v1/utils/compile.py
@@ -115,23 +115,20 @@ def validate_pairing(
 def cap_remote_agent_timeout(
     agent_timeout: float | None, runtime_config: RuntimeConfig, task: Task
 ) -> float | None:
-    """A remote sandbox with a bounded lifetime dies mid-run if the agent outlives it:
-    cap the agent timeout at that lifetime (with a warning) so a long run times out
-    cleanly instead of the provider killing the box."""
+    """Remote sandboxes other than Prime VMs (which have no lifetime limit) live at
+    most 24 hours: cap the agent timeout there (with a warning) so a long run times
+    out cleanly instead of the provider killing the box mid-run."""
     if agent_timeout is None or runtime_is_local(runtime_config):
         return agent_timeout
-    if isinstance(runtime_config, PrimeConfig):
-        lifetime = runtime_config.timeout
-    else:
-        lifetime = 24 * 60 * 60  # Modal's fixed max sandbox lifetime
-    if lifetime is not None and agent_timeout > lifetime:
+    if isinstance(runtime_config, PrimeConfig) and runtime_config.vm:
+        return agent_timeout
+    if agent_timeout > 24 * 60 * 60:
         logger.warning(
-            "task %r resolves to a %.1f-hour agent timeout, but this %s sandbox "
-            "lives at most %.1f hours; capping the timeout there",
+            "task %r resolves to a %.1f-hour agent timeout, but %s sandboxes have a "
+            "maximum lifetime of 24 hours; capping it at 24 hours",
             task.data.idx,
             agent_timeout / (60 * 60),
             runtime_config.type,
-            lifetime / (60 * 60),
         )
-        return lifetime
+        return 24 * 60 * 60
     return agent_timeout

--- a/verifiers/v1/utils/compile.py
+++ b/verifiers/v1/utils/compile.py
@@ -8,6 +8,7 @@ from collections.abc import Collection
 from verifiers.v1.configs.runtime import NetworkPolicyConfig
 from verifiers.v1.harness import Harness
 from verifiers.v1.runtimes import (
+    PrimeConfig,
     RuntimeConfig,
     SubprocessConfig,
     runtime_is_local,
@@ -114,20 +115,23 @@ def validate_pairing(
 def cap_remote_agent_timeout(
     agent_timeout: float | None, runtime_config: RuntimeConfig, task: Task
 ) -> float | None:
-    """Remote sandboxes live at most 24 hours: cap the agent timeout there (with a
-    warning) so a long run times out cleanly instead of the provider killing the box
-    mid-run."""
-    if (
-        agent_timeout is not None
-        and agent_timeout > 24 * 60 * 60
-        and not runtime_is_local(runtime_config)
-    ):
+    """A remote sandbox with a bounded lifetime dies mid-run if the agent outlives it:
+    cap the agent timeout at that lifetime (with a warning) so a long run times out
+    cleanly instead of the provider killing the box."""
+    if agent_timeout is None or runtime_is_local(runtime_config):
+        return agent_timeout
+    if isinstance(runtime_config, PrimeConfig):
+        lifetime = runtime_config.timeout
+    else:
+        lifetime = 24 * 60 * 60  # Modal's fixed max sandbox lifetime
+    if lifetime is not None and agent_timeout > lifetime:
         logger.warning(
-            "task %r resolves to a %.1f-hour agent timeout, but %s sandboxes have a "
-            "maximum lifetime of 24 hours; capping it at 24 hours",
+            "task %r resolves to a %.1f-hour agent timeout, but this %s sandbox "
+            "lives at most %.1f hours; capping the timeout there",
             task.data.idx,
             agent_timeout / (60 * 60),
             runtime_config.type,
+            lifetime / (60 * 60),
         )
-        return 24 * 60 * 60
+        return lifetime
     return agent_timeout


### PR DESCRIPTION
## Summary
- Default Prime VM sandboxes to no lifetime timeout: the runtime sends `timeout_minutes=-1` (Prime's convention for an unbounded lifetime) instead of the previous 24h cap.
- Container sandboxes (`vm=false`) keep the fixed 24h lifetime (`CONTAINER_LIFETIME`) — only VM sandboxes support running without a limit.
- The lifetime is not configurable; it follows the sandbox mode.
- `idle_timeout > 24h` is now rejected only for container sandboxes; VM sandboxes accept any idle timeout.
- `cap_remote_agent_timeout` skips Prime VM configs (no lifetime to cap against); Prime containers and Modal keep the 24h cap.
- `run()` bounds the SDK's background-job poll at the container lifetime, or an effectively unbounded deadline for VMs.

## Verification
- prime-sandboxes 0.2.37 against the live API: `timeout_minutes=0` is rejected (`422: timeout_minutes must be negative for infinite or >= 1`); `timeout_minutes=-1` creates a VM sandbox that reaches RUNNING and deletes cleanly.
- `PrimeRuntime` from this branch with the default config: sandbox came up RUNNING with `timeout_minutes=-1` and was deleted on `stop()`.
- Config validators: `vm=false` valid (24h lifetime); container `idle_timeout > 24h` errors; VM accepts any idle timeout; agent-timeout cap is a no-op for Prime VMs and caps containers at 24h.

## Breaking
- Prime VM sandboxes no longer self-delete after 24h. `idle_timeout` (default 3600s) is now the only automatic cleanup for them; rely on it or delete explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote sandbox lifetime and timeout capping. Failed teardown can leave VMs running indefinitely except for idle_timeout.
> 
> **Overview**
> Prime **VM** sandboxes no longer get a 24h hard lifetime. Create now sends `timeout_minutes=-1` (provider “no limit”); containers still use a fixed 24h `CONTAINER_LIFETIME`.
> 
> Idle-timeout validation and `cap_remote_agent_timeout` only enforce the 24h ceiling for non-VM remotes (Prime containers, Modal, etc.). VM agent timeouts are left uncapped. `run()` polls with a 365-day deadline for VMs so the SDK still has a finite wait.
> 
> **Breaking:** VMs no longer self-delete after 24h. Cleanup is `idle_timeout` (default 1h) or explicit delete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69a76318e5a84186f789ba76a7fce9ad85514fb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default Prime VM sandboxes to no lifetime timeout
> - VM sandboxes are now created with `timeout_minutes=-1` (provider convention for no limit) and polled with a 365-day timeout, effectively removing the lifetime cap
> - Container sandboxes remain capped at 24 hours via `CONTAINER_LIFETIME` (renamed from `MAX_LIFETIME`)
> - `PrimeConfig._validate_idle_timeout` skips the 24h upper-bound check for VM sandboxes; container sandboxes still enforce it
> - `cap_remote_agent_timeout` in [compile.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2412/files#diff-c5d7bd0167850a8d2492d083675cba0e1127f6565f85bd87f59dbaf86ac47bc1) now exempts `PrimeConfig` with `vm=True` from the 24h agent-timeout cap and warning
> - Risk: VM sandboxes with no lifetime cap can run indefinitely; reviewers should confirm `PrimeRuntime.run` in [prime.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2412/files#diff-d22d61279ff7587a2b14c72ab1a0fc9d3f805a735338a70f8efc7fe19aaa8502) and `cap_remote_agent_timeout` in [compile.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2412/files#diff-c5d7bd0167850a8d2492d083675cba0e1127f6565f85bd87f59dbaf86ac47bc1) correctly gate which runtimes get the exemption
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 69a7631.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->