### PR TITLE
fix(v1): enforce artifact transport boundaries

### DIFF
--- a/verifiers/v1/utils/artifacts.py
+++ b/verifiers/v1/utils/artifacts.py
@@ -1,9 +1,11 @@
-"""Artifact collection and restoration across runtimes."""
+"""Bounded, validated artifact collection and restoration across runtimes."""
 
 from __future__ import annotations
 
+import io
 import logging
 import shlex
+import tarfile
 import uuid
 from pathlib import PurePosixPath
 from typing import TYPE_CHECKING
@@ -104,7 +106,12 @@ async def collect(
 
 
 async def restore(runtime: Runtime, collected: dict[str, bytes | None]) -> None:
-    """Extract `collected` in `runtime` at the original absolute paths."""
+    """Extract `collected` in `runtime` at the original absolute paths.
+
+    Archive bytes are untrusted: the agent controls both their source files and the
+    runtime tooling that creates them. Every archive is therefore validated on the host
+    before the grading runtime is changed. Only regular files and directories travel.
+    """
     if not collected:
         return
     # Restoring into the subprocess runtime would extract absolute paths onto the
@@ -114,6 +121,8 @@ async def restore(runtime: Runtime, collected: dict[str, bytes | None]) -> None:
             "refusing to restore artifacts into the subprocess runtime: extraction "
             "writes to absolute paths on the host. Grade in a container."
         )
+    for root, archive in collected.items():
+        _validate_restore(root, archive)
     # Clear every root up front, not per entry: a later nested root would otherwise
     # delete content an earlier one just restored. Clearing also drops any file or
     # symlink the image left at the target.
@@ -135,29 +144,59 @@ async def _tar_out(runtime: Runtime, artifact: Artifact, budget: int) -> bytes:
     path = f"/tmp/vf-artifact-{uuid.uuid4().hex}.tar"
     excludes = " ".join(f"--exclude={shlex.quote(p)}" for p in artifact.exclude)
     try:
+        # macOS tar otherwise adds AppleDouble sidecars next to a directory root.
         await _run(
             runtime,
-            f"tar -cf {shlex.quote(path)} -C / {excludes} -- "
+            f"COPYFILE_DISABLE=1 tar -cf {shlex.quote(path)} -C / {excludes} -- "
             f"{shlex.quote(artifact.source.lstrip('/'))}",
             f"collect artifact {artifact.source!r}",
         )
-        # Size it in the box: an oversized collection is refused before it reaches host
-        # memory, not after.
-        sized = await runtime.run(["sh", "-c", f"wc -c < {shlex.quote(path)}"], {})
-        if (raw := sized.stdout.strip()).isdigit() and int(raw) > budget:
-            raise RuntimeError(
-                f"artifact {artifact.source!r} takes the collection over the "
-                f"{MAX_ARTIFACT_BYTES} byte limit. The grading box boots from the "
-                "agent's image, so only the delta needs to travel — narrow the source "
-                "or add `exclude` patterns."
-            )
-        return await runtime.read(path)
+        # The runtime enforces the remaining collection budget while transferring the
+        # bytes, so replacing or growing the archive cannot race a separate size probe.
+        return await runtime.read(path, max_bytes=budget)
     finally:
         # Best-effort: the box is about to be destroyed and the name is unique per call.
         try:
             await runtime.run(["rm", "-f", path], {})
         except Exception:
             logger.debug("failed to remove %s", path, exc_info=True)
+
+
+def _validate_restore(root: str, archive: bytes | None) -> None:
+    """Reject archive content that could restore outside its declared root."""
+    root_path = PurePosixPath(root)
+    if (
+        root_path.anchor != "/"
+        or ".." in root_path.parts
+        or root_path == PurePosixPath("/")
+    ):
+        raise RuntimeError(
+            f"artifact root {root!r} must be an absolute path below '/' with no '..'"
+        )
+    if archive is None:
+        return
+
+    try:
+        with tarfile.open(fileobj=io.BytesIO(archive), mode="r:") as tar:
+            for member in tar:
+                member_path = PurePosixPath(member.name)
+                destination = PurePosixPath("/") / member_path
+                if (
+                    not member.name
+                    or member_path.is_absolute()
+                    or ".." in member_path.parts
+                    or not destination.is_relative_to(root_path)
+                ):
+                    raise RuntimeError(
+                        f"artifact member {member.name!r} is outside declared root "
+                        f"{root!r}"
+                    )
+                if not (member.isfile() or member.isdir()):
+                    raise RuntimeError(
+                        f"artifact member {member.name!r} is a link or special file"
+                    )
+    except tarfile.TarError as exc:
+        raise RuntimeError(f"unreadable artifact archive for {root!r}: {exc}") from exc
 
 
 async def _run(runtime: Runtime, command: str, action: str) -> None:


### PR DESCRIPTION
## Overview

This change makes grading artifact transport enforce the two boundaries its API already expresses: collection has a fixed host-transfer budget, and each archive may restore only regular files and directories beneath its declared artifact root.

The implementation stays inside the shared v1 artifact transport layer, so Harbor separate verification and isolated agentic judging receive the same behavior without provider-specific handling or interface changes.

## Trust boundary

Artifact transport crosses three ownership domains:

1. A solver runtime produces files and creates a tar archive.
2. The host temporarily holds the archive bytes between runtimes.
3. A fresh grading runtime restores those bytes before running verifier-controlled code.

The archive cannot be treated as trusted merely because framework code invoked tar. The solver controls the source filesystem and may leave processes running or alter runtime tooling. The host therefore treats the resulting bytes as untrusted input and validates them before allowing any grading-runtime mutation.

## Bounded transfer

Collection now passes the remaining rollout artifact budget directly to Runtime.read through max_bytes.

This removes the separate size-probe and read sequence. The byte ceiling is enforced by the same operation that transfers bytes out of the runtime, so replacing or growing the temporary archive between two operations cannot turn a checked archive into an unbounded host read.

The existing aggregate budget remains unchanged: each collected archive consumes from MAX_ARTIFACT_BYTES, and the next archive receives only the remaining budget.

## Archive preflight

Restore performs a complete host-side preflight of every collected root and archive before clearing, writing, or extracting anything in the grading runtime.

Declared roots must:

- be absolute POSIX paths;
- be below the filesystem root rather than naming the root itself; and
- contain no parent-traversal component.

Every tar member must:

- have a non-empty relative name;
- contain no parent-traversal component;
- resolve beneath the declared artifact root; and
- be either a regular file or a directory.

Malformed tar data is rejected. Symbolic links, hard links, devices, FIFOs, sockets, and other special member types are rejected as one explicit transport policy. This deliberately favors a small, auditable restoration contract over reproducing every filesystem feature across trust boundaries.

## Restore ordering

All archives are validated before the first root is cleared. A rejected archive therefore leaves every grading-runtime root untouched, including roots belonging to otherwise valid archives earlier in declaration order.

Once preflight succeeds, restoration retains the existing ordering semantics:

- all declared roots are cleared together before extraction;
- optional missing artifacts still clear their corresponding grading-runtime roots;
- archives restore at their original absolute paths; and
- nested valid files and directories continue to work.

Clearing all roots first remains important for overlapping declarations: a later nested root cannot delete content that an earlier archive has already restored.

## macOS archive behavior

Archive creation sets COPYFILE_DISABLE=1. The macOS tar implementation otherwise adds AppleDouble sidecar entries next to a directory root, placing generated metadata outside the root that was declared for transport. Disabling those sidecars keeps macOS collection consistent with the same root-containment contract used by Linux runtimes.

The environment variable is harmless for tar implementations that do not implement AppleDouble metadata.

## Compatibility and interfaces

The public Artifact, collect, restore, task-state, Harbor, and agentic-judge interfaces are unchanged. Archive storage remains an ordered mapping from absolute source root to tar bytes or an optional-missing marker.

The intentional behavioral restriction is that links and special files are no longer transportable artifacts. Tasks that need linked content must publish regular files and directories, or materialize the required target content during finalization.

## Scope

The change is contained to verifiers/v1/utils/artifacts.py. It does not add dependencies, alter runtime providers, change artifact size limits, change grading lifecycle ownership, or introduce a second transport implementation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes security-critical artifact handling across the solver–host–grading trust boundary; incorrect validation could allow path escape or unsafe extraction, while stricter rules may break tasks that relied on symlinks in artifacts.
> 
> **Overview**
> Hardens v1 artifact **collect** and **restore** so untrusted tar bytes from the solver runtime cannot bypass size limits or write outside declared roots.
> 
> **Collection** passes the remaining rollout budget into `runtime.read(..., max_bytes=budget)` instead of a separate `wc -c` check, closing a race where the archive could grow between probe and read. **macOS** collection sets `COPYFILE_DISABLE=1` so AppleDouble sidecars are not packed beside directory roots.
> 
> **Restore** runs host-side preflight (`_validate_restore`) on every root and archive **before** any grading-runtime `rm` or extract: roots must be absolute paths under `/` (not `/` itself); each tar member must stay under its root with no `..`, and only regular files and directories are allowed—links and special entries fail fast. Malformed archives surface as `RuntimeError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f9b702883155bf5ec4ca3aabe3a69edfec693da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce artifact transport boundaries in v1 restore and `_tar_out`
> - Adds `_validate_restore` in [artifacts.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2464/files#diff-0d082bad54931be61d7ef55ddce0757034be3013f69ae71cb803cd8416df9138) to host-side validate tar archives before extraction: rejects absolute member paths, `..` traversal, links/special files, and malformed or unreadable archives with `RuntimeError`
> - `restore()` now calls `_validate_restore` on each root/archive pair before any destructive operation
> - `_tar_out` prepends `COPYFILE_DISABLE=1` to avoid AppleDouble sidecar files and replaces the separate size probe with a single `runtime.read(path, max_bytes=budget)` call
> - Behavioral Change: `restore()` now rejects archives it previously accepted; callers passing archives with absolute paths, traversal entries, or non-regular/non-directory members will receive `RuntimeError` before extraction
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f9b702.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->