### PR TITLE
feat: add context compaction to the rlm harness

### DIFF
--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -2,11 +2,11 @@
 
 import hashlib
 import logging
-import random
 import shlex
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, PositiveInt, model_validator
+from pydantic_config import BaseConfig
 
 from verifiers.v1.acp import ACPConfig, ACPHarness, ACPTurn, JsonObject
 from verifiers.v1.clients import ModelContext
@@ -34,30 +34,24 @@ class _SessionSnapshot(BaseModel):
     metrics: dict[str, int | float]
 
 
+class CompactionConfig(BaseConfig):
+    """Context compaction policy for the RLM agent loop."""
+
+    summarize_at_tokens: PositiveInt | None = None
+    """Compact at this token count. When unset, compact when 16k tokens remain below the
+    model context window when the provider advertises it."""
+
+
 class RLMHarnessConfig(HarnessConfig):
-    version: str = Field(
-        default="4a6369611c06d3943ac40681f374a464feb706b9", min_length=1
-    )
+    version: str = Field(default="4ef3438", min_length=1)
     """Git ref (branch, tag, or commit) of nano-rlm to install."""
     max_depth: int = 0
     """Recursion depth RLM may spawn sub-harnesses to."""
     builtin_skills: list[BuiltinSkill] = Field(default_factory=list)
     """Built-in rlm skills to enable (RLM_SKILLS), e.g. `["edit"]`; empty enables none.
     The tool set is fixed (ipython); the base `skills` field takes SKILL.md paths."""
-    summarize_at_tokens: PositiveInt | tuple[PositiveInt, PositiveInt] | None = None
-    """Auto-compaction threshold (RLM_SUMMARIZE_AT_TOKENS): compact the context once it grows
-    past this many tokens. An int is a fixed threshold; a `(lo, hi)` pair draws a per-group
-    threshold (seeded by the task index, so a task's rollouts share one draw and tasks vary).
-    `None` disables auto-compaction; ints must be positive."""
-
-    @model_validator(mode="after")
-    def validate_range(self) -> "RLMHarnessConfig":
-        value = self.summarize_at_tokens
-        if isinstance(value, tuple) and value[0] > value[1]:
-            raise ValueError(
-                "`summarize_at_tokens` range must be (lo, hi) with lo <= hi."
-            )
-        return self
+    compaction: CompactionConfig | None = None
+    """Context compaction policy. Set an empty config to use automatic thresholds."""
 
     @model_validator(mode="after")
     def reject_disabled_tools(self) -> "RLMHarnessConfig":
@@ -105,16 +99,6 @@ class RLMHarness(ACPHarness[RLMHarnessConfig]):
             raise RuntimeError(f"rlm install failed: {result.stderr.strip()[-500:]}")
         await super().setup(runtime)
 
-    def summarize_threshold(self, task_idx: int | None) -> int | None:
-        """Resolve a fixed or per-task compaction threshold."""
-        value = self.config.summarize_at_tokens
-        if value is None:
-            return None
-        if isinstance(value, tuple):
-            lo, hi = value
-            return random.Random(task_idx or 0).randint(lo, hi)
-        return value
-
     def _runtime_metadata(
         self,
         ctx: ModelContext,
@@ -122,9 +106,9 @@ class RLMHarness(ACPHarness[RLMHarnessConfig]):
         runtime: Runtime,
         endpoint: str,
         secret: str,
-        data: TaskData,
         system_prompt: str | None,
     ) -> JsonObject:
+        compaction = self.config.compaction
         payload = {
             "session_id": trace.id,
             "model": ctx.model,
@@ -134,7 +118,10 @@ class RLMHarness(ACPHarness[RLMHarnessConfig]):
             },
             "policy": {
                 "max_depth": self.config.max_depth,
-                "summarize_at_tokens": self.summarize_threshold(data.idx),
+                "compaction": compaction is not None,
+                "summarize_at_tokens": (
+                    compaction.summarize_at_tokens if compaction else None
+                ),
                 "max_concurrent_subagents": max(4, self.config.max_depth),
             },
             "system_prompt_path": None,
@@ -161,7 +148,7 @@ class RLMHarness(ACPHarness[RLMHarnessConfig]):
             command=[f"{self._install_dir()}/bin/rlm", "--acp"],
             prompt=prompt,
             session_meta=self._runtime_metadata(
-                ctx, trace, runtime, endpoint, secret, data, system_prompt
+                ctx, trace, runtime, endpoint, secret, system_prompt
             ),
         )
 


### PR DESCRIPTION
## Summary

- add the same optional `CompactionConfig` to the RLM harness as the bash harness carries
- cross ACP with a flat policy: a `compaction` toggle plus `summarize_at_tokens`
- pin merged nano-rlm compaction commit `4ef3438`

Builds on merged [#2454](https://github.com/PrimeIntellect-ai/verifiers/pull/2454), which adds Bash compaction and the interception `/v1/models` relay.
Companion [nano-rlm #147](https://github.com/PrimeIntellect-ai/nano-rlm/pull/147) is merged.

## Breaking

- `RLMHarnessConfig.summarize_at_tokens` moves to `RLMHarnessConfig.compaction.summarize_at_tokens` and no longer accepts a `(lo, hi)` range.
- Leave `compaction` unset to disable proactive and reactive compaction.

## Verification

- `uv run pytest -q tests/v1` — passed; live E2E tests skipped without `PRIME_API_KEY`
- `uv run pytest -q tests/v1/test_configs.py` — 12 passed
- `uv run ruff check verifiers/v1/harnesses/rlm/harness.py`
- `uv run ruff format --check verifiers/v1/harnesses/rlm/harness.py`

Terminal-Bench 2 e2e: 8 tasks, local vLLM `poolside/Laguna-XS-2.1` at 32k (glm45 reasoning + glm47 tool parsers), `compaction = {}` so the engine discovers the threshold itself (`32768 − 16384 = 16384`). Trace analysis of the pinned engine:

- Threshold discovery and the proactive trigger work through ACP: compaction fired on the 3 episodes whose context crossed ~17k; episodes that stayed below (0.7k-6.7k peaks) never compacted; 20KB tool truncation visible where tool output was large.
- The runs surfaced and the pin fixes three integration bugs, each verified against the failing trace: `/models` discovery crashing on Python 3.10 containers (raw `cast_to` parse; now `models.list()`), and two interactions with semantic-edge bookkeeping. A failed checkpoint attempt and a resampled unusable reply each left the compaction's summary-request claim held, which killed the retry with "compaction already has a summary request".
- Laguna answers checkpoint prompts entirely in the reasoning channel, so under the summaries-are-content-only rule its compactions exercise the resample-then-end-cleanly path; summary carry-over across branches was demonstrated on content-channel models (Qwen3-0.6B, deepseek-v4-flash).
- A final combined verification run on a content-channel model is pending before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking harness configuration and ACP runtime policy shape affect rollout behavior and compaction timing; changes are localized to the RLM harness but alter long-running agent context management.
> 
> **Overview**
> **RLM harness compaction** is restructured to match the bash harness: a nested `CompactionConfig` with optional `summarize_at_tokens`, exposed over ACP as `policy.compaction` (on/off) plus the threshold when set.
> 
> **Breaking config change:** `RLMHarnessConfig.summarize_at_tokens` is removed in favor of `compaction`; the `(lo, hi)` per-task random range and `summarize_threshold()` are dropped. **`compaction` unset** means compaction is off; an **empty** `compaction` object enables automatic thresholding (e.g. context window minus 16k when advertised).
> 
> The pinned **nano-rlm** ref updates to **`4ef3438`** for the merged compaction engine. `_runtime_metadata` no longer takes `TaskData` since thresholds are no longer task-index–seeded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f39bb2ac39865ef3c12b7b6bfd0a7fbebf44a92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `CompactionConfig` to `RLMHarness` and remove per-task threshold randomization
> - Introduces `CompactionConfig` (derived from `BaseConfig`) with an optional `summarize_at_tokens: PositiveInt` field, replacing the flat `summarize_at_tokens` tuple-range field on `RLMHarnessConfig`.
> - Removes `RLMHarness.summarize_threshold`, which previously computed per-task randomized thresholds seeded by task index. `_runtime_metadata` now reads thresholds directly from `self.config.compaction` and emits a boolean `compaction` flag in the session policy.
> - Changes the default `version` git ref for `RLMHarnessConfig` to `4ef3438`.
> - Behavioral Change: `summarize_at_tokens` no longer accepts `(lo, hi)` tuple ranges; callers must provide a single `PositiveInt` inside `CompactionConfig`. The `data` parameter was removed from `RLMHarness._runtime_metadata`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f39bb2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->