### PR TITLE
feat(v1): stamp renderer mm token type map onto traces

### DIFF
--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -12,7 +12,7 @@ from typing import Any, ClassVar, TypeVar
 from openai import OpenAIError
 from renderers import OverlongPromptError as RendererOverlongPromptError
 from renderers import RenderedTokens, Renderer, RendererConfig
-from renderers.base import ToolCallParseStatus
+from renderers.base import ToolCallParseStatus, is_multimodal
 
 from verifiers.v1.clients.base import build_async_openai
 from verifiers.v1.clients.client import SESSION_ID_HEADER, Client
@@ -97,7 +97,10 @@ def serialize_completion(response: Response, model: str) -> dict:
 
 
 def response_from_generate(
-    result: dict, model: str, bridged_turn: PendingTurn | None = None
+    result: dict,
+    model: str,
+    bridged_turn: PendingTurn | None = None,
+    mm_token_type_id_map: dict[int, int] | None = None,
 ) -> Response:
     """Parse a `renderers.client.generate` result dict into a typed `Response`,
     mirroring the chat client's `response_from_wire` (plus the token encoding)."""
@@ -154,6 +157,7 @@ def response_from_generate(
             message_spans=message_spans,
             is_content=attribution.is_content if attribution is not None else None,
             multi_modal_data=result.get("multi_modal_data"),
+            mm_token_type_id_map=mm_token_type_id_map,
             routed_experts=result.get("routed_experts"),
             kept_tokens=KeptTokens(**kept)
             if (kept := result.get("kept_tokens"))
@@ -371,6 +375,9 @@ class TrainClient(Client):
 
         async with pool.acquire() as slot:
             renderer = slot.renderer
+            mm_token_type_id_map = (
+                renderer.mm_token_type_id_map if is_multimodal(renderer) else None
+            )
             # Only build the (O(context)) previous-turn token ids once the cheap guards pass — a
             # multimodal prompt or a tail that isn't a clean `[tool*, user?]` extension can't bridge.
             can_bridge = (
@@ -434,7 +441,9 @@ class TrainClient(Client):
                 raise OverlongPromptError(str(e)) from e
             except OpenAIError as e:
                 raise model_error(e) from e
-        response = response_from_generate(result, model, bridged_turn)
+        response = response_from_generate(
+            result, model, bridged_turn, mm_token_type_id_map
+        )
         # No provider response to relay (we generated), so serialize one for the program; the
         # interception server hands `Response.raw` back regardless of client.
         response.raw = serialize_completion(response, model)

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -535,6 +535,9 @@ def _commit_turn(turn: PendingTurn, response: Response) -> int:
     prompt = turn.prompt
     tokens = response.tokens
     multi_modal_data = tokens.multi_modal_data if tokens else None
+    # Constant per renderer, so re-stamping every turn is idempotent.
+    if tokens is not None and tokens.mm_token_type_id_map:
+        trace.mm_token_type_id_map = tokens.mm_token_type_id_map
     prompt_ids = tokens.prompt_ids if tokens else []
     spans = tokens.message_spans if tokens else None
     is_content = tokens.is_content if tokens else None

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -7,7 +7,7 @@ from collections.abc import Callable, Iterable, Iterator, Mapping
 from typing import TYPE_CHECKING, Any, Generic
 
 import numpy as np
-from pydantic import BaseModel, Field, PrivateAttr
+from pydantic import BaseModel, Field, PrivateAttr, field_serializer
 from renderers.base import MultiModalData
 from typing_extensions import TypeVar
 
@@ -193,6 +193,8 @@ class Branch(BaseModel):
     index: int
     nodes: list[MessageNode]
     calls: list[ModelCall] = Field(default_factory=list)
+    mm_token_type_id_map: dict[int, int] = Field(default_factory=dict)
+    """The trace's `mm_token_type_id_map`, carried so `mm_token_type_ids` is self-contained."""
 
     @property
     def messages(self) -> Messages:
@@ -300,6 +302,16 @@ class Branch(BaseModel):
         return merged if found else None
 
     @property
+    def mm_token_type_ids(self) -> list[int] | None:
+        """Per-token modality markers aligned to `token_ids` (0 = text, 1 = image
+        placeholder, 2 = video placeholder), driving the trainer's vision-encoder
+        slicing; None for branches carrying no multimodal data."""
+        if self.multi_modal_data is None:
+            return None
+        mapping = self.mm_token_type_id_map
+        return [mapping.get(t, 0) for t in self.token_ids]
+
+    @property
     def routed_experts(self) -> np.ndarray | None:
         """uint8 `[tokens, layers, top_k]` routing; partial data returns None."""
         nodes = [n for n in self.nodes if n.token_ids]
@@ -378,6 +390,10 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
     """The message graph; branches are derived views and storage stays linear in turns."""
     calls: list[ModelCall] = Field(default_factory=list)
     """Every model call; automatically recorded at intercept time + linked into `nodes`."""
+    mm_token_type_id_map: dict[int, int] = Field(default_factory=dict)
+    """Special-token id -> modality marker (1 = image placeholder, 2 = video placeholder)
+    from the renderer that tokenized this trace, stamped at turn commit. Applied to a
+    branch's `token_ids` by `Branch.mm_token_type_ids`; empty for text-only renderers."""
     request_rewrites: list[InterceptRecord] = Field(default_factory=list)
     """Request changes made by `@intercept`, in execution order."""
     response_rewrites: list[InterceptRecord] = Field(default_factory=list)
@@ -408,6 +424,12 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
 
     _head_index: dict = PrivateAttr(default_factory=dict)
     """`(parent, msg_hash) -> node_id` for the graph builder."""
+
+    @field_serializer("mm_token_type_id_map")
+    def serialize_mm_token_type_id_map(self, mapping: dict[int, int]) -> dict[str, int]:
+        """The wire unpacks with msgpack's `strict_map_key`, which forbids int map keys —
+        dump str keys; validation coerces them back to int."""
+        return {str(k): v for k, v in mapping.items()}
 
     @property
     def reward(self) -> float:
@@ -464,6 +486,7 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
                     index=i,
                     nodes=[self.nodes[n] for n in path],
                     calls=[by_node[n] for n in path if n in by_node],
+                    mm_token_type_id_map=self.mm_token_type_id_map,
                 )
             )
         return branches

--- a/verifiers/v1/types.py
+++ b/verifiers/v1/types.py
@@ -212,6 +212,10 @@ class TurnTokens(BaseModel):
     # Transient carrier (excluded): the renderer's multimodal sidecar (image tensors + offsets),
     # attributed per node by the turn's `commit`, then dropped — never persisted.
     multi_modal_data: MultiModalData | None = Field(default=None, exclude=True)
+    # Transient carrier (excluded): the renderer's special-token id -> modality marker map,
+    # stamped onto `Trace.mm_token_type_id_map` by the turn's `commit`. None unless the
+    # rendering renderer is multimodal.
+    mm_token_type_id_map: dict[int, int] | None = Field(default=None, exclude=True)
     # Transient carrier (excluded): the MoE expert-routing data from `generate` (expert ids
     # per token), attributed per node by the turn's `commit` into `MessageNode.routed_experts`,
     # then dropped. None unless the engine ran with `enable_return_routed_experts`.


### PR DESCRIPTION
## Summary

- Stamp the renderer's `mm_token_type_id_map` (special-token id → modality marker, e.g. `<|image_pad|>` → 1) onto the trace, so traces are training-ready for multimodal without consumers building a renderer.
- `TrainClient.get_response` reads the map off the turn's renderer (`is_multimodal` gate) and carries it transiently on `TurnTokens`; `_commit_turn` stamps it onto `Trace.mm_token_type_id_map`.
- `Branch.mm_token_type_ids` exposes the training-ready per-token stream: the map applied to `branch.token_ids`, `None` for branches with no multimodal data. Same semantics prime-rl previously computed in its orchestrator with a locally built renderer.
- The map serializes with str keys (`field_serializer`) because the env-server wire unpacks with msgpack `strict_map_key`, which forbids int map keys; pydantic coerces them back to int on validation.

Companion: PrimeIntellect-ai/prime-rl#3349 (drops the orchestrator-side renderer and consumes `Branch.mm_token_type_ids`).

## Verification

- Unit: map round-trips through the msgpack wire dump (`model_dump(mode="python")` → `packb`/`unpackb` → `model_validate`) and JSON disk dump; `Branch.mm_token_type_ids` matches the map applied to concatenated node tokens.
- `tests/v1` suite green (18 skips need `PRIME_API_KEY`); `tests/test_renderer_client.py`, `tests/test_client_multimodal_types.py`, `tests/test_types.py` green.
- E2E with the companion PR: 6-step multimodal RL run (color-codeword, Qwen/Qwen3.5-4B, 1 train + 1 infer GPU) before (prime-rl main) and after (both PRs); after-run trains through all steps — the trainer hard-fails on image samples without `mm_token_type_ids`, so completing steps proves delivery — and an offline check on the dumped traces confirms the stamped map equals the renderer map the orchestrator used to build, with identical per-token ids on every branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches training-trace schema and multimodal token attribution used by the trainer. Serialization of int map keys is wire-sensitive, but the map is constant per renderer and stamped idempotently.
> 
> **Overview**
> Traces now carry the renderer's special-token → modality map so multimodal training samples are self-contained (`Branch.mm_token_type_ids`) without consumers reconstructing a renderer.
> 
> `TrainClient` reads `mm_token_type_id_map` from a multimodal renderer, carries it on transient `TurnTokens`, and `_commit_turn` stamps it onto `Trace`. Branches copy the map and expose per-token markers (0 text / 1 image / 2 video) aligned to `token_ids`.
> 
> Integer map keys serialize as strings for msgpack `strict_map_key`; pydantic coerces them back on load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9f1c5d32314f3b686257435cc2660c1343e341d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stamp renderer `mm_token_type_id_map` onto `Trace` and `Branch`
> - Captures the renderer's `mm_token_type_id_map` for multimodal renderers in `TrainClient.get_response`, carrying it through `TurnTokens` and `response_from_generate`
> - `graph._commit_turn` now persists the map onto the `Trace` when tokens carry it
> - Adds a persistent `mm_token_type_id_map` field to `Trace` and `Branch`; `Branch.mm_token_type_ids` computes per-token modality ids aligned to `token_ids`
> - `Trace` serializes the map with stringified keys for msgpack strict map key compatibility
> - Risk: `Trace` serialization now relies on the `field_serializer` in [trace.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2424/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e) to stringify keys; any out-of-tree code that reads `mm_token_type_id_map` directly may see string keys instead of the original key type
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a9f1c5d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->