### PR TITLE
feat: split run configs into launch TOML and resolved dir

### DIFF
--- a/verifiers/v1/cli/eval/main.py
+++ b/verifiers/v1/cli/eval/main.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 USAGE = (
     "usage: uv run eval [<taskset-id>] [--env.id <id>] [options] [@ file.toml]\n"
-    "       uv run eval @ <run-dir>/configs/eval.json --resume   (re-run the run's missing/errored rollouts)"
+    "       uv run eval @ <run-dir>/configs/resolved/eval.json --resume   (re-run the run's missing/errored rollouts)"
 )
 
 

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -140,7 +140,6 @@ async def _server(
 async def run_eval(config: EvalConfig) -> list[Episode]:
     from verifiers.v1.utils.loaders import load_environment, load_taskset
 
-    logger.info("eval config:\n%s", config.model_dump_json(indent=2))
     # The env comes up in this process only for an in-process run; a served run's
     # workers each load their own, and this process owns just the taskset.
     env = None if config.serve is not None else load_environment(config.env)

--- a/verifiers/v1/cli/output.py
+++ b/verifiers/v1/cli/output.py
@@ -124,7 +124,11 @@ def write_launch_toml(results_dir: Path, name: str = "eval") -> None:
     tomls = [(p, p.read_text()) for p in paths if p.suffix == ".toml" and p.is_file()]
     if not tomls:
         return
-    texts = [text for _, text in tomls] if len(tomls) == 1 else [f"# @ {p}\n{text}" for p, text in tomls]
+    texts = (
+        [text for _, text in tomls]
+        if len(tomls) == 1
+        else [f"# @ {p}\n{text}" for p, text in tomls]
+    )
     config_dir = results_dir / CONFIG_DIR
     config_dir.mkdir(parents=True, exist_ok=True)
     (config_dir / f"{name}.toml").write_text("\n".join(texts))

--- a/verifiers/v1/cli/output.py
+++ b/verifiers/v1/cli/output.py
@@ -121,11 +121,11 @@ def write_launch_toml(results_dir: Path, name: str = "eval") -> None:
     argv = sys.argv[1:]
     paths = []
     for i, arg in enumerate(argv):
-        if arg == "@" and i + 1 < len(argv):
+        # root config references only: `@ file`; a `--flag @ file` / `--flag @file`
+        # is a nested reference and belongs under its flag, not in the launch copy
+        if arg == "@" and i + 1 < len(argv) and (i == 0 or not argv[i - 1].startswith("--")):
             paths.append(Path(argv[i + 1]))
-        elif arg.startswith("@") and len(arg) > 1:
-            paths.append(Path(arg[1:]))
-    texts = [p.read_text() for p in paths if p.is_file()]
+    texts = [p.read_text() for p in paths if p.suffix == ".toml" and p.is_file()]
     if not texts:
         return
     if len(texts) > 1:

--- a/verifiers/v1/cli/output.py
+++ b/verifiers/v1/cli/output.py
@@ -121,11 +121,10 @@ def write_launch_toml(results_dir: Path, name: str = "eval") -> None:
             and (i == 0 or not argv[i - 1].startswith("--"))
         ):
             paths.append(Path(argv[i + 1]))
-    texts = [p.read_text() for p in paths if p.suffix == ".toml" and p.is_file()]
-    if not texts:
+    tomls = [(p, p.read_text()) for p in paths if p.suffix == ".toml" and p.is_file()]
+    if not tomls:
         return
-    if len(texts) > 1:
-        texts = [f"# @ {p}\n{t}" for p, t in zip(paths, texts)]
+    texts = [text for _, text in tomls] if len(tomls) == 1 else [f"# @ {p}\n{text}" for p, text in tomls]
     config_dir = results_dir / CONFIG_DIR
     config_dir.mkdir(parents=True, exist_ok=True)
     (config_dir / f"{name}.toml").write_text("\n".join(texts))

--- a/verifiers/v1/cli/output.py
+++ b/verifiers/v1/cli/output.py
@@ -29,9 +29,13 @@ TRACES_FILE = "traces.jsonl"
 """Filename a run's rollout episodes are written to (one JSON episode per line)."""
 
 CONFIG_DIR = "configs"
-"""Directory inside a run dir holding its resolved config (one `<cli>.json`, re-runnable
-via `@ <run-dir>/configs/<cli>.json`). Resolved configs are JSON, not TOML: JSON keeps
-nulls, so explicit None settings round-trip exactly on re-parse."""
+"""Directory inside a run dir holding its configs: the launch TOML copied verbatim to
+`configs/<cli>.toml`, and the resolved config at `configs/resolved/<cli>.json`
+(re-runnable via `@ <run-dir>/configs/resolved/<cli>.json`). Resolved configs are JSON,
+not TOML: JSON keeps nulls, so explicit None settings round-trip exactly on re-parse."""
+
+RESOLVED_DIR = "resolved"
+"""Subdirectory of `configs/` holding the resolved per-component JSON dumps."""
 
 
 def create_attempt_log_dir(run_dir: Path) -> Path:
@@ -76,13 +80,13 @@ def config_digest(config: BaseModel) -> str:
 
 
 def saved_config_path(run_dir: Path) -> Path | None:
-    """The run's saved resolved config (`configs/<cli>.json`), None if absent."""
-    candidates = (
-        sorted((run_dir / CONFIG_DIR).glob("*.json"))
-        if (run_dir / CONFIG_DIR).is_dir()
-        else []
-    )
-    return candidates[0] if candidates else None
+    """The run's saved resolved config (`configs/resolved/<cli>.json`; legacy runs
+    kept it at `configs/<cli>.json`), None if absent."""
+    for config_dir in (run_dir / CONFIG_DIR / RESOLVED_DIR, run_dir / CONFIG_DIR):
+        candidates = sorted(config_dir.glob("*.json")) if config_dir.is_dir() else []
+        if candidates:
+            return candidates[0]
+    return None
 
 
 # Compiling an adapter is the expensive part; run output reuses only a few model classes.
@@ -100,22 +104,45 @@ def output_path(config: EvalConfig) -> Path:
 def write_config(
     config: BaseModel, results_dir: Path, filename: str = "eval.json"
 ) -> Path:
-    """Write the run's resolved config to `configs/<filename>` (re-readable via
+    """Write the run's resolved config to `configs/resolved/<filename>` (re-readable via
     `@ <path>`); return its path. The full model dump is written, nulls included, so the
     file round-trips exactly."""
-    config_dir = results_dir / CONFIG_DIR
+    config_dir = results_dir / CONFIG_DIR / RESOLVED_DIR
     config_dir.mkdir(parents=True, exist_ok=True)
     config_path = config_dir / filename
     config_path.write_text(json.dumps(config.model_dump(mode="json"), indent=2))
     return config_path
 
 
+def write_launch_toml(results_dir: Path, name: str = "eval") -> None:
+    """Copy the launch `@` TOML file(s) verbatim to `configs/<name>.toml`."""
+    import sys
+
+    argv = sys.argv[1:]
+    paths = []
+    for i, arg in enumerate(argv):
+        if arg == "@" and i + 1 < len(argv):
+            paths.append(Path(argv[i + 1]))
+        elif arg.startswith("@") and len(arg) > 1:
+            paths.append(Path(arg[1:]))
+    texts = [p.read_text() for p in paths if p.is_file()]
+    if not texts:
+        return
+    if len(texts) > 1:
+        texts = [f"# @ {p}\n{t}" for p, t in zip(paths, texts)]
+    config_dir = results_dir / CONFIG_DIR
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / f"{name}.toml").write_text("\n".join(texts))
+
+
 def save_config(
     config: BaseModel, results_dir: Path, filename: str = "eval.json"
 ) -> None:
-    """Set up the run's output dir: write the resolved config and start a fresh (empty)
-    `traces.jsonl`. Call once up front, before episodes start landing."""
+    """Set up the run's output dir: write the resolved config, copy the launch TOML,
+    and start a fresh (empty) `traces.jsonl`. Call once up front, before episodes start
+    landing."""
     write_config(config, results_dir, filename)
+    write_launch_toml(results_dir, Path(filename).stem)
     (results_dir / TRACES_FILE).write_text(
         ""
     )  # fresh; appended to as rollouts complete

--- a/verifiers/v1/cli/output.py
+++ b/verifiers/v1/cli/output.py
@@ -123,7 +123,11 @@ def write_launch_toml(results_dir: Path, name: str = "eval") -> None:
     for i, arg in enumerate(argv):
         # root config references only: `@ file`; a `--flag @ file` / `--flag @file`
         # is a nested reference and belongs under its flag, not in the launch copy
-        if arg == "@" and i + 1 < len(argv) and (i == 0 or not argv[i - 1].startswith("--")):
+        if (
+            arg == "@"
+            and i + 1 < len(argv)
+            and (i == 0 or not argv[i - 1].startswith("--"))
+        ):
             paths.append(Path(argv[i + 1]))
     texts = [p.read_text() for p in paths if p.suffix == ".toml" and p.is_file()]
     if not texts:


### PR DESCRIPTION
## Summary
- Write each run's launch `@` TOML file verbatim to `configs/eval.toml`, next to the resolved dump, which moves to `configs/resolved/eval.json`.
- Only root `@ file` references are copied (nested `--flag @ file` / `--flag @file` configs belong under their flag and are excluded), and only `.toml` sources — a resume from the resolved JSON writes no launch copy.
- `saved_config_path` (resume/replay) checks `configs/resolved/` first and falls back to the legacy `configs/<cli>.json` location.
- Drop the startup INFO log of the full eval config — it is persisted to disk, so the log line was redundant.

Companion to the prime-rl run-dashboard PR (PrimeIntellect-ai/prime-rl#3351), which reads both layouts: the launch TOML as the default config view and the resolved JSONs concatenated into one searchable document.

## Breaking
- The resolved config moves from `configs/eval.json` to `configs/resolved/eval.json`. Reading (resume, replay) handles both layouts; anything that writes or globs the old path directly must switch to `configs/resolved/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moves the on-disk resolved config path used for resume/replay. Reading falls back to the legacy location, but anything that writes or hardcodes configs/*.json will break.
> 
> **Overview**
> Runs now keep two config artifacts: a verbatim copy of root `@` launch TOML at `configs/<cli>.toml`, and the resolved dump at `configs/resolved/<cli>.json` instead of `configs/<cli>.json`. Nested `--flag @ file` refs and JSON resumes are not copied.
> 
> `saved_config_path` looks in `configs/resolved/` first, then the old `configs/*.json` layout, so resume/replay still work on existing runs. Help text points at the new path. The full eval-config INFO dump at startup is removed because the file is already on disk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7c83add73ab419bdca56852e35c65dd15fcd3bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split run configs into launch TOML at `configs/<cli>.toml` and resolved JSON at `configs/resolved/<cli>.json`
> - `save_config` now writes the resolved config JSON to `configs/resolved/<cli>.json` and copies the launch TOML (from `@`-referenced files in `sys.argv`) to `configs/<cli>.toml`, creating nested directories as needed.
> - `saved_config_path` looks under `configs/resolved/` first and falls back to the legacy `configs/` path so older runs still resume.
> - `write_launch_toml` concatenates multiple TOML inputs with a header comment naming each source path.
> - Minor cleanups: usage string now points to `configs/resolved/eval.json`, and the startup config JSON log line in `run_eval` is removed.
> - Behavioral Change: `write_config` in [output.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2429/files#diff-07fce45dd0fa633f34d25e19962ab801b705a509774833de0d81bfe872787e8b) writes to a new `configs/resolved/` subdirectory; any code or scripts expecting `<run-dir>/configs/<cli>.json` will need to look under `configs/resolved/` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f7c83ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->