### PR TITLE
Fix Modal process stdin writes

### DIFF
--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -71,7 +71,7 @@ class ModalProcess(RuntimeProcess):
         self.stderr: AsyncIterator[bytes] = process.stderr
 
     async def write(self, data: bytes) -> None:
-        await self._process.stdin.write.aio(data)
+        self._process.stdin.write(data)
         await self._process.stdin.drain.aio()
 
     async def wait(self) -> int:


### PR DESCRIPTION
## Summary

Fix persistent process stdin writes in the Modal runtime by using the synchronous write API before asynchronously draining the stream.

## Context

This was discovered while validating a persistent ACP harness against Modal. The first stdin write to an already-running process failed because stdin.write does not expose the Modal .aio interface. This is a generic Modal runtime fix rather than an ACP- or harness-specific workaround.

## Validation

- Reproduced the failure on current main with the locked Modal version
- Verified repeated writes to a live persistent Modal process
- Passed Ruff, formatting, type checking, non-E2E v1 tests, and focused pre-commit checks

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ModalProcess.write` to call `stdin.write` synchronously
> The `write` method in [modal.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2471/files#diff-a6217d92f043d6050e8609d4341d62b5d097d5db796f6197cd604e09d81683c0) now calls `stdin.write(data)` synchronously and only awaits `stdin.drain()`. Previously it awaited the write call itself via `.aio()`, which caused the bug this PR fixes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f3de328.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->