### PR TITLE
Report unchecked gold validation

### DIFF
--- a/verifiers/v1/cli/dashboard/validate.py
+++ b/verifiers/v1/cli/dashboard/validate.py
@@ -21,6 +21,7 @@ _STYLE = {
     "running": "cyan",
     "valid": "green",
     "invalid": "yellow",
+    "unchecked": "dim",
     "error": "red",
     "timeout": "red",
 }
@@ -29,7 +30,7 @@ _MARK_WIDTH = max(len(state) for state in _STYLE)
 # the name left-aligned inside — the outcome reads at a glance. `escape` keeps the brackets
 # literal: Rich parses `[name]` in a cell as markup and would otherwise drop it.
 _MARK = {state: escape(f"[{state:<{_MARK_WIDTH}}]") for state in _STYLE}
-_DONE = ("valid", "invalid", "error", "timeout")
+_DONE = ("valid", "invalid", "unchecked", "error", "timeout")
 # State -> (visible label, color); insertion order is the summary order.
 _OUTCOMES = {state: (state, _STYLE[state]) for state in _DONE}
 

--- a/verifiers/v1/cli/validate.py
+++ b/verifiers/v1/cli/validate.py
@@ -158,6 +158,7 @@ def summarize(rows: Sequence[ResultRow], total: int, mode: str) -> dict[str, Any
     outcomes = {reason: counts[reason] for reason in REASONS}
     outcomes["missing"] = missing
     checked = outcomes["valid"] + outcomes["invalid"]
+    rate_total = total - outcomes["unchecked"]
     terminal = checked + outcomes["unchecked"]
     summary: dict[str, Any] = {
         "mode": mode,
@@ -166,9 +167,7 @@ def summarize(rows: Sequence[ResultRow], total: int, mode: str) -> dict[str, Any
         "terminal": terminal,
         "owed": missing + outcomes["error"] + outcomes["timeout"],
         "outcomes": outcomes,
-        "valid_rate": round(outcomes["valid"] / total, 6)
-        if total and checked
-        else None,
+        "valid_rate": round(outcomes["valid"] / rate_total, 6) if checked else None,
     }
     if mode == "all":
         checks: dict[str, dict[str, int]] = {}

--- a/verifiers/v1/cli/validate.py
+++ b/verifiers/v1/cli/validate.py
@@ -43,8 +43,8 @@ logger = logging.getLogger(__name__)
 RESULTS_FILE = "results.jsonl"
 SUMMARY_FILE = "summary.json"
 LOG_FILE = "logs/validate.log"
-FINAL_REASONS = frozenset({"valid", "invalid"})
-REASONS = ("valid", "invalid", "error", "timeout")
+FINAL_VALUES = {"valid": True, "invalid": False, "unchecked": None}
+REASONS = ("valid", "invalid", "unchecked", "error", "timeout")
 
 ResultRow = dict[str, Any]
 
@@ -99,8 +99,8 @@ def _is_final(row: object, key: str, mode: str) -> bool:
     return (
         row.get("task_key") == key
         and row.get("mode") == mode
-        and reason in FINAL_REASONS
-        and row.get("valid") is (reason == "valid")
+        and reason in FINAL_VALUES
+        and row.get("valid") is FINAL_VALUES[reason]
     )
 
 
@@ -157,7 +157,8 @@ def summarize(rows: Sequence[ResultRow], total: int, mode: str) -> dict[str, Any
     missing = max(0, total - len(rows))
     outcomes = {reason: counts[reason] for reason in REASONS}
     outcomes["missing"] = missing
-    terminal = outcomes["valid"] + outcomes["invalid"]
+    checked = outcomes["valid"] + outcomes["invalid"]
+    terminal = checked + outcomes["unchecked"]
     summary: dict[str, Any] = {
         "mode": mode,
         "total": total,
@@ -165,7 +166,9 @@ def summarize(rows: Sequence[ResultRow], total: int, mode: str) -> dict[str, Any
         "terminal": terminal,
         "owed": missing + outcomes["error"] + outcomes["timeout"],
         "outcomes": outcomes,
-        "valid_rate": round(outcomes["valid"] / total, 6) if total else None,
+        "valid_rate": round(outcomes["valid"] / total, 6)
+        if total and checked
+        else None,
     }
     if mode == "all":
         checks: dict[str, dict[str, int]] = {}
@@ -194,24 +197,26 @@ def save_run(config: ValidateConfig, results_dir: Path, total: int) -> None:
     write_summary(results_dir, summarize([], total, validation_mode(config)))
 
 
-def _classify(valid: bool, exc: BaseException | None) -> str:
-    if valid:
+def _classify(valid: bool | None, exc: BaseException | None) -> str:
+    if valid is True:
         return "valid"
     if isinstance(exc, asyncio.TimeoutError):
         return "timeout"
     if exc is not None:
         return "error"
+    if valid is None:
+        return "unchecked"
     return "invalid"
 
 
 def _row(
-    task, mode: str, valid: bool, exc: BaseException | None, start: float
+    task, mode: str, valid: bool | None, exc: BaseException | None, start: float
 ) -> ResultRow:
     return {
         "index": task.data.idx,
         "name": task.data.name,
         "mode": mode,
-        "valid": bool(valid),
+        "valid": valid,
         "reason": _classify(valid, exc),
         "elapsed": round(time.time() - start, 2),
         "error": str(exc) if exc is not None else None,
@@ -230,7 +235,8 @@ async def _run_check(task: Task, config: ValidateConfig, mode: str) -> ResultRow
         if config.timeout.setup is not None
         else task.data.timeout.setup
     )
-    valid, exc = False, None
+    valid: bool | None = False
+    exc = None
     try:
         runtime.env = dict(task.runtime_env())
         trace = Trace(
@@ -275,11 +281,13 @@ def _all_reason(rows: list[ResultRow]) -> str:
         return "error"
     if "timeout" in reasons:
         return "timeout"
-    return "invalid"
+    if "invalid" in reasons:
+        return "invalid"
+    return "unchecked"
 
 
 def _all_error(rows: list[ResultRow]) -> tuple[str | None, str | None]:
-    failed = [row for row in rows if not row["valid"]]
+    failed = [row for row in rows if row["reason"] not in ("valid", "unchecked")]
     parts = [f"{row['mode']}: {row['error'] or row['reason']}" for row in failed]
     error_types = {str(row["error_type"]) for row in failed if row["error_type"]}
     return ("; ".join(parts) or None, "+".join(sorted(error_types)) or None)
@@ -290,13 +298,14 @@ async def _run_all(task: Task, config: ValidateConfig) -> ResultRow:
     gold = await _run_check(task, config, "gold")
     setup = await _run_check(task, config, "setup")
     rows = [gold, setup]
+    reason = _all_reason(rows)
     error, error_type = _all_error(rows)
     return {
         "index": task.data.idx,
         "name": task.data.name,
         "mode": "all",
-        "valid": all(row["valid"] for row in rows),
-        "reason": _all_reason(rows),
+        "valid": None if reason == "unchecked" else reason == "valid",
+        "reason": reason,
         "elapsed": round(time.time() - start, 2),
         "error": error,
         "error_type": error_type,
@@ -406,9 +415,7 @@ async def run_validate(config: ValidateConfig) -> list[dict]:
     )
     async with display:
         if not plan:
-            logger.info(
-                "nothing to resume: all %d task(s) are valid or invalid", len(tasks)
-            )
+            logger.info("nothing to resume: all %d task(s) are terminal", len(tasks))
             return rows
         await asyncio.gather(
             *(_one(position, task, key) for position, task, key in plan)

--- a/verifiers/v1/task.py
+++ b/verifiers/v1/task.py
@@ -173,8 +173,9 @@ class Task(Generic[DataT, StateT, ConfigT]):
     async def finalize(self, trace: Trace, runtime: Runtime) -> None:
         return None
 
-    async def validate(self, runtime: Runtime) -> bool:
-        return True
+    async def validate(self, runtime: Runtime) -> bool | None:
+        """Check the ground truth, or return None when no model-free check exists."""
+        return None
 
     async def score(
         self,

--- a/verifiers/v1/tasksets/lean/taskset.py
+++ b/verifiers/v1/tasksets/lean/taskset.py
@@ -126,11 +126,11 @@ class LeanTask(Task[LeanData, State, LeanTaskConfig]):
         trace.info["compile_output"] = output[-4000:]
         return 1.0 if compiled else 0.0
 
-    async def validate(self, runtime: Runtime) -> bool:
+    async def validate(self, runtime: Runtime) -> bool | None:
         """Compile the gold proof; rows without one have nothing to preflight."""
         gold = (self.data.formal_proof or "").rstrip()
         if not gold:
-            return True
+            return None
         content = build_starter_file(
             self.data.formal_statement,
             header=self.data.header,


### PR DESCRIPTION
## Overview

Represent model-free gold validation as a tri-state result so tasksets without a gold check are reported as unchecked instead of valid.

This is an alternative implementation of the issue identified by @ATMAECHO in #2293. It makes the absence of a check part of the Task.validate contract instead of inferring it from method overrides.

## Details

- Make Task.validate return None by default while preserving explicit True and False results.
- Persist unchecked as a terminal result with valid: null, including resume and summary handling.
- Preserve invalid, timeout, and error precedence when gold and setup checks are combined.
- Show unchecked outcomes in the validation dashboard and leave valid_rate unset when nothing was checked.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing the default `Task.validate` from `True` to `None` shifts reporting for any task that relied on the inherited default without overriding the method.
> 
> **Overview**
> Gold validation is now **tri-state**: `Task.validate` may return `None` when there is no model-free check, instead of implicitly counting those tasks as valid.
> 
> The default `Task.validate` returns **`None`** (was `True`). The validate CLI persists **`reason: "unchecked"`** with **`valid: null`**, treats unchecked as **terminal** for resume/summary, and shows it in the **dashboard** (dim style). **`valid_rate`** is computed only over tasks that were actually checked (valid + invalid); it stays unset when nothing was checked. Combined gold+setup runs keep **error/timeout/invalid** precedence and surface **unchecked** when neither sub-check failed.
> 
> **Lean** tasks without a gold proof now return **`None`** instead of passing validation by default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8b1e4a5ba6a07a873b7d20d4e33988d72c313b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `unchecked` tri-state outcome to validation pipeline and dashboard
> Introduces `valid: bool | None` across the validation system so tasks without a model-free check are reported as `unchecked` instead of implicitly passing.
>
> - Changes `Task.validate` and `LeanTask.validate` to return `None` when no gold proof exists, rather than defaulting to `True`
> - Updates `FINAL_VALUES`, `_classify`, `_row`, `_all_reason`, and `_all_error` in [validate.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2466/files#diff-f9da541290540aab599f22057f02b6cfcd418d89dfa7bf9cbe3c325d970d5a67) to handle the tri-state: `unchecked` is terminal, excluded from error aggregation, and `valid_rate` is computed over checked items only
> - Adds `unchecked` styling and mark to the dashboard in [validate.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2466/files#diff-2ded55a5b55a7c27d925b91343c516de853d005e99d07590ceb341bdc9e9149e)
> - Behavioral Change: `LeanTask.validate` no longer returns `True` for tasks without a gold proof — callers that treated any truthy return as "valid" will now see `None`; persisted result rows store `valid=None` for unchecked outcomes
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d8b1e4a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->