### PR TITLE
feat(train-client): add exact-token generate_tokens and parse_completions

### DIFF
--- a/tests/v1/test_train_client_tokens.py
+++ b/tests/v1/test_train_client_tokens.py
@@ -1,0 +1,72 @@
+"""TrainClient's exact-token seams: `generate_tokens` (prompt_ids posted
+verbatim, sampling via `wire_args`, prompt_logprobs passed through) and
+`parse_completion`."""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from verifiers.v1.clients.train import ElasticRendererPool, RendererSlot, TrainClient
+from verifiers.v1.configs.client import TrainClientConfig
+from verifiers.v1.types import SamplingConfig
+
+
+class _FakeRenderer:
+    def get_stop_token_ids(self) -> list[int]:
+        return [151645]
+
+    def parse_response(self, completion_ids, tools=None):
+        return SimpleNamespace(
+            content=f"parsed:{completion_ids}", reasoning_content=None, tool_calls=[]
+        )
+
+
+@pytest.fixture
+def client(monkeypatch) -> TrainClient:
+    async def fake_grow(self):
+        return RendererSlot(_FakeRenderer())
+
+    monkeypatch.setattr(ElasticRendererPool, "grow", fake_grow)
+    return TrainClient(TrainClientConfig(base_url="http://engine:8000/v1"))
+
+
+def test_generate_tokens_posts_prompt_ids_verbatim(client, monkeypatch) -> None:
+    import renderers.client as renderers_client
+
+    captured: dict = {}
+
+    async def fake_generate(**kwargs):
+        captured.update(kwargs)
+        return {
+            "request_id": "r1",
+            "prompt_ids": kwargs["prompt_ids"],
+            "completion_ids": [7, 8],
+            "completion_logprobs": [-0.1, -0.2],
+            "finish_reason": "stop",
+            "prompt_logprobs": [None, {"2": {"logprob": -0.5}}, {"3": {"logprob": -1.0}}],
+        }
+
+    monkeypatch.setattr(renderers_client, "generate", fake_generate)
+
+    result = asyncio.run(
+        client.generate_tokens(
+            "model-x",
+            [1, 2, 3],
+            SamplingConfig(max_tokens=4, extra_body={"prompt_logprobs": 1, "top_k": 20}),
+        )
+    )
+
+    assert captured["prompt_ids"] == [1, 2, 3]
+    assert captured["messages"] == []
+    assert captured["model"] == "model-x"
+    # wire_args flattens extra_body under the typed fields
+    assert captured["sampling_params"] == {"prompt_logprobs": 1, "top_k": 20, "max_tokens": 4}
+    assert result["completion_ids"] == [7, 8]
+    assert result["prompt_logprobs"] == [None, {"2": {"logprob": -0.5}}, {"3": {"logprob": -1.0}}]
+    assert result["stop_token_ids"] == [151645]
+
+
+def test_parse_completion_round_trips_through_the_renderer(client) -> None:
+    parsed = asyncio.run(client.parse_completion("model-x", [5, 6]))
+    assert parsed.content == "parsed:[5, 6]"

--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -448,5 +448,64 @@ class TrainClient(Client):
         response.raw = serialize_completion(response, model)
         return response
 
+    async def generate_tokens(
+        self,
+        model: str,
+        prompt_ids: list[int],
+        sampling: SamplingConfig | None = None,
+        *,
+        session_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Exact-token continuation: POST a prebuilt token sequence to the
+        `/inference/v1/generate` engine and return the generate result dict
+        (completion_ids, completion_logprobs, finish_reason, prompt_logprobs,
+        ...) plus `stop_token_ids` from the renderer. The public seam for envs
+        that resume or branch from exact token ids — re-rendering an
+        intervention prefix can change BPE identity, this path cannot."""
+        from renderers.client import generate
+
+        sampling_params = (
+            sampling if sampling is not None else SamplingConfig()
+        ).wire_args()
+        chat_template_kwargs = sampling_params.pop("chat_template_kwargs", None)
+        pool = ElasticRendererPool(
+            self.config.renderer_model_name or model,
+            self.config.renderer,
+            chat_template_kwargs=chat_template_kwargs,
+            multiplex=self.config.multiplex,
+        )
+        async with pool.acquire() as slot:
+            try:
+                result = await generate(
+                    client=self.client,
+                    renderer=slot.renderer,
+                    messages=[],
+                    model=model,
+                    prompt_ids=list(prompt_ids),
+                    sampling_params=sampling_params,
+                    extra_headers={SESSION_ID_HEADER: session_id}
+                    if session_id
+                    else None,
+                )
+            except RendererOverlongPromptError as e:
+                raise OverlongPromptError(str(e)) from e
+            except OpenAIError as e:
+                raise model_error(e) from e
+            # Decode-side read: safe on the bare renderer without lock or hop.
+            result["stop_token_ids"] = slot.renderer.get_stop_token_ids()
+        return result
+
+    async def parse_completion(self, model: str, completion_ids: list[int]):
+        """Parse raw completion token ids into the renderer's structured response
+        (content / reasoning_content split) — for callers that assembled a
+        completion from more than one generate call."""
+        pool = ElasticRendererPool(
+            self.config.renderer_model_name or model,
+            self.config.renderer,
+            multiplex=self.config.multiplex,
+        )
+        async with pool.acquire() as slot:
+            return slot.renderer.parse_response(list(completion_ids))
+
     async def close(self) -> None:
         await self.client.close()


### PR DESCRIPTION
generate_tokens POSTs a prebuilt token sequence through renderers.client.generate (no rendering — re-rendering an intervention prefix can change BPE identity) and returns completion ids/logprobs plus prompt_logprobs and the renderer's stop ids. parse_completion parses a completion assembled from more than one generate call. The seam for envs that resume or branch from exact token ids (policy-composition).