### PR TITLE
fix(v1): use typed ACP turn in RLM harness

### DIFF
--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -7,7 +7,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, PositiveInt, model_validator
 
-from verifiers.v1.acp import ACPConfig, ACPHarness, ACPTurnResult, JsonObject
+from verifiers.v1.acp import ACPConfig, ACPHarness, ACPTurn, JsonObject
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.runtimes import Runtime
@@ -157,7 +157,7 @@ class RLMHarness(ACPHarness[RLMHarnessConfig]):
             ),
         )
 
-    def acp_turn_result(self, trace: Trace, result: ACPTurnResult) -> None:
+    def acp_turn_result(self, trace: Trace, result: ACPTurn) -> None:
         snapshot = _SessionSnapshot.model_validate(
             result.response_metadata.get(RLM_SESSION_METADATA_KEY)
         )


### PR DESCRIPTION
## Summary

- update the RLM harness to consume the ACPTurn type exported by the merged ACP base
- restore built-in harness discovery after stacked PR #2439 was restacked onto PR #2438

## Root cause

PR #2439 retained the earlier ACPTurnResult name while PR #2438 landed the public type as ACPTurn. Importing the built-in harness package therefore raised ImportError.

## Validation

- exact deterministic V1 CI command: 71 passed
- full test suite: 915 passed, 75 credential-gated skips
- uv run ty check verifiers
- uv run ruff check --fix .
- changed-file pre-commit hooks

The all-files Markdown hook still reports the pre-existing inline-HTML table in verifiers/legacy/envs/experimental/composable/tasksets/swe/README.md, as already documented in PR #2438.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-name alignment only; no change to RLM turn handling or metrics recording logic.
> 
> **Overview**
> Updates the **RLM harness** so it imports and uses **`ACPTurn`** from `verifiers.v1.acp` instead of the obsolete **`ACPTurnResult`** name on the import and on **`acp_turn_result`**.
> 
> This matches the public ACP base type from the merged stack and fixes **`ImportError`** when built-in harness discovery loads the RLM package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d872359784c5f1a69d7a91798fb689d0314d886. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->