### PR TITLE
feat: relay overlong prompt errors to the harness

### DIFF
--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -10,8 +10,7 @@ from dataclasses import dataclass, field
 from typing import Any, ClassVar, TypeVar
 
 from openai import OpenAIError
-from renderers import OverlongPromptError as RendererOverlongPromptError
-from renderers import RenderedTokens, Renderer, RendererConfig
+from renderers import OverlongPromptError, RenderedTokens, Renderer, RendererConfig
 from renderers.base import ToolCallParseStatus, is_multimodal
 
 from verifiers.v1.clients.base import build_async_openai
@@ -19,7 +18,7 @@ from verifiers.v1.clients.client import SESSION_ID_HEADER, Client
 from verifiers.v1.configs.client import TrainClientConfig
 from verifiers.v1.dialects import FINISH_REASONS, ChatDialect, Dialect, parse_tools
 from verifiers.v1.dialects.chat import message_to_wire
-from verifiers.v1.errors import OverlongPromptError, model_error
+from verifiers.v1.errors import ProviderError, model_error
 from verifiers.v1.graph import PendingTurn
 from verifiers.v1.types import (
     AssistantMessage,
@@ -436,8 +435,10 @@ class TrainClient(Client):
                     if session_id
                     else None,
                 )
-            except RendererOverlongPromptError as e:
-                raise OverlongPromptError(str(e)) from e
+            except OverlongPromptError as e:
+                # The renderer's pre-flight overflow never reached the provider: a
+                # deterministic 400, so the harness SDK never retries it.
+                raise ProviderError(str(e), status_code=400) from e
             except OpenAIError as e:
                 raise model_error(e) from e
         response = response_from_generate(

--- a/verifiers/v1/dialects/responses.py
+++ b/verifiers/v1/dialects/responses.py
@@ -28,7 +28,7 @@ from verifiers.v1.dialects.base import (
     parse_sse_event,
     provider_allowed_domains,
 )
-from verifiers.v1.errors import OverlongPromptError, model_error
+from verifiers.v1.errors import model_error
 from verifiers.v1.types import (
     AssistantMessage,
     ContentPart,
@@ -322,15 +322,11 @@ def response_from_wire(response: OpenAIResponse) -> Response:
         code = error.get("code") if isinstance(error, dict) else None
         message = error.get("message") if isinstance(error, dict) else None
         detail = ": ".join(str(value) for value in (status, code, message) if value)
-        if code == "context_length_exceeded":
-            raise OverlongPromptError(
-                f"upstream Responses request did not complete: {detail}"
-            )
         status_code = (
             429
             if code in ("rate_limit_exceeded", "rate_limit_error")
             else 400
-            if code == "invalid_prompt"
+            if code in ("invalid_prompt", "context_length_exceeded")
             else 502
         )
         raise model_error(

--- a/verifiers/v1/errors.py
+++ b/verifiers/v1/errors.py
@@ -42,16 +42,6 @@ class ProviderError(RolloutError):
         self.status_code = status_code
 
 
-class OverlongPromptError(ProviderError):
-    """The prompt exceeded the model's context window — a budget limit, ended as a clean
-    truncation rather than recorded as an error. Defaults to a 400 (what the interception
-    server surfaces for it — deterministic, so an SDK never retries it); `model_error`
-    keeps the provider's real status when the failure carried one."""
-
-    def __init__(self, message: str = "", *, status_code: int = 400) -> None:
-        super().__init__(message, status_code=status_code)
-
-
 class HarnessError(RolloutError):
     """The harness failed to install or launch, or its agent process exited unsuccessfully."""
 
@@ -99,20 +89,6 @@ async def boundary(error_cls: type[RolloutError], what: str) -> AsyncIterator[No
         raise error_cls(f"{what}: {type(e).__name__}: {e}") from e
 
 
-_CONTEXT_LENGTH_PHRASES = (
-    "this model's maximum context length is",
-    "is longer than the model's context length",
-    "is longer than the maximum model length",
-    "exceeds the model's context length",
-    "exceed the configured limit",
-    "exceeds the configured limit",
-    "exceeded model",
-    "prompt_too_long",
-    "context length",
-    "maximum model length",
-)
-
-
 def _provider_status(e: OpenAIError | str) -> int:
     """The HTTP status to surface for an SDK error: the provider's own for an HTTP status error, a
     retryable 5xx for a transport/timeout fault, else 502."""
@@ -130,23 +106,12 @@ def _provider_status(e: OpenAIError | str) -> int:
 def model_error(
     e: OpenAIError | str, *, status_code: int | None = None
 ) -> ProviderError:
-    """Map a provider failure to our error type: an overlong prompt (a budget limit the interception
-    server turns into a clean truncation) is told apart from any other provider call failure, which
-    becomes a plain `ProviderError`. `status_code` is the HTTP status surfaced to the harness (whose
-    SDK then retries 5xx/429/timeout and not 4xx); derived from an SDK error when not given. Accepts
-    an SDK error (the renderer) or the provider's raw error body (the httpx proxy)."""
-    from openai import APIStatusError
-
+    """Map a provider failure to a `ProviderError`. `status_code` is the HTTP status surfaced to
+    the harness (whose SDK then retries 5xx/429/timeout and not 4xx); derived from an SDK error
+    when not given. Accepts an SDK error (the renderer) or the provider's raw error body (the
+    httpx proxy)."""
     # Some SDK errors stringify empty; fall back to the type so the message is never blank.
     text = str(e) or (type(e).__name__ if isinstance(e, BaseException) else "")
-    if any(phrase in text.casefold() for phrase in _CONTEXT_LENGTH_PHRASES):
-        # Keep the provider's real status when the failure carried one; else the class
-        # default (the 400 the interception server surfaces for overlong prompts).
-        if status_code is None and isinstance(e, APIStatusError):
-            status_code = e.status_code
-        return OverlongPromptError(
-            text, **({} if status_code is None else {"status_code": status_code})
-        )
     return ProviderError(
         text,
         status_code=status_code if status_code is not None else _provider_status(e),

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -46,7 +46,6 @@ from verifiers.v1.dialects.base import (
     is_sse_done_event,
 )
 from verifiers.v1.errors import (
-    OverlongPromptError,
     ProviderError,
     RolloutError,
     TaskError,
@@ -714,17 +713,6 @@ class InterceptionServer(Interception):
                             dialect.error_body(f"rollout stopped: {stopped}"),
                             status=400,
                         )
-                except OverlongPromptError as e:
-                    # An overlong prompt is a budget limit, not a crash: end the rollout
-                    # cleanly as a truncation — refuse the call to halt the harness (same
-                    # shape as `refused` above).
-                    error = e
-                    session.trace.stop("context_length")
-                    logger.debug("prompt too long: id=%s", session.trace.id)
-                    return web.json_response(
-                        dialect.error_body("rollout stopped: context_length"),
-                        status=400,
-                    )
                 except RolloutError as e:
                     # Stash the real cause; the rollout re-raises it after the harness returns.
                     # Relay the provider's status so the harness SDK retries 5xx/429 and not 4xx.
@@ -802,13 +790,6 @@ class InterceptionServer(Interception):
                     body,
                     headers=request.headers,
                     session_id=session.trace.id,
-                )
-            except OverlongPromptError as e:
-                error = e
-                session.trace.stop("context_length")
-                logger.debug("prompt too long: id=%s", session.trace.id)
-                return web.json_response(
-                    dialect.error_body("rollout stopped: context_length"), status=400
                 )
             except RolloutError as e:
                 error = e
@@ -1007,13 +988,6 @@ class InterceptionServer(Interception):
                     for event in deferred:
                         await resp.write(event)
                     await resp.write_eof()
-            return resp
-        except OverlongPromptError as e:
-            # A streamed terminal provider failure is discovered only after its response body
-            # was relayed. Context exhaustion remains a clean truncation like earlier failures.
-            error = e
-            session.trace.stop("context_length")
-            logger.debug("prompt too long: id=%s", session.trace.id)
             return resp
         except RolloutError as e:
             # A streamed terminal provider failure is discovered only after the

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -522,7 +522,6 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
             "max_input_tokens",
             "max_output_tokens",
             "max_total_tokens",
-            "context_length",
         ):
             return True
         last = next((c for c in reversed(self.calls) if c.error is None), None)


### PR DESCRIPTION
## Summary

- relay an overlong prompt to the harness like any other provider failure
- return the provider's original error message with a deterministic 400
- stop synthesizing a `context_length` body and stopping the trace
- remove the now-unused `OverlongPromptError` type and `model_error` phrase-sniffing
- raise a plain `ProviderError(status_code=400)` at the renderer pre-flight and Responses `context_length_exceeded` sites

First half of the compaction stack; the harness-side recovery lands on top in the follow-up PR.

## Breaking

- Interception no longer stops a trace on an overlong prompt. A harness that does not recover (e.g. by compacting) fails the rollout like any other provider error.
- `"context_length"` is gone as a stop condition, so `Trace.is_truncated` no longer reports it.

## Verification

- `uv run pytest -q tests/v1` — passed; live E2E tests skipped without `PRIME_API_KEY`
- `uv run ruff check` / `uv run ruff format --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `OverlongPromptError` with `ProviderError(status_code=400)`
> - Removes `OverlongPromptError` class and its heuristic phrase-based detection from [errors.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2453/files#diff-5621d6869aa43b8c83352b3f958fe94b199952c4ae37c042fe2a25106962cb5b); `model_error` now always returns `ProviderError` with an explicit status code.
> - Renderer preflight overflow in `TrainClient.get_response` now raises `ProviderError(status_code=400)` instead of wrapping in `OverlongPromptError`.
> - `response_from_wire` maps `context_length_exceeded` and `invalid_prompt` to status 400, rate limits to 429, and everything else to 502 via `model_error`.
> - Removes dedicated `OverlongPromptError` branches in both streaming and non-streaming `InterceptionServer.request` handlers; these errors now flow through the generic `RolloutError` path.
> - `Trace.is_truncated` no longer treats `context_length` as a truncation condition.
> - Behavioral Change: overlong prompts no longer produce a special `context_length` trace stop or custom 400 body; they surface as generic `ProviderError` failures with the provider's status. Callers checking for `OverlongPromptError` specifically or relying on `Trace.is_truncated` for context-length stops need to update.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe0dad7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking behavior for rollouts and any code checking `OverlongPromptError` or `is_truncated` for context-length stops; core model-call error handling changes but is scoped to overlong-prompt semantics.
> 
> **Overview**
> Overlong prompts are no longer treated as a special “clean truncation” path inside interception. **`OverlongPromptError` is removed** from `verifiers.v1.errors`, along with **`model_error`’s phrase-based context-length detection**.
> 
> Renderer pre-flight overflow in **`TrainClient`** and Responses **`context_length_exceeded`** now surface as **`ProviderError` with HTTP 400** (using the renderer’s `OverlongPromptError` only at the catch site in train). The interception server **drops dedicated handlers** that stopped the trace with `"context_length"` and a synthetic `rollout stopped: context_length` body; those failures follow the normal **`RolloutError` / `ProviderError`** HTTP relay with the provider message.
> 
> **`Trace.is_truncated`** no longer treats **`context_length`** as a stop condition. Harnesses that relied on automatic trace stop or that exception type must handle 400 provider failures explicitly (e.g. compaction in a follow-up).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe0dad7ccfed8a7a05d3df95a8bd58f327297e96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->