### PR TITLE
fix(v1): strip hub org prefix before importing a plugin module

### DIFF
--- a/verifiers/v1/utils/loaders.py
+++ b/verifiers/v1/utils/loaders.py
@@ -68,7 +68,10 @@ def narrow_plugin_field(
 
 
 def _import_plugin(plugin_id: str, kind: str, group: str) -> ModuleType:
-    module = plugin_id.replace("-", "_").lower()
+    # Hub ids are `owner/name[@version]` (installed as just `name`); strip both
+    # before normalizing so a hub id imports the same module a bare id would.
+    name = plugin_id.rsplit("/", 1)[-1].split("@", 1)[0]
+    module = name.replace("-", "_").lower()
     namespaced = f"{group}.{module}"
     target = namespaced if importlib.util.find_spec(namespaced) else module
     try:


### PR DESCRIPTION
## Summary

- `_import_plugin` only did `.replace("-", "_").lower()`, so a hub id like `prime/prime_forge_v1` was passed straight to `import_module` and always raised `ModuleNotFoundError`, even after `prime env install` landed the package on disk as `prime_forge_v1`.
- Strip the `owner/` prefix and `@version` suffix before normalizing, same as a bare id.

Found via a hosted FFT training run stuck crash-looping on `prime/prime_forge_v1`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Plugin import path is core to loading tasksets, harnesses, judges, and envs. The change is small and targeted, but a bad strip would mis-resolve modules for hub-style ids.
> 
> **Overview**
> Hub plugin ids like `owner/name[@version]` now import the same module as a bare `name`. `_import_plugin` previously passed the full hub id into `import_module`, so installed packages (e.g. `prime_forge_v1`) failed with `ModuleNotFoundError` even after `prime env install`.
> 
> Strips the `owner/` prefix and `@version` suffix before hyphen-to-underscore normalization. Bare ids are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af9ed0290442db85aaf27c2f685aea537a9687ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->