### PR TITLE
fix(v1): forward sampling parameters across dialects

### DIFF
--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -359,12 +359,8 @@ class TrainClient(Client):
         multi_modal_data = None
         prompt_attribution: RenderedTokens | None = None
         model = body["model"]
-        raw_sampling = sampling.model_dump(exclude_none=True)
-        sampling_params: dict[str, Any] = dict(
-            raw_sampling.pop("extra_body", None) or {}
-        )
+        sampling_params = sampling.wire_args()
         chat_template_kwargs = sampling_params.pop("chat_template_kwargs", None)
-        sampling_params.update(raw_sampling)
         pool = ElasticRendererPool(
             self.config.renderer_model_name or model,
             self.config.renderer,

--- a/verifiers/v1/dialects/anthropic.py
+++ b/verifiers/v1/dialects/anthropic.py
@@ -443,6 +443,7 @@ class AnthropicDialect(Dialect[MessageCreateParams, AnthropicMessage]):
             "top_p",
             "top_k",
             "max_tokens",
+            "service_tier",
             "stop_sequences",
             "thinking",
             "tool_choice",
@@ -700,19 +701,17 @@ class AnthropicDialect(Dialect[MessageCreateParams, AnthropicMessage]):
         # Preserve native fields except the eval's model + sampling. `temperature`/`top_p` are
         # authoritative (always dropped, the eval's applied if set); `max_tokens` is required by
         # the API, so the program's is kept unless the eval sets one.
-        s = sampling.model_dump(exclude_none=True)
-        overrides: dict = {"model": model}
-        if "temperature" in s:
-            overrides["temperature"] = s["temperature"]
-        if "top_p" in s:
-            overrides["top_p"] = s["top_p"]
-        if "max_tokens" in s:
-            overrides["max_tokens"] = s["max_tokens"]
-        if "reasoning_effort" in s:
+        s = sampling.wire_args()
+        reasoning_effort = s.pop("reasoning_effort", None)
+        sampling_output_config = s.pop("output_config", None)
+        overrides: dict = {**s, "model": model}
+        if sampling_output_config is not None or reasoning_effort is not None:
             overrides["output_config"] = {
                 **dict(body.get("output_config") or {}),
-                "effort": s["reasoning_effort"],
+                **dict(sampling_output_config or {}),
             }
+            if reasoning_effort is not None:
+                overrides["output_config"]["effort"] = reasoning_effort
         steered = {
             k: v
             for k, v in body.items()

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -347,6 +347,7 @@ class ChatDialect(Dialect[CompletionCreateParams, ChatCompletion]):
             "presence_penalty",
             "repetition_penalty",
             "response_format",
+            "service_tier",
             "tool_choice",
             "parallel_tool_calls",
             "extra_body",
@@ -550,7 +551,15 @@ class ChatDialect(Dialect[CompletionCreateParams, ChatCompletion]):
         # Preserve the program's native fields, overlaying only what the eval owns: the model and
         # the sampling knobs it set. The selected model is authoritative even if a permissive
         # sampling config carries an extra field named `model`.
+        overrides = sampling.wire_args()
+        max_token_keys = {"max_tokens", "max_completion_tokens"}
+        max_tokens_overridden = not max_token_keys.isdisjoint(overrides)
+        steered = {
+            k: v
+            for k, v in body.items()
+            if not max_tokens_overridden or k not in max_token_keys
+        }
         return cast(
             CompletionCreateParams,
-            {**body, **sampling.model_dump(exclude_none=True), "model": model},
+            {**steered, **overrides, "model": model},
         )

--- a/verifiers/v1/dialects/responses.py
+++ b/verifiers/v1/dialects/responses.py
@@ -427,6 +427,7 @@ class ResponsesDialect(Dialect[ResponseCreateParams, OpenAIResponse]):
             "max_output_tokens",
             "max_tool_calls",
             "reasoning",
+            "service_tier",
             "text",
             "tool_choice",
             "parallel_tool_calls",
@@ -756,32 +757,32 @@ class ResponsesDialect(Dialect[ResponseCreateParams, OpenAIResponse]):
     ) -> ResponseCreateParams:
         # Preserve native fields except the eval's model + sampling, mapped to the Responses shape
         # (`max_tokens` -> `max_output_tokens`); sampling is authoritative.
-        s = sampling.model_dump(exclude_none=True)
+        s = sampling.wire_args()
+        max_tokens = s.pop("max_tokens", None)
+        reasoning_effort = s.pop("reasoning_effort", None)
+        sampling_reasoning = s.pop("reasoning", None)
         name = model.rsplit("/", 1)[-1]
         reasoning_model = (
             name.startswith(("gpt-5", "o1", "o3", "o4"))
             and "-chat" not in name
             and ("/" not in model or model.startswith("openai/"))
         )
-        overrides: dict = {"model": model}
+        overrides: dict = {**s, "model": model}
         if reasoning_model:
             # Preserve opaque reasoning state so it can be replayed on the next turn.
-            include = list(body.get("include") or [])
+            include = list(overrides.get("include") or body.get("include") or [])
             if "reasoning.encrypted_content" not in include:
                 include.append("reasoning.encrypted_content")
             overrides["include"] = include
-        if "temperature" in s:
-            overrides["temperature"] = s["temperature"]
-        if "top_p" in s:
-            overrides["top_p"] = s["top_p"]
-        if "max_tokens" in s:
-            overrides["max_output_tokens"] = s["max_tokens"]
-        reasoning = dict(body.get("reasoning") or {})
-        if reasoning_model:
-            # Summaries provide the trace's readable reasoning text.
-            reasoning = {"summary": "auto", **reasoning}
-        if "reasoning_effort" in s:
-            reasoning["effort"] = s["reasoning_effort"]
+        if max_tokens is not None:
+            overrides["max_output_tokens"] = max_tokens
+        reasoning = {
+            **({"summary": "auto"} if reasoning_model else {}),
+            **dict(body.get("reasoning") or {}),
+            **dict(sampling_reasoning or {}),
+        }
+        if reasoning_effort is not None:
+            reasoning["effort"] = reasoning_effort
         if reasoning:
             overrides["reasoning"] = reasoning
         steered = {

--- a/verifiers/v1/types.py
+++ b/verifiers/v1/types.py
@@ -250,6 +250,11 @@ class SamplingConfig(BaseModel):
         None, validation_alias=AliasChoices("max_tokens", "max_completion_tokens")
     )
 
+    def wire_args(self) -> dict[str, Any]:
+        """Flatten OpenAI-style ``extra_body`` before building a provider request."""
+        args = self.model_dump(exclude_none=True)
+        return {**(args.pop("extra_body", None) or {}), **args}
+
 
 Sampling = SamplingConfig
 

--- a/verifiers/v1/types.py
+++ b/verifiers/v1/types.py
@@ -253,7 +253,10 @@ class SamplingConfig(BaseModel):
     def wire_args(self) -> dict[str, Any]:
         """Flatten OpenAI-style ``extra_body`` before building a provider request."""
         args = self.model_dump(exclude_none=True)
-        return {**(args.pop("extra_body", None) or {}), **args}
+        extra_body = args.pop("extra_body", None) or {}
+        if "max_tokens" in args:
+            extra_body.pop("max_completion_tokens", None)
+        return {**extra_body, **args}
 
 
 Sampling = SamplingConfig

--- a/verifiers/v1/types.py
+++ b/verifiers/v1/types.py
@@ -253,7 +253,11 @@ class SamplingConfig(BaseModel):
     def wire_args(self) -> dict[str, Any]:
         """Flatten OpenAI-style ``extra_body`` before building a provider request."""
         args = self.model_dump(exclude_none=True)
-        extra_body = args.pop("extra_body", None) or {}
+        extra_body = {
+            key: value
+            for key, value in (args.pop("extra_body", None) or {}).items()
+            if value is not None
+        }
         if "max_tokens" in args:
             extra_body.pop("max_completion_tokens", None)
         return {**extra_body, **args}


### PR DESCRIPTION
## Overview

Forward eval sampling parameters consistently across Chat Completions, Responses, Anthropic Messages, and training requests.

## Details

- Flatten extra_body before building provider wire arguments, with explicit sampling fields taking precedence.
- Preserve provider-specific sampling fields while retaining protocol-specific max-token and reasoning mappings.
- Record service_tier in effective sampling metadata.
- Avoid conflicting Chat Completions max-token aliases when an eval supplies the override.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how sampling overrides are merged into provider requests, which can alter generation (max tokens, reasoning, extra_body). Logic is localized to dialect override paths, not auth or data handling.
> 
> **Overview**
> Eval sampling now reaches Chat Completions, Responses, Anthropic Messages, and training requests through a shared `SamplingConfig.wire_args()` helper. That flattens OpenAI-style `extra_body` into top-level wire args (typed knobs win), so extra provider fields are no longer dropped.
> 
> Dialect `apply_overrides` paths merge those flattened args instead of a small hardcoded subset, while still remapping protocol-specific keys (`max_tokens` → `max_output_tokens`, `reasoning_effort` into reasoning/`output_config`). Chat Completions drops conflicting `max_tokens`/`max_completion_tokens` aliases when the eval supplies either. `service_tier` is recorded in each dialect’s sampling metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4d847b469f00ac514e5920d399d6895195311d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Forward sampling parameters across v1 dialects via `wire_args`
> - Adds `SamplingConfig.wire_args()` to flatten non-None fields, lift `extra_body` values, and resolve `max_tokens` vs `max_completion_tokens` conflicts.
> - Updates `TrainClient` and all dialects (`Anthropic`, `Chat`, `Responses`) to use `wire_args()` instead of manual `model_dump` logic.
> - Adds `service_tier` to `sampling_fields` for all dialects.
> - Improves dialect-specific handling: merges `output_config`/`reasoning_effort` for Anthropic and Responses, and maps `max_tokens` to `max_output_tokens` for Responses.
> - Behavioral Change: `AnthropicDialect` now preserves body `temperature` and `top_p` unless explicitly overridden; `ChatDialect` drops both `max_tokens` and `max_completion_tokens` from the body when any max token override is provided.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b4d847b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->