### PR TITLE
feat(v1): resolve stable Prime Agent releases

### DIFF
--- a/tests/v1/test_prime_agent_release.py
+++ b/tests/v1/test_prime_agent_release.py
@@ -1,0 +1,68 @@
+import pytest
+
+import verifiers.v1.harnesses.prime_agent.harness as prime_agent
+from verifiers.v1.harnesses.prime_agent.harness import (
+    PrimeAgentHarness,
+    PrimeAgentHarnessConfig,
+    PrimeAgentRelease,
+)
+
+
+def release(version: str = "0.8.1") -> PrimeAgentRelease:
+    return PrimeAgentRelease(
+        version=version,
+        sha256={
+            package: f"{index:x}" * 64
+            for index, package in enumerate(prime_agent.RELEASE_PACKAGES, 1)
+        },
+    )
+
+
+def test_release_requires_every_tarball() -> None:
+    resolved = release()
+    entries = [
+        {"file": resolved.file(package), "sha256": sha256}
+        for package, sha256 in resolved.sha256.items()
+    ]
+    assert prime_agent._release("v0.8.1", entries) == resolved
+
+    with pytest.raises(ValueError, match="prime-agent-tui-0.8.1.tgz"):
+        prime_agent._release("0.8.1", entries[:-1])
+
+
+def test_release_rejects_unsupported_versions() -> None:
+    with pytest.raises(ValueError, match="older than"):
+        PrimeAgentHarnessConfig(id="prime_agent", release="0.8.0")
+    with pytest.raises(ValueError, match="invalid"):
+        PrimeAgentHarnessConfig(id="prime_agent", release="0.8.1-beta.1")
+    with pytest.raises(ValueError, match="does not match"):
+        PrimeAgentHarnessConfig(
+            id="prime_agent", release="0.8.2", resolved_release=release()
+        )
+
+
+@pytest.mark.asyncio
+async def test_prepared_release_survives_config_round_trip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolved = release()
+
+    async def fetch(_: str) -> PrimeAgentRelease:
+        return resolved
+
+    monkeypatch.setattr(prime_agent, "_fetch_release", fetch)
+    harness = PrimeAgentHarness(PrimeAgentHarnessConfig(id="prime_agent"))
+    await harness.prepare()
+
+    saved = harness.config.model_dump(mode="json")
+
+    async def fail(_: str) -> PrimeAgentRelease:
+        raise AssertionError("frozen release was fetched again")
+
+    monkeypatch.setattr(prime_agent, "_fetch_release", fail)
+    loaded = PrimeAgentHarnessConfig.model_validate(saved)
+    assert await PrimeAgentHarness(loaded)._resolve() == resolved
+
+    saved["resolved_release"]["version"] = "0.8.0"
+    with pytest.raises(ValueError, match="older than"):
+        PrimeAgentHarnessConfig.model_validate(saved)

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -37,6 +37,17 @@ RunSlotFn = Callable[[RunSlot], Awaitable[Episode]]
 OnComplete = Callable[[Episode], Awaitable[None]]
 
 
+async def _prepare_harnesses(config: EvalConfig) -> None:
+    """Freeze mutable harness inputs once, before saving or spawning workers."""
+    from verifiers.v1.utils.loaders import load_harness
+
+    harnesses = {
+        id(harness): load_harness(harness)
+        for harness in config.env.agent_harnesses().values()
+    }
+    await asyncio.gather(*(harness.prepare() for harness in harnesses.values()))
+
+
 @contextlib.asynccontextmanager
 async def _in_process(
     env: Env,
@@ -139,6 +150,8 @@ async def _server(
 
 async def run_eval(config: EvalConfig) -> list[Episode]:
     from verifiers.v1.utils.loaders import load_environment, load_taskset
+
+    await _prepare_harnesses(config)
 
     # The env comes up in this process only for an in-process run; a served run's
     # workers each load their own, and this process owns just the taskset.

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -37,17 +37,6 @@ RunSlotFn = Callable[[RunSlot], Awaitable[Episode]]
 OnComplete = Callable[[Episode], Awaitable[None]]
 
 
-async def _prepare_harnesses(config: EvalConfig) -> None:
-    """Freeze mutable harness inputs once, before saving or spawning workers."""
-    from verifiers.v1.utils.loaders import load_harness
-
-    harnesses = {
-        id(harness): load_harness(harness)
-        for harness in config.env.agent_harnesses().values()
-    }
-    await asyncio.gather(*(harness.prepare() for harness in harnesses.values()))
-
-
 @contextlib.asynccontextmanager
 async def _in_process(
     env: Env,
@@ -149,9 +138,14 @@ async def _server(
 
 
 async def run_eval(config: EvalConfig) -> list[Episode]:
-    from verifiers.v1.utils.loaders import load_environment, load_taskset
+    from verifiers.v1.utils.loaders import load_environment, load_harness, load_taskset
 
-    await _prepare_harnesses(config)
+    harnesses = {
+        id(harness): harness for harness in config.env.agent_harnesses().values()
+    }
+    await asyncio.gather(
+        *(load_harness(harness).prepare() for harness in harnesses.values())
+    )
 
     # The env comes up in this process only for an in-process run; a served run's
     # workers each load their own, and this process owns just the taskset.

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -92,6 +92,9 @@ class Harness(ABC, Generic[ConfigT]):
             )
         return system, prompt
 
+    async def prepare(self) -> None:
+        """Freeze evaluation-scoped inputs before config persistence and workers."""
+
     async def setup(self, runtime: Runtime) -> None:
         """Provision this harness in `runtime` before its execution timeout starts."""
 

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -104,7 +104,10 @@ def _source(requested: str) -> str:
 
 async def _fetch_release(requested: str) -> PrimeAgentRelease:
     source = _source(requested)
-    async with httpx.AsyncClient(follow_redirects=True, timeout=30) as client:
+    transport = httpx.AsyncHTTPTransport(retries=3)
+    async with httpx.AsyncClient(
+        follow_redirects=True, timeout=30, transport=transport
+    ) as client:
         response = await client.get(source)
         response.raise_for_status()
         if requested == "stable":

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -1,6 +1,5 @@
 """Prime Agent over its native ACP mode."""
 
-import asyncio
 import hashlib
 import json
 import logging
@@ -9,7 +8,7 @@ import shlex
 from dataclasses import dataclass
 
 import httpx
-from pydantic import PrivateAttr, field_validator, model_validator
+from pydantic import field_validator, model_validator
 
 from verifiers.v1.acp import ACPConfig, ACPHarness, ACPTurn
 from verifiers.v1.clients import ModelContext
@@ -43,9 +42,7 @@ ENV_AGENT_DIR = "PRIME_AGENT_CODING_AGENT_DIR"
 
 @dataclass(frozen=True)
 class PrimeAgentRelease:
-    requested: str
     version: str
-    source: str
     sha256: dict[str, str]
 
     @property
@@ -71,145 +68,61 @@ def _version(value: object) -> str:
         raise ValueError(f"invalid Prime Agent stable version: {value!r}")
     if version < MINIMUM_VERSION:
         minimum = ".".join(str(part) for part in MINIMUM_VERSION)
-        raise ValueError(
-            f"Prime Agent {raw} is older than the required {minimum}; "
-            "wait for the stable release or request a supported exact version"
-        )
+        raise ValueError(f"Prime Agent {raw} is older than the required {minimum}")
     return raw
 
 
-def _release_from_entries(
-    requested: str,
-    version: object,
-    source: str,
-    entries: object,
-) -> PrimeAgentRelease:
+def _release(version: object, entries: object) -> PrimeAgentRelease:
     resolved = _version(version)
-    if requested == "stable":
-        expected_source = LATEST_RELEASE_URL
-    else:
-        if _version(requested) != resolved:
-            raise ValueError(
-                f"Prime Agent release {requested!r} resolved to unexpected "
-                f"version {resolved!r}"
-            )
-        expected_source = f"{GITHUB_RELEASE_URL}/v{resolved}/SHA256SUMS"
-    if source != expected_source:
-        raise ValueError(
-            f"Prime Agent release metadata came from unexpected source {source!r}"
-        )
     if not isinstance(entries, list):
-        raise TypeError(f"Prime Agent release metadata from {source} has no tarballs")
-    hashes: dict[str, str] = {}
+        raise TypeError("Prime Agent release metadata has no tarballs")
+    files: dict[str, str] = {}
     for entry in entries:
         if not isinstance(entry, dict):
-            raise TypeError(f"invalid tarball entry in {source}")
-        package = entry.get("package")
-        if not isinstance(package, str) or package not in RELEASE_PACKAGES:
-            raise ValueError(f"unexpected package {package!r} in {source}")
-        expected = f"{package}-{resolved}.tgz"
-        if entry.get("file") != expected:
-            raise ValueError(
-                f"Prime Agent release metadata names {entry.get('file')!r}, "
-                f"expected {expected!r}"
-            )
+            raise TypeError("invalid Prime Agent tarball entry")
+        file = entry.get("file")
         sha256 = entry.get("sha256")
-        if not isinstance(sha256, str) or not re.fullmatch(r"[0-9a-fA-F]{64}", sha256):
-            raise ValueError(f"invalid SHA-256 for {expected} in {source}")
-        if package in hashes:
-            raise ValueError(f"duplicate {package} entry in {source}")
-        hashes[package] = sha256.lower()
-    missing = sorted(set(RELEASE_PACKAGES) - hashes.keys())
-    if missing:
-        raise ValueError(
-            f"Prime Agent release metadata is missing {missing} in {source}"
-        )
-    return PrimeAgentRelease(
-        requested=requested,
-        version=resolved,
-        source=source,
-        sha256=hashes,
-    )
+        if isinstance(file, str) and isinstance(sha256, str):
+            if file in files:
+                raise ValueError(f"duplicate Prime Agent tarball {file!r}")
+            files[file] = sha256.lower()
+    hashes: dict[str, str] = {}
+    for package in RELEASE_PACKAGES:
+        file = f"{package}-{resolved}.tgz"
+        sha256 = files.get(file, "")
+        if not re.fullmatch(r"[0-9a-f]{64}", sha256):
+            raise ValueError(f"missing or invalid SHA-256 for {file}")
+        hashes[package] = sha256
+    return PrimeAgentRelease(version=resolved, sha256=hashes)
 
 
-def _release_from_sums(
-    requested: str, version: str, source: str, text: str
-) -> PrimeAgentRelease:
-    resolved = _version(version)
-    entries = []
-    for line in text.splitlines():
-        fields = line.split()
-        if len(fields) != 2:
-            continue
-        sha256, file = fields
-        for package in RELEASE_PACKAGES:
-            if file == f"{package}-{resolved}.tgz":
-                entries.append({"package": package, "file": file, "sha256": sha256})
-                break
-    return _release_from_entries(requested, resolved, source, entries)
+def _source(requested: str) -> str:
+    if requested == "stable":
+        return LATEST_RELEASE_URL
+    return f"{GITHUB_RELEASE_URL}/v{requested}/SHA256SUMS"
 
 
 async def _fetch_release(requested: str) -> PrimeAgentRelease:
-    requested = requested.strip().lower()
-    transport = httpx.AsyncHTTPTransport(retries=3)
-    async with httpx.AsyncClient(
-        follow_redirects=True,
-        timeout=30,
-        transport=transport,
-    ) as client:
+    source = _source(requested)
+    async with httpx.AsyncClient(follow_redirects=True, timeout=30) as client:
+        response = await client.get(source)
+        response.raise_for_status()
         if requested == "stable":
-            response = await client.get(LATEST_RELEASE_URL)
-            response.raise_for_status()
             try:
                 metadata = response.json()
             except json.JSONDecodeError as e:
                 raise ValueError(
-                    f"invalid Prime Agent release metadata from {LATEST_RELEASE_URL}"
+                    f"invalid Prime Agent release metadata from {source}"
                 ) from e
             if not isinstance(metadata, dict):
-                raise ValueError(
-                    f"invalid Prime Agent release metadata from {LATEST_RELEASE_URL}"
-                )
-            resolved = _version(metadata.get("version"))
-            expected_tarball = f"releases/v{resolved}/prime-agent-{resolved}.tgz"
-            if (
-                metadata.get("package") != "prime-agent"
-                or metadata.get("tarball") != expected_tarball
-            ):
-                raise ValueError(
-                    f"invalid Prime Agent release metadata from {LATEST_RELEASE_URL}"
-                )
-            return _release_from_entries(
-                requested,
-                metadata.get("version"),
-                LATEST_RELEASE_URL,
-                metadata.get("tarballs"),
-            )
-        version = _version(requested)
-        source = f"{GITHUB_RELEASE_URL}/v{version}/SHA256SUMS"
-        response = await client.get(source)
-        response.raise_for_status()
-        return _release_from_sums(requested, version, source, response.text)
-
-
-_RELEASE_TASKS: dict[str, asyncio.Task[PrimeAgentRelease]] = {}
-_RELEASE_TASKS_LOCK = asyncio.Lock()
-
-
-async def _resolve_release(requested: str) -> PrimeAgentRelease:
-    """Share one in-flight fetch without caching stable across evaluations."""
-    async with _RELEASE_TASKS_LOCK:
-        task = _RELEASE_TASKS.get(requested)
-        if task is None:
-            task = asyncio.create_task(_fetch_release(requested))
-            _RELEASE_TASKS[requested] = task
-    try:
-        return await asyncio.shield(task)
-    finally:
-        if task.done():
-            async with _RELEASE_TASKS_LOCK:
-                if _RELEASE_TASKS.get(requested) is task:
-                    del _RELEASE_TASKS[requested]
+                raise ValueError(f"invalid Prime Agent release metadata from {source}")
+            return _release(metadata.get("version"), metadata.get("tarballs"))
+        entries = []
+        for line in response.text.splitlines():
+            fields = line.split()
+            if len(fields) == 2:
+                entries.append({"sha256": fields[0], "file": fields[1]})
+        return _release(requested, entries)
 
 
 INSTALL = r"""
@@ -271,12 +184,10 @@ class PrimeAgentHarnessConfig(HarnessConfig):
     """Prime Agent stable channel, or an exact stable version such as ``0.8.1``."""
 
     resolved_release: PrimeAgentRelease | None = None
-    """Evaluation-frozen release provenance; populated before workers start."""
+    """Release frozen before the evaluation is saved or workers start."""
 
     autonomous: bool = False
     """Enable Prime Agent's autonomous continuation loop."""
-
-    _release_lock: asyncio.Lock | None = PrivateAttr(default=None)
 
     @field_validator("release", mode="before")
     @classmethod
@@ -288,25 +199,17 @@ class PrimeAgentHarnessConfig(HarnessConfig):
 
     @model_validator(mode="after")
     def _validate_resolved_release(self) -> "PrimeAgentHarnessConfig":
-        release = self.resolved_release
-        if release is None:
+        resolved = self.resolved_release
+        if resolved is None:
             return self
         entries = [
-            {
-                "package": package,
-                "file": release.file(package),
-                "sha256": release.sha256.get(package),
-            }
-            for package in RELEASE_PACKAGES
+            {"file": resolved.file(package), "sha256": sha256}
+            for package, sha256 in resolved.sha256.items()
         ]
-        validated = _release_from_entries(
-            self.release,
-            release.version,
-            release.source,
-            entries,
-        )
-        if release != validated:
-            raise ValueError("invalid frozen Prime Agent release metadata")
+        if _release(resolved.version, entries) != resolved:
+            raise ValueError("invalid frozen Prime Agent release")
+        if self.release != "stable" and self.release != resolved.version:
+            raise ValueError("frozen Prime Agent release does not match exact version")
         return self
 
 
@@ -371,22 +274,15 @@ class PrimeAgentHarness(ACPHarness[PrimeAgentHarnessConfig]):
         statuses.append(status)
 
     async def _resolve(self) -> PrimeAgentRelease:
-        if self.config.resolved_release is not None:
-            return self.config.resolved_release
-        if self.config._release_lock is None:
-            self.config._release_lock = asyncio.Lock()
-        async with self.config._release_lock:
-            if self.config.resolved_release is None:
-                try:
-                    self.config.resolved_release = await _resolve_release(
-                        self.config.release
-                    )
-                except (httpx.HTTPError, TypeError, ValueError) as e:
-                    raise RuntimeError(
-                        f"failed to resolve Prime Agent release "
-                        f"{self.config.release!r}: {e}"
-                    ) from e
-            return self.config.resolved_release
+        if self.config.resolved_release is None:
+            try:
+                self.config.resolved_release = await _fetch_release(self.config.release)
+            except (httpx.HTTPError, TypeError, ValueError) as e:
+                raise RuntimeError(
+                    f"failed to resolve Prime Agent release "
+                    f"{self.config.release!r}: {e}"
+                ) from e
+        return self.config.resolved_release
 
     def _resolved(self) -> PrimeAgentRelease:
         release = self.config.resolved_release
@@ -403,7 +299,7 @@ class PrimeAgentHarness(ACPHarness[PrimeAgentHarnessConfig]):
         await ensure_node(runtime)
         logger.info(
             "prime-agent: release %s resolved to %s (%s)",
-            release.requested,
+            self.config.release,
             release.version,
             release.cache_key,
         )
@@ -451,9 +347,9 @@ class PrimeAgentHarness(ACPHarness[PrimeAgentHarnessConfig]):
 
         release = self._resolved()
         trace.info["prime_agent_release"] = {
-            "requested": release.requested,
+            "requested": self.config.release,
             "version": release.version,
-            "source": release.source,
+            "source": _source(self.config.release),
             "cache_key": release.cache_key,
             "artifacts": [
                 {

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -1,10 +1,15 @@
 """Prime Agent over its native ACP mode."""
 
+import asyncio
 import hashlib
 import json
 import logging
+import re
 import shlex
-from typing import Literal
+from dataclasses import dataclass
+
+import httpx
+from pydantic import PrivateAttr, field_validator, model_validator
 
 from verifiers.v1.acp import ACPConfig, ACPHarness, ACPTurn
 from verifiers.v1.clients import ModelContext
@@ -19,10 +24,17 @@ logger = logging.getLogger(__name__)
 GITHUB_RELEASE_URL = (
     "https://github.com/PrimeIntellect-ai/prime-agent/releases/download"
 )
-PRIME_AGENT_COMMIT: Literal["b5ee2f81a59510e7225a0db10d65102e91e98803"] = (
-    "b5ee2f81a59510e7225a0db10d65102e91e98803"
+LATEST_RELEASE_URL = (
+    "https://github.com/PrimeIntellect-ai/prime-agent/"
+    "releases/latest/download/latest.json"
 )
-PRIME_AGENT_VERSION = "0.8.0-beta.549.1.b5ee2f8"
+MINIMUM_VERSION = (0, 8, 1)
+RELEASE_PACKAGES = (
+    "prime-agent",
+    "prime-agent-ai",
+    "prime-agent-core",
+    "prime-agent-tui",
+)
 PRIME_AGENT_DIR = "/var/tmp/vf-prime-agent"
 STATE_ROOT = "/tmp/vf-prime-agent-runs"
 SKILLS_DIR = ".agents/skills"
@@ -32,14 +44,185 @@ KEY_VAR = "PRIME_AGENT_INTERCEPT_KEY"
 ENV_AGENT_DIR = "PRIME_AGENT_CODING_AGENT_DIR"
 
 
+@dataclass(frozen=True)
+class PrimeAgentRelease:
+    requested: str
+    version: str
+    source: str
+    sha256: dict[str, str]
+
+    @property
+    def cache_key(self) -> str:
+        manifest = json.dumps(
+            {"version": self.version, "sha256": self.sha256},
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        digest = hashlib.sha256(manifest.encode()).hexdigest()[:16]
+        return f"{self.version}-{digest}"
+
+    def file(self, package: str) -> str:
+        return f"{package}-{self.version}.tgz"
+
+
+def _version(value: object) -> str:
+    raw = value.removeprefix("v") if isinstance(value, str) else ""
+    if not re.fullmatch(r"\d+\.\d+\.\d+", raw):
+        raise ValueError(f"invalid Prime Agent stable version: {value!r}")
+    version = tuple(int(part) for part in raw.split("."))
+    if raw != ".".join(str(part) for part in version):
+        raise ValueError(f"invalid Prime Agent stable version: {value!r}")
+    if version < MINIMUM_VERSION:
+        minimum = ".".join(str(part) for part in MINIMUM_VERSION)
+        raise ValueError(
+            f"Prime Agent {raw} is older than the required {minimum}; "
+            "wait for the stable release or request a supported exact version"
+        )
+    return raw
+
+
+def _release_from_entries(
+    requested: str,
+    version: object,
+    source: str,
+    entries: object,
+) -> PrimeAgentRelease:
+    resolved = _version(version)
+    if requested == "stable":
+        expected_source = LATEST_RELEASE_URL
+    else:
+        if _version(requested) != resolved:
+            raise ValueError(
+                f"Prime Agent release {requested!r} resolved to unexpected "
+                f"version {resolved!r}"
+            )
+        expected_source = f"{GITHUB_RELEASE_URL}/v{resolved}/SHA256SUMS"
+    if source != expected_source:
+        raise ValueError(
+            f"Prime Agent release metadata came from unexpected source {source!r}"
+        )
+    if not isinstance(entries, list):
+        raise TypeError(f"Prime Agent release metadata from {source} has no tarballs")
+    hashes: dict[str, str] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise TypeError(f"invalid tarball entry in {source}")
+        package = entry.get("package")
+        if not isinstance(package, str) or package not in RELEASE_PACKAGES:
+            raise ValueError(f"unexpected package {package!r} in {source}")
+        expected = f"{package}-{resolved}.tgz"
+        if entry.get("file") != expected:
+            raise ValueError(
+                f"Prime Agent release metadata names {entry.get('file')!r}, "
+                f"expected {expected!r}"
+            )
+        sha256 = entry.get("sha256")
+        if not isinstance(sha256, str) or not re.fullmatch(r"[0-9a-fA-F]{64}", sha256):
+            raise ValueError(f"invalid SHA-256 for {expected} in {source}")
+        if package in hashes:
+            raise ValueError(f"duplicate {package} entry in {source}")
+        hashes[package] = sha256.lower()
+    missing = sorted(set(RELEASE_PACKAGES) - hashes.keys())
+    if missing:
+        raise ValueError(
+            f"Prime Agent release metadata is missing {missing} in {source}"
+        )
+    return PrimeAgentRelease(
+        requested=requested,
+        version=resolved,
+        source=source,
+        sha256=hashes,
+    )
+
+
+def _release_from_sums(
+    requested: str, version: str, source: str, text: str
+) -> PrimeAgentRelease:
+    resolved = _version(version)
+    entries = []
+    for line in text.splitlines():
+        fields = line.split()
+        if len(fields) != 2:
+            continue
+        sha256, file = fields
+        for package in RELEASE_PACKAGES:
+            if file == f"{package}-{resolved}.tgz":
+                entries.append({"package": package, "file": file, "sha256": sha256})
+                break
+    return _release_from_entries(requested, resolved, source, entries)
+
+
+async def _fetch_release(requested: str) -> PrimeAgentRelease:
+    requested = requested.strip().lower()
+    transport = httpx.AsyncHTTPTransport(retries=3)
+    async with httpx.AsyncClient(
+        follow_redirects=True,
+        timeout=30,
+        transport=transport,
+    ) as client:
+        if requested == "stable":
+            response = await client.get(LATEST_RELEASE_URL)
+            response.raise_for_status()
+            try:
+                metadata = response.json()
+            except json.JSONDecodeError as e:
+                raise ValueError(
+                    f"invalid Prime Agent release metadata from {LATEST_RELEASE_URL}"
+                ) from e
+            if not isinstance(metadata, dict):
+                raise ValueError(
+                    f"invalid Prime Agent release metadata from {LATEST_RELEASE_URL}"
+                )
+            resolved = _version(metadata.get("version"))
+            expected_tarball = f"releases/v{resolved}/prime-agent-{resolved}.tgz"
+            if (
+                metadata.get("package") != "prime-agent"
+                or metadata.get("tarball") != expected_tarball
+            ):
+                raise ValueError(
+                    f"invalid Prime Agent release metadata from {LATEST_RELEASE_URL}"
+                )
+            return _release_from_entries(
+                requested,
+                metadata.get("version"),
+                LATEST_RELEASE_URL,
+                metadata.get("tarballs"),
+            )
+        version = _version(requested)
+        source = f"{GITHUB_RELEASE_URL}/v{version}/SHA256SUMS"
+        response = await client.get(source)
+        response.raise_for_status()
+        return _release_from_sums(requested, version, source, response.text)
+
+
+_RELEASE_TASKS: dict[str, asyncio.Task[PrimeAgentRelease]] = {}
+_RELEASE_TASKS_LOCK = asyncio.Lock()
+
+
+async def _resolve_release(requested: str) -> PrimeAgentRelease:
+    """Share one in-flight fetch without caching stable across evaluations."""
+    async with _RELEASE_TASKS_LOCK:
+        task = _RELEASE_TASKS.get(requested)
+        if task is None:
+            task = asyncio.create_task(_fetch_release(requested))
+            _RELEASE_TASKS[requested] = task
+    try:
+        return await asyncio.shield(task)
+    finally:
+        if task.done():
+            async with _RELEASE_TASKS_LOCK:
+                if _RELEASE_TASKS.get(requested) is task:
+                    del _RELEASE_TASKS[requested]
+
+
 INSTALL = r"""
 set -e
 export PATH="/var/tmp/vf-node/bin:$PATH"
-prefix="$VF_PRIME_AGENT_DIR/$PRIME_AGENT_COMMIT"
+prefix="$VF_PRIME_AGENT_DIR/$PRIME_AGENT_CACHE_KEY"
 [ -x "$prefix/bin/prime-agent" ] && exit 0
 export NPM_CONFIG_PREFIX="$prefix"
 export PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL=0
-release_url="$VF_PRIME_AGENT_GITHUB_RELEASE_URL/beta"
+release_url="$VF_PRIME_AGENT_GITHUB_RELEASE_URL/v$PRIME_AGENT_RELEASE_VERSION"
 agent_tarball="prime-agent-$PRIME_AGENT_RELEASE_VERSION.tgz"
 ai_tarball="prime-agent-ai-$PRIME_AGENT_RELEASE_VERSION.tgz"
 core_tarball="prime-agent-core-$PRIME_AGENT_RELEASE_VERSION.tgz"
@@ -51,10 +234,10 @@ for tarball in "$agent_tarball" "$ai_tarball" "$core_tarball" "$tui_tarball"; do
         "$release_url/$tarball" -o "$download_dir/$tarball"
 done
 printf '%s  %s\n' \
-    'f3b98bd7bf70dc25077dbd6afcec8d651570bead96919b42b8fde36d3e7d7268' "$agent_tarball" \
-    '0d655397ca9fda765afb5ba7b2b65ab74b928f9c178e548ef3befc0358f39ce2' "$ai_tarball" \
-    '0cb81e79422887a43d850722812c6a4589760eb69441cb4c042e665cbfdff5e1' "$core_tarball" \
-    '307ec5e5a320f9a0355b08ec352230cb406f82fac0ebbd6e33f6306a3e9452a8' "$tui_tarball" \
+    "$PRIME_AGENT_SHA256" "$agent_tarball" \
+    "$PRIME_AGENT_AI_SHA256" "$ai_tarball" \
+    "$PRIME_AGENT_CORE_SHA256" "$core_tarball" \
+    "$PRIME_AGENT_TUI_SHA256" "$tui_tarball" \
     > "$download_dir/SHA256SUMS"
 (cd "$download_dir" && sha256sum -c SHA256SUMS)
 mkdir "$download_dir/package-root"
@@ -87,11 +270,47 @@ PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL=1 npm install -g \
 
 
 class PrimeAgentHarnessConfig(HarnessConfig):
-    commit: Literal["b5ee2f81a59510e7225a0db10d65102e91e98803"] = PRIME_AGENT_COMMIT
-    """Prime Agent main commit to install."""
+    release: str = "stable"
+    """Prime Agent stable channel, or an exact stable version such as ``0.8.1``."""
+
+    resolved_release: PrimeAgentRelease | None = None
+    """Evaluation-frozen release provenance; populated before workers start."""
 
     autonomous: bool = False
     """Enable Prime Agent's autonomous continuation loop."""
+
+    _release_lock: asyncio.Lock | None = PrivateAttr(default=None)
+
+    @field_validator("release", mode="before")
+    @classmethod
+    def _validate_release(cls, value: object) -> str:
+        if not isinstance(value, str):
+            raise TypeError("Prime Agent release must be 'stable' or an exact version")
+        value = value.strip().lower()
+        return value if value == "stable" else _version(value)
+
+    @model_validator(mode="after")
+    def _validate_resolved_release(self) -> "PrimeAgentHarnessConfig":
+        release = self.resolved_release
+        if release is None:
+            return self
+        entries = [
+            {
+                "package": package,
+                "file": release.file(package),
+                "sha256": release.sha256.get(package),
+            }
+            for package in RELEASE_PACKAGES
+        ]
+        validated = _release_from_entries(
+            self.release,
+            release.version,
+            release.source,
+            entries,
+        )
+        if release != validated:
+            raise ValueError("invalid frozen Prime Agent release metadata")
+        return self
 
 
 class PrimeAgentHarness(ACPHarness[PrimeAgentHarnessConfig]):
@@ -154,10 +373,43 @@ class PrimeAgentHarness(ACPHarness[PrimeAgentHarnessConfig]):
             lifecycle[LIFECYCLE_META_NAMESPACE] = statuses
         statuses.append(status)
 
+    async def _resolve(self) -> PrimeAgentRelease:
+        if self.config.resolved_release is not None:
+            return self.config.resolved_release
+        if self.config._release_lock is None:
+            self.config._release_lock = asyncio.Lock()
+        async with self.config._release_lock:
+            if self.config.resolved_release is None:
+                try:
+                    self.config.resolved_release = await _resolve_release(
+                        self.config.release
+                    )
+                except (httpx.HTTPError, TypeError, ValueError) as e:
+                    raise RuntimeError(
+                        f"failed to resolve Prime Agent release "
+                        f"{self.config.release!r}: {e}"
+                    ) from e
+            return self.config.resolved_release
+
+    def _resolved(self) -> PrimeAgentRelease:
+        release = self.config.resolved_release
+        if release is None:
+            raise RuntimeError("Prime Agent release was not resolved during setup")
+        return release
+
+    async def prepare(self) -> None:
+        await self._resolve()
+
     async def setup(self, runtime: Runtime) -> None:
+        release = await self._resolve()
         await self.install_skills(runtime, SKILLS_DIR)
         await ensure_node(runtime)
-        logger.info("prime-agent: ensuring commit %s is installed", self.config.commit)
+        logger.info(
+            "prime-agent: release %s resolved to %s (%s)",
+            release.requested,
+            release.version,
+            release.cache_key,
+        )
         lock = f"{PRIME_AGENT_DIR}/install.lock"
         guarded = (
             f"mkdir -p {PRIME_AGENT_DIR} && "
@@ -170,8 +422,12 @@ class PrimeAgentHarness(ACPHarness[PrimeAgentHarnessConfig]):
                 **self.config.resolved_env,
                 "VF_PRIME_AGENT_DIR": PRIME_AGENT_DIR,
                 "VF_PRIME_AGENT_GITHUB_RELEASE_URL": GITHUB_RELEASE_URL,
-                "PRIME_AGENT_COMMIT": self.config.commit,
-                "PRIME_AGENT_RELEASE_VERSION": PRIME_AGENT_VERSION,
+                "PRIME_AGENT_CACHE_KEY": release.cache_key,
+                "PRIME_AGENT_RELEASE_VERSION": release.version,
+                "PRIME_AGENT_SHA256": release.sha256["prime-agent"],
+                "PRIME_AGENT_AI_SHA256": release.sha256["prime-agent-ai"],
+                "PRIME_AGENT_CORE_SHA256": release.sha256["prime-agent-core"],
+                "PRIME_AGENT_TUI_SHA256": release.sha256["prime-agent-tui"],
             },
         )
         if result.exit_code != 0:
@@ -196,6 +452,20 @@ class PrimeAgentHarness(ACPHarness[PrimeAgentHarnessConfig]):
                 "surface is ipython"
             )
 
+        release = self._resolved()
+        trace.info["prime_agent_release"] = {
+            "requested": release.requested,
+            "version": release.version,
+            "source": release.source,
+            "cache_key": release.cache_key,
+            "artifacts": [
+                {
+                    "file": release.file(package),
+                    "sha256": release.sha256[package],
+                }
+                for package in RELEASE_PACKAGES
+            ],
+        }
         root = self._root(trace)
         agent_dir = f"{root}/agent"
         created = await runtime.run(
@@ -293,7 +563,7 @@ class PrimeAgentHarness(ACPHarness[PrimeAgentHarnessConfig]):
             )
 
     def _bin(self) -> str:
-        return f"{PRIME_AGENT_DIR}/{self.config.commit}/bin/prime-agent"
+        return f"{PRIME_AGENT_DIR}/{self._resolved().cache_key}/bin/prime-agent"
 
     @staticmethod
     def _root(trace: Trace) -> str:

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -24,10 +24,7 @@ logger = logging.getLogger(__name__)
 GITHUB_RELEASE_URL = (
     "https://github.com/PrimeIntellect-ai/prime-agent/releases/download"
 )
-LATEST_RELEASE_URL = (
-    "https://github.com/PrimeIntellect-ai/prime-agent/"
-    "releases/latest/download/latest.json"
-)
+LATEST_RELEASE_URL = "https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/latest.json"
 MINIMUM_VERSION = (0, 8, 1)
 RELEASE_PACKAGES = (
     "prime-agent",


### PR DESCRIPTION
## Summary

- resolve the Prime Agent stable channel from the published R2 manifest
- retain an exact stable-version override for reproducible evaluations
- freeze the selected version and four artifact hashes before saving the config or starting workers
- verify all four versioned release tarballs and key the install cache by their combined identity
- record the frozen release and artifact hashes in every trace

The resolver is Prime-specific. It has no global task registry or per-config concurrency locks.

## Release evidence

[Prime Agent `v0.8.1`](https://github.com/PrimeIntellect-ai/prime-agent/releases/tag/v0.8.1) was published from [Prime Agent #1794](https://github.com/PrimeIntellect-ai/prime-agent/pull/1794) at `514633727bf26d74f39f3119c2b0e31a5ceb2a9d`. The Git tag and stable release target that exact commit.

GitHub and R2 publish identical `latest.json` manifests. Their stable pointers contain `v0.8.1`. All four GitHub and R2 tarballs match `SHA256SUMS`, the manifest, and GitHub's asset digests.

## Validation

- `uv run --frozen pytest tests/v1 -q`
- `uv run --frozen ruff check .`
- `uv run --frozen ruff format --check .`
- `uv run --frozen ty check verifiers`
- focused frozen-config, version-floor, exact-override, and four-artifact tests
- published stable and exact `0.8.1` resolution against R2 and GitHub metadata
- local installer wiring and cache-identity checks
- `git diff --check`

No paid evaluation was run. The credentialed GitHub Test workflow is intentionally canceled for this PR. Equivalent noncredential validation runs locally.

This PR remains draft pending review and allowed CI.
