### PR TITLE
fix(v1): configure Terminus context handling

### DIFF
--- a/verifiers/v1/harnesses/terminus_2/harness.py
+++ b/verifiers/v1/harnesses/terminus_2/harness.py
@@ -17,6 +17,10 @@ logger = logging.getLogger(__name__)
 class Terminus2HarnessConfig(HarnessConfig):
     version: str = Field(default="0.21.0", pattern=r"^[A-Za-z0-9._+-]+$")
     """Harbor release to install, pinned for reproducibility."""
+    enable_summarize: bool = False
+    """Let Terminus compact its history after context exhaustion."""
+    interleaved_thinking: bool = True
+    """Keep reasoning from prior turns in the next model request."""
 
 
 class Terminus2Harness(Harness[Terminus2HarnessConfig]):
@@ -56,10 +60,21 @@ class Terminus2Harness(Harness[Terminus2HarnessConfig]):
             f"--system-prompt={system_prompt or ''}",
             f"--task={prompt}",
         ]
+        if self.config.enable_summarize:
+            args.append("--enable-summarize")
+        if not self.config.interleaved_thinking:
+            args.append("--no-interleaved-thinking")
         try:
             source = PROGRAM_SOURCE.replace("{version}", self.config.version)
             program = await runtime.prepare_uv_script(source, self.config.resolved_env)
-            return await runtime.run_program([*program, *args], env)
+            result = await runtime.run_program([*program, *args], env)
+            error = trace.calls[-1].error if trace.calls else None
+            if (
+                error is not None
+                and "context length" in error.message.casefold().replace("_", " ")
+            ):
+                trace.stop("context_length")
+            return result
         finally:
             # Harbor normally destroys its whole sandbox; this adapter borrows the
             # Verifiers runtime, so clean up Terminus's detached tmux server ourselves.

--- a/verifiers/v1/harnesses/terminus_2/program.py
+++ b/verifiers/v1/harnesses/terminus_2/program.py
@@ -11,6 +11,7 @@ from pathlib import Path, PurePosixPath
 
 from harbor.agents.terminus_2 import Terminus2
 from harbor.environments.base import ExecResult
+from harbor.llms.base import ContextLengthExceededError
 from harbor.models.agent.context import AgentContext
 from harbor.models.trial.paths import EnvironmentPaths
 
@@ -53,6 +54,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--model", required=True)
     parser.add_argument("--system-prompt", default="")
     parser.add_argument("--task", required=True)
+    parser.add_argument("--enable-summarize", action="store_true")
+    parser.add_argument("--no-interleaved-thinking", action="store_true")
     return parser.parse_args()
 
 
@@ -69,7 +72,8 @@ async def main() -> None:
         api_base=args.base_url,
         llm_kwargs={"custom_llm_provider": "openai", "api_key": args.api_key},
         record_terminal_session=False,
-        interleaved_thinking=True,
+        enable_summarize=args.enable_summarize,
+        interleaved_thinking=not args.no_interleaved_thinking,
     )
     if system_prompt:
         call = agent._llm.call
@@ -87,7 +91,10 @@ async def main() -> None:
         agent._llm.call = call_with_system_prompt
     environment = LocalEnvironment()
     await agent.setup(environment)
-    await agent.run(task, environment, AgentContext())
+    try:
+        await agent.run(task, environment, AgentContext())
+    except ContextLengthExceededError:
+        return
 
 
 if __name__ == "__main__":

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -518,6 +518,7 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
     def is_truncated(self) -> bool:
         """True for framework limits or a length-finished final response."""
         if self.stop_condition in (
+            "context_length",
             "max_turns",
             "max_input_tokens",
             "max_output_tokens",


### PR DESCRIPTION
Summary

- Default Terminus summarization to off and interleaved thinking to on.
- Expose both Harbor options through Terminus2HarnessConfig.
- Convert Harbor context exhaustion into a clean context_length stop.
- Count context_length stops as truncated traces.

Validation

- Pre-commit Ruff checks passed.
- Deterministic V1 suite passed locally.

No tests are added in this PR.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--enable-summarize` and `--no-interleaved-thinking` flags to Terminus2 harness and handle context length errors
> - Adds `enable_summarize` (default `False`) and `interleaved_thinking` (default `True`) fields to `Terminus2HarnessConfig`, which map to `--enable-summarize` and `--no-interleaved-thinking` CLI flags in [program.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2458/files#diff-8c108b7a53c752a95d1e682451dc464065424adb3863387cd1a2c83b058e18f0)
> - When a model call error message contains 'context length', `Terminus2Harness.launch` now calls `trace.stop("context_length")`; the program also catches `ContextLengthExceededError` and exits cleanly instead of propagating the exception
> - Extends `Trace.is_truncated` in [trace.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2458/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e) to return `True` when `stop_condition` is `'context_length'`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 898eac4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->