### PR TITLE
feat: run evals through the env server by default

### DIFF
--- a/docs/v1/evaluation.md
+++ b/docs/v1/evaluation.md
@@ -42,6 +42,12 @@ The output from evaluations are written into `outputs/<env>--<model>--<harness>/
 - `num_rollouts` — rollouts per task
 - `verbose` — log at debug instead of info
 - `shuffle` — samples the task order (fixed seed); an error on an infinite taskset
+- `server` — on by default: rollouts run through an elastic env-server worker pool
+  (sized by `[serve]`); `--no-server` runs them in-process
+- `rich` — the live dashboard (default); `--no-rich` streams logs to the console and
+  prints each trace as JSON at the end
+- `rich.show_logs` — replace the dashboard's per-rollout rows with a live tail of the
+  run's logs (`logs/eval.log`), the env workers' lines included
 
 ## Resuming evaluations
 

--- a/docs/v1/evaluation.md
+++ b/docs/v1/evaluation.md
@@ -42,8 +42,8 @@ The output from evaluations are written into `outputs/<env>--<model>--<harness>/
 - `num_rollouts` — rollouts per task
 - `verbose` — log at debug instead of info
 - `shuffle` — samples the task order (fixed seed); an error on an infinite taskset
-- `server` — on by default: rollouts run through an elastic env-server worker pool
-  (sized by `[serve]`); `--no-server` runs them in-process
+- `serve` — on by default: rollouts run through an elastic env-server worker pool
+  (`[serve]` sizes it, e.g. `serve.pool.type`); `--no-serve` runs them in-process
 - `rich` — the live dashboard (default); `--no-rich` streams logs to the console and
   prints each trace as JSON at the end
 - `rich.show_logs` — replace the dashboard's per-rollout rows with a live tail of the

--- a/docs/v1/evaluation.md
+++ b/docs/v1/evaluation.md
@@ -29,7 +29,7 @@ Validate the config by using `uv run eval @ config.toml --dry-run`. To run the e
 
 Use dotted arguments to set values using the CLI, e.g. `--sampling.temperature 0.5`. CLI arguments overwrite toml arguments when both are present.
 
-The output from evaluations are written into `outputs/<env>--<model>--<harness>/<uuid>/` by default, where `<env>` is the taskset, prefixed by the paired env id when `--env.id` sets one (use `output_dir` to overwrite the folder). The folder contains the used `config.toml`, all the episodes in `traces.jsonl`, as well as logs of the run and workers in `eval.log`.
+The output from evaluations are written into `outputs/<env>--<model>--<harness>/<uuid>/` by default, where `<env>` is the taskset, prefixed by the paired env id when `--env.id` sets one (use `output_dir` to overwrite the folder). The folder contains the used `config.toml`, all the episodes in `traces.jsonl`, as well as logs of the run and workers in `logs/attempt_<n>/eval.log` — one directory per launch attempt (a resume starts a new one), with `logs/latest` pointing at the current attempt.
 
 ## Common config values
 
@@ -47,7 +47,7 @@ The output from evaluations are written into `outputs/<env>--<model>--<harness>/
 - `rich` — the live dashboard (default); `--no-rich` streams logs to the console and
   prints each trace as JSON at the end
 - `rich.show_logs` — replace the dashboard's per-rollout rows with a live tail of the
-  run's logs (`logs/eval.log`), the env workers' lines included
+  attempt's logs (`logs/latest/eval.log`), the env workers' lines included
 
 ## Resuming evaluations
 

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -5,7 +5,7 @@ settings that still exercise the path, then assert on the resulting `Trace`(s) â
 not unit tests of individual components. They need a model API key (`PRIME_API_KEY`);
 without one the `e2e`-marked tests skip (config parsing still runs).
 
-`run_v1` mirrors the eval CLI's in-process path (`run_eval` with `--no-server`). Placement coverage (harness x harness runtime x tool
+`run_v1` mirrors the eval CLI's in-process path (`run_eval` with `--no-serve`). Placement coverage (harness x harness runtime x tool
 server runtime) is PAIRWISE, not a full cross product: each test carries a curated list of
 combinations (in test_e2e.py) that hits every axis value and the cross-boundary pairs with
 distinct networking. The full cross bought flake exposure and CI minutes, not coverage â€” add
@@ -184,17 +184,16 @@ def _eval_config(
             "reasoning_effort": reasoning_effort,
         },
         rich=None,
-        server=server,
+        serve=({"pool": pool} if pool else {}) if server else None,
         output_dir=output_dir.parent,
         run={"dir": output_dir.name},
-        **({"serve": {"pool": pool}} if pool else {}),
         model=CI_MODEL,
     )
 
 
 @pytest.fixture
 def run_v1():
-    """Run a v1 taskset end-to-end in-process (`run_eval` with `--no-server`) and return
+    """Run a v1 taskset end-to-end in-process (`run_eval` with `--no-serve`) and return
     its traces."""
 
     async def _run(taskset: str, **kwargs) -> list[Trace]:

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -5,7 +5,7 @@ settings that still exercise the path, then assert on the resulting `Trace`(s) �
 not unit tests of individual components. They need a model API key (`PRIME_API_KEY`);
 without one the `e2e`-marked tests skip (config parsing still runs).
 
-`run_v1` mirrors the eval CLI's server path (`run_eval`). Placement coverage (harness x harness runtime x tool
+`run_v1` mirrors the eval CLI's in-process path (`run_eval` with `--no-server`). Placement coverage (harness x harness runtime x tool
 server runtime) is PAIRWISE, not a full cross product: each test carries a curated list of
 combinations (in test_e2e.py) that hits every axis value and the cross-boundary pairs with
 distinct networking. The full cross bought flake exposure and CI minutes, not coverage — add
@@ -42,7 +42,7 @@ from verifiers.v1.cli.eval.runner import run_eval
 from verifiers.v1.configs.cli.eval import EvalConfig
 from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.trace import Trace
-from verifiers.v1.utils.loaders import harness_config_type, load_environment
+from verifiers.v1.utils.loaders import harness_config_type
 
 CI_MODEL = "openai/gpt-5.6-luna"
 
@@ -132,6 +132,7 @@ def _eval_config(
     env: dict | None = None,
     pool: dict | None = None,
     reasoning_effort: str | None = None,
+    server: bool = False,
 ) -> EvalConfig:
     """Build the smallest `EvalConfig` that still exercises the path, shared by the in-process
     (`run_v1`) and env-server (`run_v1_server`) fixtures. `taskset_overrides` merges onto the
@@ -182,7 +183,8 @@ def _eval_config(
             "max_tokens": max_tokens,
             "reasoning_effort": reasoning_effort,
         },
-        rich=False,
+        rich=None,
+        server=server,
         output_dir=output_dir.parent,
         run={"dir": output_dir.name},
         **({"serve": {"pool": pool}} if pool else {}),
@@ -192,12 +194,12 @@ def _eval_config(
 
 @pytest.fixture
 def run_v1():
-    """Run a v1 taskset end-to-end in-process (`run_eval`, the `--rich` CLI path) and return
+    """Run a v1 taskset end-to-end in-process (`run_eval` with `--no-server`) and return
     its traces."""
 
     async def _run(taskset: str, **kwargs) -> list[Trace]:
         config = _eval_config(taskset, **kwargs)
-        records = await run_eval(load_environment(config.env), config)
+        records = await run_eval(config)
         # The runner answers durability envelopes; the tests assert on traces.
         return [t for r in records for t in r.traces]
 
@@ -206,17 +208,16 @@ def run_v1():
 
 @pytest.fixture
 def run_v1_server():
-    """Run a v1 taskset through the env-server worker pool (`run_eval_server`) — the path a
-    `--server` CLI run and prime-rl training both take. Spawns the broker + a worker, so it's
-    the only fixture that exercises serving resources (shared tool servers, interception pool)
-    being stood up by the *server* rather than the in-process runner. Pinned to a single static
-    worker for determinism."""
-    from verifiers.v1.cli.eval.runner import run_eval_server
+    """Run a v1 taskset through the env-server worker pool (`run_eval`'s default path) —
+    the path a CLI run and prime-rl training both take. Spawns the broker + a worker, so
+    it's the only fixture that exercises serving resources (shared tool servers,
+    interception pool) being stood up by the *server* rather than the in-process runner.
+    Pinned to a single static worker for determinism."""
 
     async def _run(taskset: str, **kwargs) -> list[Trace]:
         kwargs.setdefault("pool", {"type": "static", "num_workers": 1})
-        config = _eval_config(taskset, **kwargs)
-        records = await run_eval_server(config)
+        config = _eval_config(taskset, server=True, **kwargs)
+        records = await run_eval(config)
         return [t for r in records for t in r.traces]
 
     return _run

--- a/tests/v1/test_envs.py
+++ b/tests/v1/test_envs.py
@@ -69,7 +69,7 @@ def test_eval(taskset: str):
         "uv", "run", "--no-sync", "eval", taskset,
         *model,
         "-n", "1", "-r", "1", *caps,
-        "--sampling.max-tokens", "512", "--rich", "false",
+        "--sampling.max-tokens", "512", "--no-rich",
     ]  # fmt: skip
     try:
         proc = subprocess.run(

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -2,6 +2,8 @@
 
 import contextlib
 import time
+from collections import deque
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
@@ -499,10 +501,11 @@ def _stage(trace: Trace) -> str:
 
 def _started(slot: RunSlot) -> float:
     # Sort key: when a rollout began (its first trace's boot start; setup for
-    # pre-boot-span traces on resume). A still-pending rollout has no trace yet, so it
-    # sorts last (+inf) — behind everything already in flight, in task order.
+    # pre-boot-span traces on resume; the slot's own dispatch stamp on a served run).
+    # A still-pending rollout has neither, so it sorts last (+inf) — behind everything
+    # already in flight, in task order.
     if not slot.traces:
-        return float("inf")
+        return slot.started if slot.started is not None else float("inf")
     return min(t.timing.boot.start or t.timing.setup.start for t in slot.traces)
 
 
@@ -548,6 +551,13 @@ def Rows(groups: list[list[RunSlot]], now: float, runtime_type: str) -> Table:
                             error.type if error is not None else "error",
                             "",
                         )
+                    )
+                elif slot.started is not None:
+                    # Dispatched to an env server: running, but with no live trace to
+                    # read stages/turns from — detail lands when the episode completes.
+                    elapsed = format_time(now - slot.started)
+                    group_rows.append(
+                        ("running", [f"task {base}", *[""] * 7], "", elapsed)
                     )
                 else:  # queued behind the concurrency cap — only its task is known yet
                     group_rows.append(("pending", [f"task {base}", *[""] * 7], "", ""))
@@ -687,6 +697,42 @@ class Pager:
         return self.page
 
 
+class LogTail:
+    """Incremental tail of the run's log file for `--show-logs`: read only what was
+    appended since the last frame, keep a bounded window of whole lines."""
+
+    def __init__(self, path: Path, max_lines: int = 1000) -> None:
+        self.path = path
+        self.lines: deque[str] = deque(maxlen=max_lines)
+        self._pos = 0
+        self._partial = ""
+
+    def _poll(self) -> None:
+        try:
+            size = self.path.stat().st_size
+        except OSError:  # not written yet — the first record creates it
+            return
+        if size < self._pos:  # truncated/replaced — start over
+            self._pos, self._partial = 0, ""
+        if size == self._pos:
+            return
+        with self.path.open("r", encoding="utf-8", errors="replace") as file:
+            file.seek(self._pos)
+            chunk = file.read()
+            self._pos = file.tell()
+        *complete, self._partial = (self._partial + chunk).split("\n")
+        self.lines.extend(complete)
+
+    def view(self, height: int) -> Group:
+        """The newest lines that fit, one Text per line (no markup parsing — log
+        content stays literal), each cropped to the terminal width."""
+        self._poll()
+        window = list(self.lines)[-height:]
+        return Group(
+            *(Text(line, no_wrap=True, overflow="ellipsis") for line in window)
+        )
+
+
 def _rows_of(group: list[RunSlot]) -> int:
     """How many display rows a task's slots take: one per trace, one for a slot with
     none yet (pending) or none at all (the env's hook failed before any trace)."""
@@ -727,6 +773,7 @@ def _render(
     start: float,
     pager: Pager,
     push: "PushState | None" = None,
+    tail: LogTail | None = None,
 ) -> Group:
     now = time.time()
     warning = _warning(config)
@@ -741,6 +788,16 @@ def _render(
     if footer is not None:
         reserved += len(_CONSOLE.render_lines(footer))
     rows_per_page = max(1, _CONSOLE.size.height - reserved - 1)
+    if tail is not None:  # --show-logs: the run's log stream in place of rollout rows
+        parts = [
+            header,
+            Progress(slots, start),
+            Rule(style="dim"),
+            tail.view(rows_per_page),
+        ]
+        if footer is not None:
+            parts.append(footer)
+        return Group(*parts)
     page_groups, index, count = _paginate(_groups(slots), rows_per_page, pager, now)
     progress = Progress(
         slots,
@@ -776,8 +833,13 @@ async def dashboard(
     push: "PushState | None" = None,
 ):
     pager = Pager()
+    tail = (
+        LogTail(output_path(config) / "logs" / "eval.log")
+        if config.rich is not None and config.rich.show_logs
+        else None
+    )
     async with live_view(
-        lambda: _render(slots, config, start, pager, push),
+        lambda: _render(slots, config, start, pager, push, tail),
         on_key=pager.on_key,
     ):
         yield

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -15,7 +15,7 @@ from rich.table import Table
 from rich.text import Text
 
 from verifiers.v1.cli.dashboard.base import live_view
-from verifiers.v1.cli.output import output_path
+from verifiers.v1.cli.output import attempt_log_file, output_path
 from verifiers.v1.configs.cli.eval import EvalConfig
 from verifiers.v1.env import RunSlot
 from verifiers.v1.trace import Trace
@@ -697,14 +697,18 @@ class Pager:
         return self.page
 
 
+_TAIL_BYTES = 256 * 1024
+"""How far back into a pre-existing log file the tail's first read reaches."""
+
+
 class LogTail:
-    """Incremental tail of the run's log file for `--show-logs`: read only what was
-    appended since the last frame, keep a bounded window of whole lines."""
+    """Incremental tail of the run's log file for `--rich.show-logs`: read only what
+    was appended since the last frame, keep a bounded window of whole lines."""
 
     def __init__(self, path: Path, max_lines: int = 1000) -> None:
         self.path = path
         self.lines: deque[str] = deque(maxlen=max_lines)
-        self._pos = 0
+        self._pos: int | None = None
         self._partial = ""
 
     def _poll(self) -> None:
@@ -712,15 +716,24 @@ class LogTail:
             size = self.path.stat().st_size
         except OSError:  # not written yet — the first record creates it
             return
-        if size < self._pos:  # truncated/replaced — start over
-            self._pos, self._partial = 0, ""
+        if (
+            self._pos is not None and size < self._pos
+        ):  # truncated/replaced — start over
+            self._pos, self._partial = None, ""
         if size == self._pos:
             return
-        with self.path.open("r", encoding="utf-8", errors="replace") as file:
-            file.seek(self._pos)
-            chunk = file.read()
+        # The first read starts at most _TAIL_BYTES from the end: a pre-existing file
+        # (a reused run dir) must not be read whole on the render path.
+        first = self._pos is None
+        start = max(0, size - _TAIL_BYTES) if first else self._pos
+        with self.path.open("rb") as file:
+            file.seek(start)
+            data = file.read()
             self._pos = file.tell()
+        chunk = data.decode("utf-8", errors="replace")
         *complete, self._partial = (self._partial + chunk).split("\n")
+        if first and start:  # landed mid-line — drop the cut first line
+            complete = complete[1:]
         self.lines.extend(complete)
 
     def view(self, height: int) -> Group:
@@ -834,7 +847,7 @@ async def dashboard(
 ):
     pager = Pager()
     tail = (
-        LogTail(output_path(config) / "logs" / "eval.log")
+        LogTail(attempt_log_file(output_path(config)))
         if config.rich is not None and config.rich.show_logs
         else None
     )

--- a/verifiers/v1/cli/eval/main.py
+++ b/verifiers/v1/cli/eval/main.py
@@ -8,7 +8,6 @@ import sys
 
 from pydantic_config import cli
 
-import verifiers.v1 as vf
 from verifiers.v1.cli.eval.runner import run_eval
 from verifiers.v1.cli.output import (
     TRACES_FILE,
@@ -116,13 +115,11 @@ def main(argv: list[str] | None = None) -> None:
         setup_logging("DEBUG" if config.verbose else "INFO")
         logger.info("wrote config to %s", write_config(config, output_path(config)))
         return
-    # Execution path: in-process by default; `--server` opts into the env-server worker pool
-    # (the path prime-rl trains through). The `--rich` dashboard reads live in-process run
-    # slots, so it's in-process only (`server + rich` is rejected at config validation).
-    # Always tee the run's logs to a file under the output dir (in-process and server mode).
+    # Always tee the run's logs to a file under the output dir — in server mode (the
+    # default) the workers write there too, and `--rich.show-logs` tails it live.
     log_file = str(output_path(config) / "logs" / "eval.log")
     level = "DEBUG" if config.verbose else "INFO"
-    if config.rich:
+    if config.rich is not None:
         setup_logging(level, log_file=log_file, console=False)
         # drop stray stdlib records that bypass loguru (else they print over the UI)
         logging.lastResort = None
@@ -135,22 +132,19 @@ def main(argv: list[str] | None = None) -> None:
     install_interrupt()
 
     try:
-        if config.server:  # opt-in: drive rollouts through the env-server worker pool
-            from verifiers.v1.cli.eval.runner import run_eval_server
-
-            episodes = asyncio.run(run_eval_server(config))
-        else:  # in-process (default), with or without the live dashboard
-            env = vf.load_environment(config.env)
-            episodes = asyncio.run(run_eval(env, config))
+        # Through the env-server worker pool by default; in-process with --no-server.
+        episodes = asyncio.run(run_eval(config))
     except KeyboardInterrupt:
         # Graceful cleanup has already run (each rollout's `finally`); partial results are on
         # disk. Exit on the conventional Ctrl-C code without a traceback.
         raise SystemExit(130)
-    if config.push and not config.rich:
+    if config.push and config.rich is None:
         from verifiers.v1.utils.platform import push_traces
 
         push_traces(episodes, config)
-    if not config.rich:  # --rich is the whole output; otherwise dump each trace as JSON
+    if (
+        config.rich is None
+    ):  # --rich is the whole output; otherwise dump each trace as JSON
         for episode in episodes:
             for trace in episode.traces:
                 print(trace.model_dump_json(indent=2, exclude_none=True))

--- a/verifiers/v1/cli/eval/main.py
+++ b/verifiers/v1/cli/eval/main.py
@@ -12,6 +12,7 @@ from verifiers.v1.cli.eval.runner import run_eval
 from verifiers.v1.cli.output import (
     TRACES_FILE,
     config_digest,
+    create_attempt_log_dir,
     output_path,
     saved_config_path,
     write_config,
@@ -115,9 +116,10 @@ def main(argv: list[str] | None = None) -> None:
         setup_logging("DEBUG" if config.verbose else "INFO")
         logger.info("wrote config to %s", write_config(config, output_path(config)))
         return
-    # Always tee the run's logs to a file under the output dir — in server mode (the
-    # default) the workers write there too, and `--rich.show-logs` tails it live.
-    log_file = str(output_path(config) / "logs" / "eval.log")
+    # Always tee this attempt's logs to `logs/attempt_<n>/eval.log` (`logs/latest`
+    # points there) — in server mode (the default) the workers write there too, and
+    # `--rich.show-logs` tails it live.
+    log_file = str(create_attempt_log_dir(output_path(config)) / "eval.log")
     level = "DEBUG" if config.verbose else "INFO"
     setup_logging(level, log_file=log_file, console=config.rich is None)
     # First Ctrl-C / SIGTERM warns and raises KeyboardInterrupt so a killed/timed-out eval still

--- a/verifiers/v1/cli/eval/main.py
+++ b/verifiers/v1/cli/eval/main.py
@@ -127,7 +127,7 @@ def main(argv: list[str] | None = None) -> None:
     install_interrupt()
 
     try:
-        # Through the env-server worker pool by default; in-process with --no-server.
+        # Through the env-server worker pool by default; in-process with --no-serve.
         episodes = asyncio.run(run_eval(config))
     except KeyboardInterrupt:
         # Graceful cleanup has already run (each rollout's `finally`); partial results are on

--- a/verifiers/v1/cli/eval/main.py
+++ b/verifiers/v1/cli/eval/main.py
@@ -119,12 +119,7 @@ def main(argv: list[str] | None = None) -> None:
     # default) the workers write there too, and `--rich.show-logs` tails it live.
     log_file = str(output_path(config) / "logs" / "eval.log")
     level = "DEBUG" if config.verbose else "INFO"
-    if config.rich is not None:
-        setup_logging(level, log_file=log_file, console=False)
-        # drop stray stdlib records that bypass loguru (else they print over the UI)
-        logging.lastResort = None
-    else:
-        setup_logging(level, log_file=log_file, console=True)
+    setup_logging(level, log_file=log_file, console=config.rich is None)
     # First Ctrl-C / SIGTERM warns and raises KeyboardInterrupt so a killed/timed-out eval still
     # runs each rollout's `finally` (tears down containers/sandboxes) and any worker pool it
     # spawned; further signals during that cleanup are swallowed so an impatient second Ctrl-C

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -2,7 +2,7 @@
 
 Rollouts run through the env-server worker pool by default (`[serve]` sizes it;
 elastic — one worker, scaling on demand), the same path prime-rl trains through.
-`--no-server` runs them in-process instead. Both paths share this runner — task
+`--no-serve` runs them in-process instead. Both paths share this runner — task
 selection, resume, persistence, the dashboard — and differ only in how one slot
 becomes one episode: `env.run_slot` in-process, a `run` request to the pool
 otherwise. The dashboard watches the same `RunSlot`s either way; a served slot
@@ -26,6 +26,7 @@ from verifiers.v1.cli.output import (
 from verifiers.v1.cli.resume import distribute
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.cli.eval import EvalConfig
+from verifiers.v1.configs.serve import ServeConfig
 from verifiers.v1.env import Env, RunSlot
 from verifiers.v1.episode import Episode, EvalRunInfo
 
@@ -58,6 +59,7 @@ async def _in_process(
 @contextlib.asynccontextmanager
 async def _server(
     config: EvalConfig,
+    serve: ServeConfig,
     semaphore: asyncio.Semaphore | None,
     on_complete: OnComplete,
 ) -> AsyncIterator[RunSlotFn]:
@@ -86,7 +88,7 @@ async def _server(
     proc = mpctx.Process(
         target=serve_env,
         kwargs=dict(
-            **pool_serve_kwargs(config.serve.pool),
+            **pool_serve_kwargs(serve.pool),
             address="tcp://127.0.0.1:0",
             address_queue=address_queue,
             death_pipe=child_conn,
@@ -94,7 +96,9 @@ async def _server(
             config_data=env_config_data(config.env),  # picklable across the spawn
             # `-c` seeds each worker's episode bound unless `[serve]` pins one — so a
             # pool carries `workers * bound` episodes, as `multiplex` implies.
-            max_concurrent=config.worker_max_concurrent,
+            max_concurrent=serve.max_concurrent
+            if serve.max_concurrent is not None
+            else config.max_concurrent,
         ),
         daemon=False,
     )
@@ -138,7 +142,7 @@ async def run_eval(config: EvalConfig) -> list[Episode]:
     logger.info("eval config:\n%s", config.model_dump_json(indent=2))
     # The env comes up in this process only for an in-process run; a served run's
     # workers each load their own, and this process owns just the taskset.
-    env = None if config.server else load_environment(config.env)
+    env = None if config.serve is not None else load_environment(config.env)
     taskset = env.taskset if env is not None else load_taskset(config.env.taskset)
     if config.num_tasks is None and taskset.INFINITE:
         raise ValueError(
@@ -179,7 +183,7 @@ async def run_eval(config: EvalConfig) -> list[Episode]:
         save_config(config, out)
         via = (
             f" via the env-server {config.serve.pool.type} pool"
-            if config.server
+            if config.serve is not None
             else ""
         )
         logger.info(
@@ -204,7 +208,7 @@ async def run_eval(config: EvalConfig) -> list[Episode]:
     backend = (
         _in_process(env, config, semaphore, on_complete)
         if env is not None
-        else _server(config, semaphore, on_complete)
+        else _server(config, config.serve, semaphore, on_complete)
     )
     async with backend as run_slot:
         # The display slots: in-process ones are the env's own (it fills their live

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -1,9 +1,19 @@
-"""The eval runner: fan episodes out with bounded concurrency."""
+"""The eval runner: fan episodes out with bounded concurrency.
+
+Rollouts run through the env-server worker pool by default (`[serve]` sizes it;
+elastic — one worker, scaling on demand), the same path prime-rl trains through.
+`--no-server` runs them in-process instead. Both paths share this runner — task
+selection, resume, persistence, the dashboard — and differ only in how one slot
+becomes one episode: `env.run_slot` in-process, a `run` request to the pool
+otherwise. The dashboard watches the same `RunSlot`s either way; a served slot
+has no live traces, so its per-turn detail lands when the episode completes.
+"""
 
 import asyncio
 import contextlib
 import logging
 import time
+from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import cast
 
 from verifiers.v1.cli.dashboard import dashboard
@@ -21,123 +31,46 @@ from verifiers.v1.episode import Episode, EvalRunInfo
 
 logger = logging.getLogger(__name__)
 
+RunSlotFn = Callable[[RunSlot], Awaitable[Episode]]
+OnComplete = Callable[[Episode], Awaitable[None]]
 
-async def run_eval(env: Env, config: EvalConfig) -> list[Episode]:
-    logger.info("eval config:\n%s", config.model_dump_json(indent=2))
-    taskset = env.taskset
-    if config.num_tasks is None and taskset.INFINITE:
-        raise ValueError(
-            f"{type(taskset).__name__} is infinite - bound the run with -n"
-        )
-    selected = taskset.shuffle() if config.shuffle else taskset
-    if config.num_tasks is not None:
-        selected = selected.head(config.num_tasks)
-    tasks = list(selected)
+
+@contextlib.asynccontextmanager
+async def _in_process(
+    env: Env,
+    config: EvalConfig,
+    semaphore: asyncio.Semaphore | None,
+    on_complete: OnComplete,
+) -> AsyncIterator[RunSlotFn]:
+    """Run slots in-process: serving resources (shared tool servers, interception)
+    come up once for the run; the env's agents borrow them."""
     ctx = ModelContext(
         client=config.client, model=config.model, sampling=config.sampling
     )
-    semaphore = (
-        asyncio.Semaphore(config.max_concurrent) if config.max_concurrent else None
-    )
-    out = output_path(config)
-    # One (task, rollouts-to-run) pair per selected task; resume shrinks the counts.
-    plan = [(task, config.num_rollouts) for task in tasks]
-    # Kept on-disk rollouts rejoin the run as finished episodes; only owed ones re-run.
-    finished: list[Episode] = []
-    if config.resume:
-        keys = [task.hash for task in tasks]
-        loaded, owed = resume.load(
-            out,
-            keys,
-            config.num_rollouts,
-            lambda episode: env.complete(cast(Episode, episode)),
-        )
-        finished = [cast(Episode, episode) for episode in loaded]
-        if not owed:  # already complete - report it and exit successfully
-            print(resume.nothing_to_resume_msg(out, len(tasks), config.num_rollouts))
-            raise SystemExit(0)
-        counts = distribute(keys, owed, config.num_rollouts)
-        plan = [(task, n) for task, n in zip(tasks, counts) if n]
-        logger.info(
-            "resuming %s: %d task(s), %d rollout(s) owed",
-            out,
-            len(plan),
-            sum(owed.values()),
-        )
-    else:
-        save_config(config, out)
-        logger.info(
-            "running %dx%d rollouts on %s",
-            len(tasks),
-            config.num_rollouts,
-            config.model,
-        )
-    start = time.time()
-    logger.info("results: %s", out)
 
-    write_lock = asyncio.Lock()
+    async def run(slot: RunSlot) -> Episode:
+        return await env.run_slot(slot, ctx, semaphore, on_complete)
 
-    async def on_complete(episode: Episode) -> None:
-        episode.record_run(EvalRunInfo(id=config.run.id, name=config.run.name))
-        await append_episode(out, episode, write_lock)
-
-    # Serving resources (shared tool servers, interception) come up once for the
-    # run; plan slots inside so the env's agents borrow them.
     async with env.serving():
-        planned = [slot for task, n in plan for slot in env.slots(task, n=n)]
-        slots = [RunSlot.finished(episode) for episode in finished] + planned
-        push_state = None
-        if config.push and config.rich:
-            from verifiers.v1.utils.platform import PushState
-
-            push_state = PushState()
-        display = (
-            dashboard(slots, config, start, push=push_state)
-            if config.rich
-            else contextlib.nullcontext()
-        )
-        async with display:
-            results = await asyncio.gather(
-                *(env.run_slot(slot, ctx, semaphore, on_complete) for slot in planned)
-            )
-            episodes = finished + list(results)
-            if (
-                push_state is not None
-            ):  # upload off the event loop so the view keeps refreshing
-                from verifiers.v1.utils.platform import push_traces
-
-                push_state.started = True
-                await asyncio.to_thread(push_traces, episodes, config, push_state)
-    return episodes
+        yield run
 
 
-async def run_eval_server(config: EvalConfig) -> list[Episode]:
-    """Run evaluation through the env-server worker pool."""
+@contextlib.asynccontextmanager
+async def _server(
+    config: EvalConfig,
+    semaphore: asyncio.Semaphore | None,
+    on_complete: OnComplete,
+) -> AsyncIterator[RunSlotFn]:
+    """Run slots through a spawned env-server worker pool: each rollout is its own
+    `run` request, dispatched least-busy across workers. The workers own the env
+    (and its serving resources); this process owns the taskset and the results."""
     import multiprocessing as mp
     from functools import partial
 
     from verifiers.v1.configs.serve import pool_serve_kwargs
     from verifiers.v1.serve import EnvClient, env_config_data, serve_env
-    from verifiers.v1.utils.loaders import load_taskset
     from verifiers.v1.utils.logging import setup_logging
 
-    server_kwargs = {
-        "config_data": env_config_data(config.env),  # picklable across the spawn
-        # `-c` seeds each worker's episode bound unless `[serve]` pins one — so a
-        # pool carries `workers * bound` episodes, as `multiplex` implies.
-        "max_concurrent": config.worker_max_concurrent,
-    }
-    # The client owns the taskset: load it here, once — the server (and its pool
-    # workers) never load data, they rebuild each dispatched task from its request.
-    taskset = load_taskset(config.env.taskset)
-    if config.num_tasks is None and taskset.INFINITE:
-        raise ValueError(
-            f"{type(taskset).__name__} is infinite - bound the run with -n"
-        )
-    selected = taskset.shuffle() if config.shuffle else taskset
-    if config.num_tasks is not None:
-        selected = selected.head(config.num_tasks)
-    tasks = list(selected)
     # Spawned processes inherit no logging — hand them the main process's setup so
     # their rollout logs land in the output dir.
     level = "DEBUG" if config.verbose else "INFO"
@@ -155,7 +88,10 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
             address_queue=address_queue,
             death_pipe=child_conn,
             log_setup=partial(setup_logging, level, log_file),
-            **server_kwargs,
+            config_data=env_config_data(config.env),  # picklable across the spawn
+            # `-c` seeds each worker's episode bound unless `[serve]` pins one — so a
+            # pool carries `workers * bound` episodes, as `multiplex` implies.
+            max_concurrent=config.worker_max_concurrent,
         ),
         daemon=False,
     )
@@ -164,65 +100,140 @@ async def run_eval_server(config: EvalConfig) -> list[Episode]:
     try:
         address = await asyncio.to_thread(address_queue.get, timeout=600)
         client = EnvClient(address=address)
-        await client.wait_for_server_startup(timeout=600)
-        # A run dispatches — and resumes — tasks by content: the client owns them,
-        # and `task.hash` is their identity.
-        plan = [
-            ({"task_data": task.data.model_dump(mode="json")}, config.num_rollouts)
-            for task in tasks
-        ]
-        out = output_path(config)
-        finished: list[Episode] = []
-        if config.resume:
-            keys = [task.hash for task in tasks]
-            loaded, owed = resume.load(out, keys, config.num_rollouts)
-            finished = [cast(Episode, episode) for episode in loaded]
-            counts = distribute(keys, owed, config.num_rollouts)
-            if not owed:  # already complete - report it and exit successfully
-                print(resume.nothing_to_resume_msg(out, len(plan), config.num_rollouts))
-                raise SystemExit(0)
-            plan = [(payload, n) for (payload, _), n in zip(plan, counts) if n]
-            logger.info(
-                "resuming %s: %d task(s), %d rollout(s) owed",
-                out,
-                len(plan),
-                sum(owed.values()),
-            )
-        else:
-            save_config(config, out)
-            logger.info(
-                "running %dx%d rollouts via the env-server %s pool on %s",
-                len(plan),
-                config.num_rollouts,
-                config.serve.pool.type,
-                config.model,
-            )
-        logger.info("results: %s", out)
-        semaphore = (
-            asyncio.Semaphore(config.max_concurrent) if config.max_concurrent else None
-        )
-        write_lock = asyncio.Lock()
+        try:
+            await client.wait_for_server_startup(timeout=600)
 
-        async def run_unit(payload: dict) -> list[Episode]:
-            async with semaphore or contextlib.nullcontext():
-                episode = await client.run(
-                    client=config.client,
-                    model=config.model,
-                    sampling=config.sampling,
-                    **payload,
-                )
-            episode.record_run(EvalRunInfo(id=config.run.id, name=config.run.name))
-            await append_episode(out, episode, write_lock)
-            return [cast(Episode, episode)]
+            async def run(slot: RunSlot) -> Episode:
+                async with semaphore or contextlib.nullcontext():
+                    slot.started = time.time()
+                    episode = await client.run(
+                        client=config.client,
+                        model=config.model,
+                        sampling=config.sampling,
+                        task_data=slot.task.data.model_dump(mode="json"),
+                    )
+                slot.traces = list(episode.traces)
+                slot.episode = cast(Episode, episode)
+                slot.done = True
+                await on_complete(cast(Episode, episode))
+                return cast(Episode, episode)
 
-        # Each rollout is its own `run` request, dispatched least-busy across workers.
-        units = [run_unit(payload) for payload, n in plan for _ in range(n)]
-        results = await asyncio.gather(*units)
-        await client.close()
-        return finished + [record for unit in results for record in unit]
+            yield run
+        finally:
+            await client.close()
     finally:
         proc.terminate()
         with contextlib.suppress(Exception):
             await asyncio.to_thread(proc.join, 10)
         with contextlib.suppress(Exception):
             parent_conn.close()
+
+
+async def run_eval(config: EvalConfig) -> list[Episode]:
+    from verifiers.v1.utils.loaders import load_environment, load_taskset
+
+    logger.info("eval config:\n%s", config.model_dump_json(indent=2))
+    # The env comes up in this process only for an in-process run; a served run's
+    # workers each load their own, and this process owns just the taskset.
+    env = None if config.server else load_environment(config.env)
+    taskset = env.taskset if env is not None else load_taskset(config.env.taskset)
+    if config.num_tasks is None and taskset.INFINITE:
+        raise ValueError(
+            f"{type(taskset).__name__} is infinite - bound the run with -n"
+        )
+    selected = taskset.shuffle() if config.shuffle else taskset
+    if config.num_tasks is not None:
+        selected = selected.head(config.num_tasks)
+    tasks = list(selected)
+    out = output_path(config)
+    # One (task, rollouts-to-run) pair per selected task; resume shrinks the counts.
+    plan = [(task, config.num_rollouts) for task in tasks]
+    # Kept on-disk rollouts rejoin the run as finished episodes; only owed ones re-run.
+    finished: list[Episode] = []
+    if config.resume:
+        keys = [task.hash for task in tasks]
+        # In-process, the env's own keep-verdict decides what resumes; a served run
+        # can't ask the worker-side env, so it keeps the default `episode.ok`.
+        complete = (
+            (lambda episode: env.complete(cast(Episode, episode)))
+            if env is not None
+            else None
+        )
+        loaded, owed = resume.load(out, keys, config.num_rollouts, complete)
+        finished = [cast(Episode, episode) for episode in loaded]
+        if not owed:  # already complete - report it and exit successfully
+            print(resume.nothing_to_resume_msg(out, len(tasks), config.num_rollouts))
+            raise SystemExit(0)
+        counts = distribute(keys, owed, config.num_rollouts)
+        plan = [(task, n) for task, n in zip(tasks, counts) if n]
+        logger.info(
+            "resuming %s: %d task(s), %d rollout(s) owed",
+            out,
+            len(plan),
+            sum(owed.values()),
+        )
+    else:
+        save_config(config, out)
+        via = (
+            f" via the env-server {config.serve.pool.type} pool"
+            if config.server
+            else ""
+        )
+        logger.info(
+            "running %dx%d rollouts on %s%s",
+            len(plan),
+            config.num_rollouts,
+            config.model,
+            via,
+        )
+    start = time.time()
+    logger.info("results: %s", out)
+
+    semaphore = (
+        asyncio.Semaphore(config.max_concurrent) if config.max_concurrent else None
+    )
+    write_lock = asyncio.Lock()
+
+    async def on_complete(episode: Episode) -> None:
+        episode.record_run(EvalRunInfo(id=config.run.id, name=config.run.name))
+        await append_episode(out, episode, write_lock)
+
+    backend = (
+        _in_process(env, config, semaphore, on_complete)
+        if env is not None
+        else _server(config, semaphore, on_complete)
+    )
+    async with backend as run_slot:
+        # The display slots: in-process ones are the env's own (it fills their live
+        # traces); a served rollout's is a client-side stand-in its worker never sees.
+        planned = [
+            slot
+            for task, n in plan
+            for slot in (
+                env.slots(task, n)
+                if env is not None
+                else [RunSlot(task) for _ in range(n)]
+            )
+        ]
+        slots = [RunSlot.finished(episode) for episode in finished] + planned
+        push_state = None
+        if config.push and config.rich is not None:
+            from verifiers.v1.utils.platform import PushState
+
+            push_state = PushState()
+        display = (
+            dashboard(slots, config, start, push=push_state)
+            if config.rich is not None
+            else contextlib.nullcontext()
+        )
+        async with display:
+            results = await asyncio.gather(*(run_slot(slot) for slot in planned))
+            episodes = finished + list(results)
+            if (
+                push_state is not None
+            ):  # upload off the event loop so the view keeps refreshing
+                from verifiers.v1.utils.platform import push_traces
+
+                push_state.started = True
+                await asyncio.to_thread(push_traces, episodes, config, push_state)
+    return episodes

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -72,9 +72,12 @@ async def _server(
     from verifiers.v1.utils.logging import setup_logging
 
     # Spawned processes inherit no logging — hand them the main process's setup so
-    # their rollout logs land in the output dir.
+    # their rollout logs land in the output dir. They share its stderr, so console
+    # output follows the main process's choice: off under the dashboard (worker log
+    # lines would print over the Live view and shift it), on otherwise.
     level = "DEBUG" if config.verbose else "INFO"
     log_file = str(output_path(config) / "logs" / "eval.log")
+    console = config.rich is None
     mpctx = mp.get_context("spawn")
     address_queue: mp.Queue = mpctx.Queue()
     # Death pipe: serve_env self-terminates if this process dies abruptly — we keep
@@ -87,7 +90,7 @@ async def _server(
             address="tcp://127.0.0.1:0",
             address_queue=address_queue,
             death_pipe=child_conn,
-            log_setup=partial(setup_logging, level, log_file),
+            log_setup=partial(setup_logging, level, log_file, console),
             config_data=env_config_data(config.env),  # picklable across the spawn
             # `-c` seeds each worker's episode bound unless `[serve]` pins one — so a
             # pool carries `workers * bound` episodes, as `multiplex` implies.

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -20,6 +20,7 @@ from verifiers.v1.cli.dashboard import dashboard
 from verifiers.v1.cli.eval import resume
 from verifiers.v1.cli.output import (
     append_episode,
+    attempt_log_file,
     output_path,
     save_config,
 )
@@ -78,7 +79,7 @@ async def _server(
     # output follows the main process's choice: off under the dashboard (worker log
     # lines would print over the Live view and shift it), on otherwise.
     level = "DEBUG" if config.verbose else "INFO"
-    log_file = str(output_path(config) / "logs" / "eval.log")
+    log_file = str(attempt_log_file(output_path(config)))
     console = config.rich is None
     mpctx = mp.get_context("spawn")
     address_queue: mp.Queue = mpctx.Queue()

--- a/verifiers/v1/cli/output.py
+++ b/verifiers/v1/cli/output.py
@@ -12,6 +12,7 @@ by this surface contain episodes only.
 import asyncio
 import hashlib
 import json
+import os
 from functools import cache
 from pathlib import Path
 
@@ -31,6 +32,40 @@ CONFIG_DIR = "configs"
 """Directory inside a run dir holding its resolved config (one `<cli>.json`, re-runnable
 via `@ <run-dir>/configs/<cli>.json`). Resolved configs are JSON, not TOML: JSON keeps
 nulls, so explicit None settings round-trip exactly on re-parse."""
+
+
+def create_attempt_log_dir(run_dir: Path) -> Path:
+    """Create `logs/attempt_<n>` for this launch attempt and atomically repoint the
+    relative `logs/latest` symlink at it (prime-rl's log layout). Every launch —
+    fresh or `--resume` — gets its own numbered log directory, so a resume never
+    appends to an earlier attempt's logs."""
+    logs_dir = run_dir / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    attempts = (
+        int(p.name.removeprefix("attempt_"))
+        for p in logs_dir.glob("attempt_*")
+        if p.name.removeprefix("attempt_").isdigit()
+    )
+    attempt_dir = logs_dir / f"attempt_{1 + max(attempts, default=0)}"
+    attempt_dir.mkdir()
+    # Atomically repoint the relative `latest` symlink: create a temp link, then rename.
+    tmp_link = logs_dir / f".{attempt_dir.name}"
+    if tmp_link.is_symlink() or tmp_link.exists():
+        tmp_link.unlink()
+    os.symlink(attempt_dir.name, tmp_link)
+    os.replace(tmp_link, logs_dir / "latest")
+    return attempt_dir
+
+
+def attempt_log_file(run_dir: Path) -> Path:
+    """The current attempt's `eval.log`. The CLI creates the attempt dir once at
+    startup; everyone after it — the runner's worker spawn, the dashboard's log
+    tail — resolves through `logs/latest`, so the whole invocation shares one file.
+    A direct `run_eval` call (no CLI) creates the first attempt itself."""
+    latest = run_dir / "logs" / "latest"
+    if not latest.exists():
+        create_attempt_log_dir(run_dir)
+    return latest / "eval.log"
 
 
 def config_digest(config: BaseModel) -> str:

--- a/verifiers/v1/cli/replay.py
+++ b/verifiers/v1/cli/replay.py
@@ -229,11 +229,7 @@ def main(argv: list[str] | None = None) -> None:
         return
 
     log_file = str(out / "logs" / "replay.log")
-    if config.rich:
-        setup_logging(level, log_file=log_file, console=False)
-        logging.lastResort = None
-    else:
-        setup_logging(level, log_file=log_file, console=True)
+    setup_logging(level, log_file=log_file, console=not config.rich)
     # Graceful shutdown: first Ctrl-C/SIGTERM unwinds the scoring teardown `finally`;
     # a second is swallowed so it can't orphan resources mid-cleanup.
     install_interrupt()

--- a/verifiers/v1/cli/validate.py
+++ b/verifiers/v1/cli/validate.py
@@ -503,8 +503,6 @@ def main(argv: list[str] | None = None) -> None:
         log_file=str(out / LOG_FILE),
         console=not config.rich,
     )
-    if config.rich:
-        logging.lastResort = None  # drop stdlib records that bypass loguru
     # Graceful shutdown: first Ctrl-C/SIGTERM unwinds each task's teardown `finally`
     # (containers/sandboxes); a second is swallowed so it can't orphan them mid-cleanup.
     install_interrupt()

--- a/verifiers/v1/configs/cli/eval.py
+++ b/verifiers/v1/configs/cli/eval.py
@@ -36,8 +36,8 @@ class RichConfig(BaseConfig):
     """The live dashboard."""
 
     show_logs: bool = False
-    """Replace the dashboard's per-rollout rows with a live tail of the run's log file
-    (`logs/eval.log`) — the env's own log lines included."""
+    """Replace the dashboard's per-rollout rows with a live tail of the attempt's log
+    file (`logs/latest/eval.log`) — the env's own log lines included."""
 
 
 class RunConfig(BaseConfig):

--- a/verifiers/v1/configs/cli/eval.py
+++ b/verifiers/v1/configs/cli/eval.py
@@ -32,6 +32,14 @@ def default_run_name(env: EnvConfig, model: str) -> str:
     return slug.lower()
 
 
+class RichConfig(BaseConfig):
+    """The live dashboard."""
+
+    show_logs: bool = False
+    """Replace the dashboard's per-rollout rows with a live tail of the run's log file
+    (`logs/eval.log`) — the env's own log lines included."""
+
+
 class RunConfig(BaseConfig):
     name: str | None = None
     """Run name. Auto-generated as `<env>--<model>--<harness>--<short-id>` when unset."""
@@ -53,8 +61,8 @@ class EvalConfig(BaseConfig):
     """The environment — which env, its seed taskset, each agent, its knobs. Narrowed to
     the selected env's config class by the env id, else the taskset id."""
     serve: ServeConfig = ServeConfig()
-    """How the env is hosted under `--server`: the worker pool, each worker's episode
-    bound. Ignored by an in-process run."""
+    """How the env is hosted: the worker pool, each worker's episode bound. Ignored
+    by an in-process run (`--no-server`)."""
     run: RunConfig = Field(default_factory=RunConfig)
     """Run identity: `run.name` names the run directory under `output_dir`, `run.id` is
     stamped on traces."""
@@ -95,12 +103,13 @@ class EvalConfig(BaseConfig):
     clean: bool = Field(False, exclude=True)
     """Delete the run directory (`output_dir / run.dir`) before running, overwriting a
     previous run's results. Excluded from the saved config."""
-    rich: bool = True
-    """Show a live dashboard instead of per-rollout logs (in-process only; an unset
-    `rich` defaults off under `--server`)."""
-    server: bool = False
-    """Drive rollouts through the env-server worker pool (sized by `[serve]`) instead of
-    in-process — the path prime-rl trains through. Incompatible with `--rich`."""
+    rich: RichConfig | None = Field(default_factory=RichConfig)
+    """The live dashboard (on by default; `--no-rich` streams logs to the console
+    instead). A server run has no live per-turn view, so its rollout rows fill in as
+    each episode completes; `--rich.show-logs` swaps the rows for the run's logs."""
+    server: bool = True
+    """Drive rollouts through the env-server worker pool (sized by `[serve]`, elastic
+    by default) — the path prime-rl trains through. `--no-server` runs in-process."""
     push: bool = True
     """Upload the finished run to the Prime Intellect platform (the private Evaluations
     tab) at the end of the eval. On by default; disable with `--no-push`. Needs
@@ -115,21 +124,6 @@ class EvalConfig(BaseConfig):
     run dir comes from the resolved config (`output_dir / run.dir`), so resume with the
     run's own config — e.g. `uv run eval @ <run-dir>/config.toml --resume`. Excluded
     from the saved config."""
-
-    @model_validator(mode="after")
-    def reject_rich_with_server(self):
-        """The dashboard reads live in-process run slots, so it can't ride the
-        worker pool: an unset `rich` defaults off under `--server`; an explicit
-        `--rich --server` is refused."""
-        if self.server and self.rich:
-            if "rich" not in self.model_fields_set:
-                self.rich = False
-                return self
-            raise ValueError(
-                "`--rich` (the live dashboard) runs in-process and can't be combined with "
-                "`--server`; drop `--rich`."
-            )
-        return self
 
     @property
     def env_id(self) -> str:

--- a/verifiers/v1/configs/cli/eval.py
+++ b/verifiers/v1/configs/cli/eval.py
@@ -60,9 +60,10 @@ class EvalConfig(BaseConfig):
     env: SerializeAsAny[EnvConfig] = SingleAgentEnvConfig()
     """The environment — which env, its seed taskset, each agent, its knobs. Narrowed to
     the selected env's config class by the env id, else the taskset id."""
-    serve: ServeConfig = ServeConfig()
-    """How the env is hosted: the worker pool, each worker's episode bound. Ignored
-    by an in-process run (`--no-server`)."""
+    serve: ServeConfig | None = Field(default_factory=ServeConfig)
+    """How the env is hosted: the env-server worker pool (elastic by default) and each
+    worker's episode bound — the path prime-rl trains through. `--no-serve` runs the
+    rollouts in-process instead."""
     run: RunConfig = Field(default_factory=RunConfig)
     """Run identity: `run.name` names the run directory under `output_dir`, `run.id` is
     stamped on traces."""
@@ -93,7 +94,7 @@ class EvalConfig(BaseConfig):
     )
     """Episodes in flight at once, `None` for no limit. An episode plays its agents one
     at a time, so this is the live agent runs too — until `--env.max-concurrent-agents`
-    says otherwise. Under `--server` it seeds each worker's bound, unless
+    says otherwise. Under `[serve]` it also seeds each worker's bound, unless
     `--serve.max-concurrent` pins one."""
     verbose: bool = Field(False, validation_alias=AliasChoices("verbose", "v"))
     """Log at debug level instead of the default info."""
@@ -105,11 +106,8 @@ class EvalConfig(BaseConfig):
     previous run's results. Excluded from the saved config."""
     rich: RichConfig | None = Field(default_factory=RichConfig)
     """The live dashboard (on by default; `--no-rich` streams logs to the console
-    instead). A server run has no live per-turn view, so its rollout rows fill in as
+    instead). A served run has no live per-turn view, so its rollout rows fill in as
     each episode completes; `--rich.show-logs` swaps the rows for the run's logs."""
-    server: bool = True
-    """Drive rollouts through the env-server worker pool (sized by `[serve]`, elastic
-    by default) — the path prime-rl trains through. `--no-server` runs in-process."""
     push: bool = True
     """Upload the finished run to the Prime Intellect platform (the private Evaluations
     tab) at the end of the eval. On by default; disable with `--no-push`. Needs
@@ -128,15 +126,6 @@ class EvalConfig(BaseConfig):
     @property
     def env_id(self) -> str:
         return self.env.env_id or ""
-
-    @property
-    def worker_max_concurrent(self) -> int | None:
-        """A served worker's episode bound: its own pin, else the run's `--max-concurrent`."""
-        return (
-            self.serve.max_concurrent
-            if self.serve.max_concurrent is not None
-            else self.max_concurrent
-        )
 
     @model_validator(mode="before")
     @classmethod

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -50,12 +50,15 @@ def _as_error(e: Exception) -> Error:
 @dataclass
 class RunSlot:
     """One planned episode, observable while it happens: `traces` collects the
-    current attempt (a retry restarts the list), `episode`/`done` land when final."""
+    current attempt (a retry restarts the list), `episode`/`done` land when final.
+    A runner that can't watch live traces (the env-server path) stamps `started`
+    at dispatch so the slot still reads as running."""
 
     task: Task
     traces: list[Trace] = field(default_factory=list)
     episode: Episode | None = None
     done: bool = False
+    started: float | None = None
 
     @classmethod
     def finished(cls, episode: Episode) -> "RunSlot":

--- a/verifiers/v1/utils/logging.py
+++ b/verifiers/v1/utils/logging.py
@@ -46,6 +46,10 @@ def setup_logging(
     logger.remove()
     if console:
         logger.add(sys.stderr, level=lvl, format=FORMAT)
+    else:
+        # The terminal is off-limits: stray stdlib records that bypass the intercept
+        # below must not fall through to stderr either (they'd print over the UI).
+        logging.lastResort = None
     if log_file is not None:
         Path(log_file).parent.mkdir(parents=True, exist_ok=True)
         logger.add(log_file, level=lvl, format=FORMAT)


### PR DESCRIPTION
## Summary

- Consolidate the eval CLI's two runners (`run_eval` in-process, `run_eval_server`) into one `run_eval(config)`. Task selection, resume, persistence, push, and the dashboard are shared; the two paths differ only in how one slot becomes one episode (`env.run_slot` vs. a `run` request to the pool).
- Run rollouts through the env-server worker pool by default (elastic: one worker, scales on demand). `serve` becomes an optional config block (`ServeConfig | None`), so one field says whether the env is hosted and how: `--no-serve` keeps the in-process path, `--serve.pool.*` sizes the pool as before.
- The rich dashboard now works in both modes. A served slot has no live traces, so it shows as a running rollout with an elapsed timer (`RunSlot.started`, stamped at dispatch); per-turn detail (stage, turns, branches, usage) fills in when the episode completes. In-process rows are unchanged.
- `rich` becomes an optional config block (`RichConfig | None`): `--no-rich` disables the dashboard, and the new `--rich.show-logs` swaps the per-rollout rows for a live tail of the run's log file (`logs/eval.log`) — the env workers' log lines included, since server workers already tee into the same file.
- Server workers follow the main process's console choice: under the dashboard they log to the file only (their stderr lines used to print over the Live view and shift it). `setup_logging(console=False)` now also nulls `logging.lastResort` itself, so the eval/replay/validate CLIs drop their per-site copies of that line.
- Adopt prime-rl's log layout: each launch — fresh or `--resume` — writes `logs/attempt_<n>/eval.log`, with a relative `logs/latest` symlink repointed atomically. The CLI creates the attempt dir at startup; the worker spawn and the dashboard tail resolve through `latest`, so one invocation shares one file and a resume never appends to an earlier attempt's logs. The tail also bounds its first read to the last 256KB of a pre-existing file, so it can never load a grown log whole on the render path.

### Dashboard in server mode

While an episode runs (no live per-turn view yet):

```
╭ [rollout ] task idx=0    0.3s
╰ [rollout ] task idx=0    0.2s
```

Once it completes, the row fills in as before:

```
╭ [success ] task idx=0 agent=solver · c938f08e · docker(d4aaa48a71d2) ·   1 turn · 1 branch · 480/354 tokens   reward=0.00 ·  8s
╰ [success ] task idx=0 agent=judge  · e1483310 · docker(d4aaa48a71d2) · 19 turns · 1 branch · 8.3K/3.4K tokens               57s
```

With `--rich.show-logs`, the rows section becomes the log stream (header, progress bar, and aggregates stay on top):

```
22:12:40  INFO rollout start: id=c9367141… task=0 harness=bash runtime=subprocess
22:12:49  INFO rollout done:  id=c8a9b91a… task=0 reward=0.000 turns=1 stop=single_turn
```

## Breaking

- The `server` bool is gone, and serving is on by default: `uv run eval <taskset>` now runs through the elastic env-server pool. `--server` becomes a no-op of the default; use `--no-serve` for the previous in-process behavior.
- `rich` changes from `bool` to an optional config block. `--rich false` becomes `--no-rich`; `rich = false` in TOML becomes `rich = "None"` (or drop the dashboard flags from the CLI: `--no-rich`). Saved configs from older runs no longer validate for `--resume`.
- `run_eval(env, config)` becomes `run_eval(config)`; `run_eval_server` is removed.
- The `--rich`/`--server` incompatibility validator is gone — the combination is now the default.
- The run log moves from `logs/eval.log` to `logs/attempt_<n>/eval.log` (read it via the `logs/latest` symlink).

## Verification

Full `{serve, no-serve} × {rollout rows, --rich.show-logs}` matrix, e2e on two envs (all runs completed, traces on disk, `err 0.00`):

| | rows | `--rich.show-logs` |
|---|---|---|
| **serve (default)**, `reverse-text` (single agent, bash/prime) | ✅ `[rollout]` while running → full detail on completion | ✅ worker logs streamed live |
| **serve (default)**, `shared-agentic-judge` (solver+judge, docker) | ✅ per-role rows, `judge` reward + `judge/solved` metric | ✅ |
| **`--no-serve`**, `reverse-text` | ✅ live stages unchanged (setup/rollout/scoring seen) | ✅ |
| **`--no-serve`**, `shared-agentic-judge` | ✅ (one episode solved: solver `reward=1.00`, judge verified) | ✅ |

Also verified:

- `--resume` on a finished server-mode run reports `nothing to resume` from the new saved-config shape.
- Server + dashboard leaves the terminal to the Live view: a pty capture of a full run shows zero worker log lines in the terminal stream, while the same lines land in the attempt's `eval.log`.
- Attempt layout e2e: a fresh run creates `logs/attempt_1` (`latest → attempt_1`, tailed by `--rich.show-logs`); `--resume` creates `attempt_2` and repoints `latest`, leaving `attempt_1` untouched.
- `tests/v1 -m "not e2e"` passes (70 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the default eval execution path to a spawned worker pool and breaks saved-config/`--resume` compatibility (`server`/`rich` shape, log layout). Core CLI, multiprocessing, and logging behavior all move together.
> 
> **Overview**
> **Eval rollouts now go through the env-server worker pool by default** (elastic; `--no-serve` for in-process). `run_eval(config)` is the single runner; `run_eval_server` and the `server` bool are gone. `serve` is `ServeConfig | None`.
> 
> The live dashboard works in both modes. Served slots have no live traces, so they show as running with an elapsed timer (`RunSlot.started`) until the episode lands. `rich` is now an optional `RichConfig` (`--no-rich`; `--rich.show-logs` tails `logs/latest/eval.log`).
> 
> Logs follow prime-rl’s attempt layout: each launch (including resume) writes `logs/attempt_<n>/eval.log` with an atomic `logs/latest` symlink. Workers inherit the main process’s console choice so they don’t print over the Live view; `setup_logging(console=False)` nulls `logging.lastResort`.
> 
> **Breaking:** `uv run eval` serves by default; `--rich false` → `--no-rich`; old saved configs won’t validate for `--resume`; `run_eval(env, config)` → `run_eval(config)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9be07166dadfad15bc7fb6ec47d97102c51ac4fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->