### PR TITLE
fix: batch Prime background job polling

### DIFF
--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -37,10 +37,9 @@ from verifiers.v1.utils.prime import ensure_prime_auth
 
 logger = logging.getLogger(__name__)
 
-IDLE_FALLBACK_LIFETIME = 30 * 24 * 60 * 60
-"""Lifetime (seconds) given to container sandboxes that set an idle timeout: the
-platform requires a finite lifetime there as a safety fallback should idle detection
-fail. Far above any real run, so effectively unbounded."""
+EFFECTIVELY_UNBOUNDED_SECONDS = 30 * 24 * 60 * 60
+"""Safety deadline for APIs that require a finite bound. Normal execution remains
+bounded by idle detection or rollout cancellation; 30 days is above any real run."""
 
 
 BASE_LABELS: list[str] = []
@@ -191,7 +190,7 @@ class PrimeRuntime(Runtime):
             "timeout_minutes": (
                 -1
                 if self.config.vm or idle_minutes is None
-                else max(IDLE_FALLBACK_LIFETIME // 60, idle_minutes + 1)
+                else max(EFFECTIVELY_UNBOUNDED_SECONDS // 60, idle_minutes + 1)
             ),
             "idle_timeout_minutes": idle_minutes,
             "gpu_type": gpu_type,
@@ -294,21 +293,18 @@ class PrimeRuntime(Runtime):
         )
 
     async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
-        # Poll the job by hand: the SDK's run_background_job needs a finite deadline,
-        # but the sandbox has no lifetime limit — the rollout's stage timeouts bound
-        # this via cancellation instead.
         try:
-            job = await self._client.start_background_job(
+            # The shared SDK client coalesces concurrent VM job polls into batches.
+            # Rollout cancellation remains the practical execution timeout; this
+            # long SDK deadline is only a final safety bound.
+            result = await self._client.run_background_job(
                 self.info.id,
                 shlex.join(argv),
+                timeout=EFFECTIVELY_UNBOUNDED_SECONDS,
                 working_dir=self.config.workdir,
                 env=self.process_env(env),
+                poll_interval=1,
             )
-            while True:
-                result = await self._client.get_background_job(self.info.id, job)
-                if result.completed:
-                    break
-                await asyncio.sleep(1)
         except (
             Exception
         ) as e:  # a sandbox/API failure is one rollout's problem, not the eval's


### PR DESCRIPTION
## Summary

Prime runtime command execution now delegates to the Prime SDK `run_background_job` helper instead of manually polling each job with `get_background_job`. Because runtimes already share one SDK client per event loop, concurrent VM job checks can now coalesce into batches of up to 100 rather than producing one gateway `/read-file` request per job.

The call preserves the previous one-second polling cadence and uses the existing effectively-unbounded 30-day safety deadline. Rollout cancellation remains the practical execution timeout, and result/error mapping is unchanged.

## Verification

- `uv run --isolated pytest tests/`: 915 passed, 76 credential-gated tests skipped
- focused delegation test: passed
- Ruff, formatting, and pre-push `ty` checks: passed
- all-files Markdown lint remains blocked by pre-existing inline HTML findings in the untouched ScaleSWE README

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every Prime `run()` waits on VM jobs; behavior is intended to match prior polling but relies on SDK batching and timeout semantics.
> 
> **Overview**
> **Prime sandbox command execution** now uses the shared SDK `run_background_job` helper instead of starting a job and polling `get_background_job` in a loop. That lets concurrent polls on the per–event-loop client batch (up to ~100 jobs), cutting per-job gateway traffic while keeping **1s** `poll_interval` and the same long safety deadline.
> 
> The idle-timeout sandbox lifetime fallback constant is renamed to `EFFECTIVELY_UNBOUNDED_SECONDS` with a clearer docstring; container `timeout_minutes` still uses that 30-day bound. Rollout cancellation remains the real timeout; `ProgramResult` mapping is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2e7304fc834badb1bae74f33160425538cbdb4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace manual polling with SDK `run_background_job` in `PrimeRuntime.run`
> - Replaces the manual `start_background_job` + `get_background_job` while-loop with 1s sleeps in `PrimeRuntime.run` with a single SDK `run_background_job` call using `timeout=EFFECTIVELY_UNBOUNDED_SECONDS` and `poll_interval=1`.
> - Renames `IDLE_FALLBACK_LIFETIME` to `EFFECTIVELY_UNBOUNDED_SECONDS` in [prime.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2462/files#diff-d22d61279ff7587a2b14c72ab1a0fc9d3f805a735338a70f8efc7fe19aaa8502) and updates all references including the sandbox timeout calculation.
> - Risk: polling behavior and timeout enforcement now depend on the SDK's `run_background_job` implementation rather than the previous manual loop.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b2e7304.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->