### PR TITLE
feat(v1): add httpx[socks] to harness inline script dependencies

### DIFF
--- a/verifiers/v1/harnesses/bash/program.py
+++ b/verifiers/v1/harnesses/bash/program.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["openai", "mcp>=1.24.0,<2", "httpx", "tenacity"]
+# dependencies = ["openai", "mcp>=1.24.0,<2", "httpx[socks]", "tenacity"]
 # ///
 """Secrets arrive through argv so local tool subprocesses do not inherit them."""
 

--- a/verifiers/v1/harnesses/browser_use/program.py
+++ b/verifiers/v1/harnesses/browser_use/program.py
@@ -4,7 +4,7 @@
 #     "browser-harness==0.1.8",
 #     "openai",
 #     "mcp>=1.24.0,<2",
-#     "httpx",
+#     "httpx[socks]",
 #     "tenacity",
 # ]
 # ///

--- a/verifiers/v1/harnesses/null/program.py
+++ b/verifiers/v1/harnesses/null/program.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.11"
-# dependencies = ["openai", "mcp>=1.24.0,<2", "httpx", "tenacity"]
+# dependencies = ["openai", "mcp>=1.24.0,<2", "httpx[socks]", "tenacity"]
 # ///
 """The interception endpoint and secret arrive through argv rather than the environment."""
 


### PR DESCRIPTION
In some proxy environments (e.g. when a SOCKS5 proxy is configured), the v1
harness programs fail to start: httpx raises an error at runtime when a
`socks5://` proxy URL is configured unless it is installed with the `socks`
extra.

This change adds the `socks` extra to the PEP 723 inline script dependencies
of the `bash`, `browser_use`, and `null` harnesses, so they can start and run
normally through SOCKS proxies.

Each change is a single-line dependency update.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `httpx[socks]` to harness inline script dependencies
> Replaces `httpx` with `httpx[socks]` in the script metadata headers of the `bash`, `browser_use`, and `null` harnesses ([program.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2421/files#diff-d4cd8c8ecce1607fa0d58ad9d6be1b24a81ace7b7dd85521910d4082319a2400), [program.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2421/files#diff-ef4ab9f701283b63b308953085dfac1bba4f972b5b476b2c7849d2252e3a957a), [program.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2421/files#diff-d4e93ef3c6afb0d7441cceeef2d60bd8618168a7d72b8d1df78f16dbe0289304)). This installs the `socksio` extra so httpx can use SOCKS proxies.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f44fe08.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->