### PR TITLE
fix: parse last XML answer in message completions

### DIFF
--- a/tests/test_xml_parser.py
+++ b/tests/test_xml_parser.py
@@ -101,6 +101,17 @@ class TestXMLParser:
             result == "45"
         )  # Should return just the last answer, not a full parse() namespace
 
+    def test_parse_answer_from_message_completion_uses_last_answer(self, xml_parser):
+        """Test extracting the last answer from a message completion."""
+        completion = [
+            {
+                "role": "assistant",
+                "content": "<answer>44</answer><reasoning>Actually, that's not right either.</reasoning><answer>45</answer>",
+            }
+        ]
+        result = xml_parser.parse_answer(completion)
+        assert result == "45"
+
     def test_parse_answer_no_answer_field(self, xml_parser):
         """Test parse_answer when no answer field is found."""
         completion = [

--- a/verifiers/legacy/parsers/xml_parser.py
+++ b/verifiers/legacy/parsers/xml_parser.py
@@ -105,7 +105,7 @@ class XMLParser(Parser):
                     if isinstance(msg, dict)
                     else (msg.content or "")
                 )
-                parsed = self.parse(content)
+                parsed = self.parse(content, last=True)
                 if (
                     parsed
                     and hasattr(parsed, self.answer_field)


### PR DESCRIPTION
## Summary

- make `XMLParser.parse_answer` consistently select the last matching answer block for string and message completions
- add regression coverage for multiple answer tags within one assistant message

Fixes #2447

## Testing

- `pytest tests/test_xml_parser.py` — 19 passed
- Ruff check and format check passed for both changed files

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `XMLParser.parse_answer` to use last `<answer>` tag in message completions
> In `parse_answer`, assistant message content is now parsed with `last=True`, so the last matching answer tag is returned instead of the first. Adds a test confirming `45` is extracted from a message with multiple `<answer>` tags.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fcd1cdd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->