### PR TITLE
fix: require aiohttp>=3.14.1 (interception uses web.RequestKey)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "aiolimiter>=1.2.1",
     "setproctitle>=1.3.0",
     "httpx>=0.27.0",
-    "aiohttp>=3.9.0",
+    "aiohttp>=3.14.1",
     "prime-pydantic-config[toml]>=0.4.3",
     "uvloop>=0.21.0; sys_platform != 'win32' and sys_platform != 'cygwin' and platform_python_implementation != 'PyPy'",
     "loguru>=0.7.0",


### PR DESCRIPTION
`verifiers/v1/interception/server.py` uses `aiohttp.web.RequestKey` (added in aiohttp **3.14**), but `pyproject.toml` pins `aiohttp>=3.9.0`. An env that resolves 3.9–3.13 (e.g. 3.13.5) crashes at import:

```
AttributeError: module 'aiohttp.web' has no attribute 'RequestKey'. Did you mean: 'Request'?
```

Bump the floor to `aiohttp>=3.14.1` to match the code. Found while dogfooding this branch (nano-rlm lineage eval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require `aiohttp>=3.14.1` in `pyproject.toml`
> Bumps the minimum `aiohttp` version from `>=3.9.0` to `>=3.14.1` because the interception code relies on `web.RequestKey`, which is available only in newer releases. Risk: environments pinned to an older `aiohttp` will fail dependency resolution on install.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3689d12.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency constraint only; no runtime logic changes. Environments that must stay on aiohttp &lt;3.14 will fail resolution on install instead of crashing at import.
> 
> **Overview**
> Raises the declared **`aiohttp`** floor in **`pyproject.toml`** from **`>=3.9.0`** to **`>=3.14.1`** so installs match what the v1 interception server already assumes.
> 
> **`verifiers/v1/interception/server.py`** registers typed request context via **`web.RequestKey`** (e.g. idempotent rollout attempts). That API exists only from aiohttp 3.14 onward; resolving 3.9–3.13 previously led to an **`AttributeError`** at import time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3689d12439244ba151150d8bebf004e0a97924e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->