### PR TITLE
fix(v1): collect isolated judge artifacts in owned rollouts

### DIFF
--- a/tests/v1/fixtures/echo_agentic_v1.py
+++ b/tests/v1/fixtures/echo_agentic_v1.py
@@ -31,13 +31,6 @@ class EchoAgenticData(vf.TaskData):
 
 
 class EchoAgenticTask(vf.Task[EchoAgenticData]):
-    async def finalize(self, trace: vf.Trace, runtime: Runtime) -> None:
-        # Subprocess uses a runtime-owned temporary cwd, not a restorable absolute
-        # path; isolated agentic judging requires a container anyway.
-        if runtime.type == "subprocess":
-            return
-        trace.state.artifacts = await vf.collect(runtime, self.data.artifacts)
-
     @vf.reward(weight=1.0)
     async def wrote_phrase(self, runtime: Runtime) -> float:
         try:

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -362,21 +362,26 @@ class Agent:
         runtime: Runtime | None = None,
         tools: Mapping[str, SharedToolServer] | None = None,
         on_trace: Callable[[Trace], None] | None = None,
+        collect_artifacts: bool = False,
     ) -> Trace:
         """Run this agent on `task` once and return the trace: one segment — the
         program runs on the task's prompt until it exits (a multi-turn exchange
         is `interaction()`). `runtime` places it into a live borrowed box instead of
         provisioning one; `tools` are live servers borrowed from their
         owner, counted in the pairing check; `on_trace` observes the trace the
-        moment it's minted, before any I/O. Retries whole while the trace ends
-        with a retryable error (`config.retries`) — never into a borrowed box;
-        the final trace keeps earlier attempts' errors."""
+        moment it's minted, before any I/O. `collect_artifacts` captures the task's
+        declared artifacts after its finalizer while its container runtime is still
+        alive. Retries whole while the trace ends with a retryable error
+        (`config.retries`) — never into a borrowed box; the final trace keeps earlier
+        attempts' errors."""
         if self._closed:
             raise RuntimeError("Agent is closed; create a new agent")
         retry = self.config.retries
         history: list = []
         for attempt in range(retry.max_retries + 1):
-            trace = await self._run_once(task, runtime, tools, on_trace)
+            trace = await self._run_once(
+                task, runtime, tools, on_trace, collect_artifacts
+            )
             if attempt == retry.max_retries or not trace_should_retry(trace, retry):
                 break
             if runtime is not None:
@@ -407,9 +412,20 @@ class Agent:
         runtime: Runtime | None,
         shared_tools: Mapping[str, SharedToolServer] | None,
         on_trace: Callable[[Trace], None] | None,
+        collect_artifacts: bool,
     ) -> Trace:
         params = self._rollout_params(task, runtime, dict(shared_tools or {}))
-        run = Rollout(task=task, on_trace=on_trace, **params)
+        if collect_artifacts and isinstance(params["runtime_config"], SubprocessConfig):
+            raise TypeError(
+                "artifact collection requires a container runtime; subprocess "
+                "artifacts live in a host-only temporary working directory"
+            )
+        run = Rollout(
+            task=task,
+            on_trace=on_trace,
+            collect_artifacts=collect_artifacts,
+            **params,
+        )
         try:
             if await run.open():
                 await run.step()
@@ -626,6 +642,7 @@ class _EpisodeAgent(Agent):
         runtime: Runtime | None = None,
         tools: Mapping[str, SharedToolServer] | None = None,
         on_trace: Callable[[Trace], None] | None = None,
+        collect_artifacts: bool = False,
     ) -> Trace:
         async with self._gate or nullcontext():
             trace = await super().run(
@@ -633,6 +650,7 @@ class _EpisodeAgent(Agent):
                 runtime=runtime,
                 tools=tools if tools is not None else self._shared_for(task),
                 on_trace=self._watch(on_trace),
+                collect_artifacts=collect_artifacts,
             )
         self._completed.append(trace)
         return trace

--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -342,7 +342,7 @@ class IsolatedAgenticJudgeEnv(AgenticJudgeEnv):
     """Judge only collected artifacts in a fresh box with the solver's policy."""
 
     async def run(self, task: vf.Task, agents: vf.Agents) -> None:
-        solution = await agents.solver.run(task)
+        solution = await agents.solver.run(task, collect_artifacts=True)
         if not solution.ok:
             raise RuntimeError("the solver's rollout failed, so the judge never ran")
         await agents.judge.run(

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -32,6 +32,7 @@ from verifiers.v1.state import state_cls
 from verifiers.v1.task import Task
 from verifiers.v1.trace import AgentInfo, Trace, TraceTask
 from verifiers.v1.types import Messages, Request, Response, SystemMessage, UserMessage
+from verifiers.v1.utils.artifacts import collect
 from verifiers.v1.utils.decorators import discover_decorated, invoke
 
 logger = logging.getLogger(__name__)
@@ -69,6 +70,7 @@ class Rollout:
         interception: Interception | None = None,
         runtime: Runtime | None = None,
         on_trace: Callable[[Trace], None] | None = None,
+        collect_artifacts: bool = False,
     ) -> None:
         self.task = task
         self.harness = harness
@@ -81,6 +83,7 @@ class Rollout:
         self._interception = interception
         self.runtime = runtime
         self._borrowed_runtime = runtime
+        self._collect_artifacts = collect_artifacts
         self.trace: Trace = Trace(
             task=TraceTask(
                 type=type(task).__name__,
@@ -466,12 +469,14 @@ class Rollout:
             if not self._failed and self._opened:
                 trace.timing.finalize.start = time.time()
                 async with boundary(TaskError, "task finalize"):
-                    await asyncio.wait_for(
-                        invoke(
+                    async with asyncio.timeout(self._timeouts.finalize):
+                        await invoke(
                             self.task.finalize, {"trace": trace, "runtime": runtime}
-                        ),
-                        self._timeouts.finalize,
-                    )
+                        )
+                        if self._collect_artifacts and not trace.state.artifacts:
+                            trace.state.artifacts = await collect(
+                                runtime, self.task.data.artifacts
+                            )
                 now = time.time()
                 trace.timing.finalize.end = now
                 trace.timing.scoring.start = now


### PR DESCRIPTION
## Overview

Collect isolated solver artifacts through the normal Agent.run owned-runtime lifecycle, after task finalization and before scoring and teardown.

## Details

- Add an opt-in collect_artifacts argument to Agent.run and Rollout.
- Preserve artifacts produced by a task finalizer; otherwise use the existing artifact collection helper within the same finalize boundary.
- Let the isolated agentic judge request collection without provisioning or borrowing the solver runtime itself.
- Exercise the generic path by removing the echo fixture custom collection finalizer.

## Related work

This is an alternative implementation of the artifact-lifecycle problem reported in #2342 by @crazywriter1. It preserves Agent.run ownership and whole-rollout retry semantics while reusing the same artifact representation consumed by JudgeTask.

It complements #2464: that PR hardens artifact transfer and restoration boundaries, while this PR controls when the existing collection path runs before an owned solver runtime is torn down.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout teardown timing and artifact population semantics; callers that relied on task `finalize` for artifacts must opt in with `collect_artifacts=True`, and isolated judging now depends on container solver runtimes.
> 
> **Overview**
> Adds an opt-in **`collect_artifacts`** flag on **`Agent.run`** (and **`Rollout`**) so declared task artifacts are gathered **after `finalize`** while the owned container runtime is still up, without tasks implementing their own collection.
> 
> **`IsolatedAgenticJudgeEnv`** enables this on the solver rollout so **`JudgeTask.from_trace(..., share_runtime=False)`** receives **`solution.state.artifacts`** before the solver box is torn down. **`collect_artifacts=True`** is rejected for **subprocess** runtimes (host-only temp cwd).
> 
> Rollout **finalize** is now bounded with **`asyncio.timeout`** instead of **`wait_for`**; collection runs only when artifacts are still empty, so a custom **`finalize`** that already populated **`trace.state.artifacts`** is left alone. The echo agentic fixture drops its task-level **`finalize`** in favor of this path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0df3f33b386c210b44d3f4c9f5d0a4bc3926decb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `collect_artifacts` flag to `Rollout` and `Agent.run` for isolated judge rollouts
> - Adds a `collect_artifacts` boolean parameter (default `False`) to `Rollout.__init__`, `Agent.run`, `Agent._run_once`, and `_EpisodeAgent.run`, propagating the flag through to the rollout.
> - When `collect_artifacts=True`, `Rollout.close` collects artifacts via `collect(runtime, self.task.data.artifacts)` after `task.finalize` if `trace.state.artifacts` is still empty. `IsolatedAgenticJudgeEnv.run` now passes `collect_artifacts=True` to the solver agent so judge can access solver-produced artifacts.
> - Replaces `asyncio.wait_for` with an `asyncio.timeout` context manager in `Rollout.close` for the finalize phase; timeout behavior is unchanged.
> - Removes the `EchoAgenticTask.finalize` method in the test fixture since artifact collection is now handled by the rollout.
> - Risk: `Agent._run_once` raises `TypeError` when `collect_artifacts=True` and the resolved runtime is a `SubprocessConfig`; callers passing the flag with a subprocess runtime will fail at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0df3f33.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->