### PR TITLE
fix(v1): prefer final judge choices over draft boxes

### DIFF
--- a/tests/v1/test_scoring.py
+++ b/tests/v1/test_scoring.py
@@ -138,6 +138,12 @@ def test_parse_judge_choice_prefers_final_marker_then_boxed() -> None:
         vf.parse_judge_choice(
             "Final Judgment: A better choice is \\boxed{B}", choices=("A", "B")
         )
+        == "A"
+    )
+    assert (
+        vf.parse_judge_choice(
+            "Final Judgment: \\boxed{A}\nFinal Judgment: B", choices=("A", "B")
+        )
         == "B"
     )
     assert (

--- a/tests/v1/test_scoring.py
+++ b/tests/v1/test_scoring.py
@@ -113,7 +113,17 @@ def test_parse_pytest_outcomes_strips_xfail_xpass_reasons() -> None:
     }
 
 
-def test_parse_judge_choice_uses_first_choice_after_verdict_marker() -> None:
-    response = "Final Judgment: B because it is a better answer"
-
-    assert vf.parse_judge_choice(response, choices=("A", "B")) == "B"
+def test_parse_judge_choice_prefers_final_marker_then_boxed() -> None:
+    assert (
+        vf.parse_judge_choice(
+            "Draft: \\boxed{A}\nFinal Judgment: B", choices=("A", "B")
+        )
+        == "B"
+    )
+    assert (
+        vf.parse_judge_choice(
+            "Draft: \\boxed{A}\nFinal Judgment:\nReasoning mentions B",
+            choices=("A", "B"),
+        )
+        == "A"
+    )

--- a/tests/v1/test_scoring.py
+++ b/tests/v1/test_scoring.py
@@ -135,5 +135,11 @@ def test_parse_judge_choice_prefers_final_marker_then_boxed() -> None:
         == "B"
     )
     assert (
+        vf.parse_judge_choice(
+            "Final Judgment: A better choice is \\boxed{B}", choices=("A", "B")
+        )
+        == "B"
+    )
+    assert (
         vf.parse_judge_choice("Draft: \\boxed{A}\nAnswer: B", choices=("A", "B")) == "A"
     )

--- a/tests/v1/test_scoring.py
+++ b/tests/v1/test_scoring.py
@@ -127,3 +127,13 @@ def test_parse_judge_choice_prefers_final_marker_then_boxed() -> None:
         )
         == "A"
     )
+    assert (
+        vf.parse_judge_choice(
+            "Draft: \\boxed{B}\nFinal Judgment: This is a \\boxed{B}",
+            choices=("A", "B"),
+        )
+        == "B"
+    )
+    assert (
+        vf.parse_judge_choice("Draft: \\boxed{A}\nAnswer: B", choices=("A", "B")) == "A"
+    )

--- a/verifiers/v1/utils/score.py
+++ b/verifiers/v1/utils/score.py
@@ -55,23 +55,32 @@ def parse_judge_choice(
         return None
 
     text = content.rsplit("</think>", 1)[-1].strip()
-    text = extract_boxed_answer(text, strict=True).strip() or text
-
     text_upper = text.upper()
     choices_by_upper = {choice.upper(): choice for choice in choices}
     allowed = "|".join(re.escape(choice) for choice in choices_by_upper)
     choice_re = rf"(?<!\w)({allowed})(?!\w)"
-    verdict_re = (
-        r"(?:^|\n)\s*(?:FINAL\s+JUDGMENT|FINAL\s+ANSWER|FINAL\s+VERDICT|"
-        r"JUDGMENT|VERDICT|ANSWER)\s*(?:IS\s*)?[:\-]?\s*"
+
+    horizontal_space = r"[^\S\n]"
+    marker_tail = (
+        rf"{horizontal_space}*(?:IS{horizontal_space}*)?[:\-]?"
+        rf"{horizontal_space}*[^\n]*?{choice_re}"
+    )
+    final_choices = re.findall(
+        rf"^{horizontal_space}*FINAL{horizontal_space}+"
+        rf"(?:JUDGMENT|ANSWER|VERDICT){marker_tail}",
+        text_upper,
+        re.MULTILINE,
+    )
+    bare_choices = re.findall(
+        rf"^{horizontal_space}*(?:JUDGMENT|ANSWER|VERDICT){marker_tail}",
+        text_upper,
+        re.MULTILINE,
     )
 
-    verdict = re.search(verdict_re, text_upper)
-    if verdict:
-        match = re.search(choice_re, text_upper[verdict.end() :])
-        return choices_by_upper.get(match.group(1)) if match else None
-
-    matches = re.findall(choice_re, text_upper)
+    boxed = extract_boxed_answer(text, strict=True).strip()
+    matches = (
+        final_choices or bare_choices or re.findall(choice_re, (boxed or text).upper())
+    )
     return choices_by_upper.get(matches[-1]) if matches else None
 
 

--- a/verifiers/v1/utils/score.py
+++ b/verifiers/v1/utils/score.py
@@ -65,9 +65,18 @@ def parse_judge_choice(
         rf"{horizontal_space}*(?:IS{horizontal_space}*)?[:\-]?"
         rf"{horizontal_space}*{choice_re}"
     )
-    final_choices = re.findall(
+    final_marker = (
         rf"^{horizontal_space}*FINAL{horizontal_space}+"
-        rf"(?:JUDGMENT|ANSWER|VERDICT){marker_tail}",
+        rf"(?:JUDGMENT|ANSWER|VERDICT)"
+    )
+    final_boxed_choices = re.findall(
+        rf"{final_marker}[^\n]*{re.escape(BOXED_START.upper())}{horizontal_space}*"
+        rf"{choice_re}{horizontal_space}*\}}",
+        text_upper,
+        re.MULTILINE,
+    )
+    final_choices = re.findall(
+        rf"{final_marker}{marker_tail}",
         text_upper,
         re.MULTILINE,
     )
@@ -80,7 +89,8 @@ def parse_judge_choice(
     boxed = extract_boxed_answer(text, strict=True).strip()
     boxed_choices = re.findall(choice_re, boxed.upper())
     matches = (
-        final_choices
+        final_boxed_choices
+        or final_choices
         or boxed_choices
         or bare_choices
         or re.findall(choice_re, text_upper)

--- a/verifiers/v1/utils/score.py
+++ b/verifiers/v1/utils/score.py
@@ -59,42 +59,30 @@ def parse_judge_choice(
     choices_by_upper = {choice.upper(): choice for choice in choices}
     allowed = "|".join(re.escape(choice) for choice in choices_by_upper)
     choice_re = rf"(?<!\w)({allowed})(?!\w)"
-
     horizontal_space = r"[^\S\n]"
-    marker_tail = (
-        rf"{horizontal_space}*(?:IS{horizontal_space}*)?[:\-]?"
-        rf"{horizontal_space}*{choice_re}"
-    )
-    final_marker = (
-        rf"^{horizontal_space}*FINAL{horizontal_space}+"
-        rf"(?:JUDGMENT|ANSWER|VERDICT)"
-    )
-    final_boxed_choices = re.findall(
-        rf"{final_marker}[^\n]*{re.escape(BOXED_START.upper())}{horizontal_space}*"
-        rf"{choice_re}{horizontal_space}*\}}",
-        text_upper,
-        re.MULTILINE,
-    )
     final_choices = re.findall(
-        rf"{final_marker}{marker_tail}",
+        rf"^{horizontal_space}*FINAL{horizontal_space}+"
+        rf"(?:JUDGMENT|ANSWER|VERDICT){horizontal_space}*"
+        rf"(?:IS{horizontal_space}*)?[:\-]?{horizontal_space}*{choice_re}",
         text_upper,
         re.MULTILINE,
     )
-    bare_choices = re.findall(
-        rf"^{horizontal_space}*(?:JUDGMENT|ANSWER|VERDICT){marker_tail}",
-        text_upper,
-        re.MULTILINE,
+    if final_choices:
+        return choices_by_upper.get(final_choices[-1])
+
+    text = extract_boxed_answer(text, strict=True).strip() or text
+    text_upper = text.upper()
+    verdict_re = (
+        r"(?:^|\n)\s*(?:FINAL\s+JUDGMENT|FINAL\s+ANSWER|FINAL\s+VERDICT|"
+        r"JUDGMENT|VERDICT|ANSWER)\s*(?:IS\s*)?[:\-]?\s*"
     )
 
-    boxed = extract_boxed_answer(text, strict=True).strip()
-    boxed_choices = re.findall(choice_re, boxed.upper())
-    matches = (
-        final_boxed_choices
-        or final_choices
-        or boxed_choices
-        or bare_choices
-        or re.findall(choice_re, text_upper)
-    )
+    verdict = re.search(verdict_re, text_upper)
+    if verdict:
+        match = re.search(choice_re, text_upper[verdict.end() :])
+        return choices_by_upper.get(match.group(1)) if match else None
+
+    matches = re.findall(choice_re, text_upper)
     return choices_by_upper.get(matches[-1]) if matches else None
 
 

--- a/verifiers/v1/utils/score.py
+++ b/verifiers/v1/utils/score.py
@@ -63,7 +63,7 @@ def parse_judge_choice(
     horizontal_space = r"[^\S\n]"
     marker_tail = (
         rf"{horizontal_space}*(?:IS{horizontal_space}*)?[:\-]?"
-        rf"{horizontal_space}*[^\n]*?{choice_re}"
+        rf"{horizontal_space}*{choice_re}"
     )
     final_choices = re.findall(
         rf"^{horizontal_space}*FINAL{horizontal_space}+"
@@ -78,8 +78,12 @@ def parse_judge_choice(
     )
 
     boxed = extract_boxed_answer(text, strict=True).strip()
+    boxed_choices = re.findall(choice_re, boxed.upper())
     matches = (
-        final_choices or bare_choices or re.findall(choice_re, (boxed or text).upper())
+        final_choices
+        or boxed_choices
+        or bare_choices
+        or re.findall(choice_re, text_upper)
     )
     return choices_by_upper.get(matches[-1]) if matches else None
 


### PR DESCRIPTION
## Overview

Prefer explicit final judge verdicts over boxed answers, so a draft boxed answer cannot mask a later final decision.

Alternative implementation to #2256.

## Details

- Read direct choices from Final Judgment, Final Answer, and Final Verdict lines before applying any boxed-answer fallback.
- When more than one explicit final verdict appears, use the last one.
- If no explicit final verdict is present, keep the existing boxed-answer and general marker behavior.
- Keep the change contained to parse_judge_choice without adding another parsing helper.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prefer final judge markers over boxed answers in `parse_judge_choice`
> - Adds an early scan in `parse_judge_choice` in [score.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2465/files#diff-d7b5bdc04a1f81bad34edd56c57b6adbbb2c5a52979c6a0f4c4320f8e0b4c73a) for lines starting with `FINAL` plus `JUDGMENT|ANSWER|VERDICT` followed immediately by a valid choice token, returning the last such match's canonical choice.
> - Falls back to existing boxed-answer extraction and legacy `verdict_re` heuristics only when no explicit final-line choice is found; `text_upper` is recomputed after boxed extraction for the legacy path.
> - Updates tests in [test_scoring.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2465/files#diff-109cb864931995c9d68f4a26cfac4129b926f253d1e2ce88e2313ad098963f6c) to cover precedence, multiple-marker, and non-final-label scenarios.
> - Behavioral Change: judge outputs with both a boxed answer and a later explicit `Final Judgment:` line now resolve to the explicit line instead of the box; outputs relying solely on boxed answers are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 59239af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->