### PR TITLE
feat: raise prime sandbox creation wait to ~6 minutes per phase

### DIFF
--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -225,7 +225,7 @@ class PrimeRuntime(Runtime):
                     self.config.image,
                     self.info.id,
                 )
-            await self._client.wait_for_creation(self.info.id)
+            await self._client.wait_for_creation(self.info.id, max_attempts=180)
             logger.info(
                 "prime: sandbox %s up (image=%s)", self.info.id, self.config.image
             )


### PR DESCRIPTION
## Summary
- Pass `max_attempts=180` to `wait_for_creation` in the prime runtime (SDK default is 60).
- The SDK maps attempts to a wall-clock budget of `5 + (n - 5) * 2` seconds per phase. The wait budget goes from 115s to 355s, applied separately to the PENDING phase and the reachability phase.

## Why
Under platform load, sandboxes regularly take longer than 115s to leave PENDING. The rollout then errors and issues a delete against a sandbox the platform is still provisioning. That delete can race the creation and orphan the sandbox — a recent incident left ~30k orphaned sandboxes on the platform. Waiting longer trades slower rollout errors for fewer spurious timeouts and fewer delete-vs-provision races.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise `max_attempts` to 180 in `PrimeRuntime.start` sandbox wait
> The sandbox provisioning sequence in `PrimeRuntime.start` now passes `max_attempts=180` explicitly to `wait_for_creation`, raising the creation wait to roughly 6 minutes per phase. Previously the call relied on the method's default value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ae0d76.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Prime sandbox provisioning timeouts. The change is small, but it affects when failed creates are torn down and was motivated by delete-vs-provision races that can orphan sandboxes.
> 
> **Overview**
> Prime sandbox startup now waits longer for `wait_for_creation` (`max_attempts=180` instead of the SDK default of 60). That is about ~6 minutes per phase rather than ~2, so slow PENDING boots under platform load are less likely to time out, trigger a delete, and race the still-running provision.
> 
> This is a one-line timeout change in `PrimeRuntime.start`; first-use image builds still use their own separate wait budget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ae0d76e714aec95465800d46838cc563baf30ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->