### PR TITLE
fix: end the null harness cleanly on context overflow

### DIFF
--- a/verifiers/v1/harnesses/null/program.py
+++ b/verifiers/v1/harnesses/null/program.py
@@ -17,14 +17,30 @@ from tenacity import AsyncRetrying, stop_after_attempt, wait_exponential_jitter
 MCP_CALL_ATTEMPTS = 6
 MCP_TIMEOUT = 600.0
 
+# Overflow wording by provider, matched case-insensitively against the full error body.
+# Each marker is attributed to the API that produces it; unattributable generics stay out
+# (e.g. "too many tokens" also matches Bedrock throttling).
 CONTEXT_OVERFLOW_MARKERS = (
-    "request entity too large",
-    "context_length",
-    "context length",
-    "context window",
+    # OpenAI error code "context_length_exceeded"; OpenRouter relays the raw body.
+    "context_length_exceeded",
+    # OpenAI Responses/Completions: "Your input exceeds the context window of this model".
+    "exceeds the context window",
+    # OpenAI chat: "Input tokens exceed the configured limit of N tokens. Please reduce
+    # the length of the messages."; Groq words it the same way.
+    "reduce the length of the messages",
+    # vLLM: "This model's maximum context length is N tokens"; the renderers pre-flight:
+    # "Prompt length (N) exceeds maximum context length (M)"; Mistral uses the same words.
+    "maximum context length",
+    # Anthropic: "prompt is too long: N tokens > M maximum".
     "prompt is too long",
-    "too many tokens",
-    "token limit exceeded",
+    # Anthropic byte-size overflow: HTTP 413 {"type": "request_too_large"}.
+    "request_too_large",
+    # HTTP proxies reject an oversized body with 413 "Request Entity Too Large".
+    "request entity too large",
+    # Google: "The input token count (N) exceeds the maximum number of tokens allowed (M)".
+    "exceeds the maximum number of tokens",
+    # xAI: "This model's maximum prompt length is N but the request contains M tokens".
+    "maximum prompt length is",
 )
 
 

--- a/verifiers/v1/harnesses/null/program.py
+++ b/verifiers/v1/harnesses/null/program.py
@@ -11,11 +11,26 @@ from contextlib import AsyncExitStack, asynccontextmanager, suppress
 from pathlib import Path
 
 import httpx
-from openai import AsyncOpenAI
+from openai import AsyncOpenAI, BadRequestError
 from tenacity import AsyncRetrying, stop_after_attempt, wait_exponential_jitter
 
 MCP_CALL_ATTEMPTS = 6
 MCP_TIMEOUT = 600.0
+
+CONTEXT_OVERFLOW_MARKERS = (
+    "request entity too large",
+    "context_length",
+    "context length",
+    "context window",
+    "prompt is too long",
+    "too many tokens",
+    "token limit exceeded",
+)
+
+
+def is_context_overflow(error: BadRequestError) -> bool:
+    details = f"{error} {error.body or ''}".casefold()
+    return any(marker in details for marker in CONTEXT_OVERFLOW_MARKERS)
 
 
 async def chat(
@@ -181,7 +196,14 @@ async def main() -> None:
     elif args.prompt:
         messages.append({"role": "user", "content": args.prompt})
     while True:
-        message = await chat(client, args.model, messages, tools)
+        try:
+            message = await chat(client, args.model, messages, tools)
+        except BadRequestError as error:
+            # Context exhaustion is a budget limit, not a crash: this harness has no
+            # compaction, so end the run cleanly with what the conversation holds.
+            if not is_context_overflow(error):
+                raise
+            return
         messages.append(message.model_dump(exclude_none=True))
         if not message.tool_calls:
             break

--- a/verifiers/v1/harnesses/null/program.py
+++ b/verifiers/v1/harnesses/null/program.py
@@ -11,15 +11,12 @@ from contextlib import AsyncExitStack, asynccontextmanager, suppress
 from pathlib import Path
 
 import httpx
-from openai import AsyncOpenAI, BadRequestError
+from openai import APIStatusError, AsyncOpenAI
 from tenacity import AsyncRetrying, stop_after_attempt, wait_exponential_jitter
 
 MCP_CALL_ATTEMPTS = 6
 MCP_TIMEOUT = 600.0
 
-# Overflow wording by provider, matched case-insensitively against the full error body.
-# Each marker is attributed to the API that produces it; unattributable generics stay out
-# (e.g. "too many tokens" also matches Bedrock throttling).
 CONTEXT_OVERFLOW_MARKERS = (
     # OpenAI error code "context_length_exceeded"; OpenRouter relays the raw body.
     "context_length_exceeded",
@@ -44,9 +41,12 @@ CONTEXT_OVERFLOW_MARKERS = (
 )
 
 
-def is_context_overflow(error: BadRequestError) -> bool:
+def is_context_overflow(error: APIStatusError) -> bool:
     details = f"{error} {error.body or ''}".casefold()
-    return any(marker in details for marker in CONTEXT_OVERFLOW_MARKERS)
+    # An overflow is deterministic: a 400, or a 413 for a byte-size cap.
+    return error.status_code in (400, 413) and any(
+        marker in details for marker in CONTEXT_OVERFLOW_MARKERS
+    )
 
 
 async def chat(
@@ -214,7 +214,7 @@ async def main() -> None:
     while True:
         try:
             message = await chat(client, args.model, messages, tools)
-        except BadRequestError as error:
+        except APIStatusError as error:
             # Context exhaustion is a budget limit, not a crash: this harness has no
             # compaction, so end the run cleanly with what the conversation holds.
             if not is_context_overflow(error):

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -409,9 +409,9 @@ class Rollout:
                     0.0, self._agent_time_remaining - (loop.time() - segment_start)
                 )
             self.deadline_at = None
-        if self._session.error is not None:
-            self.fail(self._session.error)
-            return False
+        # A harness that completes cleanly after a failed model call handled it (e.g. it
+        # ends its run on context overflow); the failure stays recorded on the call. A
+        # harness that dies on it surfaces the stashed error through the except above.
         # A segment that committed nothing can't be waiting on the user; treating
         # it as continuable would consult the user against a conversation that
         # never moved, forever.

--- a/verifiers/v1/session.py
+++ b/verifiers/v1/session.py
@@ -131,10 +131,10 @@ class RolloutSession:
     `register` (one server-owned client per distinct endpoint config), so every rollout it
     multiplexes shares one keepalive connection pool instead of opening its own."""
     error: "RolloutError | None" = None
-    """The latest unresolved model-call failure. The harness only sees it as an HTTP error
-    (and may swallow it, or exit non-zero), so the rollout re-raises this original error once the
-    harness returns — recording the real `ProviderError` instead of a secondary `HarnessError`.
-    Reset before each model turn, so a successful retry clears it."""
+    """The latest unresolved model-call failure. The harness only sees it as an HTTP error, so
+    when its program dies on it the rollout records this original error instead of a secondary
+    `HarnessError`. A harness that completes cleanly after the failure handled it. Reset before
+    each model turn, so a successful retry clears it."""
     idempotent_requests: dict[str, IdempotentRequest] = field(default_factory=dict)
     """Explicit keys or marked SDK retries mapped to their replay state."""
     released: bool = False


### PR DESCRIPTION
## Summary

- catch a context-overflow error in the null harness program and return cleanly instead of crashing
- trust a clean harness completion: the rollout no longer re-raises a stashed model-call error after the program exits successfully
- a program that dies on the error still surfaces it through the harness exception path, and the failed call stays recorded on the trace either way

Follow-up to #2453: the null harness has no compaction, so the relayed overlong prompt error killed its program and failed the rollout.

## Breaking

- A harness program that completes cleanly after a failed model call now produces an `ok` trace (the failure stays visible on the call record). Previously the rollout failed with the stashed error even on a clean exit.

## Verification

- `uv run pytest -q tests/v1` — passed; live E2E tests skipped without `PRIME_API_KEY`
- `uv run ruff check` / `uv run ruff format --check`

E2E repro against a local vLLM (`vllm serve Qwen/Qwen3-0.6B --max-model-len 4096 --enable-auto-tool-choice --tool-call-parser hermes`), one dummy task whose toolset returns a ~49KB payload so the turn after the tool call exceeds the 4k window (one-off fixture, not part of this PR):

| | rollout | trace |
| --- | --- | --- |
| before (`main`) | failed: `ProviderError: upstream 400: This model's maximum context length is 4096 tokens…` | `ok=false`, `stop_condition=error` |
| after (this PR) | completed | `ok=true`, `stop_condition=agent_completed`, the overlong call still recorded with its `ProviderError` on `trace.calls` |

Same task against the OpenAI API (`gpt-5.6-luna`, `reasoning_effort="none"`), payload ~1.2M tokens: the API rejects with `400 code="context_length_exceeded": "Input tokens exceed the configured limit of 922000 tokens…"` — the program catches it and the rollout completes with `ok=true`, `stop_condition=agent_completed`, the failed call recorded on `trace.calls`.

Same task against OpenRouter directly (`openai/gpt-4o-mini`, payload ~500k tokens): the 400 wraps the upstream error but relays its raw body (`"This model's maximum context length is 128000 tokens…"`, `provider_error_code: context_length_exceeded`) — caught, rollout completes with `ok=true`, `stop_condition=agent_completed`.

Also probed `deepseek/deepseek-v4-flash` on Prime Inference with the same task at growing payloads:

- a 706k-token prompt is accepted (the run completes normally, `ok=true`), so the window is large;
- past the window (~1M tokens and up), the gateway rejects with a generic `400 "Invalid request."` that carries **no context-length markers** — the harness correctly treats it as a non-overflow provider error, re-raises, and the rollout fails with the real `ProviderError`. The clean-exit path cannot trigger on this provider until it relays the upstream context-length message (this also blinds every marker-based overflow detector: our loops, pi/prime-agent, Codex).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change: clean harness exit after a model-call failure now yields an ok trace instead of failing the rollout; marker-based overflow detection can miss generic provider 400s without length wording.
> 
> **Overview**
> **Context overflow** is now treated as a normal budget stop for the null harness (which has no compaction): model `BadRequestError`s are classified via provider-specific **markers** in `is_context_overflow`, and matching failures **exit the program** instead of crashing.
> 
> **Rollout behavior** changes when the harness finishes successfully after a failed model call: the driver **no longer re-raises** the stashed `session.error`, so the trace can be **`ok`** with the failure still on the call record. Harnesses that **raise** on the error still fail the rollout through the existing exception path.
> 
> `RolloutSession.error` docs are updated to describe this split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 426b36e78679579a068b9fe67bd359ca532a4eb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ## Summary
>
> - catch a context-overflow error in the null harness program and return cleanly instead of crashing
> - trust a clean harness completion: the rollout no longer re-raises a stashed model-call error after the program exits successfully
> - a program that dies on the error still surfaces it through the harness exception path, and the failed call stays recorded on the trace either way
>
> Follow-up to #2453: the null harness has no compaction, so the relayed overlong prompt error killed its program and failed the rollout.
>
> ## Breaking
>
> - A harness program that completes cleanly after a failed model call now produces an `ok` trace (the failure stays visible on the call record). Previously the rollout failed with the stashed error even on a clean exit.
>
> ## Verification
>
> - `uv run pytest -q tests/v1` — passed; live E2E tests skipped without `PRIME_API_KEY`
> - `uv run ruff check` / `uv run ruff format --check`
>
> E2E repro against a local vLLM (`vllm serve Qwen/Qwen3-0.6B --max-model-len 4096 --enable-auto-tool-choice --tool-call-parser hermes`), one dummy task whose toolset returns a ~49KB payload so the turn after the tool call exceeds the 4k window (one-off fixture, not part of this PR):
>
> | | rollout | trace |
> | --- | --- | --- |
> | before (`main`) | failed: `ProviderError: upstream 400: This model's maximum context length is 4096 tokens…` | `ok=false`, `stop_condition=error` |
> | after (this PR) | completed | `ok=true`, `stop_condition=agent_completed`, the overlong call still recorded with its `ProviderError` on `trace.calls` |
>
> Same task against the OpenAI API (`gpt-5.6-luna`, `reasoning_effort="none"`), payload ~1.2M tokens: the API rejects with `400 code="context_length_exceeded": "Input tokens exceed the configured limit of 922000 tokens…"` — the program catches it and the rollout completes with `ok=true`, `stop_condition=agent_completed`, the failed call recorded on `trace.calls`.
>
> Same task against OpenRouter directly (`openai/gpt-4o-mini`, payload ~500k tokens): the 400 wraps the upstream error but relays its raw body (`"This model's maximum context length is 128000 tokens…"`, `provider_error_code: context_length_exceeded`) — caught, rollout completes with `ok=true`, `stop_condition=agent_completed`.
>
> Also probed `deepseek/deepseek-v4-flash` on Prime Inference with the same task at growing payloads:
>
> - a 706k-token prompt is accepted (the run completes normally, `ok=true`), so the window is large;
> - past the window (~1M tokens and up), the gateway rejects with a generic `400 "Invalid request."` that carries **no context-length markers** — the harness correctly treats it as a non-overflow provider error, re-raises, and the rollout fails with the real `ProviderError`. The clean-exit path cannot trigger on this provider until it relays the upstream context-length message (this also blinds every marker-based overflow detector: our loops, pi/prime-agent, Codex).
>
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)
>
> <!-- CURSOR_SUMMARY -->
> ---
>
> > [!NOTE]
> > **Medium Risk**
> > Behavior change: clean harness exit after a model-call failure now yields an ok trace instead of failing the rollout; marker-based overflow detection can miss generic provider 400s without length wording.
> > 
> > **Overview**
> > **Context overflow** is now treated as a normal budget stop for the null harness (which has no compaction): model `BadRequestError`s are classified via provider-specific **markers** in `is_context_overflow`, and matching failures **exit the program** instead of crashing.
> > 
> > **Rollout behavior** changes when the harness finishes successfully after a failed model call: the driver **no longer re-raises** the stashed `session.error`, so the trace can be **`ok`** with the failure still on the call record. Harnesses that **raise** on the error still fail the rollout through the existing exception path.
> > 
> > `RolloutSession.error` docs are updated to describe this split.
> > 
> > <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 426b36e78679579a068b9fe67bd359ca532a4eb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
> <!-- /CURSOR_SUMMARY --><!-- Macroscope's changelog starts here -->
> #### Changes since #2456 opened
>
> - Updated `CONTEXT_OVERFLOW_MARKERS` constant in the null harness to use provider-specific context overflow detection phrases [426b36e]
> - Changed exception handling from `openai.BadRequestError` to `openai.APIStatusError` and added HTTP status code validation (400 or 413) to the `is_context_overflow` function's overflow detection logic, which now requires both a matching context overflow marker in the error details and one of the specified status codes [f00bf5d]
> <!-- Macroscope's changelog ends here -->
>
<!-- Macroscope's pull request summary ends here -->