### PR TITLE
Attribute the capability notice to the harness

### DIFF
--- a/verifiers/v1/dialects/base.py
+++ b/verifiers/v1/dialects/base.py
@@ -32,9 +32,10 @@ HTTP_URL_ADAPTER = TypeAdapter(AnyHttpUrl)
 
 PROVIDER_CAPABILITY_POLICY_CODE = "provider_capability_unavailable"
 CAPABILITY_NOTICE = (
-    "Network protocol blocked fetching a resource. Continue without those capabilities; "
-    "use local tools or inline data already present in the conversation, and do not retry "
-    "the blocked provider-side operation."
+    "[Harness notice — environment network policy, not part of the task] Network protocol "
+    "blocked fetching a resource. Continue without those capabilities; use local tools or "
+    "inline data already present in the conversation, and do not retry the blocked "
+    "provider-side operation."
 )
 
 


### PR DESCRIPTION
`append_user_notice` splices `CAPABILITY_NOTICE` into the earliest **user** message, where it reads as part of the task text. Consumers treat it as task content: in no-network sandbox environments (e.g. the GA task factory's solver boxes) **every rollout** carries it, transcripts embed it verbatim into evidence, and we caught a reviewing agent building a false causal story from it ("a provider-side resource failed mid-task") inside a real verdict.

Minimal fix: a bracketed harness attribution — `[Harness notice — environment network policy, not part of the task]` — so the notice is self-identifying wherever it lands. No structural change to message handling; both dialect call sites inherit it.

Draft because this repo has many consumers whose prompts change by these bytes — flagging for a maintainer look rather than self-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prefix `CAPABILITY_NOTICE` with harness attribution in base verifier dialect
> Updates the `CAPABILITY_NOTICE` constant in [base.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2432/files#diff-10ccce5f7f0d991c33492a01e73014e10883deb74f7006253f1c690422d841bd) to prepend `[Harness notice — environment network policy, not part of the task]` so consumers understand the notice comes from the harness, not the task. The core guidance text is otherwise unchanged.
> - Risk: any surface rendering `CAPABILITY_NOTICE` will now display the longer prefixed string; verify layout/buffer sizes that assume a shorter constant.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da90334.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->