### PR TITLE
feat(v1): add Trace.reward_shaping for trainer reward-shaping terms

### DIFF
--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -404,6 +404,10 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
     preceding error)."""
     metrics: dict[str, float | None] = Field(default_factory=dict)
     """Unweighted, named metrics; `None` as in `rewards`."""
+    reward_shaping: dict[str, float] = Field(default_factory=dict)
+    """Additive training-reward terms recorded by a consumer's reward shapers (a length
+    penalty, ...), keyed by shaper name. A training annotation like `MessageNode.advantages`:
+    `reward` stays the env's verdict; the trainer scores against `reward` plus these terms."""
     info: dict[str, Any] = Field(default_factory=dict)
     """Scratch space for task-specific metadata."""
     state: StateT = Field(default_factory=State, exclude=True)


### PR DESCRIPTION
## Summary

Adds `Trace.reward_shaping: dict[str, float]` — additive training-reward terms a consumer's reward shapers record on a trace, keyed by shaper name (e.g. `{"length_penalty": -0.1}`).

This is a training annotation in the same sense as `MessageNode.advantages`: verifiers holds the field, the trainer fills it. `Trace.reward` stays the env's verdict; the trainer scores against `reward + sum(reward_shaping.values())`. Keeping the two apart means task-success metrics, curricula and evals keep reading the unshaped reward while credit assignment sees the shaped one.

Companion: https://github.com/PrimeIntellect-ai/prime-rl/pull/3376 moves prime-rl's length penalty out of GRPO into a reward-shaping layer and writes its terms here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `reward_shaping` field to `Trace` model for trainer reward-shaping terms
> Adds a `reward_shaping: dict[str, float]` field to the `Trace` pydantic model, defaulting to an empty dict. It stores additive training-reward terms keyed by shaper name. The field is included in JSON output from `to_record()` since it is not excluded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e084c75. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->