### PR TITLE
Simplify V1 dialect implementations

### DIFF
--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -59,8 +59,11 @@ def serialize_completion(response: Response, model: str) -> dict:
         message["tool_calls"] = [
             {
                 "id": c.id,
-                "type": "function",
-                "function": {"name": c.name, "arguments": c.arguments},
+                "type": c.type,
+                c.type: {
+                    "name": c.name,
+                    "input" if c.type == "custom" else "arguments": c.arguments,
+                },
             }
             for c in response.message.tool_calls
         ]

--- a/verifiers/v1/dialects/__init__.py
+++ b/verifiers/v1/dialects/__init__.py
@@ -5,7 +5,6 @@ from verifiers.v1.dialects.chat import (
     ChatDialect,
     parse_message,
     parse_tools,
-    response_from_wire,
 )
 from verifiers.v1.dialects.responses import ResponsesDialect
 
@@ -23,5 +22,4 @@ __all__ = [
     "StreamParser",
     "parse_message",
     "parse_tools",
-    "response_from_wire",
 ]

--- a/verifiers/v1/dialects/anthropic.py
+++ b/verifiers/v1/dialects/anthropic.py
@@ -46,7 +46,7 @@ from verifiers.v1.types import (
 )
 
 # Anthropic stop_reason -> vf finish_reason.
-STOP_REASONS = {
+STOP_REASONS: dict[str, FinishReason] = {
     "end_turn": "stop",
     "max_tokens": "length",
     "tool_use": "tool_calls",
@@ -299,30 +299,29 @@ def parse_messages(body: dict) -> Messages:
 def response_from_wire(message: AnthropicMessage) -> Response:
     """An Anthropic `Message` -> a vf `Response` (its content blocks folded into one assistant
     message: text -> content, thinking -> reasoning, tool_use -> tool calls)."""
-    data = message.model_dump()
-    blocks = data.get("content") or []
-    state = [block for block in blocks if block["type"] in THINKING]
-    state.sort(key=lambda block: THINKING.index(block["type"]))
+    state: list[dict] = []
     content: list[str] = []
     reasoning: list[str] = []
     calls: list[ToolCall] = []
-    for block in blocks:
-        kind = block.get("type")
-        if kind == "text":
-            content.append(block.get("text", ""))
-        elif kind == "thinking":
-            reasoning.append(block.get("thinking", ""))
-        elif kind == "tool_use":
+    for block in message.content:
+        if block.type in THINKING:
+            state.append(block.model_dump())
+        if block.type == "text":
+            content.append(block.text)
+        elif block.type == "thinking":
+            reasoning.append(block.thinking)
+        elif block.type == "tool_use":
             calls.append(
                 ToolCall(
-                    id=block.get("id", ""),
-                    name=block.get("name", ""),
-                    arguments=json.dumps(block.get("input") or {}),
+                    id=block.id,
+                    name=block.name,
+                    arguments=json.dumps(block.input or {}),
                 )
             )
-    finish: FinishReason = STOP_REASONS.get(data.get("stop_reason") or "")
+    state.sort(key=lambda block: THINKING.index(block["type"]))
+    finish = STOP_REASONS.get(message.stop_reason or "")
     provider_usage = message.usage
-    output_details = data.get("usage", {}).get("output_tokens_details")
+    output_details = provider_usage.model_dump().get("output_tokens_details")
     # Anthropic reports three disjoint input buckets. Cache writes are uncached work;
     # cache reads are the reusable subset exposed separately by vf.Usage.
     usage = Usage(
@@ -338,9 +337,9 @@ def response_from_wire(message: AnthropicMessage) -> Response:
         cost=getattr(provider_usage, "cost", None),
     )
     return Response(
-        id=data.get("id", ""),
+        id=message.id,
         created=0,
-        model=data.get("model", ""),
+        model=message.model,
         message=AssistantMessage(
             content="".join(content) or None,
             reasoning_content="".join(reasoning) or None,
@@ -384,21 +383,14 @@ class AnthropicStreamParser(StreamParser):
                 "signature_delta",
             ):
                 field_name = delta_type.removesuffix("_delta")
-                fields = self.block_parts.get(index)
-                if fields is None:
-                    fields = {}
-                    self.block_parts[index] = fields
-                parts = fields.get(field_name)
-                if parts is None:
-                    parts = [block.get(field_name, "")]
-                    fields[field_name] = parts
+                parts = self.block_parts.setdefault(index, {}).setdefault(
+                    field_name, [block.get(field_name, "")]
+                )
                 parts.append(delta.get(field_name, ""))
             elif delta_type == "input_json_delta":
-                parts = self.partial_json.get(index)
-                if parts is None:
-                    parts = []
-                    self.partial_json[index] = parts
-                parts.append(delta.get("partial_json", ""))
+                self.partial_json.setdefault(index, []).append(
+                    delta.get("partial_json", "")
+                )
         elif kind == "message_delta":
             self.message.update(
                 {

--- a/verifiers/v1/dialects/anthropic.py
+++ b/verifiers/v1/dialects/anthropic.py
@@ -10,15 +10,14 @@ import json
 import re
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
-from typing import cast
 
 from anthropic.types import Message as AnthropicMessage
-from anthropic.types import MessageCreateParams
 from anthropic.types import Usage as AnthropicUsage
 
 from verifiers.v1.configs.runtime import NetworkPolicyConfig
 from verifiers.v1.dialects.base import (
     Dialect,
+    RawRequest,
     StreamParser,
     append_user_notice,
     blocked_url,
@@ -428,7 +427,7 @@ class ModdedAnthropicMessage(AnthropicMessage):
     usage: ModdedUsage  # type: ignore[assignment]
 
 
-class AnthropicDialect(Dialect[MessageCreateParams, AnthropicMessage]):
+class AnthropicDialect(Dialect[AnthropicMessage]):
     sampling_fields = frozenset(
         {
             "temperature",
@@ -447,8 +446,8 @@ class AnthropicDialect(Dialect[MessageCreateParams, AnthropicMessage]):
     response_type = ModdedAnthropicMessage
 
     def mediate_external_capabilities(
-        self, body: MessageCreateParams, policy: NetworkPolicyConfig
-    ) -> tuple[MessageCreateParams, list[str]]:
+        self, body: RawRequest, policy: NetworkPolicyConfig
+    ) -> tuple[RawRequest, list[str]]:
         mediated = body
         capabilities: list[str] = []
 
@@ -561,7 +560,7 @@ class AnthropicDialect(Dialect[MessageCreateParams, AnthropicMessage]):
             "error": {"type": "invalid_request_error", "message": message},
         }
 
-    def parse_request(self, body: MessageCreateParams) -> Request:
+    def parse_request(self, body: RawRequest) -> Request:
         tools = [
             Tool(
                 name=t["name"],
@@ -672,7 +671,7 @@ class AnthropicDialect(Dialect[MessageCreateParams, AnthropicMessage]):
     def stream_parser(self) -> StreamParser:
         return AnthropicStreamParser(self.validate_response)
 
-    def parse_sampling(self, body: MessageCreateParams) -> Sampling:
+    def parse_sampling(self, body: RawRequest) -> Sampling:
         settings = {k: v for k, v in body.items() if k in self.sampling_fields}
         # Lift `output_config.effort` (where `apply_overrides` puts the eval's
         # reasoning effort) onto the typed knob; keep any other output-config keys.
@@ -687,8 +686,8 @@ class AnthropicDialect(Dialect[MessageCreateParams, AnthropicMessage]):
         return Sampling.model_validate(settings)
 
     def apply_overrides(
-        self, body: MessageCreateParams, model: str, sampling: SamplingConfig
-    ) -> MessageCreateParams:
+        self, body: RawRequest, model: str, sampling: SamplingConfig
+    ) -> RawRequest:
         # Preserve native fields except the eval's model + sampling. `temperature`/`top_p` are
         # authoritative (always dropped, the eval's applied if set); `max_tokens` is required by
         # the API, so the program's is kept unless the eval sets one.
@@ -710,4 +709,4 @@ class AnthropicDialect(Dialect[MessageCreateParams, AnthropicMessage]):
             for k, v in body.items()
             if k not in ("temperature", "top_p") and k not in overrides
         }
-        return cast(MessageCreateParams, {**steered, **overrides})
+        return {**steered, **overrides}

--- a/verifiers/v1/dialects/base.py
+++ b/verifiers/v1/dialects/base.py
@@ -1,6 +1,6 @@
 """The `Dialect` abstraction: one native wire format, translated to vf for the trace.
 
-A `Dialect[ReqT, RespT]` is the per-format translator the interception server uses to build the
+A `Dialect[RespT]` is the per-format translator the interception server uses to build the
 trace from the program's native request + the provider's native response. The server serves
 every registered dialect's `routes` (see `dialects.DIALECTS`), so a request's format is resolved
 from the endpoint the program's SDK posts to — the harness declares nothing.
@@ -15,7 +15,7 @@ import json
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping
-from typing import ClassVar, Generic, TypeVar
+from typing import Any, ClassVar, Generic, TypeVar
 from urllib.parse import urlsplit
 
 from pydantic import AnyHttpUrl, BaseModel, ValidationError
@@ -24,8 +24,8 @@ from pydantic_core import from_json
 from verifiers.v1.configs.runtime import NetworkPolicyConfig, network_rule_matches
 from verifiers.v1.types import Request, Response, Sampling, SamplingConfig
 
-ReqT = TypeVar("ReqT", bound=Mapping[str, object])
 RespT = TypeVar("RespT", bound=BaseModel)
+RawRequest = dict[str, Any]
 
 logger = logging.getLogger(__name__)
 
@@ -188,11 +188,11 @@ class StreamParser(ABC):
         """Finalize and return the assembled response after the stream ends."""
 
 
-class Dialect(ABC, Generic[ReqT, RespT]):
-    """One native API's wire format, fully typed over its request (`ReqT`) and response
-    (`RespT`). The single place a protocol lives: implement a `Dialect` + register it in
-    `dialects.DIALECTS` and a harness speaking that format works end-to-end (the eval client and
-    interception server are generic over this interface)."""
+class Dialect(ABC, Generic[RespT]):
+    """One native API's wire format, typed over its validated response (`RespT`). Requests stay
+    as mutable native JSON because the gateway preserves provider extensions while mediating and
+    rewriting them. Implement a `Dialect` + register it in `dialects.DIALECTS` and a harness
+    speaking that format works end-to-end."""
 
     sampling_fields: ClassVar[frozenset[str]] = frozenset()
     """Request keys that are call settings — what shapes generation given the same
@@ -226,7 +226,7 @@ class Dialect(ABC, Generic[ReqT, RespT]):
         (default: an `Authorization: Bearer` token; Anthropic uses `x-api-key`)."""
         return headers.get("Authorization", "").removeprefix("Bearer ")
 
-    def streaming(self, body: ReqT) -> bool:
+    def streaming(self, body: RawRequest) -> bool:
         """Whether the request asks for a streamed (SSE) response."""
         return bool(body.get("stream"))
 
@@ -244,17 +244,17 @@ class Dialect(ABC, Generic[ReqT, RespT]):
 
     @abstractmethod
     def mediate_external_capabilities(
-        self, body: ReqT, policy: NetworkPolicyConfig
-    ) -> tuple[ReqT, list[str]]:
+        self, body: RawRequest, policy: NetworkPolicyConfig
+    ) -> tuple[RawRequest, list[str]]:
         """Remove provider-side capabilities during restricted execution. Implementations add
         the same policy context on every call because the agent does not retain injected request
         content. Returned paths never contain request values."""
 
     @abstractmethod
-    def parse_request(self, body: ReqT) -> Request:
+    def parse_request(self, body: RawRequest) -> Request:
         """The native request -> the typed model request."""
 
-    def parse_sampling(self, body: ReqT) -> Sampling:
+    def parse_sampling(self, body: RawRequest) -> Sampling:
         """The native request's call settings -> the canonical `Sampling` (for the
         trace's per-call records): the `sampling_fields` whitelist, with this format's
         aliases mapped onto the typed knobs; dialect-specific keys ride as extras."""
@@ -271,7 +271,9 @@ class Dialect(ABC, Generic[ReqT, RespT]):
         return self.response_type.model_validate(raw)
 
     @abstractmethod
-    def rewrite_request(self, body: ReqT, before: Request, after: Request) -> None:
+    def rewrite_request(
+        self, body: RawRequest, before: Request, after: Request
+    ) -> None:
         """Patch rewritten user/tool messages into the native conversation."""
 
     @abstractmethod
@@ -287,7 +289,9 @@ class Dialect(ABC, Generic[ReqT, RespT]):
         """Create the per-request incremental parser for a native SSE response."""
 
     @abstractmethod
-    def apply_overrides(self, body: ReqT, model: str, sampling: SamplingConfig) -> ReqT:
+    def apply_overrides(
+        self, body: RawRequest, model: str, sampling: SamplingConfig
+    ) -> RawRequest:
         """Return `body` with the eval's `model` + `sampling` imposed in this protocol's shape —
         model overlays; sampling is authoritative (the program's sampling keys are dropped, the
         eval's applied). Capability mediation may subsequently remove restricted fields."""

--- a/verifiers/v1/dialects/base.py
+++ b/verifiers/v1/dialects/base.py
@@ -14,21 +14,20 @@ exception is `apply_overrides` (impose the eval's model + sampling in this forma
 import json
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterator, Mapping
+from collections.abc import Callable, Mapping
 from typing import ClassVar, Generic, TypeVar
 from urllib.parse import urlsplit
 
-from pydantic import AnyHttpUrl, BaseModel, TypeAdapter, ValidationError
+from pydantic import AnyHttpUrl, BaseModel, ValidationError
 from pydantic_core import from_json
 
 from verifiers.v1.configs.runtime import NetworkPolicyConfig, network_rule_matches
 from verifiers.v1.types import Request, Response, Sampling, SamplingConfig
 
-ReqT = TypeVar("ReqT")
+ReqT = TypeVar("ReqT", bound=Mapping[str, object])
 RespT = TypeVar("RespT", bound=BaseModel)
 
 logger = logging.getLogger(__name__)
-HTTP_URL_ADAPTER = TypeAdapter(AnyHttpUrl)
 
 PROVIDER_CAPABILITY_POLICY_CODE = "provider_capability_unavailable"
 CAPABILITY_NOTICE = (
@@ -43,7 +42,7 @@ def blocked_url(value: str, policy: NetworkPolicyConfig) -> bool:
     if value.lower().startswith("data:"):
         return False
     try:
-        url = HTTP_URL_ADAPTER.validate_python(value)
+        url = AnyHttpUrl(value)
     except ValidationError:
         return True
     host = url.host.lower().rstrip(".").strip("[]")
@@ -173,26 +172,6 @@ def parse_sse_event(raw: bytes) -> dict | None:
             "SSE JSON fast-path failed; falling back to stdlib with invalid UTF-8 replacement"
         )
         return json.loads(data.decode("utf-8", errors="replace"))
-
-
-def iter_sse_reverse(raw: bytes) -> Iterator[dict]:
-    """Yield JSON SSE payloads from the end without decoding earlier events."""
-    decoded = raw.decode("utf-8", errors="replace")
-    first_newline = decoded.find("\n")
-    separator = (
-        "\r\n\r\n"
-        if first_newline > 0 and decoded[first_newline - 1] == "\r"
-        else "\n\n"
-    )
-    for block in reversed(decoded.split(separator)):
-        data = "\n".join(
-            line.removeprefix("data:").strip()
-            for line in block.splitlines()
-            if line.startswith("data:")
-        )
-        if not data or data == "[DONE]":
-            continue
-        yield json.loads(data)
 
 
 class StreamParser(ABC):

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -11,15 +11,15 @@ import time
 from collections.abc import Mapping
 from dataclasses import dataclass
 from dataclasses import field as dataclass_field
-from typing import Any, cast
+from typing import Any
 from urllib.parse import urlsplit
 
 from openai.types.chat import ChatCompletion
-from openai.types.chat.completion_create_params import CompletionCreateParams
 
 from verifiers.v1.configs.runtime import NetworkPolicyConfig
 from verifiers.v1.dialects.base import (
     Dialect,
+    RawRequest,
     StreamParser,
     append_user_notice,
     blocked_url,
@@ -104,18 +104,22 @@ def parse_message(raw: dict) -> Message:
             if isinstance(content, list)
             else content or ""
         )
-        calls = [
-            ToolCall(
-                id=c["id"],
-                name=c["function"]["name"],
-                arguments=c["function"]["arguments"],
+        calls = []
+        for call in raw.get("tool_calls") or []:
+            kind = call.get("type", "function")
+            native = call[kind]
+            calls.append(
+                ToolCall(
+                    id=call["id"],
+                    type=kind,
+                    name=native["name"],
+                    arguments=native["input" if kind == "custom" else "arguments"],
+                )
             )
-            for c in (raw.get("tool_calls") or [])
-        ] or None
         return AssistantMessage(
             content=text or None,
             reasoning_content=reasoning_text(raw),
-            tool_calls=calls,
+            tool_calls=calls or None,
             provider_state=details if isinstance(details, list) and details else None,
         )
     return UserMessage(content=content_to_parts(content))
@@ -168,8 +172,13 @@ def message_to_wire(message: Message) -> dict:
             wire["tool_calls"] = [
                 {
                     "id": call.id,
-                    "type": "function",
-                    "function": {"name": call.name, "arguments": call.arguments},
+                    "type": call.type,
+                    call.type: {
+                        "name": call.name,
+                        "input"
+                        if call.type == "custom"
+                        else "arguments": call.arguments,
+                    },
                 }
                 for call in message.tool_calls
             ]
@@ -190,13 +199,8 @@ def response_from_wire(completion: ChatCompletion) -> Response:
     """An OpenAI chat.completion -> a vf `Response` (the one place raw provider objects cross
     into our typed `Response`). No token ids: training tokens come from the renderer client."""
     choice = completion.choices[0]
-    message = choice.message
-    data = message.model_dump()
-    details = data.get("reasoning_details")
-    tool_calls = [
-        ToolCall(id=tc.id, name=tc.function.name, arguments=tc.function.arguments)
-        for tc in (message.tool_calls or [])
-    ] or None
+    message = parse_message(choice.message.model_dump())
+    assert isinstance(message, AssistantMessage)
     finish: FinishReason = (
         choice.finish_reason if choice.finish_reason in FINISH_REASONS else None
     )
@@ -205,12 +209,7 @@ def response_from_wire(completion: ChatCompletion) -> Response:
         id=completion.id,
         created=completion.created,
         model=completion.model,
-        message=AssistantMessage(
-            content=message.content,
-            reasoning_content=reasoning_text(data),
-            tool_calls=tool_calls,
-            provider_state=details if isinstance(details, list) and details else None,
-        ),
+        message=message,
         finish_reason=finish,
         usage=usage,
     )
@@ -225,7 +224,7 @@ class ChatStreamParser(StreamParser):
     )
     message_parts: dict[str, list[str]] = dataclass_field(default_factory=dict)
     tool_calls: dict[int, dict] = dataclass_field(default_factory=dict)
-    tool_arguments: dict[int, list[str]] = dataclass_field(default_factory=dict)
+    tool_inputs: dict[int, list[str]] = dataclass_field(default_factory=dict)
     reasoning_details: list[dict] = dataclass_field(default_factory=list)
     reasoning_detail_parts: dict[int, tuple[str, list[str]]] = dataclass_field(
         default_factory=dict
@@ -278,16 +277,19 @@ class ChatStreamParser(StreamParser):
                     self.reasoning_details.append(detail)
             for tool_call in delta.get("tool_calls") or []:
                 index = tool_call.get("index", 0)
-                slot = self.tool_calls.setdefault(
-                    index,
-                    {"type": "function", "function": {"name": "", "arguments": ""}},
-                )
+                slot = self.tool_calls.setdefault(index, {})
                 slot["id"] = tool_call.get("id") or slot.get("id", "")
-                function = tool_call.get("function") or {}
-                if function.get("name"):
-                    slot["function"]["name"] = function["name"]
-                self.tool_arguments.setdefault(index, []).append(
-                    function.get("arguments") or ""
+                kind = tool_call.get("type") or (
+                    "custom" if tool_call.get("custom") is not None else "function"
+                )
+                slot["type"] = kind
+                native = slot.setdefault(kind, {"name": ""})
+                delta_native = tool_call.get(kind) or {}
+                if delta_native.get("name"):
+                    native["name"] = delta_native["name"]
+                input_field = "input" if kind == "custom" else "arguments"
+                self.tool_inputs.setdefault(index, []).append(
+                    delta_native.get(input_field) or ""
                 )
 
     def finish(self) -> Response:
@@ -296,8 +298,10 @@ class ChatStreamParser(StreamParser):
                 self.message[key] = "".join(parts)
         for index, (content_field, parts) in self.reasoning_detail_parts.items():
             self.reasoning_details[index][content_field] = "".join(parts)
-        for index, parts in self.tool_arguments.items():
-            self.tool_calls[index]["function"]["arguments"] = "".join(parts)
+        for index, parts in self.tool_inputs.items():
+            call = self.tool_calls[index]
+            input_field = "input" if call["type"] == "custom" else "arguments"
+            call[call["type"]][input_field] = "".join(parts)
         if self.tool_calls:
             self.message["tool_calls"] = [
                 self.tool_calls[index] for index in sorted(self.tool_calls)
@@ -324,7 +328,7 @@ class ChatStreamParser(StreamParser):
         return response
 
 
-class ChatDialect(Dialect[CompletionCreateParams, ChatCompletion]):
+class ChatDialect(Dialect[ChatCompletion]):
     sampling_fields = frozenset(
         {
             "temperature",
@@ -354,14 +358,14 @@ class ChatDialect(Dialect[CompletionCreateParams, ChatCompletion]):
     response_type = ModdedChatCompletion
 
     def mediate_external_capabilities(
-        self, body: CompletionCreateParams, policy: NetworkPolicyConfig
-    ) -> tuple[CompletionCreateParams, list[str]]:
+        self, body: RawRequest, policy: NetworkPolicyConfig
+    ) -> tuple[RawRequest, list[str]]:
         mediated = body
         capabilities: list[str] = []
 
         if mediated.pop("web_search_options", None) is not None:
             capabilities.append("web_search_options")
-        if cast(dict, mediated).pop("plugins", None) is not None:
+        if mediated.pop("plugins", None) is not None:
             capabilities.append("plugins")
 
         audio = mediated.get("audio")
@@ -475,7 +479,7 @@ class ChatDialect(Dialect[CompletionCreateParams, ChatCompletion]):
         append_user_notice(mediated.setdefault("messages", []))
         return mediated, capabilities
 
-    def parse_request(self, body: CompletionCreateParams) -> Request:
+    def parse_request(self, body: RawRequest) -> Request:
         if body.get("n", 1) != 1:
             raise ValueError("chat completions require n=1")
         messages: Messages = []
@@ -492,7 +496,7 @@ class ChatDialect(Dialect[CompletionCreateParams, ChatCompletion]):
                     tool_names[call.id] = call.name
         return Request(messages=messages, tools=parse_tools(body.get("tools")))
 
-    def parse_sampling(self, body: CompletionCreateParams) -> Sampling:
+    def parse_sampling(self, body: RawRequest) -> Sampling:
         settings = {k: v for k, v in body.items() if k in self.sampling_fields}
         # Canonicalize the max-tokens alias; when both ride the wire (an eval override
         # on top of a harness's `max_completion_tokens`), the override wins.
@@ -542,12 +546,9 @@ class ChatDialect(Dialect[CompletionCreateParams, ChatCompletion]):
         return ChatStreamParser()
 
     def apply_overrides(
-        self, body: CompletionCreateParams, model: str, sampling: SamplingConfig
-    ) -> CompletionCreateParams:
+        self, body: RawRequest, model: str, sampling: SamplingConfig
+    ) -> RawRequest:
         # Preserve the program's native fields, overlaying only what the eval owns: the model and
         # the sampling knobs it set. The selected model is authoritative even if a permissive
         # sampling config carries an extra field named `model`.
-        return cast(
-            CompletionCreateParams,
-            {**body, **sampling.model_dump(exclude_none=True), "model": model},
-        )
+        return {**body, **sampling.model_dump(exclude_none=True), "model": model}

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -312,10 +312,13 @@ class ChatStreamParser(StreamParser):
             call = self.tool_calls[index]
             input_field = "input" if call["type"] == "custom" else "arguments"
             call[call["type"]][input_field] = "".join(parts)
-        if self.tool_calls:
-            self.message["tool_calls"] = [
-                self.tool_calls[index] for index in sorted(self.tool_calls)
-            ]
+        tool_calls = [
+            self.tool_calls[index]
+            for index in sorted(self.tool_calls)
+            if self.tool_calls[index].get("type") in _CLIENT_TOOL_TYPES
+        ]
+        if tool_calls:
+            self.message["tool_calls"] = tool_calls
         if self.reasoning_details:
             self.message["reasoning_details"] = self.reasoning_details
         head = self.head or {}

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -84,12 +84,6 @@ def reasoning_text(data: Mapping[str, Any]) -> str | None:
     return None
 
 
-def _content_text(content) -> str:
-    if isinstance(content, list):
-        return "".join(p.get("text", "") for p in content if isinstance(p, dict))
-    return content or ""
-
-
 def parse_message(raw: dict) -> Message:
     """An OpenAI chat request message dict -> a typed Message. User/system bodies keep their
     image parts (multimodal ingress); assistant bodies flatten to text."""
@@ -105,6 +99,11 @@ def parse_message(raw: dict) -> Message:
         )
     if role == "assistant":
         details = raw.get("reasoning_details")
+        text = (
+            "".join(part.get("text", "") for part in content if isinstance(part, dict))
+            if isinstance(content, list)
+            else content or ""
+        )
         calls = [
             ToolCall(
                 id=c["id"],
@@ -114,7 +113,7 @@ def parse_message(raw: dict) -> Message:
             for c in (raw.get("tool_calls") or [])
         ] or None
         return AssistantMessage(
-            content=_content_text(content) or None,
+            content=text or None,
             reasoning_content=reasoning_text(raw),
             tool_calls=calls,
             provider_state=details if isinstance(details, list) and details else None,
@@ -224,9 +223,7 @@ class ChatStreamParser(StreamParser):
     message: dict = dataclass_field(
         default_factory=lambda: {"role": "assistant", "content": None}
     )
-    message_parts: dict[str, list[str]] = dataclass_field(
-        default_factory=lambda: {key: [] for key in REASONING_FIELDS[:2] + ("content",)}
-    )
+    message_parts: dict[str, list[str]] = dataclass_field(default_factory=dict)
     tool_calls: dict[int, dict] = dataclass_field(default_factory=dict)
     tool_arguments: dict[int, list[str]] = dataclass_field(default_factory=dict)
     reasoning_details: list[dict] = dataclass_field(default_factory=list)
@@ -251,7 +248,7 @@ class ChatStreamParser(StreamParser):
             delta = choice.get("delta") or {}
             for key in ("content", "reasoning_content", "reasoning"):
                 if delta.get(key) is not None:
-                    self.message_parts[key].append(delta[key])
+                    self.message_parts.setdefault(key, []).append(delta[key])
             for detail in delta.get("reasoning_details") or []:
                 previous = self.reasoning_details[-1] if self.reasoning_details else {}
                 detail_type = detail.get("type")
@@ -511,7 +508,7 @@ class ChatDialect(Dialect[CompletionCreateParams, ChatCompletion]):
             body.get("messages", []), before.messages, after.messages, strict=True
         ):
             if rewritten != original:
-                native["content"] = message_to_wire(rewritten)["content"]
+                native["content"] = _content_to_wire(rewritten.content)
                 if isinstance(rewritten, ToolMessage):
                     if rewritten.name is None:
                         native.pop("name", None)

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -106,7 +106,9 @@ def parse_message(raw: dict) -> Message:
         )
         calls = []
         for call in raw.get("tool_calls") or []:
-            kind = call.get("type", "function")
+            kind = call.get("type") or (
+                "custom" if call.get("custom") is not None else "function"
+            )
             native = call[kind]
             calls.append(
                 ToolCall(
@@ -279,9 +281,17 @@ class ChatStreamParser(StreamParser):
                 index = tool_call.get("index", 0)
                 slot = self.tool_calls.setdefault(index, {})
                 slot["id"] = tool_call.get("id") or slot.get("id", "")
-                kind = tool_call.get("type") or (
-                    "custom" if tool_call.get("custom") is not None else "function"
-                )
+                kind = tool_call.get("type")
+                if kind is None:
+                    kind = (
+                        "custom"
+                        if tool_call.get("custom") is not None
+                        else "function"
+                        if tool_call.get("function") is not None
+                        else slot.get("type")
+                    )
+                if kind is None:
+                    continue
                 slot["type"] = kind
                 native = slot.setdefault(kind, {"name": ""})
                 delta_native = tool_call.get(kind) or {}

--- a/verifiers/v1/dialects/responses.py
+++ b/verifiers/v1/dialects/responses.py
@@ -12,10 +12,12 @@ import re
 from collections import deque
 from typing import cast
 
-from openai.types.responses import (
+from openai.types.responses.response_create_params import ResponseCreateParams
+from openai.types.responses.response_usage import (
+    InputTokensDetails,
+    OutputTokensDetails,
     ResponseUsage,
 )
-from openai.types.responses.response_create_params import ResponseCreateParams
 from pydantic import BaseModel, ConfigDict
 
 from verifiers.v1.configs.runtime import NetworkPolicyConfig
@@ -24,7 +26,7 @@ from verifiers.v1.dialects.base import (
     StreamParser,
     append_user_notice,
     blocked_url,
-    iter_sse_reverse,
+    parse_sse_event,
     provider_allowed_domains,
 )
 from verifiers.v1.errors import OverlongPromptError, model_error
@@ -97,19 +99,17 @@ BLANK_PNG = (
 )
 
 
-class ProviderUsageInputTokensDetails(BaseModel):
+class ProviderUsageInputTokensDetails(InputTokensDetails):
     """Permissive input token details: OpenAI-compatible providers may omit fields
     the pinned SDK declares required (e.g. ``cache_write_tokens``)."""
 
-    model_config = ConfigDict(extra="allow")
     cache_write_tokens: int | None = None
     cached_tokens: int | None = None
 
 
-class ProviderUsageOutputTokensDetails(BaseModel):
+class ProviderUsageOutputTokensDetails(OutputTokensDetails):
     """Permissive output token details: providers may omit ``reasoning_tokens``."""
 
-    model_config = ConfigDict(extra="allow")
     reasoning_tokens: int | None = None
 
 
@@ -275,16 +275,17 @@ def mediate_content(value, path: str, policy: NetworkPolicyConfig):
     return mediated, capabilities
 
 
-def fold_assistant(items: list[dict]) -> AssistantMessage:
-    """One run of assistant-side items -> one typed assistant message."""
+def fold_assistant(items: list[dict] | None) -> AssistantMessage:
+    """Assistant-side Responses items -> one typed assistant message."""
     content = ""
     reasoning: list[str] = []
     calls: list[ToolCall] = []
-    for item in items:
-        if item.get("type") == "reasoning":
+    for item in items or []:
+        kind = item.get("type")
+        if kind == "reasoning":
             reasoning += [s.get("text", "") for s in item.get("summary") or []]
             reasoning += [c.get("text", "") for c in item.get("content") or []]
-        elif item.get("type") in ("function_call", "custom_tool_call"):
+        elif kind in ("function_call", "custom_tool_call"):
             calls.append(
                 ToolCall(
                     id=item.get("call_id", ""),
@@ -292,7 +293,7 @@ def fold_assistant(items: list[dict]) -> AssistantMessage:
                     arguments=item.get("arguments", item.get("input", "")),
                 )
             )
-        else:  # an assistant message item
+        else:
             raw = item.get("content")
             content += (
                 raw
@@ -336,33 +337,11 @@ def response_from_wire(response: OpenAIResponse) -> Response:
             f"upstream Responses request did not complete: {detail}",
             status_code=status_code,
         )
-    content = ""
-    reasoning: list[str] = []
-    calls: list[ToolCall] = []
-    for item in data.get("output") or []:
-        kind = item.get("type")
-        if kind == "message":
-            content += "".join(
-                p.get("text", "")
-                for p in item.get("content") or []
-                if p.get("type") == "output_text"
-            )
-        elif kind == "reasoning":
-            reasoning += [s.get("text", "") for s in item.get("summary") or []]
-            reasoning += [c.get("text", "") for c in item.get("content") or []]
-        elif kind in ("function_call", "custom_tool_call"):
-            calls.append(
-                ToolCall(
-                    id=item.get("call_id", ""),
-                    name=item.get("name", ""),
-                    arguments=item.get("arguments", item.get("input", "")),
-                )
-            )
-    tool_calls = calls or None
+    message = fold_assistant(data.get("output"))
     finish: FinishReason = (
         "length"
         if data.get("status") == "incomplete"
-        else ("tool_calls" if tool_calls else "stop")
+        else ("tool_calls" if message.tool_calls else "stop")
     )
     usage = None
     if response.usage:
@@ -384,12 +363,7 @@ def response_from_wire(response: OpenAIResponse) -> Response:
         id=data.get("id", ""),
         created=data.get("created_at", 0),
         model=data.get("model", ""),
-        message=AssistantMessage(
-            content=content or None,
-            reasoning_content="\n".join(r for r in reasoning if r) or None,
-            tool_calls=tool_calls,
-            provider_state=data.get("output"),
-        ),
+        message=message,
         finish_reason=finish,
         usage=usage,
     )
@@ -409,8 +383,9 @@ class ResponsesStreamParser(StreamParser):
 
     def finish(self) -> Response:
         events = self.terminal_events or self.events
-        for event in iter_sse_reverse(b"".join(events)):
-            if event.get("type") in FINAL_EVENTS:
+        for raw in reversed(events):
+            event = parse_sse_event(raw)
+            if event and event.get("type") in FINAL_EVENTS:
                 response = response_from_wire(
                     OpenAIResponse.model_validate(event["response"])
                 )
@@ -595,10 +570,7 @@ class ResponsesDialect(Dialect[ResponseCreateParams, OpenAIResponse]):
                 run = []
             if assistant:
                 run.append(item)
-            elif item.get("type") in (
-                "function_call_output",
-                "custom_tool_call_output",
-            ):
+            elif item.get("type") in TEXT_TOOL_OUTPUT_TYPES:
                 output = item.get("output")
                 content = (
                     parse_content(output)

--- a/verifiers/v1/dialects/responses.py
+++ b/verifiers/v1/dialects/responses.py
@@ -10,9 +10,7 @@ parsing reads the `output` items. Relay-only: the eval client forwards the progr
 import json
 import re
 from collections import deque
-from typing import cast
 
-from openai.types.responses.response_create_params import ResponseCreateParams
 from openai.types.responses.response_usage import (
     InputTokensDetails,
     OutputTokensDetails,
@@ -23,6 +21,7 @@ from pydantic import BaseModel, ConfigDict
 from verifiers.v1.configs.runtime import NetworkPolicyConfig
 from verifiers.v1.dialects.base import (
     Dialect,
+    RawRequest,
     StreamParser,
     append_user_notice,
     blocked_url,
@@ -289,6 +288,7 @@ def fold_assistant(items: list[dict] | None) -> AssistantMessage:
             calls.append(
                 ToolCall(
                     id=item.get("call_id", ""),
+                    type="custom" if kind == "custom_tool_call" else "function",
                     name=item.get("name", ""),
                     arguments=item.get("arguments", item.get("input", "")),
                 )
@@ -394,7 +394,7 @@ class ResponsesStreamParser(StreamParser):
         raise ValueError("Responses stream ended without a terminal event")
 
 
-class ResponsesDialect(Dialect[ResponseCreateParams, OpenAIResponse]):
+class ResponsesDialect(Dialect[OpenAIResponse]):
     sampling_fields = frozenset(
         {
             "temperature",
@@ -414,8 +414,8 @@ class ResponsesDialect(Dialect[ResponseCreateParams, OpenAIResponse]):
     response_type = OpenAIResponse
 
     def mediate_external_capabilities(
-        self, body: ResponseCreateParams, policy: NetworkPolicyConfig
-    ) -> tuple[ResponseCreateParams, list[str]]:
+        self, body: RawRequest, policy: NetworkPolicyConfig
+    ) -> tuple[RawRequest, list[str]]:
         mediated = body
         capabilities: list[str] = []
 
@@ -425,7 +425,7 @@ class ResponsesDialect(Dialect[ResponseCreateParams, OpenAIResponse]):
 
         if mediated.pop("prompt", None) is not None:
             capabilities.append("prompt")
-        if cast(dict, mediated).pop("plugins", None) is not None:
+        if mediated.pop("plugins", None) is not None:
             capabilities.append("plugins")
 
         raw_input = mediated.get("input")
@@ -533,7 +533,7 @@ class ResponsesDialect(Dialect[ResponseCreateParams, OpenAIResponse]):
         # trailing `[DONE]`, so the turn-ending event is the final event, not the sentinel.
         return any(marker in chunk for marker in _TERMINAL_MARKERS)
 
-    def parse_sampling(self, body: ResponseCreateParams) -> Sampling:
+    def parse_sampling(self, body: RawRequest) -> Sampling:
         settings = {k: v for k, v in body.items() if k in self.sampling_fields}
         # Lift `reasoning.effort` onto the typed knob; keep any other reasoning keys
         # (e.g. `summary`) as the wire sent them.
@@ -549,7 +549,7 @@ class ResponsesDialect(Dialect[ResponseCreateParams, OpenAIResponse]):
             settings["max_tokens"] = settings.pop("max_output_tokens")
         return Sampling.model_validate(settings)
 
-    def parse_request(self, body: ResponseCreateParams) -> Request:
+    def parse_request(self, body: RawRequest) -> Request:
         prompt: Messages = []
         if instructions := body.get("instructions"):
             prompt.append(SystemMessage(content=instructions))
@@ -724,8 +724,8 @@ class ResponsesDialect(Dialect[ResponseCreateParams, OpenAIResponse]):
         return ResponsesStreamParser()
 
     def apply_overrides(
-        self, body: ResponseCreateParams, model: str, sampling: SamplingConfig
-    ) -> ResponseCreateParams:
+        self, body: RawRequest, model: str, sampling: SamplingConfig
+    ) -> RawRequest:
         # Preserve native fields except the eval's model + sampling, mapped to the Responses shape
         # (`max_tokens` -> `max_output_tokens`); sampling is authoritative.
         s = sampling.model_dump(exclude_none=True)
@@ -761,4 +761,4 @@ class ResponsesDialect(Dialect[ResponseCreateParams, OpenAIResponse]):
             for k, v in body.items()
             if k not in _SAMPLING_KEYS and k not in overrides
         }
-        return cast(ResponseCreateParams, {**steered, **overrides})
+        return {**steered, **overrides}

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -288,9 +288,14 @@ def message_hash(message: Message) -> str:
             add(json.dumps(state, sort_keys=True))
         for tc in message.tool_calls or []:
             add("tool_call")
+            add(tc.type)
             add(tc.id)
             add(tc.name)
-            add(_canonical_tool_arguments(tc.arguments))
+            add(
+                tc.arguments
+                if tc.type == "custom"
+                else _canonical_tool_arguments(tc.arguments)
+            )
     elif isinstance(message, ToolMessage):
         add("tool_call_id")
         add(message.tool_call_id)

--- a/verifiers/v1/tasksets/nemo_gym/response.py
+++ b/verifiers/v1/tasksets/nemo_gym/response.py
@@ -22,14 +22,17 @@ def trace_to_nemo_response(
         )
 
     output: list[dict[str, Any]] = []
+    call_types: dict[str, str] = {}
     started = False
 
     for node in branches[0].nodes:
         message = node.message
         if isinstance(message, AssistantMessage) and node.sampled:
             started = True
+            call_types.update((call.id, call.type) for call in message.tool_calls or [])
             if message.provider_state and all(
-                item.get("type") in {"reasoning", "message", "function_call"}
+                item.get("type")
+                in {"reasoning", "message", "function_call", "custom_tool_call"}
                 for item in message.provider_state
             ):
                 output.extend(message.provider_state)
@@ -62,9 +65,12 @@ def trace_to_nemo_response(
                 )
             output.extend(
                 {
-                    "type": "function_call",
+                    "type": "custom_tool_call"
+                    if call.type == "custom"
+                    else "function_call",
                     "call_id": call.id,
-                    **call.model_dump(exclude={"id"}),
+                    "name": call.name,
+                    ("input" if call.type == "custom" else "arguments"): call.arguments,
                 }
                 for call in message.tool_calls or []
             )
@@ -78,7 +84,9 @@ def trace_to_nemo_response(
             )
             output.append(
                 {
-                    "type": "function_call_output",
+                    "type": "custom_tool_call_output"
+                    if call_types.get(message.tool_call_id) == "custom"
+                    else "function_call_output",
                     "call_id": message.tool_call_id,
                     "output": content,
                 }

--- a/verifiers/v1/types.py
+++ b/verifiers/v1/types.py
@@ -65,9 +65,10 @@ class UserMessage(BaseModel):
 
 class ToolCall(BaseModel):
     id: str
+    type: Literal["function", "custom"] = "function"
     name: str
     arguments: str
-    """Raw JSON string of arguments, exactly as the model emitted it."""
+    """Raw function arguments or custom-tool input, exactly as the model emitted it."""
 
 
 class AssistantMessage(BaseModel):


### PR DESCRIPTION
## Overview

This PR makes the V1 dialect boundary smaller and more consistent while preserving the native data sent by clients and providers. It removes duplicated parsing code, uses SDK models where they fit, and keeps provider-specific behavior where the SDK is too strict.

## What changed

- Requests now use one mutable `RawRequest` type instead of SDK request `TypedDict`s. Responses are still validated with SDK models.
- `ToolCall` now records whether a call is a JSON function call or a free-form custom tool call.
- Chat and Responses parsing, Chat serialization, graph hashing, renderer responses, and NeMo Gym export now preserve the tool-call kind and use the matching `arguments` or `input` field.
- Chat streaming keeps an established tool-call kind across partial events. It retains partial metadata so later deltas can complete a call, but does not emit slots that never identify a supported call type.
- Anthropic responses are read directly from validated SDK content blocks instead of being converted to dictionaries and parsed again.
- Responses parsing reuses the existing assistant-item folding logic and SDK usage-detail models.
- URL parsing and complete SSE event parsing reuse existing library and dialect helpers.
- Unused conversion plumbing, an unused package export, and repeated stream-buffer setup were removed.

## Why

The gateway handles mutable JSON from multiple OpenAI-compatible providers. SDK request `TypedDict`s describe official client input, but not provider extensions or the in-place mediation performed by the gateway. Using them here caused casts and misleading type errors.

Custom tools were already allowed through the native Chat and Responses protocols, but the shared `ToolCall` model only represented JSON function calls. A returned custom call could therefore be lost, converted to the wrong shape, or fail during parsing. Recording the call kind makes the shared representation match the protocol.

Streaming providers may also send tool-call metadata before sending the call type or payload. Keeping that partial state allows later deltas to finish the call, while filtering unfinished slots prevents incomplete metadata from becoming an invalid assistant message.

Several response and streaming paths repeated work already available in the SDK or elsewhere in the dialect package. Reusing those paths reduces the amount of protocol code that can drift.

## Impact

- Existing `ToolCall` construction continues to mean a function call by default.
- Function calls keep their JSON arguments. Custom calls keep their raw text input.
- Custom calls now round-trip through relay streams, traces, renderer responses, graph identity, and NeMo Gym output without becoming function calls.
- Incomplete streamed tool-call metadata is ignored if no later delta supplies a supported call type.
- Assistant-message graph identity now distinguishes function calls from custom calls with otherwise identical fields.
- Provider-specific request fields remain intact during mediation and overrides.
- The unused package-level `response_from_wire` export is removed; dialect-specific converters remain internal.
