### PR TITLE
Add Apptainer runtime support

### DIFF
--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -73,6 +73,7 @@ from verifiers.v1.mcp import (
     ToolsetConfig,
 )
 from verifiers.v1.runtimes import (
+    ApptainerConfig,
     DockerConfig,
     PodmanConfig,
     PrimeConfig,
@@ -301,6 +302,7 @@ __all__ = [  # noqa: RUF022 - grouped by public API area
     "RuntimeInfo",
     "ProgramResult",
     "SubprocessConfig",
+    "ApptainerConfig",
     "DockerConfig",
     "PodmanConfig",
     "PrimeConfig",

--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -188,6 +188,10 @@ class _PacketReader:
             raise ValueError(f"ACP session packet is too large: {size} bytes")
         return json.loads((await self._readexactly(size)).decode())
 
+    async def close(self) -> None:
+        if close := getattr(self._source, "aclose", None):
+            await close()
+
 
 class ACPHarnessSession(HarnessSession):
     """A live ACP process, connection, and native session for one rollout."""
@@ -316,6 +320,9 @@ class ACPHarnessSession(HarnessSession):
                         metadata = result.get("response_metadata")
                         if isinstance(metadata, dict):
                             response_metadata = metadata
+            if reader is not None:
+                with contextlib.suppress(BaseException):
+                    await reader.close()
             for timeout, stop in (
                 (10 if graceful else 0.1, None),
                 (5, process.terminate),

--- a/verifiers/v1/runtimes/__init__.py
+++ b/verifiers/v1/runtimes/__init__.py
@@ -5,6 +5,11 @@ from typing import Annotated
 from pydantic import Field
 
 from verifiers.v1.configs.runtime import NetworkPolicyConfig
+from verifiers.v1.runtimes.apptainer import (
+    ApptainerConfig,
+    ApptainerRuntime,
+    ApptainerRuntimeInfo,
+)
 from verifiers.v1.runtimes.base import (
     BaseRuntimeInfo,
     ProgramResult,
@@ -34,7 +39,12 @@ from verifiers.v1.runtimes.subprocess import (
 )
 
 RuntimeConfig = Annotated[
-    SubprocessConfig | DockerConfig | PodmanConfig | PrimeConfig | ModalConfig,
+    SubprocessConfig
+    | DockerConfig
+    | PodmanConfig
+    | ApptainerConfig
+    | PrimeConfig
+    | ModalConfig,
     Field(discriminator="type"),
 ]
 
@@ -42,6 +52,7 @@ RuntimeInfo = Annotated[
     SubprocessRuntimeInfo
     | DockerRuntimeInfo
     | PodmanRuntimeInfo
+    | ApptainerRuntimeInfo
     | PrimeRuntimeInfo
     | ModalRuntimeInfo,
     Field(discriminator="type"),
@@ -57,6 +68,8 @@ def _runtime_cls(config: RuntimeConfig) -> type[Runtime]:
         return DockerRuntime
     if isinstance(config, PodmanConfig):
         return PodmanRuntime
+    if isinstance(config, ApptainerConfig):
+        return ApptainerRuntime
     return SubprocessRuntime
 
 
@@ -92,6 +105,9 @@ def runtime_is_local(config: RuntimeConfig) -> bool:
 
 
 __all__ = [
+    "ApptainerConfig",
+    "ApptainerRuntime",
+    "ApptainerRuntimeInfo",
     "BaseRuntimeInfo",
     "DockerConfig",
     "DockerRuntime",

--- a/verifiers/v1/runtimes/apptainer.py
+++ b/verifiers/v1/runtimes/apptainer.py
@@ -1,0 +1,489 @@
+"""Local Apptainer instance runtime."""
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import re
+import shutil
+import signal
+import subprocess
+import tempfile
+import threading
+import uuid
+from pathlib import Path, PurePosixPath
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from verifiers.v1.configs.runtime import NetworkPolicyConfig
+from verifiers.v1.errors import SandboxError
+from verifiers.v1.runtimes.attached import (
+    AttachedProcess,
+    open_attached_process,
+)
+from verifiers.v1.runtimes.base import (
+    BaseRuntimeInfo,
+    ProgramResult,
+    Runtime,
+)
+from verifiers.v1.utils.aio import run_shielded
+
+logger = logging.getLogger(__name__)
+
+_CLIENT_ENV_SUFFIXES = {
+    "AUTH_FILE",
+    "AUTHFILE",
+    "CACHEDIR",
+    "CONFIGDIR",
+    "DISABLE_CACHE",
+    "DOCKER_HOST",
+    "DOCKER_PASSWORD",
+    "DOCKER_USERNAME",
+    "DOWNLOAD_BUFFER_SIZE",
+    "DOWNLOAD_CONCURRENCY",
+    "DOWNLOAD_PART_SIZE",
+    "LIBRARY",
+    "TMPDIR",
+}
+_SINGLE_COLON_TRANSPORTS = {
+    "dir",
+    "docker-archive",
+    "docker-daemon",
+    "oci",
+    "oci-archive",
+}
+
+
+class ApptainerConfig(NetworkPolicyConfig):
+    type: Literal["apptainer"] = "apptainer"
+    image: str = Field(default="python:3.11-slim", min_length=1)
+    workdir: str = "/app"
+    cpu: float | None = Field(default=None, ge=0.01)
+    """CPU limit in cores. The host must support delegated cgroups v2."""
+    memory: float | None = Field(default=None, gt=0)
+    """Memory limit in GB. The host must support delegated cgroups v2."""
+    gpu: Literal["nvidia:all", "rocm:all"] | None = None
+    """Expose all accessible GPUs from one vendor; model/count isolation is unsupported."""
+    disk: None = None
+    """Apptainer has no portable unprivileged per-instance disk limit."""
+
+    @model_validator(mode="after")
+    def validate_apptainer(self) -> Self:
+        if self.network_restricted:
+            raise ValueError(
+                "Apptainer shares the host network and supports only unrestricted "
+                "networking; CNI isolation requires host administrator configuration"
+            )
+        path = PurePosixPath(self.workdir)
+        if (
+            not path.is_absolute()
+            or path == path.parent
+            or ".." in path.parts
+            or ":" in self.workdir
+            or "," in self.workdir
+        ):
+            raise ValueError(
+                "Apptainer workdir must be a non-root absolute container path without "
+                "'..', ':' or ','"
+            )
+        if not self.image.strip():
+            raise ValueError("Apptainer image must not be blank")
+        return self
+
+
+class ApptainerRuntimeInfo(ApptainerConfig, BaseRuntimeInfo):
+    pass
+
+
+async def apptainer(
+    *args: str,
+    env: dict[str, str] | None = None,
+    input: bytes | None = None,
+    client_started: asyncio.Event | None = None,
+) -> ProgramResult:
+    process = await asyncio.create_subprocess_exec(
+        "apptainer",
+        *args,
+        env=env,
+        stdin=asyncio.subprocess.PIPE if input is not None else None,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        start_new_session=True,
+    )
+    if client_started is not None:
+        client_started.set()
+    try:
+        stdout, stderr = await process.communicate(input=input)
+    except BaseException:
+        if process.returncode is None:
+            with contextlib.suppress(ProcessLookupError, PermissionError):
+                os.killpg(process.pid, signal.SIGKILL)
+        await run_shielded(process.communicate())
+        raise
+    return ProgramResult(
+        exit_code=process.returncode or 0,
+        stdout=stdout.decode(errors="replace"),
+        stderr=stderr.decode(errors="replace"),
+    )
+
+
+def image_reference(image: str) -> str:
+    """Map Docker shorthand to its URI while preserving Apptainer-native references."""
+    transport, separator, _ = image.partition(":")
+    if "://" in image or (separator and transport in _SINGLE_COLON_TRANSPORTS):
+        return image
+    path = Path(image).expanduser()
+    name = image.rsplit("/", 1)[-1]
+    if image.startswith(("/", "./", "../", "~")) or (
+        path.suffix.lower() in {".sif", ".sqsh", ".img"}
+        and ":" not in name
+        and path.is_file()
+    ):
+        return str(path.resolve())
+    return f"docker://{image}"
+
+
+class ApptainerRuntime(Runtime):
+    def __init__(self, config: ApptainerConfig, name: str | None = None) -> None:
+        super().__init__(name)
+        # Task resources are applied with model_copy(), so revalidate here before
+        # provisioning to reject unsupported disk and GPU requests.
+        self.config = ApptainerConfig.model_validate(config.model_dump())
+        self.info = ApptainerRuntimeInfo(**self.config.model_dump())
+        # Instance names are user-global, so cleanup owns a private identifier rather
+        # than the caller-supplied logical runtime name.
+        self._instance = f"vf-{uuid.uuid4().hex}"
+        self._tempdir: Path | None = None
+        self._workspace: Path | None = None
+        self._instance_started = False
+        self._cleaned = False
+        self._cleanup_lock = threading.Lock()
+
+    def _host_env(self, env: dict[str, str] | None = None) -> dict[str, str]:
+        # Preserve registry credentials and cache placement, but not ambient options
+        # that can change mounts, namespaces, privileges, resources, or guest env.
+        host_env: dict[str, str] = {}
+        for key, value in os.environ.items():
+            if key.startswith(("APPTAINERENV_", "SINGULARITYENV_")):
+                continue
+            for prefix in ("APPTAINER_", "SINGULARITY_"):
+                if key.startswith(prefix):
+                    if key.removeprefix(prefix) in _CLIENT_ENV_SUFFIXES:
+                        host_env[key] = value
+                    break
+            else:
+                host_env[key] = value
+        if env is not None:
+            host_env.update(
+                {
+                    f"APPTAINERENV_{key}": value
+                    for key, value in self.process_env(env).items()
+                }
+            )
+        return host_env
+
+    def _exec_args(self, argv: list[str]) -> list[str]:
+        return [
+            "exec",
+            "--cleanenv",
+            "--no-eval",
+            "--cwd",
+            self.config.workdir,
+            f"instance://{self._instance}",
+            *argv,
+        ]
+
+    async def _runtime_exec(self, command: list[str]) -> ProgramResult:
+        return await apptainer(*self._exec_args(command), env=self._host_env())
+
+    async def _cleanup_async(self) -> None:
+        await run_shielded(asyncio.to_thread(self.cleanup))
+
+    async def start(self) -> None:
+        try:
+            version = await apptainer("version", env=self._host_env())
+        except FileNotFoundError as e:
+            raise RuntimeError(
+                "apptainer runtime selected but the `apptainer` CLI is not installed"
+            ) from e
+        if version.exit_code != 0:
+            detail = (version.stderr or version.stdout).strip()
+            raise RuntimeError(
+                f"apptainer runtime selected but Apptainer is unavailable: {detail}"
+            )
+        match = re.search(r"(?<!\d)(\d+)\.(\d+)(?:\.\d+)?", version.stdout)
+        if match is None or tuple(map(int, match.groups()[:2])) < (1, 5):
+            found = version.stdout.strip() or "an unknown version"
+            raise RuntimeError(f"Apptainer 1.5 or newer is required; found {found}")
+
+        self._tempdir = Path(tempfile.mkdtemp(prefix="vf-apptainer-", dir="/tmp"))
+        self._workspace = self._tempdir / "workspace"
+        self._workspace.mkdir()
+        session_dir = self._tempdir / "session"
+        session_dir.mkdir()
+        image = image_reference(self.config.image)
+        transport, separator, _ = image.partition(":")
+        if "://" in image or (separator and transport in _SINGLE_COLON_TRANSPORTS):
+            local_image = self._tempdir / "image.sif"
+            operation = "pull" if "://" in image else "build"
+            try:
+                converted = await apptainer(
+                    operation,
+                    str(local_image),
+                    image,
+                    env=self._host_env(),
+                )
+            except BaseException:
+                await self._cleanup_async()
+                raise
+            if converted.exit_code != 0:
+                await self._cleanup_async()
+                detail = (converted.stderr or converted.stdout).strip()
+                raise SandboxError(f"apptainer image {operation} failed: {detail}")
+            image = str(local_image)
+
+        try:
+            inspected = await apptainer(
+                "inspect", "--startscript", image, env=self._host_env()
+            )
+        except BaseException:
+            await self._cleanup_async()
+            raise
+        if inspected.exit_code != 0:
+            await self._cleanup_async()
+            detail = (inspected.stderr or inspected.stdout).strip()
+            raise SandboxError(f"apptainer image inspection failed: {detail}")
+        if inspected.stdout.strip():
+            await self._cleanup_async()
+            raise SandboxError(
+                "Apptainer images with a startscript are unsupported because "
+                "instance start would execute it outside the Runtime process lifecycle"
+            )
+
+        try:
+            listed = await apptainer(
+                "instance", "list", "--json", self._instance, env=self._host_env()
+            )
+        except BaseException:
+            await self._cleanup_async()
+            raise
+        if listed.exit_code != 0:
+            await self._cleanup_async()
+            raise SandboxError(
+                f"Apptainer instance inspection failed: {listed.stderr.strip()}"
+            )
+        try:
+            instances = json.loads(listed.stdout)["instances"]
+            collision = any(
+                instance["instance"] == self._instance for instance in instances
+            )
+        except (KeyError, TypeError, ValueError) as error:
+            await self._cleanup_async()
+            raise SandboxError("Apptainer returned an invalid instance list") from error
+        if collision:
+            await self._cleanup_async()
+            raise SandboxError(
+                f"Apptainer instance name {self._instance!r} is already in use"
+            )
+
+        limits: list[str] = []
+        if self.config.cpu is not None:
+            limits += ["--cpus", str(self.config.cpu)]
+        if self.config.memory is not None:
+            limits += ["--memory", f"{self.config.memory}G"]
+        gpu = {
+            "nvidia:all": ["--nv"],
+            "rocm:all": ["--rocm"],
+            None: [],
+        }[self.config.gpu]
+        client_started = asyncio.Event()
+        try:
+            started = await apptainer(
+                "instance",
+                "start",
+                "--cleanenv",
+                "--containall",
+                "--no-mount",
+                "cwd,hostfs,bind-paths",
+                "--no-eval",
+                "--no-umask",
+                "--workdir",
+                str(session_dir),
+                "--writable-tmpfs",
+                "--bind",
+                f"{self._workspace}:{self.config.workdir}:rw",
+                *limits,
+                *gpu,
+                image,
+                self._instance,
+                env=self._host_env(),
+                client_started=client_started,
+            )
+        except BaseException:
+            # The local client can be cancelled after the instance was created but
+            # before it reports success, so teardown must attempt the named stop.
+            self._instance_started = client_started.is_set()
+            with contextlib.suppress(Exception):
+                await self._cleanup_async()
+            raise
+        self._instance_started = True
+        if started.exit_code != 0:
+            await self._cleanup_async()
+            raise SandboxError(
+                f"apptainer instance start failed: {started.stderr.strip()}"
+            )
+        self.info.id = self._instance
+
+    async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
+        return await apptainer(
+            *self._exec_args(argv),
+            env=self._host_env(env),
+        )
+
+    async def open_process(
+        self, argv: list[str], env: dict[str, str]
+    ) -> AttachedProcess:
+        return await open_attached_process(
+            argv,
+            command=["apptainer", *self._exec_args([])],
+            runtime_exec=self._runtime_exec,
+            runtime_name="apptainer",
+            host_env=self._host_env(env),
+        )
+
+    async def run_background(
+        self, argv: list[str], env: dict[str, str], log: str
+    ) -> None:
+        result = await apptainer(
+            *self._exec_args(
+                [
+                    "sh",
+                    "-c",
+                    'log=$1; shift; nohup "$@" > "$log" 2>&1 < /dev/null &',
+                    "vf-background",
+                    log,
+                    *argv,
+                ]
+            ),
+            env=self._host_env(env),
+        )
+        if result.exit_code != 0:
+            raise SandboxError(
+                f"apptainer background process failed: {result.stderr.strip()}"
+            )
+
+    async def _read(self, path: str) -> bytes:
+        process = await asyncio.create_subprocess_exec(
+            "apptainer",
+            *self._exec_args(["cat", "--", path]),
+            env=self._host_env(),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await process.communicate()
+        except BaseException:
+            if process.returncode is None:
+                with contextlib.suppress(ProcessLookupError):
+                    process.kill()
+            await run_shielded(process.communicate())
+            raise
+        if process.returncode != 0:
+            raise SandboxError(
+                f"read {path!r}: {stderr.decode(errors='replace').strip()}"
+            )
+        return stdout
+
+    async def write(self, path: str, data: bytes) -> None:
+        parent = str(PurePosixPath(path).parent)
+        result = await apptainer(
+            *self._exec_args(
+                [
+                    "sh",
+                    "-c",
+                    'mkdir -p "$1" && cat > "$2"',
+                    "vf-write",
+                    parent,
+                    path,
+                ]
+            ),
+            env=self._host_env(),
+            input=data,
+        )
+        if result.exit_code != 0:
+            raise SandboxError(f"write {path!r}: {result.stderr.strip()}")
+
+    def cleanup(self) -> None:
+        with self._cleanup_lock:
+            if self._cleaned:
+                return
+            if self._instance_started:
+                logger.debug("apptainer: stopping instance %s", self._instance)
+                stop_error: BaseException | None = None
+                try:
+                    stopped = subprocess.run(
+                        ["apptainer", "instance", "stop", "--force", self._instance],
+                        env=self._host_env(),
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                        timeout=30,
+                        check=False,
+                    )
+                except (OSError, subprocess.SubprocessError) as error:
+                    stop_error = error
+                else:
+                    if stopped.returncode != 0:
+                        stop_error = RuntimeError(f"exit code {stopped.returncode}")
+                if stop_error is not None:
+                    try:
+                        listed = subprocess.run(
+                            [
+                                "apptainer",
+                                "instance",
+                                "list",
+                                "--json",
+                                self._instance,
+                            ],
+                            env=self._host_env(),
+                            capture_output=True,
+                            text=True,
+                            timeout=30,
+                            check=False,
+                        )
+                        instances = json.loads(listed.stdout)["instances"]
+                        absent = listed.returncode == 0 and not any(
+                            instance["instance"] == self._instance
+                            for instance in instances
+                        )
+                    except (
+                        OSError,
+                        subprocess.SubprocessError,
+                        KeyError,
+                        TypeError,
+                        ValueError,
+                    ):
+                        absent = False
+                    if not absent:
+                        raise RuntimeError(
+                            f"failed to stop Apptainer instance {self._instance}"
+                        ) from stop_error
+                self._instance_started = False
+            if self._tempdir is not None and self._tempdir.exists():
+                try:
+                    os.chmod(self._tempdir, 0o700)
+                    for root, directories, _ in os.walk(self._tempdir):
+                        for directory in directories:
+                            with contextlib.suppress(OSError, NotImplementedError):
+                                os.chmod(
+                                    Path(root) / directory,
+                                    0o700,
+                                    follow_symlinks=False,
+                                )
+                    shutil.rmtree(self._tempdir)
+                except OSError as error:
+                    raise RuntimeError(
+                        f"failed to remove Apptainer workspace {self._tempdir}"
+                    ) from error
+            self._cleaned = True

--- a/verifiers/v1/runtimes/attached.py
+++ b/verifiers/v1/runtimes/attached.py
@@ -1,0 +1,260 @@
+"""Attached local CLI processes that need signalling inside a container."""
+
+import asyncio
+import contextlib
+import tempfile
+import uuid
+from collections.abc import AsyncIterator, Awaitable, Callable
+from typing import BinaryIO
+
+from verifiers.v1.errors import SandboxError
+from verifiers.v1.runtimes.base import ProgramResult, RuntimeProcess
+from verifiers.v1.utils.aio import run_shielded
+
+RuntimeExec = Callable[[list[str]], Awaitable[ProgramResult]]
+_START_TIMEOUT = 5
+_CONTROL_TIMEOUT = 2
+
+_PROCESS_WRAPPER = (
+    "if ! setsid -w true >/dev/null 2>&1; then "
+    "echo 'attached processes require setsid -w' >&2; exit 125; fi; "
+    'exec setsid -w sh -c \'echo $$ > "$1"; shift; exec "$@"\' '
+    'vf-process "$@"'
+)
+_SIGNAL = 'kill -"$1" "-$2" 2>/dev/null || kill -"$1" "$2"'
+_FINISH = 'kill -KILL "-$1" 2>/dev/null || true; rm -f "$2"'
+_ABORT = (
+    'i=0; while [ "$i" -lt 20 ]; do '
+    'if [ -s "$1" ]; then pid=$(cat "$1"); '
+    'kill -KILL "-$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null || true; '
+    'rm -f "$1"; exit 0; fi; '
+    "i=$((i + 1)); sleep 0.05; done; exit 1"
+)
+
+
+class _ProcessStream(AsyncIterator[bytes]):
+    def __init__(self, reader: asyncio.StreamReader) -> None:
+        self.reader = reader
+        self.captured: BinaryIO | None = None
+        self.capture_finished = False
+        self._read_lock = asyncio.Lock()
+
+    def __aiter__(self) -> "_ProcessStream":
+        return self
+
+    async def __anext__(self) -> bytes:
+        async with self._read_lock:
+            if self.captured is not None:
+                if chunk := self.captured.read(64 * 1024):
+                    return chunk
+                self.captured.close()
+                self.captured = None
+            if self.capture_finished:
+                raise StopAsyncIteration
+            chunk = await self.reader.read(64 * 1024)
+            if not chunk:
+                raise StopAsyncIteration
+            return chunk
+
+    async def capture(self) -> None:
+        async with self._read_lock:
+            if self.captured is None:
+                # It lives until the caller consumes output after wait().
+                self.captured = tempfile.SpooledTemporaryFile(  # noqa: SIM115
+                    max_size=1 << 20
+                )
+            unread = self.captured.tell()
+            self.captured.seek(0, 2)
+            finished = False
+            try:
+                while chunk := await self.reader.read(64 * 1024):
+                    self.captured.write(chunk)
+                finished = True
+            finally:
+                self.capture_finished = finished
+                self.captured.seek(unread)
+
+
+class AttachedProcess(RuntimeProcess):
+    def __init__(
+        self,
+        process: asyncio.subprocess.Process,
+        pid: int,
+        pidfile: str,
+        runtime_exec: RuntimeExec,
+        runtime_name: str,
+    ) -> None:
+        self._process = process
+        self._pid = pid
+        self._pidfile = pidfile
+        self._runtime_exec = runtime_exec
+        self._runtime_name = runtime_name
+        assert process.stdin is not None
+        assert process.stdout is not None
+        assert process.stderr is not None
+        self._stdin = process.stdin
+        self.stdout = _ProcessStream(process.stdout)
+        self.stderr = _ProcessStream(process.stderr)
+
+    async def write(self, data: bytes) -> None:
+        self._stdin.write(data)
+        await self._stdin.drain()
+
+    async def wait(self) -> int:
+        # Let concurrently scheduled stream consumers begin reading first.
+        await asyncio.sleep(0)
+        capture_streams = [self.stdout, self.stderr]
+        captures = [asyncio.create_task(stream.capture()) for stream in capture_streams]
+        try:
+            exit_code = await self._process.wait()
+            # A finished leader can leave descendants holding its streamed pipes open.
+            reaped = False
+            with contextlib.suppress(Exception):
+                cleanup = await asyncio.wait_for(
+                    self._runtime_exec(
+                        [
+                            "sh",
+                            "-c",
+                            _FINISH,
+                            "vf-process-finish",
+                            str(self._pid),
+                            self._pidfile,
+                        ]
+                    ),
+                    _CONTROL_TIMEOUT,
+                )
+                reaped = cleanup.exit_code == 0
+            if reaped:
+                await asyncio.gather(*captures)
+            else:
+                await asyncio.sleep(0)
+        finally:
+            for capture in captures:
+                capture.cancel()
+            await asyncio.gather(*captures, return_exceptions=True)
+        return exit_code
+
+    async def terminate(self) -> None:
+        await self._signal("TERM")
+
+    async def kill(self) -> None:
+        await self._signal("KILL")
+
+    def close_stdin(self) -> None:
+        self._stdin.close()
+
+    async def _signal(self, signal: str) -> None:
+        if self._process.returncode is not None:
+            return
+        result = await self._runtime_exec(
+            ["sh", "-c", _SIGNAL, "vf-signal", signal, str(self._pid)]
+        )
+        if result.exit_code != 0 and self._process.returncode is None:
+            raise SandboxError(
+                f"{self._runtime_name} exec process signal failed: "
+                f"{result.stderr.strip()}"
+            )
+
+
+async def _abort_process(
+    process: asyncio.subprocess.Process,
+    runtime_exec: RuntimeExec,
+    pidfile: str,
+) -> str:
+    """Kill a partially opened target and reap its local CLI process."""
+    try:
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(
+                runtime_exec(["sh", "-c", _ABORT, "vf-process-cleanup", pidfile]),
+                timeout=_CONTROL_TIMEOUT,
+            )
+    finally:
+        if process.returncode is None:
+            with contextlib.suppress(ProcessLookupError):
+                process.kill()
+        _, stderr = await process.communicate()
+    return stderr.decode(errors="replace").strip()
+
+
+async def open_attached_process(
+    argv: list[str],
+    *,
+    command: list[str],
+    runtime_exec: RuntimeExec,
+    runtime_name: str,
+    host_env: dict[str, str] | None = None,
+) -> AttachedProcess:
+    """Open a streamed CLI process and resolve its target PID inside the runtime."""
+    pidfile = f"/tmp/vf-process-{uuid.uuid4().hex}.pid"
+    process = await asyncio.create_subprocess_exec(
+        *command,
+        "sh",
+        "-c",
+        _PROCESS_WRAPPER,
+        "vf-process",
+        pidfile,
+        *argv,
+        env=host_env,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    ready = ProgramResult(1, "", "PID unavailable")
+    exited = False
+    try:
+        async with asyncio.timeout(_START_TIMEOUT):
+            while True:
+                ready = await runtime_exec(["cat", pidfile])
+                if ready.exit_code == 0 and ready.stdout.strip().isdigit():
+                    return AttachedProcess(
+                        process,
+                        int(ready.stdout.strip()),
+                        pidfile,
+                        runtime_exec,
+                        runtime_name,
+                    )
+                if process.returncode is not None:
+                    if exited:
+                        break
+                    exited = True
+                    continue
+                await asyncio.sleep(0.05)
+    except TimeoutError:
+        pass
+    except BaseException:
+        await run_shielded(_abort_process(process, runtime_exec, pidfile))
+        raise
+
+    stderr = await run_shielded(_abort_process(process, runtime_exec, pidfile))
+    detail = stderr or ready.stderr.strip()
+    raise SandboxError(
+        f"{runtime_name} live process failed to start: {detail or 'PID unavailable'}"
+    )
+
+
+async def run_attached_process(process: AttachedProcess) -> ProgramResult:
+    """Run an attached process to completion, killing its target on cancellation."""
+    process.close_stdin()
+
+    async def read_all(stream: AsyncIterator[bytes]) -> bytes:
+        return b"".join([chunk async for chunk in stream])
+
+    try:
+        stdout, stderr, exit_code = await asyncio.gather(
+            read_all(process.stdout), read_all(process.stderr), process.wait()
+        )
+    except BaseException:
+        with contextlib.suppress(Exception):
+            await run_shielded(
+                _abort_process(
+                    process._process,
+                    process._runtime_exec,
+                    process._pidfile,
+                )
+            )
+        raise
+    return ProgramResult(
+        exit_code=exit_code,
+        stdout=stdout.decode(errors="replace"),
+        stderr=stderr.decode(errors="replace"),
+    )

--- a/verifiers/v1/runtimes/docker/__init__.py
+++ b/verifiers/v1/runtimes/docker/__init__.py
@@ -11,8 +11,6 @@ import socket
 import subprocess
 import sys
 import tempfile
-import uuid
-from collections.abc import AsyncIterator
 from pathlib import PurePosixPath
 from typing import Literal, Self
 from urllib.parse import urlsplit
@@ -21,6 +19,7 @@ from pydantic import model_validator
 
 from verifiers.v1.configs.runtime import NetworkPolicyConfig
 from verifiers.v1.errors import SandboxError
+from verifiers.v1.runtimes.attached import open_attached_process
 from verifiers.v1.runtimes.base import (
     SERVICE_PORT,
     BaseRuntimeInfo,
@@ -87,128 +86,8 @@ class PodmanRuntimeInfo(PodmanConfig, BaseRuntimeInfo):
     pass
 
 
-async def _read_stream(reader: asyncio.StreamReader) -> AsyncIterator[bytes]:
-    while chunk := await reader.read(64 * 1024):
-        yield chunk
-
-
-class ContainerProcess(RuntimeProcess):
-    def __init__(
-        self,
-        process: asyncio.subprocess.Process,
-        engine: Literal["docker", "podman"],
-        container: str,
-        pid: int,
-    ) -> None:
-        self._process = process
-        self._engine = engine
-        self._container = container
-        self._pid = pid
-        assert process.stdin is not None
-        assert process.stdout is not None
-        assert process.stderr is not None
-        self._stdin = process.stdin
-        self.stdout = _read_stream(process.stdout)
-        self.stderr = _read_stream(process.stderr)
-
-    async def write(self, data: bytes) -> None:
-        self._stdin.write(data)
-        await self._stdin.drain()
-
-    async def wait(self) -> int:
-        return await self._process.wait()
-
-    async def terminate(self) -> None:
-        await self._signal("TERM")
-
-    async def kill(self) -> None:
-        await self._signal("KILL")
-
-    async def _signal(self, signal: str) -> None:
-        if self._process.returncode is not None:
-            return
-        result = await _run_container_cli(
-            self._engine,
-            "exec",
-            self._container,
-            "sh",
-            "-c",
-            'kill -"$1" "-$2" 2>/dev/null || kill -"$1" "$2"',
-            "vf-signal",
-            signal,
-            str(self._pid),
-        )
-        if result.exit_code != 0 and self._process.returncode is None:
-            raise SandboxError(
-                f"{self._engine} exec process signal failed: {result.stderr.strip()}"
-            )
-
-
-async def _run_container_cli(
-    engine: Literal["docker", "podman"], *args: str
-) -> ProgramResult:
-    proc = await asyncio.create_subprocess_exec(
-        engine,
-        *args,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    try:
-        stdout, stderr = await proc.communicate()
-    except BaseException:
-        if proc.returncode is None:
-            with contextlib.suppress(ProcessLookupError):
-                proc.kill()
-        await run_shielded(proc.communicate())
-        raise
-    return ProgramResult(
-        exit_code=proc.returncode or 0,
-        stdout=stdout.decode(errors="replace"),
-        stderr=stderr.decode(errors="replace"),
-    )
-
-
 def _environment_args(env: dict[str, str]) -> list[str]:
     return [arg for key, value in env.items() for arg in ("--env", f"{key}={value}")]
-
-
-async def _abort_process_startup(
-    proc: asyncio.subprocess.Process,
-    engine: Literal["docker", "podman"],
-    container: str,
-    pidfile: str,
-) -> str:
-    """Kill a partially opened container process and reap its local CLI client."""
-    # The target normally writes its PID immediately, but cancellation can win
-    # that race. Wait briefly for the file before signalling the process group.
-    cleanup = (
-        'i=0; while [ "$i" -lt 20 ]; do '
-        'if [ -s "$1" ]; then pid=$(cat "$1"); '
-        'kill -KILL "-$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null || true; '
-        'rm -f "$1"; exit 0; fi; '
-        "i=$((i + 1)); sleep 0.05; done; exit 1"
-    )
-    try:
-        with contextlib.suppress(Exception):
-            await asyncio.wait_for(
-                _run_container_cli(
-                    engine,
-                    "exec",
-                    container,
-                    "sh",
-                    "-c",
-                    cleanup,
-                    "vf-process-cleanup",
-                    pidfile,
-                ),
-                timeout=2,
-            )
-    finally:
-        if proc.returncode is None:
-            with contextlib.suppress(ProcessLookupError):
-                proc.kill()
-        _, stderr = await proc.communicate()
-    return stderr.decode(errors="replace").strip()
 
 
 _DOCKER_HOST = "host.docker.internal"
@@ -248,7 +127,25 @@ class _ContainerRuntime(Runtime):
         return SERVICE_PORT
 
     async def _run_cli(self, *args: str) -> ProgramResult:
-        return await _run_container_cli(self.engine, *args)
+        process = await asyncio.create_subprocess_exec(
+            self.engine,
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await process.communicate()
+        except BaseException:
+            if process.returncode is None:
+                with contextlib.suppress(ProcessLookupError):
+                    process.kill()
+            await run_shielded(process.communicate())
+            raise
+        return ProgramResult(
+            exit_code=process.returncode or 0,
+            stdout=stdout.decode(errors="replace"),
+            stderr=stderr.decode(errors="replace"),
+        )
 
     async def start(self) -> None:
         try:
@@ -697,62 +594,23 @@ class _ContainerRuntime(Runtime):
         env_args = _environment_args(
             self._container_env(env, use_policy_proxy=self._cut)
         )
-        pidfile = f"/tmp/vf-process-{uuid.uuid4().hex}.pid"
-        # Give the target its own process group when `setsid -w` is available so
-        # terminate()/kill() reap its descendants while the attached exec remains
-        # attached if setsid needs to fork. The inner shell records the
-        # post-setsid PID before exec preserves it as the target PID.
-        wrapper = (
-            "if setsid -w true >/dev/null 2>&1; then "
-            'exec setsid -w sh -c \'echo $$ > "$1"; shift; exec "$@"\' '
-            'vf-process "$@"; '
-            'fi; echo $$ > "$1"; shift; exec "$@"'
-        )
-        proc = await asyncio.create_subprocess_exec(
-            self.engine,
-            "exec",
-            "-i",
-            *env_args,
-            "--workdir",
-            self.config.workdir,
-            self._container,
-            "sh",
-            "-c",
-            wrapper,
-            "vf-process",
-            pidfile,
-            *argv,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        loop = asyncio.get_running_loop()
-        deadline = loop.time() + 5
-        try:
-            while True:
-                ready = await self._run_cli("exec", self._container, "cat", pidfile)
-                if ready.exit_code == 0 and ready.stdout.strip().isdigit():
-                    return ContainerProcess(
-                        proc,
-                        self.engine,
-                        self._container,
-                        int(ready.stdout.strip()),
-                    )
-                if proc.returncode is not None or loop.time() >= deadline:
-                    break
-                await asyncio.sleep(0.05)
-        except BaseException:
-            await run_shielded(
-                _abort_process_startup(proc, self.engine, self._container, pidfile)
-            )
-            raise
 
-        stderr = await run_shielded(
-            _abort_process_startup(proc, self.engine, self._container, pidfile)
-        )
-        detail = stderr or ready.stderr.strip()
-        raise SandboxError(
-            f"{self.engine} live process failed to start: {detail or 'PID unavailable'}"
+        async def runtime_exec(command: list[str]) -> ProgramResult:
+            return await self._run_cli("exec", self._container, *command)
+
+        return await open_attached_process(
+            argv,
+            command=[
+                self.engine,
+                "exec",
+                "-i",
+                *env_args,
+                "--workdir",
+                self.config.workdir,
+                self._container,
+            ],
+            runtime_exec=runtime_exec,
+            runtime_name=self.engine,
         )
 
     async def run_background(


### PR DESCRIPTION
Superseded by #2528.

## Overview

Adds first-class Apptainer 1.5 instance support as the third layer in the local-runtime stack. The runtime preserves Verifiers' process, filesystem, and resource contract while keeping Apptainer's host-network boundary explicit.

## Details

- Registers `type="apptainer"` configuration, runtime dispatch, runtime info, and public exports.
- Accepts OCI image shorthand together with local SIF paths and explicit Apptainer URI references.
- Creates a private runtime root and writable workspace, pulls remote images into that root, and rejects image start scripts before provisioning.
- Starts clean, contained instances without requiring host root or globally configured fakeroot.
- Supports foreground commands, streamed live processes, signalling, cancellation, background commands, binary reads and writes, and cleanup through a shared attached-process transport.
- Keeps control-command environment separate from payload environment so task variables cannot reshape instance lifecycle commands.
- Maps CPU and memory limits, supports the portable `nvidia:all` GPU mode, and deterministically rejects unsupported disk and GPU settings.
- Preserves host-local URL behavior under Apptainer's shared host network.
- Supports unrestricted networking only and rejects restricted allow/block policies because portable unprivileged Apptainer networking cannot enforce that contract.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New sandbox surface (Apptainer CLI, global instance names, host networking) plus Docker live-process behavior change via shared attach (`setsid -w` mandatory); removed Docker-internal process types could break out-of-tree imports.
> 
> **Overview**
> Adds **`type="apptainer"`** as a first-class local runtime: `ApptainerConfig` / `ApptainerRuntime` provision Apptainer **≥1.5** instances (image pull/build, contained instance start, exec, background jobs, read/write), with CPU/memory limits and `nvidia:all` / `rocm:all` GPU modes. Config validation rejects **restricted networking**, per-instance **disk** limits, and images with startscripts; Docker-style image strings are mapped to `docker://` or local SIF paths.
> 
> Introduces **`verifiers/v1/runtimes/attached.py`** so Docker/Podman and Apptainer share live-process attach: PID via a container pidfile, **requires `setsid -w`**, in-container signalling, and post-exit reaping. Docker’s `open_process` now delegates here; the old in-module `ContainerProcess` / startup-abort helpers are removed.
> 
> ACP shutdown now **`close()`s** the packet reader’s async stdout source during `_stop`, reducing dangling streams after harness teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c5cc32a0764a5400b5da871991da74dfda9df88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ApptainerRuntime` and refactor attached process handling across runtimes
> - Adds a full `ApptainerRuntime` selectable via `type="apptainer"` in config, supporting image pull/build, instance lifecycle, CPU/memory/GPU limits, process exec/attach, background commands, and file I/O inside the container
> - Introduces [attached.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2473/files#diff-1dc70dddf33942a95a68fecbf7700c34cd14fa17ac9cd675df54b716809649af) with `AttachedProcess`, `open_attached_process`, and `run_attached_process` to share process management logic between Docker and Apptainer runtimes; the Docker runtime's `open_process` now delegates to this module
> - `ApptainerConfig` validates workdir as a non-root absolute path without `..`, `:`, or `,`; rejects `network_restricted`; requires Apptainer >= 1.5
> - Fixes `_PacketReader` and `ACPHarnessSession._stop` to close the underlying async source on shutdown, avoiding dangling generators/streams
> - Risk: attached exec now requires `setsid -w` in the target environment and will fail fast if unavailable; Docker `ContainerProcess` and several docker helpers are removed — any out-of-tree consumers of those symbols will break
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c5cc32.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->