### PR TITLE
feat(v1): add Prime Agent ACP harness

### DIFF
--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -85,6 +85,12 @@ ACP_RESUME_PLACEMENTS = [
     pair("openclaw", "docker", "openclaw-acp-in-docker"),
     pair("pool", "prime", "pool-acp-in-prime"),
     pair("rlm", "prime", "rlm-acp-in-prime-vm"),
+    pytest.param(
+        "prime-agent",
+        "prime",
+        marks=[mark.prime],
+        id="prime-agent-acp-in-prime-vm",
+    ),
 ]
 
 # harness runtime x tool placement: every axis value once plus the two-container case
@@ -259,7 +265,7 @@ async def test_acp_resume_with_tool(run_v1, harness, harness_runtime, tmp_path):
     assert segments[1]["terminated"] is False
     assert trace.root_reply == segments[1]["last_reply"]
     # Kimi Code is broken upstream: its Responses adapter drops message `phase` on replay.
-    if harness.id != "kimi-code":
+    if harness.id not in {"kimi-code", "prime-agent"}:
         assert trace.num_branches == 1
     # Native MCP tools need not appear in the intercepted model request that
     # populates trace.tools; the ACP transcript is the source of truth for use.
@@ -267,6 +273,15 @@ async def test_acp_resume_with_tool(run_v1, harness, harness_runtime, tmp_path):
     assert segments[1]["tool_outputs"]
     if harness.id == "rlm":
         assert "turns_since_last_compaction" in trace.metrics
+    if harness.id == "prime-agent":
+        lifecycle = trace.info["acp_lifecycle"]["ai.primeintellect.prime-agent"]
+        assert len(lifecycle) == 2
+        for status in lifecycle:
+            assert status["infrastructure_status"] == "ok"
+            assert status["terminal_quiescence_observed"] is True
+            assert (
+                status["terminal_quiescence"]["quiescence"]["outstandingSubagents"] == 0
+            )
 
 
 @pytest.mark.e2e

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -265,7 +265,7 @@ async def test_acp_resume_with_tool(run_v1, harness, harness_runtime, tmp_path):
     assert segments[1]["terminated"] is False
     assert trace.root_reply == segments[1]["last_reply"]
     # Kimi Code is broken upstream: its Responses adapter drops message `phase` on replay.
-    if harness.id not in {"kimi-code", "prime-agent"}:
+    if harness.id != "kimi-code":
         assert trace.num_branches == 1
     # Native MCP tools need not appear in the intercepted model request that
     # populates trace.tools; the ACP transcript is the source of truth for use.

--- a/verifiers/v1/harnesses/__init__.py
+++ b/verifiers/v1/harnesses/__init__.py
@@ -21,6 +21,10 @@ from verifiers.v1.harnesses.null import NullHarness, NullHarnessConfig
 from verifiers.v1.harnesses.openclaw import OpenClawHarness, OpenClawHarnessConfig
 from verifiers.v1.harnesses.pi import PiHarness, PiHarnessConfig
 from verifiers.v1.harnesses.pool import PoolHarness, PoolHarnessConfig
+from verifiers.v1.harnesses.prime_agent import (
+    PrimeAgentHarness,
+    PrimeAgentHarnessConfig,
+)
 from verifiers.v1.harnesses.rlm import RLMHarness, RLMHarnessConfig
 from verifiers.v1.harnesses.terminus_2 import Terminus2Harness, Terminus2HarnessConfig
 
@@ -47,6 +51,8 @@ __all__ = [
     "PiHarnessConfig",
     "PoolHarness",
     "PoolHarnessConfig",
+    "PrimeAgentHarness",
+    "PrimeAgentHarnessConfig",
     "RLMHarness",
     "RLMHarnessConfig",
     "Terminus2Harness",

--- a/verifiers/v1/harnesses/prime_agent/__init__.py
+++ b/verifiers/v1/harnesses/prime_agent/__init__.py
@@ -1,0 +1,6 @@
+from verifiers.v1.harnesses.prime_agent.harness import (
+    PrimeAgentHarness,
+    PrimeAgentHarnessConfig,
+)
+
+__all__ = ["PrimeAgentHarness", "PrimeAgentHarnessConfig"]

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -239,7 +239,6 @@ class PrimeAgentHarness(ACPHarness[PrimeAgentHarnessConfig]):
             env=self._env(trace, secret),
             command=[wrapper],
             prompt=prompt,
-            required_agent_meta=(LIFECYCLE_META_NAMESPACE,),
         )
 
     async def cleanup(self, trace: Trace, runtime: Runtime) -> None:

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -17,7 +17,9 @@ from verifiers.v1.trace import Trace
 
 logger = logging.getLogger(__name__)
 
-INSTALL_URL = "https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/install.sh"
+GITHUB_RELEASE_URL = (
+    "https://github.com/PrimeIntellect-ai/prime-agent/releases/download"
+)
 PRIME_AGENT_DIR = "/var/tmp/vf-prime-agent"
 STATE_ROOT = "/tmp/vf-prime-agent-runs"
 SKILLS_DIR = ".agents/skills"
@@ -34,19 +36,23 @@ prefix="$VF_PRIME_AGENT_DIR/$PRIME_AGENT_VERSION"
 [ -x "$prefix/bin/prime-agent" ] && exit 0
 export NPM_CONFIG_PREFIX="$prefix"
 export PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL=0
-installer="$(mktemp "$VF_PRIME_AGENT_DIR/install.XXXXXX")"
-trap 'rm -f "$installer"' EXIT
-attempt=1
-max_attempts=10
-while ! { curl -fsSL "$VF_PRIME_AGENT_INSTALL_URL" -o "$installer" && sh "$installer"; }; do
-    [ "$attempt" -ge "$max_attempts" ] && exit 1
-    jitter="$(od -An -N2 -tu2 /dev/urandom | tr -d ' ')"
-    delay=$((attempt * 5 + jitter % 30))
-    printf 'Prime Agent install failed; retrying in %ss (%s/%s)\n' \
-        "$delay" "$attempt" "$max_attempts" >&2
-    sleep "$delay"
-    attempt=$((attempt + 1))
-done
+case "$PRIME_AGENT_VERSION" in
+    *-beta.*) release_tag=beta ;;
+    *) release_tag="v$PRIME_AGENT_VERSION" ;;
+esac
+release_url="$VF_PRIME_AGENT_GITHUB_RELEASE_URL/$release_tag"
+tarball="prime-agent-$PRIME_AGENT_VERSION.tgz"
+download_dir="$(mktemp -d "$VF_PRIME_AGENT_DIR/install.XXXXXX")"
+trap 'rm -rf "$download_dir"' EXIT
+curl -fsSL --retry 5 --retry-all-errors \
+    "$release_url/SHA256SUMS" -o "$download_dir/SHA256SUMS"
+curl -fsSL --retry 5 --retry-all-errors \
+    "$release_url/$tarball" -o "$download_dir/$tarball"
+awk -v file="$tarball" '$2 == file { print; found = 1; exit } END { if (!found) exit 1 }' \
+    "$download_dir/SHA256SUMS" > "$download_dir/SHA256SUMS.selected"
+(cd "$download_dir" && sha256sum -c SHA256SUMS.selected)
+PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL=1 npm install -g \
+    --no-fund --no-audit --loglevel=error --progress=false "$download_dir/$tarball"
 """
 
 
@@ -136,7 +142,7 @@ class PrimeAgentHarness(ACPHarness[PrimeAgentHarnessConfig]):
             {
                 **self.config.resolved_env,
                 "VF_PRIME_AGENT_DIR": PRIME_AGENT_DIR,
-                "VF_PRIME_AGENT_INSTALL_URL": INSTALL_URL,
+                "VF_PRIME_AGENT_GITHUB_RELEASE_URL": GITHUB_RELEASE_URL,
                 "PRIME_AGENT_VERSION": self.config.version,
             },
         )

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -4,8 +4,7 @@ import hashlib
 import json
 import logging
 import shlex
-
-from pydantic import Field
+from typing import Literal
 
 from verifiers.v1.acp import ACPConfig, ACPHarness, ACPTurnResult
 from verifiers.v1.clients import ModelContext
@@ -20,6 +19,10 @@ logger = logging.getLogger(__name__)
 GITHUB_RELEASE_URL = (
     "https://github.com/PrimeIntellect-ai/prime-agent/releases/download"
 )
+PRIME_AGENT_COMMIT: Literal["b5ee2f81a59510e7225a0db10d65102e91e98803"] = (
+    "b5ee2f81a59510e7225a0db10d65102e91e98803"
+)
+PRIME_AGENT_VERSION = "0.8.0-beta.549.1.b5ee2f8"
 PRIME_AGENT_DIR = "/var/tmp/vf-prime-agent"
 STATE_ROOT = "/tmp/vf-prime-agent-runs"
 SKILLS_DIR = ".agents/skills"
@@ -32,36 +35,60 @@ ENV_AGENT_DIR = "PRIME_AGENT_CODING_AGENT_DIR"
 INSTALL = r"""
 set -e
 export PATH="/var/tmp/vf-node/bin:$PATH"
-prefix="$VF_PRIME_AGENT_DIR/$PRIME_AGENT_VERSION"
+prefix="$VF_PRIME_AGENT_DIR/$PRIME_AGENT_COMMIT"
 [ -x "$prefix/bin/prime-agent" ] && exit 0
 export NPM_CONFIG_PREFIX="$prefix"
 export PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL=0
-case "$PRIME_AGENT_VERSION" in
-    *-beta.*) release_tag=beta ;;
-    *) release_tag="v$PRIME_AGENT_VERSION" ;;
-esac
-release_url="$VF_PRIME_AGENT_GITHUB_RELEASE_URL/$release_tag"
-tarball="prime-agent-$PRIME_AGENT_VERSION.tgz"
+release_url="$VF_PRIME_AGENT_GITHUB_RELEASE_URL/beta"
+agent_tarball="prime-agent-$PRIME_AGENT_RELEASE_VERSION.tgz"
+ai_tarball="prime-agent-ai-$PRIME_AGENT_RELEASE_VERSION.tgz"
+core_tarball="prime-agent-core-$PRIME_AGENT_RELEASE_VERSION.tgz"
+tui_tarball="prime-agent-tui-$PRIME_AGENT_RELEASE_VERSION.tgz"
 download_dir="$(mktemp -d "$VF_PRIME_AGENT_DIR/install.XXXXXX")"
 trap 'rm -rf "$download_dir"' EXIT
-curl -fsSL --retry 5 --retry-all-errors \
-    "$release_url/SHA256SUMS" -o "$download_dir/SHA256SUMS"
-curl -fsSL --retry 5 --retry-all-errors \
-    "$release_url/$tarball" -o "$download_dir/$tarball"
-awk -v file="$tarball" '$2 == file { print; found = 1; exit } END { if (!found) exit 1 }' \
-    "$download_dir/SHA256SUMS" > "$download_dir/SHA256SUMS.selected"
-(cd "$download_dir" && sha256sum -c SHA256SUMS.selected)
+for tarball in "$agent_tarball" "$ai_tarball" "$core_tarball" "$tui_tarball"; do
+    curl -fsSL --retry 5 --retry-all-errors \
+        "$release_url/$tarball" -o "$download_dir/$tarball"
+done
+printf '%s  %s\n' \
+    'f3b98bd7bf70dc25077dbd6afcec8d651570bead96919b42b8fde36d3e7d7268' "$agent_tarball" \
+    '0d655397ca9fda765afb5ba7b2b65ab74b928f9c178e548ef3befc0358f39ce2' "$ai_tarball" \
+    '0cb81e79422887a43d850722812c6a4589760eb69441cb4c042e665cbfdff5e1' "$core_tarball" \
+    '307ec5e5a320f9a0355b08ec352230cb406f82fac0ebbd6e33f6306a3e9452a8' "$tui_tarball" \
+    > "$download_dir/SHA256SUMS"
+(cd "$download_dir" && sha256sum -c SHA256SUMS)
+mkdir "$download_dir/package-root"
+tar -xzf "$download_dir/$agent_tarball" -C "$download_dir/package-root"
+node - \
+    "$download_dir/package-root/package/package.json" \
+    "$download_dir" \
+    "$ai_tarball" \
+    "$core_tarball" \
+    "$tui_tarball" <<'NODE'
+const fs = require("node:fs");
+const [manifestPath, downloadDir, ai, core, tui] = process.argv.slice(2);
+const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+for (const [name, file] of [
+    ["@earendil-works/pi-ai", ai],
+    ["@earendil-works/pi-agent-core", core],
+    ["@earendil-works/pi-tui", tui],
+]) {
+    manifest.dependencies[name] = `file:${downloadDir}/${file}`;
+}
+fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+NODE
+mkdir "$download_dir/repacked"
+repacked="$(npm pack "$download_dir/package-root/package" \
+    --pack-destination "$download_dir/repacked" --silent)"
 PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL=1 npm install -g \
-    --no-fund --no-audit --loglevel=error --progress=false "$download_dir/$tarball"
+    --no-fund --no-audit --loglevel=error --progress=false \
+    "$download_dir/repacked/$repacked"
 """
 
 
 class PrimeAgentHarnessConfig(HarnessConfig):
-    version: str = Field(
-        default="0.8.0-beta.548.1.9bc0055",
-        pattern=r"^[A-Za-z0-9][A-Za-z0-9._+-]*$",
-    )
-    """Prime Agent release to install, pinned for reproducibility."""
+    commit: Literal["b5ee2f81a59510e7225a0db10d65102e91e98803"] = PRIME_AGENT_COMMIT
+    """Prime Agent main commit to install."""
 
     autonomous: bool = False
     """Enable Prime Agent's autonomous continuation loop."""
@@ -130,7 +157,7 @@ class PrimeAgentHarness(ACPHarness[PrimeAgentHarnessConfig]):
     async def setup(self, runtime: Runtime) -> None:
         await self.install_skills(runtime, SKILLS_DIR)
         await ensure_node(runtime)
-        logger.info("prime-agent: ensuring %s is installed", self.config.version)
+        logger.info("prime-agent: ensuring commit %s is installed", self.config.commit)
         lock = f"{PRIME_AGENT_DIR}/install.lock"
         guarded = (
             f"mkdir -p {PRIME_AGENT_DIR} && "
@@ -143,7 +170,8 @@ class PrimeAgentHarness(ACPHarness[PrimeAgentHarnessConfig]):
                 **self.config.resolved_env,
                 "VF_PRIME_AGENT_DIR": PRIME_AGENT_DIR,
                 "VF_PRIME_AGENT_GITHUB_RELEASE_URL": GITHUB_RELEASE_URL,
-                "PRIME_AGENT_VERSION": self.config.version,
+                "PRIME_AGENT_COMMIT": self.config.commit,
+                "PRIME_AGENT_RELEASE_VERSION": PRIME_AGENT_VERSION,
             },
         )
         if result.exit_code != 0:
@@ -265,7 +293,7 @@ class PrimeAgentHarness(ACPHarness[PrimeAgentHarnessConfig]):
             )
 
     def _bin(self) -> str:
-        return f"{PRIME_AGENT_DIR}/{self.config.version}/bin/prime-agent"
+        return f"{PRIME_AGENT_DIR}/{self.config.commit}/bin/prime-agent"
 
     @staticmethod
     def _root(trace: Trace) -> str:

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -1,0 +1,288 @@
+"""Prime Agent over its native ACP mode."""
+
+import hashlib
+import json
+import logging
+import shlex
+
+from pydantic import Field
+
+from verifiers.v1.acp import ACPConfig, ACPHarness, ACPTurnResult
+from verifiers.v1.clients import ModelContext
+from verifiers.v1.configs.harness import HarnessConfig
+from verifiers.v1.harnesses.node import NODE_BIN_DIR, ensure_node
+from verifiers.v1.runtimes import Runtime
+from verifiers.v1.task import TaskData
+from verifiers.v1.trace import Trace
+
+logger = logging.getLogger(__name__)
+
+INSTALL_URL = "https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/install.sh"
+PRIME_AGENT_DIR = "/var/tmp/vf-prime-agent"
+STATE_ROOT = "/tmp/vf-prime-agent-runs"
+SKILLS_DIR = ".agents/skills"
+PROVIDER = "intercept"
+LIFECYCLE_META_NAMESPACE = "ai.primeintellect.prime-agent"
+KEY_VAR = "PRIME_AGENT_INTERCEPT_KEY"
+ENV_AGENT_DIR = "PRIME_AGENT_CODING_AGENT_DIR"
+
+
+INSTALL = r"""
+set -e
+export PATH="/var/tmp/vf-node/bin:$PATH"
+prefix="$VF_PRIME_AGENT_DIR/$PRIME_AGENT_VERSION"
+[ -x "$prefix/bin/prime-agent" ] && exit 0
+export NPM_CONFIG_PREFIX="$prefix"
+export PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL=0
+installer="$(mktemp "$VF_PRIME_AGENT_DIR/install.XXXXXX")"
+trap 'rm -f "$installer"' EXIT
+curl -fsSL "$VF_PRIME_AGENT_INSTALL_URL" -o "$installer"
+sh "$installer"
+"""
+
+
+class PrimeAgentHarnessConfig(HarnessConfig):
+    version: str = Field(
+        default="0.8.0-beta.548.1.9bc0055",
+        pattern=r"^[A-Za-z0-9][A-Za-z0-9._+-]*$",
+    )
+    """Prime Agent release to install, pinned for reproducibility."""
+
+    autonomous: bool = False
+    """Enable Prime Agent's autonomous continuation loop."""
+
+
+class PrimeAgentHarness(ACPHarness[PrimeAgentHarnessConfig]):
+    APPENDS_SYSTEM_PROMPT = True
+    SUPPORTS_MCP = True
+    SUPPORTS_RESUME = True
+    SUPPORTS_SKILLS = True
+
+    def acp_turn_result(self, trace: Trace, result: ACPTurnResult) -> None:
+        events = [
+            event
+            for metadata in result.update_metadata
+            if isinstance(event := metadata.get(LIFECYCLE_META_NAMESPACE), dict)
+        ]
+        terminal = next(
+            (
+                event
+                for event in reversed(events)
+                if event.get("phase") == "terminalQuiescence"
+            ),
+            None,
+        )
+        prompt_turn_id = terminal.get("promptTurnId") if terminal else None
+        boundary = next(
+            (
+                event
+                for event in reversed(events)
+                if event.get("phase") == "responseBoundary"
+                and event.get("promptTurnId") == prompt_turn_id
+            ),
+            None,
+        )
+        ordered = True
+        previous_sequence = 0
+        for event in events:
+            sequence = event.get("eventSequence")
+            if type(sequence) is not int or sequence <= previous_sequence:
+                ordered = False
+                break
+            previous_sequence = sequence
+        quiescence = terminal.get("quiescence") if terminal else None
+        infrastructure_ok = bool(
+            ordered
+            and boundary
+            and terminal
+            and boundary.get("outcome") in ("result", "error")
+            and boundary.get("terminalQuiescenceExpected") is True
+            and terminal.get("outcome") == boundary.get("outcome")
+            and isinstance(quiescence, dict)
+            and quiescence.get("outstandingSubagents") == 0
+            and type(quiescence.get("remainingAutonomousContinuations")) is int
+            and quiescence["remainingAutonomousContinuations"] >= 0
+        )
+        status = {
+            "prompt_turn_id": prompt_turn_id,
+            "stop_reason": result.stop_reason,
+            "infrastructure_status": "ok" if infrastructure_ok else "error",
+            "autonomous_completion": bool(
+                infrastructure_ok and terminal and terminal.get("outcome") == "result"
+            ),
+            "terminal_quiescence_observed": terminal is not None,
+            "last_lifecycle_phase": terminal.get("phase")
+            if terminal
+            else boundary.get("phase")
+            if boundary
+            else None,
+            "response_boundary": boundary,
+            "terminal_quiescence": terminal,
+        }
+        lifecycle = trace.info.get("acp_lifecycle")
+        if not isinstance(lifecycle, dict):
+            lifecycle = {}
+            trace.info["acp_lifecycle"] = lifecycle
+        statuses = lifecycle.get(LIFECYCLE_META_NAMESPACE)
+        if not isinstance(statuses, list):
+            statuses = []
+            lifecycle[LIFECYCLE_META_NAMESPACE] = statuses
+        statuses.append(status)
+        if not infrastructure_ok:
+            raise RuntimeError("Prime Agent did not publish terminal quiescence")
+
+    async def setup(self, runtime: Runtime) -> None:
+        await self.install_skills(runtime, SKILLS_DIR)
+        await ensure_node(runtime)
+        logger.info("prime-agent: ensuring %s is installed", self.config.version)
+        lock = f"{PRIME_AGENT_DIR}/install.lock"
+        guarded = (
+            f"mkdir -p {PRIME_AGENT_DIR} && "
+            f'"$(command -v flock || command -v lockf)" {lock} '
+            f"sh -c {shlex.quote(INSTALL)}"
+        )
+        result = await runtime.run(
+            ["sh", "-c", guarded],
+            {
+                **self.config.resolved_env,
+                "VF_PRIME_AGENT_DIR": PRIME_AGENT_DIR,
+                "VF_PRIME_AGENT_INSTALL_URL": INSTALL_URL,
+                "PRIME_AGENT_VERSION": self.config.version,
+            },
+        )
+        if result.exit_code != 0:
+            raise RuntimeError(
+                f"prime-agent install failed: {result.stderr.strip()[-500:]}"
+            )
+        await super().setup(runtime)
+
+    async def prepare_acp(
+        self,
+        ctx: ModelContext,
+        trace: Trace,
+        runtime: Runtime,
+        endpoint: str,
+        secret: str,
+        mcp_urls: dict[str, str],
+        data: TaskData,
+    ) -> ACPConfig:
+        if self.config.disabled_tools:
+            raise ValueError(
+                "prime-agent has no per-tool disable flag; its model-facing tool "
+                "surface is ipython"
+            )
+
+        root = self._root(trace)
+        agent_dir = f"{root}/agent"
+        created = await runtime.run(
+            [
+                "mkdir",
+                "-p",
+                "-m",
+                "700",
+                root,
+                agent_dir,
+                f"{root}/tmp",
+            ],
+            {},
+        )
+        if created.exit_code != 0:
+            raise RuntimeError(
+                f"prime-agent state directory failed: {created.stderr.strip()[-500:]}"
+            )
+        reasoning = ctx.sampling.reasoning_effort not in (
+            None,
+            "none",
+        ) or ctx.model.rsplit("/", 1)[-1].startswith(("gpt-5", "o1", "o3", "o4"))
+        models = {
+            "providers": {
+                PROVIDER: {
+                    "baseUrl": endpoint,
+                    "api": "openai-completions",
+                    "apiKey": KEY_VAR,
+                    "models": [
+                        {
+                            "id": ctx.model,
+                            "reasoning": reasoning,
+                            "input": ["text", "image"],
+                        }
+                    ],
+                }
+            }
+        }
+        models_path = f"{agent_dir}/models.json"
+        await runtime.write(models_path, json.dumps(models).encode())
+        secured = await runtime.run(["chmod", "600", models_path], {})
+        if secured.exit_code != 0:
+            raise RuntimeError(
+                f"prime-agent model config chmod failed: {secured.stderr.strip()[-500:]}"
+            )
+
+        system_prompt, prompt = self.resolve_prompt(data)
+        args = [
+            self._bin(),
+            "--mode",
+            "acp",
+            "--provider",
+            PROVIDER,
+            "--model",
+            ctx.model,
+            "--daemon-socket",
+            f"{root}/daemon.sock",
+            "--offline",
+        ]
+        if self.config.autonomous:
+            args.append("--autonomous")
+        for skill in self.config.skills:
+            args += ["--skill", f"{SKILLS_DIR}/{skill.resolve().name}"]
+        if system_prompt:
+            args += ["--append-system-prompt", system_prompt]
+
+        wrapper = f"{root}/prime-agent"
+        await runtime.write(
+            wrapper,
+            (
+                "#!/bin/sh\n"
+                "set -eu\n"
+                f'export PATH="{NODE_BIN_DIR}:$HOME/.local/bin:$PATH"\n'
+                f'exec {shlex.join(args)} "$@"\n'
+            ).encode(),
+        )
+        executable = await runtime.run(["chmod", "700", wrapper], {})
+        if executable.exit_code != 0:
+            raise RuntimeError(
+                f"prime-agent wrapper chmod failed: {executable.stderr.strip()[-500:]}"
+            )
+
+        return ACPConfig(
+            env=self._env(trace, secret),
+            command=[wrapper],
+            prompt=prompt,
+            required_agent_meta={LIFECYCLE_META_NAMESPACE: {}},
+        )
+
+    async def cleanup(self, trace: Trace, runtime: Runtime) -> None:
+        root = self._root(trace)
+        removed = await runtime.run(["rm", "-rf", root], {})
+        if removed.exit_code != 0:
+            raise RuntimeError(
+                f"prime-agent state cleanup failed: {removed.stderr.strip()[-500:]}"
+            )
+
+    def _bin(self) -> str:
+        return f"{PRIME_AGENT_DIR}/{self.config.version}/bin/prime-agent"
+
+    @staticmethod
+    def _root(trace: Trace) -> str:
+        digest = hashlib.sha256(trace.id.encode()).hexdigest()[:16]
+        return f"{STATE_ROOT}/{digest}"
+
+    def _env(self, trace: Trace, secret: str) -> dict[str, str]:
+        root = self._root(trace)
+        return {
+            **self.config.resolved_env,
+            KEY_VAR: secret,
+            ENV_AGENT_DIR: f"{root}/agent",
+            "TMPDIR": f"{root}/tmp",
+            "PRIME_AGENT_TELEMETRY": "0",
+        }

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -36,8 +36,17 @@ export NPM_CONFIG_PREFIX="$prefix"
 export PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL=0
 installer="$(mktemp "$VF_PRIME_AGENT_DIR/install.XXXXXX")"
 trap 'rm -f "$installer"' EXIT
-curl -fsSL "$VF_PRIME_AGENT_INSTALL_URL" -o "$installer"
-sh "$installer"
+attempt=1
+max_attempts=10
+while ! { curl -fsSL "$VF_PRIME_AGENT_INSTALL_URL" -o "$installer" && sh "$installer"; }; do
+    [ "$attempt" -ge "$max_attempts" ] && exit 1
+    jitter="$(od -An -N2 -tu2 /dev/urandom | tr -d ' ')"
+    delay=$((attempt * 5 + jitter % 30))
+    printf 'Prime Agent install failed; retrying in %ss (%s/%s)\n' \
+        "$delay" "$attempt" "$max_attempts" >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done
 """
 
 

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -82,33 +82,16 @@ class PrimeAgentHarness(ACPHarness[PrimeAgentHarnessConfig]):
             ),
             None,
         )
-        ordered = True
-        previous_sequence = 0
-        for event in events:
-            sequence = event.get("eventSequence")
-            if type(sequence) is not int or sequence <= previous_sequence:
-                ordered = False
-                break
-            previous_sequence = sequence
         quiescence = terminal.get("quiescence") if terminal else None
-        infrastructure_ok = bool(
-            ordered
-            and boundary
-            and terminal
-            and boundary.get("outcome") in ("result", "error")
-            and boundary.get("terminalQuiescenceExpected") is True
-            and terminal.get("outcome") == boundary.get("outcome")
-            and isinstance(quiescence, dict)
-            and quiescence.get("outstandingSubagents") == 0
-            and type(quiescence.get("remainingAutonomousContinuations")) is int
-            and quiescence["remainingAutonomousContinuations"] >= 0
+        quiescent = bool(
+            isinstance(quiescence, dict) and quiescence.get("outstandingSubagents") == 0
         )
         status = {
             "prompt_turn_id": prompt_turn_id,
             "stop_reason": result.stop_reason,
-            "infrastructure_status": "ok" if infrastructure_ok else "error",
+            "infrastructure_status": "ok" if boundary and quiescent else "unverified",
             "autonomous_completion": bool(
-                infrastructure_ok and terminal and terminal.get("outcome") == "result"
+                quiescent and terminal and terminal.get("outcome") == "result"
             ),
             "terminal_quiescence_observed": terminal is not None,
             "last_lifecycle_phase": terminal.get("phase")
@@ -128,8 +111,6 @@ class PrimeAgentHarness(ACPHarness[PrimeAgentHarnessConfig]):
             statuses = []
             lifecycle[LIFECYCLE_META_NAMESPACE] = statuses
         statuses.append(status)
-        if not infrastructure_ok:
-            raise RuntimeError("Prime Agent did not publish terminal quiescence")
 
     async def setup(self, runtime: Runtime) -> None:
         await self.install_skills(runtime, SKILLS_DIR)
@@ -258,7 +239,7 @@ class PrimeAgentHarness(ACPHarness[PrimeAgentHarnessConfig]):
             env=self._env(trace, secret),
             command=[wrapper],
             prompt=prompt,
-            required_agent_meta={LIFECYCLE_META_NAMESPACE: {}},
+            required_agent_meta=(LIFECYCLE_META_NAMESPACE,),
         )
 
     async def cleanup(self, trace: Trace, runtime: Runtime) -> None:

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -36,7 +36,7 @@ class _SessionSnapshot(BaseModel):
 
 class RLMHarnessConfig(HarnessConfig):
     version: str = Field(
-        default="5ee1c34024a183bbbd3a38a6129995f5b982631d", min_length=1
+        default="d4ce3e10e63b359f4f3d432d58a77471e9e21fe7", min_length=1
     )
     """Git ref (branch, tag, or commit) of nano-rlm to install."""
     max_depth: int = 0


### PR DESCRIPTION
## Summary

- add Prime Agent over the same generic typed ACP prompt lifecycle as nano-RLM
- pass `--autonomous` explicitly from harness configuration
- preserve MCP programs, resume state, skills, Chat reasoning lineage, and isolated per-rollout state
- trust Prime Agent's completed `session/prompt` boundary from [Prime Agent PR #1612](https://github.com/PrimeIntellect-ai/prime-agent/pull/1612)
- record response-boundary and terminal-quiescence telemetry for evidence without making it a second completion gate
- enforce single-branch lineage for the ordinary two-turn resume case

## Stack

PR 3 of the three-PR Verifiers stack. This targets nano-RLM integration PR #2439, which targets typed ACP base PR #2438.

Prime Agent PR #1612 is merged and included in the pinned beta used here. It makes `session/prompt` wait for recursive terminal quiescence and returns the final autonomous stop reason.

## Validation

- full Verifiers suite on the combined stack — 919 passed, 77 credential-gated skips
- Prime Agent Prime VM MCP/resume E2E — passed against `0.8.0-beta.548.1.9bc0055`
- single-branch assertion enabled and passed for the resumed conversation
- Seth's full feature canary against current Prime Agent `main` (`9bc0055`) — passed
  - reward `1.0`; all 13 feature checks true
  - retained-child follow-up acknowledged and child deleted
  - terminal quiescence after response boundary
  - zero outstanding subagents and autonomous continuations
  - Docker container removed
- changed-file pre-commit hooks and push-hook CI-parity type check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces network-fetched agent binaries and a new ACP harness on the eval critical path; the RLM default pin change can shift behavior for existing RLM rollouts.
> 
> **Overview**
> Adds a **Prime Agent** v1 harness that runs Prime Agent in native **ACP mode** on the shared `ACPHarness` path, with MCP, resume, skills, and optional **`autonomous`** continuation via config.
> 
> The harness **bootstraps a pinned beta** from GitHub releases (checksum-verified tarballs, global npm install under a commit-keyed prefix), wires the **intercept** provider to the eval endpoint, and keeps **per-rollout state** (models config, daemon socket, wrapper). After each ACP turn it **records lifecycle telemetry** (`responseBoundary`, `terminalQuiescence`, infrastructure status) under `trace.info["acp_lifecycle"]` for evidence without gating completion on it.
> 
> **E2E** gains a Prime VM row for `prime-agent` in the ACP resume+MCP test, asserting two turns show OK infrastructure and zero outstanding subagents at terminal quiescence. **nano-RLM**’s default install ref is bumped to a newer commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9af8996d22fba08238aded5c9817a85736d419a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->