### PR TITLE
Isolate Docker runtime networking

### DIFF
--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -253,9 +253,9 @@ async def serve_in_runtime(
 ) -> int:
     """Start a server and return its bound port.
 
-    Exposed remote servers must use the runtime's forwarded port. Local or colocated servers let
-    the OS choose and report the result through a file. With a state channel, the server fetches
-    the current rollout task from the adjacent `/task` endpoint rather than a launch argument.
+    Exposed servers must use the runtime's forwarded port. Colocated servers let the OS choose and
+    report the result through a file. With a state channel, the server fetches the current rollout
+    task from the adjacent `/task` endpoint rather than a launch argument.
     """
     # A shared server has a private service secret but no fixed state URL. Set
     # both controls explicitly so a subprocess cannot inherit stale host values.
@@ -268,7 +268,7 @@ async def serve_in_runtime(
         # Keep provider temp files in the runtime workdir so cleanup removes them.
         assert runtime.info.id is not None
         env["TMPDIR"] = runtime.info.id
-    if runtime.published_port is not None:
+    if exposed and runtime.published_port is not None:
         env["MCP_HOST"] = "0.0.0.0"
     fixed = runtime.published_port if exposed else None
     port_file = None
@@ -322,17 +322,23 @@ async def reachable_url(
     runtime; `consumer_is_local` = the consumer can use a host-local URL without a tunnel.
 
     - `colocated` -> localhost (same runtime, in-sandbox or host loopback);
-    - the server runs in a remote sandbox -> its own published URL (`expose`), reachable anywhere;
-    - else it's host-local -> localhost to a local consumer, a host tunnel to a remote one."""
+    - a non-colocated sandbox service -> its published URL (`expose`), when available;
+    - a host-local URL -> direct for a local consumer, through a host tunnel for a remote one."""
     if colocated:
         yield f"http://127.0.0.1:{port}"
-    elif not service.is_local:  # in a remote sandbox → it publishes its own port
-        yield await service.expose(port)
-    elif consumer_is_local:  # local consumer → localhost, no public tunnel
-        yield f"http://127.0.0.1:{port}"
-    else:  # remote consumer → a host tunnel publishes the port outward
-        async with PrimeTunnel().expose(port) as url:
-            yield url
+    elif published := await service.expose(port):
+        if service.is_local and not consumer_is_local:
+            published_port = urlsplit(published).port
+            if published_port is None:
+                raise ToolsetError(
+                    f"{service.type} runtime exposed an invalid URL: {published}"
+                )
+            async with PrimeTunnel().expose(published_port) as url:
+                yield url
+        else:
+            yield published
+    else:
+        raise ToolsetError(f"{service.type} runtime did not expose service port {port}")
 
 
 @dataclass(frozen=True)

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -43,9 +43,8 @@ _ENSURE_UV = (
     f"|| {{ {_INSTALL_CURL}; {_DOWNLOAD_UV}; }}"
 )
 
-# The single port a self-publishing runtime (modal/prime) forwards to a public URL for a server
-# hosted in its sandbox. A server placed in such a runtime binds this (on 0.0.0.0) and is reached
-# at the runtime's public URL.
+# The single port a runtime reserves for a non-colocated server. The server binds this on
+# 0.0.0.0; `expose()` returns either its provider URL or a host port mapping.
 SERVICE_PORT = 8000
 
 
@@ -383,13 +382,12 @@ class Runtime(ABC):
         """A fixed port this runtime exposes to the outside at startup, declared up front to the
         provider (Modal forwards only ports named at `Sandbox.create`). When set, a server placed
         here binds it instead of a host-chosen free port, and `expose` returns its public URL.
-        `None` for local runtimes (subprocess/docker), which pick a free port."""
+        `None` for runtimes without a reserved service port."""
         return None
 
     async def expose(self, port: int) -> str | None:
         """Publish a port running *inside this runtime* to a URL reachable from the host/outside,
-        or None when local. A remote runtime overrides this with the provider's native port
-        exposure (modal `tunnels()`, prime `client.expose`), torn down with the sandbox in
-        `stop()`. The reverse of a host `Tunnel` (interception.tunnel, which reaches a host
-        port from inside a runtime)."""
-        return None
+        or None when unavailable. Local runtimes use host loopback; sandbox runtimes override
+        this with a provider URL or local port mapping, torn down in `stop()`. The reverse of a
+        host `Tunnel` (interception.tunnel, which reaches a host port from inside a runtime)."""
+        return f"http://127.0.0.1:{port}"

--- a/verifiers/v1/runtimes/docker/__init__.py
+++ b/verifiers/v1/runtimes/docker/__init__.py
@@ -3,6 +3,7 @@
 import array
 import asyncio
 import contextlib
+import json
 import logging
 import shlex
 import socket
@@ -18,13 +19,19 @@ from urllib.parse import urlsplit
 from verifiers.v1.configs.runtime import NetworkPolicyConfig
 from verifiers.v1.errors import SandboxError
 from verifiers.v1.runtimes.base import (
+    SERVICE_PORT,
     BaseRuntimeInfo,
     ProgramResult,
     Runtime,
     RuntimeProcess,
     parse_gpu,
 )
-from verifiers.v1.runtimes.docker.egress import HOST_ALIAS, EgressProxy, NetworkPolicy
+from verifiers.v1.runtimes.docker.egress import (
+    HOST_ALIAS,
+    EgressProxy,
+    NetworkPolicy,
+    is_loopback_host,
+)
 from verifiers.v1.utils.aio import run_shielded
 
 logger = logging.getLogger(__name__)
@@ -127,6 +134,10 @@ async def docker(*args: str) -> ProgramResult:
     )
 
 
+def _environment_args(env: dict[str, str]) -> list[str]:
+    return [arg for key, value in env.items() for arg in ("--env", f"{key}={value}")]
+
+
 async def _abort_process_startup(
     proc: asyncio.subprocess.Process, container: str, pidfile: str
 ) -> str:
@@ -181,10 +192,16 @@ class DockerRuntime(Runtime):
         self.config = config
         self.info = DockerRuntimeInfo(**config.model_dump())
         self._container: str | None = None  # our `--name` (used for exec/rm)
+        self._image_env: dict[str, str] = {}
         self._proxy: EgressProxy | None = None
         self._proxy_host_ip: str | None = None
+        self._service_url: str | None = None
         self._stopped = False
         self._cut = False
+
+    @property
+    def published_port(self) -> int | None:
+        return SERVICE_PORT
 
     async def start(self) -> None:
         try:
@@ -205,7 +222,6 @@ class DockerRuntime(Runtime):
             raise RuntimeError(
                 f"docker runtime selected but the Docker daemon is not reachable: {detail}{hint}"
             )
-        self._container = self.name
         limits: list[str] = []
         if self.config.cpu is not None:
             limits += ["--cpus", str(self.config.cpu)]
@@ -215,10 +231,14 @@ class DockerRuntime(Runtime):
         if gpu_count:
             limits += ["--gpus", str(gpu_count)]
         restricted = self.network_restricted
+        options = [
+            "--network",
+            "bridge",
+            "--publish",
+            f"127.0.0.1::{SERVICE_PORT}",
+        ]
         if restricted:
-            network = [
-                "--network",
-                "bridge",
+            options += [
                 "--cap-drop",
                 "NET_ADMIN",
                 "--cap-drop",
@@ -229,43 +249,84 @@ class DockerRuntime(Runtime):
                 "net.ipv6.conf.all.disable_ipv6=1",
             ]
             if sys.platform != "linux":
-                network += ["--add-host", f"{_PROXY_HOST}:host-gateway"]
+                options += ["--add-host", f"{_PROXY_HOST}:host-gateway"]
         else:
-            network = ["--network", "host"]
-        env_args = [
-            arg
-            for key, value in self.env.items()
-            for arg in ("--env", f"{key}={value}")
-        ]
+            options += ["--add-host", f"{HOST_ALIAS}:host-gateway"]
+        self._container = self.name
         run = await docker(
             "run",
             "--detach",
-            *network,
+            *options,
             *limits,
-            *env_args,
+            *_environment_args(self.env),
             "--workdir",
             self.config.workdir,
             "--entrypoint",
             "sleep",
             "--name",
-            self._container,
+            self.name,
             self.config.image,
             "infinity",
         )
         if run.exit_code != 0:
             raise SandboxError(f"docker run failed: {run.stderr.strip()}")
-        self.info.id = run.stdout.strip()[
-            :12
-        ]  # `docker run -d` prints the container id
-        if restricted:
-            # Setup is trusted; colocated servers fetch their task from host interception
-            # before the final framework routes are known.
+        self.info.id = run.stdout.strip()[:12]
+        try:
+            image_env = await docker(
+                "inspect", "--format", "{{json .Config.Env}}", self._container
+            )
+            if image_env.exit_code != 0:
+                raise SandboxError(
+                    f"docker environment inspection failed: {image_env.stderr.strip()}"
+                )
+            try:
+                values = json.loads(image_env.stdout)
+                self._image_env = dict(value.split("=", 1) for value in values or [])
+            except (TypeError, ValueError) as error:
+                raise SandboxError(
+                    "docker returned invalid container environment"
+                ) from error
+            published = await docker("port", self._container, f"{SERVICE_PORT}/tcp")
+            lines = published.stdout.strip().splitlines()
+            host, separator, port = lines[0].rpartition(":") if lines else ("", "", "")
+            if (
+                published.exit_code != 0
+                or host != "127.0.0.1"
+                or not separator
+                or not port.isdigit()
+            ):
+                detail = (published.stderr or published.stdout).strip()
+                raise SandboxError(
+                    "container engine did not publish the Docker runtime service port "
+                    f"on host loopback: {detail}"
+                )
+            self._service_url = f"http://127.0.0.1:{port}"
+            # Restricted runtimes enforce policy through the proxy; unrestricted
+            # runtimes use it only for tokenized callbacks to host-loopback services.
             self._proxy = EgressProxy(
                 NetworkPolicy(
-                    NetworkPolicyConfig(), [HOST_ALIAS], allow_non_global=True
+                    NetworkPolicyConfig(),
+                    [HOST_ALIAS] if restricted else [],
+                    allow_non_global=restricted,
                 )
             )
-            if sys.platform == "linux":
+            if not restricted:
+                hosts = await docker("exec", self._container, "cat", "/etc/hosts")
+                host_gateway = None
+                for line in hosts.stdout.splitlines():
+                    fields = line.split()
+                    if HOST_ALIAS in fields[1:]:
+                        host_gateway = fields[0]
+                        break
+                if hosts.exit_code != 0 or host_gateway is None:
+                    raise SandboxError(
+                        "container engine did not provide the host-gateway mapping "
+                        "required for Docker runtime callbacks"
+                    )
+                await self._proxy.start(
+                    host_gateway if sys.platform == "linux" else "127.0.0.1"
+                )
+            elif sys.platform == "linux":
                 await self._proxy.start(listener=await self._container_listener())
             else:
                 host = await docker(
@@ -281,6 +342,13 @@ class DockerRuntime(Runtime):
                         f"could not resolve {_PROXY_HOST} in Docker: {host.stderr.strip()}"
                     )
                 await self._proxy.start("127.0.0.1")
+        except BaseException:
+            try:
+                if self._proxy is not None:
+                    await self._proxy.stop()
+            finally:
+                await asyncio.to_thread(self.cleanup)
+            raise
         logger.info(
             "docker: started container %s (image=%s)",
             self._container,
@@ -305,9 +373,9 @@ class DockerRuntime(Runtime):
                     "DAC_OVERRIDE",
                     "--security-opt",
                     "no-new-privileges",
-                    "--mount",
-                    f"type=bind,source={directory},target=/run/vf",
-                    "python:3.11-alpine",
+                    "--volume",
+                    f"{directory}:/run/vf:Z",
+                    "docker.io/library/python:3.11-alpine",
                     "python3",
                     "-c",
                     _PASS_LISTENER,
@@ -328,18 +396,43 @@ class DockerRuntime(Runtime):
         return listener
 
     def host_url(self, url: str) -> str:
-        host = urlsplit(url).hostname
-        # Keep numeric loopback container-local; the proxy maps this reserved name to
-        # the Verifiers process's loopback for interception and host-local MCP routes.
-        if self.network_restricted and host in ("127.0.0.1", "localhost"):
-            return url.replace(host, HOST_ALIAS, 1)
-        if (
-            not self.network_restricted
-            and sys.platform != "linux"
-            and host in ("127.0.0.1", "localhost")
-        ):
-            return url.replace(host, "host.docker.internal", 1)
-        return url
+        parsed = urlsplit(url)
+        host = (parsed.hostname or "").lower().rstrip(".")
+        if not is_loopback_host(host):
+            return url
+        if parsed.scheme != "http":
+            raise ValueError(
+                "Docker host callbacks support only http URLs; transparent TLS "
+                "forwarding is unavailable across a private network namespace"
+            )
+        if self.network_restricted:
+            if not (
+                host == "localhost"
+                or host.endswith(".localhost")
+                or host.startswith("127.")
+            ):
+                raise ValueError(
+                    "restricted Docker host callbacks require an IPv4 loopback URL"
+                )
+            userinfo, separator, _ = parsed.netloc.rpartition("@")
+            netloc = f"{userinfo}{separator}{HOST_ALIAS}"
+            if parsed.port is not None:
+                netloc = f"{netloc}:{parsed.port}"
+            callback = parsed._replace(netloc=netloc).geturl()
+            assert self._proxy is not None
+            route = urlsplit(callback)._replace(path="", query="", fragment="").geturl()
+            if route not in self._proxy.policy.routes:
+                self._proxy.policy.routes.append(route)
+            return callback
+        assert self._proxy is not None
+        return self._proxy.callback_url(url)
+
+    async def expose(self, port: int) -> str:
+        if port != SERVICE_PORT or self._service_url is None:
+            raise SandboxError(
+                f"docker service port {port} was not published by this runtime"
+            )
+        return self._service_url
 
     async def prepare_execution(self, routes: list[str] | None) -> None:
         """Allow the declared framework routes, then leave the proxy as the only route."""
@@ -359,23 +452,25 @@ class DockerRuntime(Runtime):
         if self._cut:
             return
         script = (
-            "set -eu; HOST=$1; "
-            "PORT=$2; "
-            'if [ -n "$HOST" ]; then apk add --no-cache iptables >/dev/null; fi; '
-            "GW=$(ip route show default | awk '/^default via/{print $3; exit}'); "
-            "SUBNET=$(ip route show | awk '/scope link/{print $1; exit}'); "
-            'if [ -n "$HOST" ]; then '
-            'if [ "$HOST" = "$GW" ]; then ip route add "$HOST/32" dev eth0; '
-            'else ip route add "$HOST/32" via "$GW"; '
-            'ip route add "$GW/32" dev eth0; fi; '
-            "fi; "
-            "ip route del default; "
-            'ip route del "$SUBNET" dev eth0; '
+            "set -eu; HOST=$1; PORT=$2; "
+            "apk add --no-cache iptables >/dev/null; "
+            "ROUTE=$(ip -4 route show default); "
+            "DEV=$(printf '%s\\n' \"$ROUTE\" | awk '{ for (i = 1; i <= NF; i++) "
+            'if ($i == "dev") { print $(i + 1); exit } }\'); '
+            "GW=$(printf '%s\\n' \"$ROUTE\" | awk '{ for (i = 1; i <= NF; i++) "
+            'if ($i == "via") { print $(i + 1); exit } }\'); '
+            "ip -4 route flush table main; ip -6 route flush table main || true; "
             "ip route add blackhole 127.0.0.11/32 table local; "
-            'if [ -n "$HOST" ]; then iptables -F OUTPUT; '
-            "iptables -A OUTPUT -o lo -j ACCEPT; "
-            'iptables -A OUTPUT -d "$HOST" -p tcp --dport "$PORT" -j ACCEPT; '
-            "iptables -A OUTPUT -j REJECT; fi"
+            'if [ -n "$GW" ]; then '
+            'ip -4 route add "$GW/32" dev "$DEV"; '
+            'ip -4 route add default via "$GW" dev "$DEV"; '
+            'else ip -4 route add default dev "$DEV"; fi; '
+            "iptables -F OUTPUT; iptables -A OUTPUT -o lo -j ACCEPT; "
+            "iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED "
+            "--ctdir REPLY -j ACCEPT; "
+            'if [ -n "$HOST" ]; then iptables -A OUTPUT -d "$HOST" '
+            '-p tcp --dport "$PORT" -j ACCEPT; fi; '
+            "iptables -A OUTPUT -j REJECT"
         )
         cut = await docker(
             "run",
@@ -386,7 +481,7 @@ class DockerRuntime(Runtime):
             "ALL",
             "--cap-add",
             "NET_ADMIN",
-            "alpine:3.22",
+            "docker.io/library/alpine:3.22",
             "sh",
             "-c",
             script,
@@ -399,8 +494,7 @@ class DockerRuntime(Runtime):
         self._cut = True
 
     def _proxy_env(self) -> dict[str, str]:
-        if self._proxy is None:
-            return {}
+        assert self._proxy is not None
         host = "127.0.0.1" if sys.platform == "linux" else _PROXY_HOST
         proxy = f"http://verifiers:{self._proxy.token}@{host}:{self._proxy.port}"
         return {
@@ -412,14 +506,34 @@ class DockerRuntime(Runtime):
             "no_proxy": "localhost,127.0.0.1",
         }
 
+    def _container_env(
+        self, env: dict[str, str], *, use_policy_proxy: bool
+    ) -> dict[str, str]:
+        env = self.process_env(env)
+        if use_policy_proxy:
+            return {**env, **self._proxy_env()}
+        if self.network_restricted:
+            return env
+        no_proxy = dict.fromkeys(
+            entry.strip()
+            for key in ("NO_PROXY", "no_proxy")
+            for value in (env.get(key, ""), self._image_env.get(key, ""))
+            for entry in value.split(",")
+            if entry.strip()
+        )
+        no_proxy.update(dict.fromkeys(("localhost", "127.0.0.1", HOST_ALIAS)))
+        bypass = ",".join(no_proxy)
+        return {**env, "NO_PROXY": bypass, "no_proxy": bypass}
+
     async def teardown(self) -> None:
         if self._proxy is not None:
             await self._proxy.stop()
         await super().teardown()
 
     async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
-        env = {**self.process_env(env), **(self._proxy_env() if self._cut else {})}
-        env_args = [arg for k, v in env.items() for arg in ("--env", f"{k}={v}")]
+        env_args = _environment_args(
+            self._container_env(env, use_policy_proxy=self._cut)
+        )
         return await docker(
             "exec", *env_args, "--workdir", self.config.workdir, self._container, *argv
         )
@@ -428,10 +542,9 @@ class DockerRuntime(Runtime):
         self, argv: list[str], env: dict[str, str]
     ) -> RuntimeProcess:
         assert self._container is not None
-        env = {**self.process_env(env), **(self._proxy_env() if self._cut else {})}
-        env_args = [
-            arg for key, value in env.items() for arg in ("--env", f"{key}={value}")
-        ]
+        env_args = _environment_args(
+            self._container_env(env, use_policy_proxy=self._cut)
+        )
         pidfile = f"/tmp/vf-process-{uuid.uuid4().hex}.pid"
         # Give the target its own process group when `setsid -w` is available so
         # terminate()/kill() reap its descendants while docker exec remains
@@ -488,9 +601,10 @@ class DockerRuntime(Runtime):
     async def run_background(
         self, argv: list[str], env: dict[str, str], log: str
     ) -> None:
-        # Detached servers survive the cut, so they need the initially permissive proxy.
-        env = {**self.process_env(env), **self._proxy_env()}
-        env_args = [arg for k, v in env.items() for arg in ("--env", f"{k}={v}")]
+        # A detached restricted server survives the cut, so it needs the policy proxy.
+        env_args = _environment_args(
+            self._container_env(env, use_policy_proxy=self.network_restricted)
+        )
         inner = f"{' '.join(shlex.quote(a) for a in argv)} > {shlex.quote(log)} 2>&1"
         run = await docker(
             "exec",
@@ -550,9 +664,7 @@ class DockerRuntime(Runtime):
     def cleanup(self) -> None:
         if self._container is None or self._stopped:
             return
-        self._stopped = (
-            True  # idempotency guard; keep `_container` so the name still shows
-        )
+        self._stopped = True
         logger.debug("docker: removing container %s", self._container)
         with contextlib.suppress(Exception):
             subprocess.run(

--- a/verifiers/v1/runtimes/docker/egress.py
+++ b/verifiers/v1/runtimes/docker/egress.py
@@ -1,4 +1,4 @@
-"""In-process HTTP(S) policy proxy for network-filtered Docker runtimes."""
+"""In-process HTTP(S) proxy for Docker policy and host callbacks."""
 
 import asyncio
 import base64
@@ -9,19 +9,33 @@ import socket
 import ssl
 from dataclasses import dataclass
 from ipaddress import ip_address
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import urljoin, urlsplit, urlunsplit
 
 import h11
 
 from verifiers.v1.configs.runtime import NetworkPolicyConfig, network_rule_matches
 
 HOST_ALIAS = "vf.host.internal"
+_CALLBACK_PREFIX = "/.vf-host/"
 _HEADER_TIMEOUT = 10
 _IO_TIMEOUT = 300
 
 
-async def _read(reader: asyncio.StreamReader) -> bytes:
-    return await asyncio.wait_for(reader.read(1 << 16), _IO_TIMEOUT)
+def is_loopback_host(host: str) -> bool:
+    host = host.lower().rstrip(".")
+    if host == "localhost" or host.endswith(".localhost"):
+        return True
+    try:
+        address = ip_address(host)
+    except ValueError:
+        return False
+    return (getattr(address, "ipv4_mapped", None) or address).is_loopback
+
+
+async def _read(
+    reader: asyncio.StreamReader, timeout: float | None = _IO_TIMEOUT
+) -> bytes:
+    return await asyncio.wait_for(reader.read(1 << 16), timeout)
 
 
 async def _drain(writer: asyncio.StreamWriter) -> None:
@@ -50,20 +64,15 @@ class NetworkPolicy:
             )
         ):
             return False
-        hostname = host.lower().rstrip(".")
-        # `localhost` is container-local and bypasses this host-side proxy. Never dial
-        # the host's namesake address, even if a colocated service appears in routes.
-        if hostname == "localhost" or hostname.endswith(".localhost"):
+        # Loopback framework services are container-local and bypass this proxy. Host
+        # callbacks use HOST_ALIAS, so proxying a loopback name would expose the host.
+        if is_loopback_host(host):
             return False
         # Framework routes are invariants, not user egress, so they cannot be blocked.
         if any(
             network_rule_matches(route, scheme, host, port) for route in self.routes
         ):
             return True
-        # The proxy dials from the host, so only framework routes may use host loopback.
-        with contextlib.suppress(ValueError):
-            if ip_address(hostname).is_loopback:
-                return False
         return self.config.permits(scheme, host, port)
 
 
@@ -105,6 +114,15 @@ async def _read_client_hello(
     return bytes(records), server_name
 
 
+@dataclass(frozen=True)
+class _Callback:
+    host: str
+    port: int
+    authority: str
+    host_alias: str
+    forward_authorization: bool
+
+
 class EgressProxy:
     def __init__(self, policy: NetworkPolicy) -> None:
         self.policy = policy
@@ -112,8 +130,41 @@ class EgressProxy:
         self._authorization = b"Basic " + base64.b64encode(
             f"verifiers:{self.token}".encode()
         )
+        self._callbacks: dict[str, _Callback] = {}
+        self._callback_tokens: dict[tuple[str, int, str, str, bool], str] = {}
         self.server: asyncio.Server | None = None
         self.port = 0
+
+    def callback_url(
+        self,
+        url: str,
+        host_alias: str = HOST_ALIAS,
+        *,
+        forward_authorization: bool = True,
+    ) -> str:
+        """Route one framework-owned host-loopback HTTP origin through this proxy."""
+        parsed = urlsplit(url)
+        host = (parsed.hostname or "").lower().rstrip(".")
+        if parsed.scheme != "http" or not is_loopback_host(host):
+            raise ValueError(f"unsupported Docker host callback URL: {url}")
+        port = parsed.port if parsed.port is not None else 80
+        authority = parsed.netloc.rpartition("@")[2]
+        key = (host, port, authority, host_alias, forward_authorization)
+        token = self._callback_tokens.get(key)
+        if token is None:
+            token = secrets.token_urlsafe(32)
+            self._callback_tokens[key] = token
+            self._callbacks[token] = _Callback(
+                host=host,
+                port=port,
+                authority=authority,
+                host_alias=host_alias,
+                forward_authorization=forward_authorization,
+            )
+        userinfo, separator, _ = parsed.netloc.rpartition("@")
+        netloc = f"{userinfo}{separator}{host_alias}:{self.port}"
+        path = f"{_CALLBACK_PREFIX}{token}{parsed.path}"
+        return urlunsplit(("http", netloc, path, parsed.query, parsed.fragment))
 
     async def start(
         self, bind_host: str | None = None, *, listener: socket.socket | None = None
@@ -146,6 +197,17 @@ class EgressProxy:
             request = client.next_event()
             if not isinstance(request, h11.Request):
                 raise TypeError("expected an HTTP request")
+            method = request.method.decode("ascii")
+            target = request.target.decode("ascii")
+            parsed = urlsplit(target)
+            callback = None
+            if method != "CONNECT" and parsed.path.startswith(_CALLBACK_PREFIX):
+                token, separator, path = parsed.path[len(_CALLBACK_PREFIX) :].partition(
+                    "/"
+                )
+                callback = self._callbacks.get(token)
+                if callback is not None:
+                    parsed = parsed._replace(path=f"/{path}" if separator else "/")
             authorization = next(
                 (
                     value
@@ -154,7 +216,9 @@ class EgressProxy:
                 ),
                 b"",
             )
-            if not hmac.compare_digest(authorization, self._authorization):
+            if callback is None and not hmac.compare_digest(
+                authorization, self._authorization
+            ):
                 response_started = True
                 writer.write(
                     b"HTTP/1.1 407 Proxy Authentication Required\r\n"
@@ -163,10 +227,10 @@ class EgressProxy:
                 )
                 await _drain(writer)
                 return
-            method = request.method.decode("ascii")
-            target = request.target.decode("ascii")
             connect = method == "CONNECT"
-            if connect:
+            if callback is not None:
+                scheme, host, port = "http", callback.host, callback.port
+            elif connect:
                 parsed = urlsplit(f"//{target}")
                 host, port = parsed.hostname or "", parsed.port or 443
                 # Some HTTP clients tunnel plain HTTP through CONNECT. Only an
@@ -186,12 +250,17 @@ class EgressProxy:
                 scheme = parsed.scheme.lower()
                 host = parsed.hostname or ""
                 port = parsed.port or (443 if scheme == "https" else 80)
-            permitted = (connect or scheme == "http") and self.policy.permits(
-                scheme, host, port, connect=connect
+            permitted = callback is not None or (
+                (connect or scheme == "http")
+                and self.policy.permits(scheme, host, port, connect=connect)
             )
             addresses = []
             if permitted:
-                dial_host = "127.0.0.1" if host.lower() == HOST_ALIAS else host
+                dial_host = host
+                if host.lower() == HOST_ALIAS:
+                    dial_host = "127.0.0.1"
+                elif callback is not None and host.lower().endswith(".localhost"):
+                    dial_host = "localhost"
                 addresses = await asyncio.wait_for(
                     asyncio.get_running_loop().getaddrinfo(
                         dial_host, port, type=socket.SOCK_STREAM
@@ -202,7 +271,11 @@ class EgressProxy:
                     network_rule_matches(route, scheme, host, port)
                     for route in self.policy.routes
                 )
-                if not framework and not self.policy.allow_non_global:
+                if (
+                    callback is None
+                    and not framework
+                    and not self.policy.allow_non_global
+                ):
                     for *_, address in addresses:
                         resolved = ip_address(address[0])
                         mapped = getattr(resolved, "ipv4_mapped", None)
@@ -248,10 +321,14 @@ class EgressProxy:
                     await _drain(upstream_writer)
                 await _relay(reader, writer, upstream_reader, upstream_writer)
             else:
+                read_timeout = None if callback is not None else _IO_TIMEOUT
                 path = urlunsplit(("", "", parsed.path or "/", parsed.query, ""))
-                authority = f"[{host}]" if ":" in host else host
-                if port != (443 if scheme == "https" else 80):
-                    authority = f"{authority}:{port}"
+                if callback is not None:
+                    authority = callback.authority
+                else:
+                    authority = f"[{host}]" if ":" in host else host
+                    if port != (443 if scheme == "https" else 80):
+                        authority = f"{authority}:{port}"
                 connection_fields = {
                     field.strip().lower()
                     for name, value in request.headers
@@ -271,8 +348,22 @@ class EgressProxy:
                     b"upgrade",
                     *connection_fields,
                 }
+                if callback is not None and not callback.forward_authorization:
+                    excluded.add(b"authorization")
+                origin_rewrites = (
+                    {
+                        f"http://{callback.host_alias}:{self.port}".lower().encode(): f"http://{callback.authority}".encode()
+                    }
+                    if callback is not None
+                    else {}
+                )
                 headers = [
-                    (name, value)
+                    (
+                        name,
+                        origin_rewrites.get(value.lower(), value)
+                        if name.lower() == b"origin"
+                        else value,
+                    )
                     for name, value in request.headers
                     if name.lower() not in excluded
                 ]
@@ -305,7 +396,7 @@ class EgressProxy:
                 while True:
                     event = client.next_event()
                     if event is h11.NEED_DATA:
-                        client.receive_data(await _read(reader))
+                        client.receive_data(await _read(reader, read_timeout))
                     elif isinstance(event, h11.Data):
                         upstream_writer.write(upstream.send(event))
                         await _drain(upstream_writer)
@@ -317,10 +408,66 @@ class EgressProxy:
                 await _drain(upstream_writer)
                 # Plain HTTP gets exactly one policy check and one request. Never copy
                 # pipelined bytes into the first request's already-selected upstream.
-                while chunk := await _read(upstream_reader):
-                    response_started = True
-                    writer.write(chunk)
-                    await _drain(writer)
+                if callback is not None:
+                    while True:
+                        head = await asyncio.wait_for(
+                            upstream_reader.readuntil(b"\r\n\r\n"), read_timeout
+                        )
+                        upstream.receive_data(head)
+                        response = upstream.next_event()
+                        if not isinstance(
+                            response, (h11.InformationalResponse, h11.Response)
+                        ):
+                            raise TypeError("expected an HTTP response")
+                        headers = []
+                        for name, value in response.headers:
+                            if name.lower() == b"location":
+                                destination = urljoin(
+                                    f"http://{callback.authority}{path}",
+                                    value.decode("latin-1"),
+                                )
+                                redirected = urlsplit(destination)
+                                redirect_host = (
+                                    (redirected.hostname or "").lower().rstrip(".")
+                                )
+                                if redirected.scheme == "http" and is_loopback_host(
+                                    redirect_host
+                                ):
+                                    redirect_port = (
+                                        redirected.port
+                                        if redirected.port is not None
+                                        else 80
+                                    )
+                                    value = self.callback_url(
+                                        destination,
+                                        callback.host_alias,
+                                        forward_authorization=(
+                                            callback.forward_authorization
+                                            and redirect_host == callback.host
+                                            and redirect_port == callback.port
+                                        ),
+                                    ).encode("latin-1")
+                            headers.append((name, value))
+                        response = type(response)(
+                            status_code=response.status_code,
+                            headers=headers,
+                            http_version=response.http_version,
+                            reason=response.reason,
+                        )
+                        response_started = True
+                        writer.write(client.send(response))
+                        await _drain(writer)
+                        if isinstance(response, h11.Response):
+                            break
+                    while chunk := await _read(upstream_reader, read_timeout):
+                        response_started = True
+                        writer.write(chunk)
+                        await _drain(writer)
+                else:
+                    while chunk := await _read(upstream_reader):
+                        response_started = True
+                        writer.write(chunk)
+                        await _drain(writer)
         except Exception:  # noqa: BLE001 - proxy failures become a generic 502
             if not response_started:
                 with contextlib.suppress(Exception):


### PR DESCRIPTION
Superseded by #2528.

## Overview

Give each Docker runtime its own network namespace so task services cannot collide with listeners on the host. Closes #2319.

## Details

- Run containers directly on Docker's bridge network and publish the reserved runtime service port on host loopback.
- Make mapped exposure part of `Runtime.expose()` so MCP URLs remain reachable without host networking.
- Route only framework-owned HTTP loopback callbacks through a token-scoped relay, preserving callback redirects without rewriting response bodies or cookies.
- Keep namespace isolation separate from restricted-egress enforcement and preserve published-port replies when restricted routing is active.
- Merge image and process `NO_PROXY` exclusions into the runtime environment used for execution.

The callback relay intentionally supports framework-owned HTTP endpoints. It rewrites loopback `Location` headers to keep redirects reachable, but it does not rewrite application cookies or provide transparent TLS forwarding.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core Docker networking, MCP reachability, and egress/callback security boundaries; misconfiguration or kernel differences in the iptables cut could break sandboxes or leak host access.
> 
> **Overview**
> **Docker runtimes no longer use host networking.** Containers run on bridge, reserve `SERVICE_PORT` (8000), and publish it to a host-chosen **127.0.0.1** port so task listeners cannot collide with the host.
> 
> **Exposure and MCP URLs** are unified on `Runtime.expose()`: the base implementation now returns `http://127.0.0.1:{port}` instead of `None`; `DockerRuntime` returns the recorded mapped URL. `reachable_url` always goes through `expose`, opens a `PrimeTunnel` when a **local** runtime must be reached from a **remote** consumer, and fails clearly if exposure is missing. `serve_in_runtime` binds `0.0.0.0` only when the server is **exposed** and the runtime has a `published_port`.
> 
> **Host-loopback callbacks** from inside Docker go through `EgressProxy.callback_url` (tokenized `/.vf-host/` paths) in unrestricted mode, with `Origin` / `Location` rewriting so HTTP redirects stay reachable; restricted mode still uses `HOST_ALIAS` and dynamic route registration. Policy egress treats all loopback targets as non-proxyable.
> 
> **Restricted egress** gets a reworked route flush + iptables cut (conntrack for replies, minimal default route). Unrestricted runtimes still start the proxy for callbacks only; exec/background env merges image and process `NO_PROXY` and applies the policy proxy only after the cut (or for detached restricted servers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d72db2a21590dfa5449db6e46d4bcd18afedcbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Isolate Docker runtime networking via bridge network and host-callback proxy
> - Docker runtime now uses bridge networking, publishes `SERVICE_PORT` (8000) to a random host loopback port, and always starts an `EgressProxy` — policy-enforced in restricted mode, callback-only in unrestricted mode.
> - `EgressProxy` gains tokenized host-callback routing so container-originated HTTP traffic can reach host-loopback services via stable proxy URLs, with correct header and redirect handling ([egress.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2469/files#diff-09ea94564846221a7800c3777052fe00328e68c1c119ee5cede79246889f2e96)).
> - MCP launch logic in [launch.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2469/files#diff-989d87123d40d48511f9e1df74594d2e30776e9a99c11eca49d9cc20bf9e2230) only sets `MCP_HOST` when `exposed=True` and the runtime has a `published_port`; `reachable_url` now selects a direct, exposed, or tunneled URL based on colocation.
> - Restricted-mode network cut in `prepare_execution` is reworked to use explicit `ip`/`iptables` routing rules; container environment composition is centralized in `_container_env`.
> - Risk: `Runtime.expose` default now returns `http://127.0.0.1:<port>` instead of `None`; callers that previously handled `None` from `expose()` need to adapt. `DockerRuntime.host_url` now raises `ValueError` for non-HTTP or non-loopback URLs where it previously may have passed through.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d72db2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->