### PR TITLE
fix(v1): serialize restricted borrowed runtimes

### DIFF
--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -81,6 +81,7 @@ class Rollout:
         self._interception = interception
         self.runtime = runtime
         self._borrowed_runtime = runtime
+        self._borrow_lock: asyncio.Lock | None = None
         self.trace: Trace = Trace(
             task=TraceTask(
                 type=type(task).__name__,
@@ -204,6 +205,9 @@ class Rollout:
             if self._borrowed_runtime is None:
                 runtime.env = runtime_env
             else:
+                if runtime.network_restricted:
+                    await runtime.borrow_lock.acquire()
+                    self._borrow_lock = runtime.borrow_lock
                 runtime = runtime.with_env(runtime_env)
                 self.runtime = runtime
             if self.task.data.prompt is None and not self._has_user:
@@ -423,17 +427,22 @@ class Rollout:
         (a cancellation mid-setup, a lifetime bug raised to the caller) means the
         driver will never reach `close()`. Safe after a partial `close()`."""
         self._closed = True
-        if self._harness_session is not None:
+        try:
+            if self._harness_session is not None:
+                with contextlib.suppress(Exception):
+                    await self._harness_session.close()
             with contextlib.suppress(Exception):
-                await self._harness_session.close()
-        with contextlib.suppress(Exception):
-            await self._stack.aclose()
-        if self.runtime is not None:
-            with contextlib.suppress(Exception):
-                await self.harness.cleanup(self.trace, self.runtime)
-        if self._borrowed_runtime is None and self.runtime is not None:
-            with contextlib.suppress(Exception):
-                await self.runtime.stop()
+                await self._stack.aclose()
+            if self.runtime is not None:
+                with contextlib.suppress(Exception):
+                    await self.harness.cleanup(self.trace, self.runtime)
+            if self._borrowed_runtime is None and self.runtime is not None:
+                with contextlib.suppress(Exception):
+                    await self.runtime.stop()
+        finally:
+            if self._borrow_lock is not None:
+                self._borrow_lock.release()
+                self._borrow_lock = None
 
     async def close(self) -> Trace:
         """Finish the rollout: tool servers and interception down, task `finalize`
@@ -522,6 +531,9 @@ class Rollout:
                     logger.warning(
                         "runtime teardown failed (rollout %s)", trace.id, exc_info=True
                     )
+            if self._borrow_lock is not None:
+                self._borrow_lock.release()
+                self._borrow_lock = None
         logger.info(
             "rollout done: id=%s task=%s reward=%.3f turns=%d stop=%s",
             trace.id,

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -153,6 +153,9 @@ class Runtime(ABC):
         # Per-run task values live on the runtime rather than its serializable config/info.
         # Explicit process values (model credentials, proxy settings, etc.) override these.
         self.env: dict[str, str] = {}
+        # Restricted runtimes have one sandbox-wide network policy. Borrowers hold
+        # this lock for their full rollout so setup cannot widen another agent's policy.
+        self.borrow_lock = asyncio.Lock()
         self._uv_interpreters: dict[str, str] = {}
         self._uv_script_locks: dict[str, asyncio.Lock] = {}
         self._setup_claimed = False


### PR DESCRIPTION
## Overview

Serialize borrowed rollouts that share a network-restricted runtime while preserving concurrency for unrestricted runtimes.

## Details

Restricted runtimes expose one sandbox-wide network policy. Concurrent borrowers can otherwise replace that shared policy during another rollout, so a borrower now holds a runtime-level lock from setup through cleanup.

The lock is released from both normal close and abort paths, including partial setup failures. Unrestricted borrowed runtimes keep their existing concurrent behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout teardown ordering and concurrency for shared restricted sandboxes; incorrect lock release could deadlock concurrent borrowers, but release paths mirror existing cleanup.
> 
> **Overview**
> **Borrowers of a network-restricted runtime now take a shared `borrow_lock` for the whole rollout** so concurrent agents cannot race on sandbox-wide network policy during setup (`with_env` / `prepare_execution`).
> 
> A runtime-level `asyncio.Lock` is added in `Runtime.__init__`. During `Rollout.open`, if the rollout borrows a restricted runtime, it **acquires** that lock before applying per-task env; `_borrow_lock` tracks ownership. **Release** happens in both `abort()` (including partial setup) and `close()` via `finally`, so failures and cancellations do not leave the lock held. **Unrestricted** borrowed runtimes are unchanged and can still run concurrently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff7b988e9b34be82eca47b5bc505ffa5986fbe8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->