### PR TITLE
feat: extend the unbounded lifetime to container sandboxes

### DIFF
--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -36,9 +36,10 @@ from verifiers.v1.utils.prime import ensure_prime_auth
 
 logger = logging.getLogger(__name__)
 
-CONTAINER_LIFETIME = 24 * 60 * 60
-"""Fixed lifetime (seconds) of container sandboxes; only VM sandboxes support an
-unbounded lifetime."""
+IDLE_FALLBACK_LIFETIME = 30 * 24 * 60 * 60
+"""Lifetime (seconds) given to container sandboxes that set an idle timeout: the
+platform requires a finite lifetime there as a safety fallback should idle detection
+fail. Far above any real run, so effectively unbounded."""
 
 
 BASE_LABELS: list[str] = []
@@ -99,20 +100,6 @@ class PrimeConfig(NetworkPolicyConfig):
             None if self.allow == ["*"] else self.allow,
             self.block or None,
         )
-        return self
-
-    @model_validator(mode="after")
-    def _validate_idle_timeout(self) -> "PrimeConfig":
-        if (
-            not self.vm
-            and self.idle_timeout is not None
-            and self.idle_timeout > CONTAINER_LIFETIME
-        ):
-            raise ValueError(
-                f"idle_timeout ({self.idle_timeout}s) must not exceed the "
-                f"{CONTAINER_LIFETIME}s ({CONTAINER_LIFETIME // 3600}h) container "
-                "sandbox lifetime"
-            )
         return self
 
 
@@ -178,8 +165,13 @@ class PrimeRuntime(Runtime):
             "memory_gb": self.config.memory,
             "disk_size_gb": self.config.disk,
             "gpu_count": gpu_count,
-            # -1 is prime's convention for no lifetime limit (VM-only)
-            "timeout_minutes": -1 if self.config.vm else CONTAINER_LIFETIME // 60,
+            # -1 is prime's convention for no lifetime limit; containers with an
+            # idle timeout must carry a finite lifetime as a safety fallback
+            "timeout_minutes": (
+                -1
+                if self.config.vm or idle_minutes is None
+                else IDLE_FALLBACK_LIFETIME // 60
+            ),
             "idle_timeout_minutes": idle_minutes,
             "gpu_type": gpu_type,
             "region": self.config.region,
@@ -281,17 +273,21 @@ class PrimeRuntime(Runtime):
         )
 
     async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
+        # Poll the job by hand: the SDK's run_background_job needs a finite deadline,
+        # but the sandbox has no lifetime limit — the rollout's stage timeouts bound
+        # this via cancellation instead.
         try:
-            result = await self._client.run_background_job(
+            job = await self._client.start_background_job(
                 self.info.id,
                 shlex.join(argv),
-                # the SDK poll needs a finite deadline: the container lifetime, or
-                # effectively unbounded for VM sandboxes
-                timeout=365 * 24 * 60 * 60 if self.config.vm else CONTAINER_LIFETIME,
                 working_dir=self.config.workdir,
                 env=self.process_env(env),
-                poll_interval=1,
             )
+            while True:
+                result = await self._client.get_background_job(self.info.id, job)
+                if result.completed:
+                    break
+                await asyncio.sleep(1)
         except (
             Exception
         ) as e:  # a sandbox/API failure is one rollout's problem, not the eval's

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -166,11 +166,12 @@ class PrimeRuntime(Runtime):
             "disk_size_gb": self.config.disk,
             "gpu_count": gpu_count,
             # -1 is prime's convention for no lifetime limit; containers with an
-            # idle timeout must carry a finite lifetime as a safety fallback
+            # idle timeout must carry a finite lifetime as a safety fallback (which
+            # must exceed the idle timeout)
             "timeout_minutes": (
                 -1
                 if self.config.vm or idle_minutes is None
-                else IDLE_FALLBACK_LIFETIME // 60
+                else max(IDLE_FALLBACK_LIFETIME // 60, idle_minutes + 1)
             ),
             "idle_timeout_minutes": idle_minutes,
             "gpu_type": gpu_type,

--- a/verifiers/v1/utils/compile.py
+++ b/verifiers/v1/utils/compile.py
@@ -115,12 +115,12 @@ def validate_pairing(
 def cap_remote_agent_timeout(
     agent_timeout: float | None, runtime_config: RuntimeConfig, task: Task
 ) -> float | None:
-    """Remote sandboxes other than Prime VMs (which have no lifetime limit) live at
+    """Remote sandboxes other than Prime's (which have no lifetime limit) live at
     most 24 hours: cap the agent timeout there (with a warning) so a long run times
     out cleanly instead of the provider killing the box mid-run."""
     if agent_timeout is None or runtime_is_local(runtime_config):
         return agent_timeout
-    if isinstance(runtime_config, PrimeConfig) and runtime_config.vm:
+    if isinstance(runtime_config, PrimeConfig):
         return agent_timeout
     if agent_timeout > 24 * 60 * 60:
         logger.warning(


### PR DESCRIPTION
## Summary
Follow-up to #2412, addressing review feedback that containers also support an unbounded lifetime.

- Container sandboxes now also get `timeout_minutes=-1` — with one platform constraint: a container that sets an idle timeout must carry a finite lifetime as a safety fallback (`422: container idle_timeout_minutes requires a finite timeout_minutes as a safety fallback`). Those get `IDLE_FALLBACK_LIFETIME` (30 days, effectively unbounded; raised above the idle timeout when one exceeds it); containers without an idle timeout get a true `-1`.
- The container-only `idle_timeout <= 24h` validator and the 24h `CONTAINER_LIFETIME` are gone.
- `cap_remote_agent_timeout` skips Prime configs entirely; Modal keeps the 24h cap.
- `run()` polls `start_background_job` + `get_background_job` directly instead of passing a sentinel deadline to `run_background_job`, which requires a finite timeout. The rollout's stage timeouts bound it via cancellation.

## Verification
Live against the API, through `PrimeRuntime` from this branch (each ran `echo hello` through the new `run()` poll, then deleted):
- container + idle timeout: created with `timeout_minutes=43200` (30d), exec exit 0
- container without idle timeout: created with `timeout_minutes=-1`, exec exit 0
- VM default: created with `timeout_minutes=-1`, exec exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extend unbounded lifetime to container sandboxes
> - Replaces `CONTAINER_LIFETIME` with a 30-day `IDLE_FALLBACK_LIFETIME` constant in [prime.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2413/files#diff-d22d61279ff7587a2b14c72ab1a0fc9d3f805a735338a70f8efc7fe19aaa8502)
> - `PrimeRuntime.start` requests `timeout_minutes=-1` for containers when no idle timeout is set, otherwise requests a finite lifetime that is the greater of 30 days or idle timeout plus 1 minute
> - Removes the `_validate_idle_timeout` validator that previously rejected idle timeouts exceeding the fixed lifetime
> - `cap_remote_agent_timeout` in [compile.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2413/files#diff-c5d7bd0167850a8d2492d083675cba0e1127f6565f85bd87f59dbaf86ac47bc1) skips the 24-hour cap for all Prime containers, not just VMs
> - `PrimeRuntime.run` polls background jobs manually without a client-side deadline
> - Behavioral Change: Prime containers without an idle timeout now run indefinitely instead of terminating after 24 hours; idle timeouts greater than the old fixed lifetime are now accepted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c99739.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sandbox lifetime and job-wait behavior for Prime containers, so misconfigured idle timeouts or failed teardown can leave boxes running much longer. Not auth/security-critical, but it affects remote resource usage.
> 
> **Overview**
> Prime container sandboxes can now live without a 24h hard cap, matching VMs. Creation uses `timeout_minutes=-1` unless an idle timeout is set; the platform then requires a finite fallback, so those boxes get a 30-day `IDLE_FALLBACK_LIFETIME` (raised above the idle timeout if needed).
> 
> The container-only `idle_timeout` validator is gone. `cap_remote_agent_timeout` skips all Prime configs, not just VMs (Modal still caps at 24h).
> 
> `PrimeRuntime.run` polls `start_background_job` / `get_background_job` instead of the SDK helper that required a finite deadline; rollout stage timeouts still cancel the wait.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c997393d2ab4f8dc0bbf95dd19841bef677fe4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->