### PR TITLE
Fix cache salt forwarding in train client

### DIFF
--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -363,6 +363,7 @@ class TrainClient(Client):
         model = body["model"]
         sampling_params = sampling.wire_args()
         chat_template_kwargs = sampling_params.pop("chat_template_kwargs", None)
+        cache_salt = sampling_params.pop("cache_salt", None)
         pool = ElasticRendererPool(
             self.config.renderer_model_name or model,
             self.config.renderer,
@@ -431,6 +432,7 @@ class TrainClient(Client):
                     prompt_attribution=prompt_attribution,
                     tools=wire_tools,
                     sampling_params=sampling_params,
+                    cache_salt=cache_salt,
                     extra_headers={SESSION_ID_HEADER: session_id}
                     if session_id
                     else None,


### PR DESCRIPTION
## Summary

Forward `cache_salt` through Renderers’ dedicated `generate` argument instead of leaving it inside `sampling_params`, where it does not reach vLLM.

This preserves policy-version prefix-cache isolation for pipeline RL: existing rollouts retain their starting cache namespace, while fresh rollouts miss KV cached under older weights.

## Validation

- `uv run ruff check verifiers/v1/clients/train.py`
- Commit hooks: Ruff check, Ruff format, and ty

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pass `cache_salt` as separate argument in `TrainClient.get_response`
> Extracts `cache_salt` from `sampling_params` via `pop` and forwards it as a distinct argument to the `generate` call in [train.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2463/files#diff-c9bcd6c691890b1de6942fe012d2e74678460b22bf335721a8bba5e939d139c3). `sampling_params` no longer carries `cache_salt` when forwarded to `generate`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7367a4a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-path wiring change in the train client; no auth or data-model changes, aligned with the legacy renderer client pattern.
> 
> **Overview**
> **Fixes `cache_salt` not reaching vLLM** when the train client calls `renderers.client.generate`.
> 
> `TrainClient.get_response` now **pops `cache_salt` from `sampling_params`** (same pattern as `chat_template_kwargs`) and passes it as a **dedicated `cache_salt` argument** to `generate`, instead of leaving it inside `sampling_params` where it was ignored.
> 
> This restores **prefix-cache namespace isolation** for pipeline RL rollouts that key KV cache on policy version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7367a4a98da1c42c10d39f6a7f6e210f60eec6dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->