### PR TITLE
fix(v1): retain Terminus reasoning history

### DIFF
--- a/verifiers/v1/harnesses/terminus_2/program.py
+++ b/verifiers/v1/harnesses/terminus_2/program.py
@@ -69,6 +69,7 @@ async def main() -> None:
         api_base=args.base_url,
         llm_kwargs={"custom_llm_provider": "openai", "api_key": args.api_key},
         record_terminal_session=False,
+        interleaved_thinking=True,
     )
     if system_prompt:
         call = agent._llm.call


### PR DESCRIPTION
## Summary

- Enable Harbor interleaved thinking for the Terminus-2 adapter.
- Preserve reasoning content in later prompts so unchanged multi-turn histories remain one training branch.

## Test

- `uv run ruff check verifiers/v1/harnesses/terminus_2/program.py`
- Confirmed with Harbor 0.21.0 that the second request contains the first response reasoning content.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pass `interleaved_thinking=True` to Terminus2 agent in `main`
> Adds the `interleaved_thinking=True` keyword argument when constructing the Terminus2 instance in [program.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2455/files#diff-8c108b7a53c752a95d1e682451dc464065424adb3863387cd1a2c83b058e18f0). This retains the agent's reasoning history across interleaved thinking steps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e22fc88.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->