### PR TITLE
Centralize V1 egress policy decisions

### DIFF
--- a/verifiers/v1/configs/runtime.py
+++ b/verifiers/v1/configs/runtime.py
@@ -54,6 +54,12 @@ class NetworkPolicyConfig(BaseConfig):
     def network_restricted(self) -> bool:
         return "*" not in self.allow or bool(self.block)
 
+    def permits(self, scheme: str, host: str, port: int) -> bool:
+        """Whether the destination is allowed by the configured egress rules."""
+        return not any(
+            network_rule_matches(rule, scheme, host, port) for rule in self.block
+        ) and any(network_rule_matches(rule, scheme, host, port) for rule in self.allow)
+
     def with_task_network_policy(self, allow: list[str], block: list[str]) -> Self:
         values = self.model_dump()
         if "*" in allow:

--- a/verifiers/v1/dialects/base.py
+++ b/verifiers/v1/dialects/base.py
@@ -21,7 +21,7 @@ from urllib.parse import urlsplit
 from pydantic import AnyHttpUrl, BaseModel, TypeAdapter, ValidationError
 from pydantic_core import from_json
 
-from verifiers.v1.configs.runtime import NetworkPolicyConfig, network_rule_matches
+from verifiers.v1.configs.runtime import NetworkPolicyConfig
 from verifiers.v1.types import Request, Response, Sampling, SamplingConfig
 
 ReqT = TypeVar("ReqT")
@@ -47,11 +47,7 @@ def blocked_url(value: str, policy: NetworkPolicyConfig) -> bool:
     except ValidationError:
         return True
     host = url.host.lower().rstrip(".").strip("[]")
-    return any(
-        network_rule_matches(rule, url.scheme, host, url.port) for rule in policy.block
-    ) or not any(
-        network_rule_matches(rule, url.scheme, host, url.port) for rule in policy.allow
-    )
+    return not policy.permits(url.scheme, host, url.port)
 
 
 def provider_allowed_domains(

--- a/verifiers/v1/runtimes/docker/__init__.py
+++ b/verifiers/v1/runtimes/docker/__init__.py
@@ -261,7 +261,9 @@ class DockerRuntime(Runtime):
             # Setup is trusted; colocated servers fetch their task from host interception
             # before the final framework routes are known.
             self._proxy = EgressProxy(
-                NetworkPolicy(["*"], [], [HOST_ALIAS], allow_non_global=True)
+                NetworkPolicy(
+                    NetworkPolicyConfig(), [HOST_ALIAS], allow_non_global=True
+                )
             )
             if sys.platform == "linux":
                 await self._proxy.start(listener=await self._container_listener())
@@ -346,18 +348,14 @@ class DockerRuntime(Runtime):
         assert self._proxy is not None
         if routes is None:
             self._proxy.policy = NetworkPolicy(
-                ["*"], [], [HOST_ALIAS], allow_non_global=True
+                NetworkPolicyConfig(), [HOST_ALIAS], allow_non_global=True
             )
             return
         framework = [
             urlsplit(url)._replace(path="", query="", fragment="").geturl()
             for url in routes
         ]
-        self._proxy.policy = NetworkPolicy(
-            self.config.allow,
-            self.config.block,
-            framework,
-        )
+        self._proxy.policy = NetworkPolicy(self.config, framework)
         if self._cut:
             return
         script = (

--- a/verifiers/v1/runtimes/docker/egress.py
+++ b/verifiers/v1/runtimes/docker/egress.py
@@ -13,7 +13,7 @@ from urllib.parse import urlsplit, urlunsplit
 
 import h11
 
-from verifiers.v1.configs.runtime import network_rule_matches
+from verifiers.v1.configs.runtime import NetworkPolicyConfig, network_rule_matches
 
 HOST_ALIAS = "vf.host.internal"
 _HEADER_TIMEOUT = 10
@@ -30,8 +30,7 @@ async def _drain(writer: asyncio.StreamWriter) -> None:
 
 @dataclass
 class NetworkPolicy:
-    allow: list[str]
-    block: list[str]
+    config: NetworkPolicyConfig
     routes: list[str]
     allow_non_global: bool = False  # trusted setup only
 
@@ -47,7 +46,7 @@ class NetworkPolicy:
                     rule.lower().startswith(f"{scheme}://")
                     and network_rule_matches(rule, scheme, host, port)
                 )
-                for rule in [*self.routes, *self.allow]
+                for rule in [*self.routes, *self.config.allow]
             )
         ):
             return False
@@ -65,11 +64,7 @@ class NetworkPolicy:
         with contextlib.suppress(ValueError):
             if ip_address(hostname).is_loopback:
                 return False
-        if any(network_rule_matches(rule, scheme, host, port) for rule in self.block):
-            return False
-        return any(
-            network_rule_matches(rule, scheme, host, port) for rule in self.allow
-        )
+        return self.config.permits(scheme, host, port)
 
 
 async def _read_client_hello(


### PR DESCRIPTION
## Overview

This PR gives provider-side URL mediation and Docker runtime egress one shared allow/block decision. Runtime-specific protections remain in the Docker proxy, but both paths now agree on the basic network policy.

## What changed

- NetworkPolicyConfig now owns the permits decision for normal allow and block rules.
- Dialect URL checks call that shared decision instead of repeating the rule matching.
- The Docker proxy now holds a NetworkPolicyConfig rather than separate copies of its allow and block lists.
- Docker still handles framework routes, localhost and loopback protection, CONNECT restrictions, and non-global addresses before applying the shared decision.

## Why

The dialect layer and Docker proxy previously implemented the same block-first, allow-required rule separately. Keeping two copies makes it easy for provider-side capability filtering and actual runtime egress to disagree after a future policy change.

The allow and block lists already belong to NetworkPolicyConfig, so the decision based on those lists belongs there too. Docker can then add only the protections that are specific to the proxy.

## Impact

- There is no intended change to which user destinations are allowed or blocked.
- A matching block rule still denies access, and a destination still needs a matching allow rule.
- Framework routes continue to bypass user egress rules so Verifiers infrastructure remains reachable.
- Docker loopback, CONNECT, and non-global-address protections are unchanged.
- Future changes to normal allow/block behavior have one implementation, so provider mediation and runtime enforcement stay aligned.
- The internal Docker NetworkPolicy constructor now accepts a NetworkPolicyConfig instead of separate allow and block lists; all repository call sites are updated.