### PR TITLE
fix(v1): clear handled model call errors

### DIFF
--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -412,6 +412,7 @@ class Rollout:
         # A harness that completes cleanly after a failed model call handled it (e.g. it
         # ends its run on context overflow); the failure stays recorded on the call. A
         # harness that dies on it surfaces the stashed error through the except above.
+        self._session.error = None
         # A segment that committed nothing can't be waiting on the user; treating
         # it as continuable would consult the user against a conversation that
         # never moved, forever.


### PR DESCRIPTION
## Summary

- clear a handled model-call error when a harness segment exits cleanly
- prevent that stale provider error from replacing a later segment's real failure

## Why

PR #2456 lets a harness complete cleanly after handling a relayed model-call failure, but the resolved error remained in `RolloutSession.error`. An interactive segment can then fail before its next model request resets that slot, causing `Rollout.step()` to record the stale provider error instead of the new request-interceptor or harness failure.

The reset happens only after `HarnessSession.turn()` succeeds, so a harness crash in the current segment still records the intercepted provider error.

## Verification

- exact two-segment regression probe: handled overflow followed by request-interceptor failure
- current-segment probe: harness failure still records the provider error
- `uv run pytest tests/ -q`
- `uv run ruff check --fix .`
- `uv run ty check verifiers`
- `uv run pre-commit run --files verifiers/v1/rollout.py`

The all-files pre-commit run retains the existing MD033 failures in the unchanged legacy SWE README; the changed-file hooks pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line lifecycle fix in rollout stepping with targeted regression tests; no auth or data-path changes.
> 
> **Overview**
> After a harness segment finishes **without** raising, **`Rollout.step()`** now sets **`self._session.error = None`**, so a provider failure that was handled in-segment (e.g. context overflow) does not linger on the session.
> 
> That stale slot previously could win in the **`step()`** exception path (**`real = self._session.error`**) when a later segment failed before the next model call cleared it—masking the new interceptor or harness error. Failures in the **current** segment are unchanged: the clear runs only after **`turn()`** succeeds, so a harness crash still surfaces the stashed provider error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b61b0459cfcca12068767666a8bd9f62dd355a1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clear `self._session.error` after segment completion in `Rollout`
> Resets the session error state to `None` after a segment finishes and after agent time remaining and deadline are updated. No other logic or return conditions were changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b61b045.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->