### PR TITLE
test(verifiers): add Qwen3.8-27B to renderer test matrices

### DIFF
--- a/tests/test_renderer_client.py
+++ b/tests/test_renderer_client.py
@@ -615,6 +615,7 @@ async def test_get_incremental_prompt_ids_accepts_multimodal_tool_user_tail():
 _TRUNCATED_ANCHOR_MODELS = [
     pytest.param("Qwen/Qwen3-8B", "auto", id="Qwen/Qwen3-8B"),
     pytest.param("Qwen/Qwen3.5-9B", "auto", id="Qwen/Qwen3.5-9B"),
+    pytest.param("Qwen/Qwen3.8-27B", "auto", id="Qwen/Qwen3.8-27B"),
     pytest.param("Qwen/Qwen3-VL-4B-Instruct", "auto", id="Qwen/Qwen3-VL-4B-Instruct"),
     pytest.param("zai-org/GLM-5", "auto", id="zai-org/GLM-5"),
     pytest.param("zai-org/GLM-4.7-Flash", "auto", id="zai-org/GLM-4.7-Flash"),

--- a/tests/test_renderer_e2e.py
+++ b/tests/test_renderer_e2e.py
@@ -71,6 +71,7 @@ def _renderer_has_extension_property(renderer) -> bool:
 _MODEL_FAMILIES = [
     ("Qwen/Qwen3-0.6B", "auto"),
     ("Qwen/Qwen3.5-9B", "auto"),
+    ("Qwen/Qwen3.8-27B", "auto"),
     ("THUDM/GLM-4.5-Air", "auto"),
     ("MiniMaxAI/MiniMax-M2.5", "auto"),
     ("Qwen/Qwen2.5-0.5B-Instruct", "default"),


### PR DESCRIPTION
## What

Adds **Qwen3.8-27B** to the renderer end-to-end and client test matrices so the new dense model is covered by the same renderer → RendererClient → Environment wire-protocol tests as the rest of the Qwen family.

## Changes

- `tests/test_renderer_e2e.py` — add `("Qwen/Qwen3.8-27B", "auto")` to `_MODEL_FAMILIES`.
- `tests/test_renderer_client.py` — add `Qwen/Qwen3.8-27B` to `_TRUNCATED_ANCHOR_MODELS`.

Qwen3.8-27B auto-resolves to the new `qwen3.8` renderer (see PrimeIntellect-ai/renderers#132).

## Testing

- `test_renderer_e2e.py` + `test_renderer_client.py` Qwen3.8 cases pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only matrix expansion; no production code or protocol changes.
> 
> **Overview**
> Adds `Qwen/Qwen3.8-27B` (auto-resolved to the `qwen3.8` renderer) to the renderer e2e and truncated-anchor client test matrices so the new dense Qwen family is covered by the same TITO wire-protocol and prefix-preserving bridge checks as other Qwen models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c93838a782688c01ccbc5b4a292294bb4fa704f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Qwen/Qwen3.8-27B` to renderer test matrices
> Adds the `Qwen/Qwen3.8-27B` model with `auto` renderer to `_TRUNCATED_ANCHOR_MODELS` in [test_renderer_client.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2416/files#diff-200d7102e1d9ee4b5d7756e0d748c586744886e7ef4ee6d662af15348f4f84be) and `_MODEL_FAMILIES` in [test_renderer_e2e.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2416/files#diff-75add59ec1e35d27316aa9e8688b75f143b07a3a7e4bdf623613c5a8e3522510). This expands parameterized test coverage to include the new model.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c93838.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->