### PR TITLE
fix(v1): seed Prime GPT-5.6 prompt cache keys

### DIFF
--- a/verifiers/v1/clients/eval.py
+++ b/verifiers/v1/clients/eval.py
@@ -2,6 +2,7 @@
 
 import re
 from collections.abc import Mapping
+from urllib.parse import urlparse
 
 import httpx
 from pydantic import ValidationError
@@ -9,7 +10,11 @@ from pydantic_core import from_json, to_json
 
 from verifiers.v1.clients.base import DEFAULT_LIMITS, DEFAULT_TIMEOUT, join_url
 from verifiers.v1.clients.client import SESSION_ID_HEADER, Client, RelayReply
-from verifiers.v1.configs.client import BaseClientConfig, resolve_api_key
+from verifiers.v1.configs.client import (
+    PRIME_INFERENCE_HOST,
+    BaseClientConfig,
+    resolve_api_key,
+)
 from verifiers.v1.dialects import Dialect
 from verifiers.v1.errors import model_error
 from verifiers.v1.graph import PendingTurn
@@ -61,6 +66,10 @@ class EvalClient(Client):
     def __init__(self, config: BaseClientConfig) -> None:
         self.base_url = config.base_url
         self.api_key = resolve_api_key(config)
+        host = urlparse(self.base_url).hostname or ""
+        self.is_prime_inference = host == PRIME_INFERENCE_HOST or host.endswith(
+            f".{PRIME_INFERENCE_HOST}"
+        )
         # Keep endpoint headers separate so they can override intercepted request headers before
         # the dialect's provider authentication is applied.
         self.headers = dict(config.headers or {})
@@ -126,6 +135,19 @@ class EvalClient(Client):
         stream: bool = False,
     ) -> httpx.Response:
         headers.setdefault("content-type", "application/json")
+        model = body.get("model")
+        cache_key = headers.get(SESSION_ID_HEADER)
+        if (
+            self.is_prime_inference
+            and isinstance(model, str)
+            and model.rsplit("/", 1)[-1].startswith("gpt-5.6")
+            and url.endswith(("/chat/completions", "/responses"))
+            and cache_key
+            and "prompt_cache_key" not in body
+        ):
+            # Prime's session header pins the gateway hop, while OpenAI uses this body field
+            # to route every turn in a GPT-5.6 rollout to the same prompt-cache bucket.
+            body = {**body, "prompt_cache_key": cache_key}
         request = self.client.build_request(
             "POST",
             url,


### PR DESCRIPTION
## Overview
Seed OpenAI GPT-5.6 prompt cache keys from Verifiers’ existing per-rollout session ID when using Prime Inference.

## Details
- Translate the existing `X-Session-ID` affinity signal into `prompt_cache_key` for Prime-hosted GPT-5.6 Chat Completions and Responses calls.
- Apply this at the shared `EvalClient` request boundary so streaming and non-streaming requests behave consistently.
- Preserve an explicit caller-provided cache key.
- Leave non-Prime endpoints, older model families, and auxiliary routes unchanged.

## Validation
- `uv run pytest tests/ -q`
- `uv run ruff check --fix .`
- `uv run ruff format --check .`
- `uv run --locked --python 3.13 ty check verifiers`
- Mocked transport matrix covering Chat Completions and Responses injection, explicit-key preservation, and non-injection cases
- Live Flex check: the first request wrote 4,514 cache tokens; the second request read all 4,514
- Changed-file pre-commit hooks pass. The all-files run reaches 321 pre-existing MD033 failures in the untouched legacy SWE README.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Seed `prompt_cache_key` for GPT-5.6 requests to Prime inference hosts in `EvalClient._request`
> - Adds host detection in `EvalClient.__init__` by comparing `base_url` host to `PRIME_INFERENCE_HOST` (including subdomains), storing the result in `is_prime_inference`.
> - When `is_prime_inference` is true, the model's final path component starts with `gpt-5.6`, the URL targets `/chat/completions` or `/responses`, and a session header is present, `_request` injects `prompt_cache_key` (set to the session header value) into the request body if it is not already set.
> - Risk: any caller relying on the absence of `prompt_cache_key` in outbound GPT-5.6 Prime inference bodies will see the field added; check `SESSION_ID_HEADER` value and `prompt_cache_key` injection in `verifiers/v1/clients/eval.py`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9a9b125.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->