### PR TITLE
fix(v1): use typed ACP turn in Prime Agent harness

### DIFF
--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -6,7 +6,7 @@ import logging
 import shlex
 from typing import Literal
 
-from verifiers.v1.acp import ACPConfig, ACPHarness, ACPTurnResult
+from verifiers.v1.acp import ACPConfig, ACPHarness, ACPTurn
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.harnesses.node import NODE_BIN_DIR, ensure_node
@@ -100,7 +100,7 @@ class PrimeAgentHarness(ACPHarness[PrimeAgentHarnessConfig]):
     SUPPORTS_RESUME = True
     SUPPORTS_SKILLS = True
 
-    def acp_turn_result(self, trace: Trace, result: ACPTurnResult) -> None:
+    def acp_turn_result(self, trace: Trace, result: ACPTurn) -> None:
         events = [
             event
             for metadata in result.update_metadata


### PR DESCRIPTION
## Summary

- update the Prime Agent harness to consume the ACPTurn type exported by the merged ACP base
- restore built-in harness discovery after stacked PR #2440 was restacked onto PRs #2438 and #2439

## Root cause

PR #2440 retained the earlier ACPTurnResult name while PR #2438 landed the public type as ACPTurn. Importing the built-in harness package therefore raised ImportError.

## Validation

- exact deterministic V1 CI command: 71 passed
- full test suite exits successfully; credential-gated live tests skipped locally
- uv run ty check verifiers
- uv run ruff check --fix .
- changed-file pre-commit hooks

The branch is based on newest main after RLM hotfix #2442.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Rename-only type alignment with no logic changes; fixes import/discovery breakage.
> 
> **Overview**
> Aligns the **Prime Agent** harness with the v1 ACP base after the public turn type was renamed from `ACPTurnResult` to **`ACPTurn`**.
> 
> The import and `acp_turn_result` parameter type are updated only; lifecycle handling is unchanged. This removes the **`ImportError`** that broke built-in harness package discovery when stacked PRs landed the new name in `verifiers.v1.acp` but Prime Agent still imported the old symbol.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ee1df9f91e6d49337a460ff9558265f70fac0c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->