### PR TITLE
Adopt MCP 2026-07-28

### DIFF
--- a/environments/compact/compact/program.py
+++ b/environments/compact/compact/program.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["openai", "mcp>=1.24.0,<2"]
+# dependencies = ["openai", "mcp==2.0.0", "httpx2"]
 # ///
 """The compacting harness's program: a context-rewrite loop (every turn branches).
 
@@ -70,9 +70,9 @@ async def chat(
 
 
 async def connect_mcp(stack: AsyncExitStack, config: dict) -> tuple[list[dict], dict]:
-    """Connect to each configured MCP server (a streamable-HTTP `url`); return
-    (tool schemas, dispatch mapping `<server>_<tool>` -> (session, raw tool name))."""
-    from mcp import ClientSession
+    """Connect to each MCP server and negotiate the newest mutually supported protocol."""
+    import httpx2
+    from mcp import Client
     from mcp.client.streamable_http import (
         create_mcp_http_client,
         streamable_http_client,
@@ -82,14 +82,14 @@ async def connect_mcp(stack: AsyncExitStack, config: dict) -> tuple[list[dict], 
     dispatch: dict[str, tuple] = {}
     for name, spec in config.get("mcpServers", {}).items():
         http_client = await stack.enter_async_context(
-            create_mcp_http_client(headers=spec.get("headers") or None)
+            create_mcp_http_client(
+                headers=spec.get("headers") or None,
+                timeout=httpx2.Timeout(30.0, read=300.0),
+            )
         )
-        read, write, *_ = await stack.enter_async_context(
-            streamable_http_client(spec["url"], http_client=http_client)
-        )
-        session = await stack.enter_async_context(ClientSession(read, write))
-        await session.initialize()
-        for tool in (await session.list_tools()).tools:
+        transport = streamable_http_client(spec["url"], http_client=http_client)
+        client = await stack.enter_async_context(Client(transport))
+        for tool in (await client.list_tools()).tools:
             full = f"{name}_{tool.name}"
             tool_schemas.append(
                 {
@@ -97,17 +97,17 @@ async def connect_mcp(stack: AsyncExitStack, config: dict) -> tuple[list[dict], 
                     "function": {
                         "name": full,
                         "description": tool.description or "",
-                        "parameters": tool.inputSchema,
+                        "parameters": tool.input_schema,
                     },
                 }
             )
-            dispatch[full] = (session, tool.name)
+            dispatch[full] = (client, tool.name)
     return tool_schemas, dispatch
 
 
 async def call_mcp(dispatch: dict, name: str, arguments: dict) -> str:
-    session, raw = dispatch[name]
-    result = await session.call_tool(raw, arguments)
+    client, raw = dispatch[name]
+    result = await client.call_tool(raw, arguments)
     texts = [b.text for b in result.content if getattr(b, "type", None) == "text"]
     return "\n".join(texts) if texts else str(result.content)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,8 @@ dependencies = [
     "datasets>=3.3.0,<6.0.0",
     "numpy>=2.1.0",
     "math-verify>=0.8.0",
-    "mcp>=1.24.0,<2",
     "openai>=2.9.0",
-    "openai-agents>=0.8.2",
+    "openai-agents>=0.20.0",
     "prime-tunnel>=0.1.8",
     "prime-sandboxes>=0.2.39",
     "pydantic>=2.12.3",
@@ -53,6 +52,8 @@ dependencies = [
     "tomli-w>=1.0.0",
     "renderers>=0.1.10",
     "typing_extensions>=4.12.2",
+    "mcp==2.0.0",
+    "httpx2>=2.0.0",
 ]
 
 [dependency-groups]
@@ -118,11 +119,11 @@ notebook = [
     "nest-asyncio>=1.6.0",
 ]
 openenv = [
+    "fastmcp==4.0.0b3",
     "openenv>=0.4.1",
 ]
 nemo-gym = [
     # NeMo Gym currently publishes Python 3.12+ packages; keep core verifiers installable on 3.11.
-    "nemo-gym==0.4.0; python_version >= '3.12'",
 ]
 [tool.uv]
 preview = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ dependencies = [
     "renderers>=0.1.10",
     "typing_extensions>=4.12.2",
     "mcp==2.0.0",
-    "httpx2>=2.0.0",
 ]
 
 [dependency-groups]
@@ -119,7 +118,6 @@ notebook = [
     "nest-asyncio>=1.6.0",
 ]
 openenv = [
-    "fastmcp==4.0.0b3",
     "openenv>=0.4.1",
 ]
 nemo-gym = [

--- a/uv.lock
+++ b/uv.lock
@@ -1194,21 +1194,22 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.4.4"
+version = "4.0.0b3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp-slim", extra = ["client", "server"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/f7/5188565d1b93ad611cbd80bf473e7ad669d1f3b689c4bedcd304e1ec3472/fastmcp-3.4.4.tar.gz", hash = "sha256:378202e26ec15b23819d9a1c0d1b0ebda096bc712720532010a0b82a45c2b1df", size = 28796458, upload-time = "2026-07-09T00:32:41.352Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/01/be88a40071d7bdce1b207c1acd2522167425393cbad33c40a778ce1f656d/fastmcp-4.0.0b3.tar.gz", hash = "sha256:1edea49ef12f6a47721ec69324bba31302eb0faccff939f2851026992fa62f93", size = 42163497, upload-time = "2026-08-14T17:48:01.224Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/67/3cef84ba38a23dca1e1e776bfda8a35ab3c7a6c94a8ca81d0715de6dd3c5/fastmcp-3.4.4-py3-none-any.whl", hash = "sha256:f86f208713212260068cf55c32936839eee856fefc7808e18a032f31eb0f718e", size = 8019, upload-time = "2026-07-09T00:32:39.411Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/0c/6cb98b816b0836fd8ad120761c5cb76e1c5a3a71dfd3b0549b37a3b52a54/fastmcp-4.0.0b3-py3-none-any.whl", hash = "sha256:4a68fb3877f160ca18ca5be4ee80c0d68c89f922b927734c36e6e99827d814fc", size = 8089, upload-time = "2026-08-14T17:47:58.59Z" },
 ]
 
 [[package]]
 name = "fastmcp-slim"
-version = "3.4.4"
+version = "4.0.0b3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "mcp-types" },
     { name = "platformdirs" },
     { name = "pydantic", extra = ["email"] },
     { name = "pydantic-settings" },
@@ -1216,16 +1217,16 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/79/f35661c6a1d76dfbe17a079f912d96fffcfdd40fad5a9144bb9e7dfb1fdf/fastmcp_slim-3.4.4.tar.gz", hash = "sha256:dcaa3e0be2127d7eacdce592c2ef0039204923dc0ec396454615cb4a3275b078", size = 590203, upload-time = "2026-07-09T00:32:20.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/35/01d59a0a8c4a7a7125f1f3b01f22b7283fea1942b7e1c5cea171bea624cc/fastmcp_slim-4.0.0b3.tar.gz", hash = "sha256:0647126ce70ebf0890912954ffb5cd162fb63bb9169a81b078ae960c8c09830e", size = 674255, upload-time = "2026-08-14T17:47:36.064Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/91/321e0b2e9ed70d0628b17ddaec76fc7b09f3e1d5d290f70bf101a2890142/fastmcp_slim-3.4.4-py3-none-any.whl", hash = "sha256:9d3a6327b9ee835188eb7323fc3b5d4cd061631b48da8ece56794bb538972505", size = 765158, upload-time = "2026-07-09T00:32:19.11Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fa/63bc5d73f77bcf52ae05c184d18ad2ff9c5b35da0d9b55500e74a5377fef/fastmcp_slim-4.0.0b3-py3-none-any.whl", hash = "sha256:59ea0be9978b45cfe3ab47f3b7413b36a5b4b929dff723d48235899eada8bb42", size = 846345, upload-time = "2026-08-14T17:47:34.541Z" },
 ]
 
 [package.optional-dependencies]
 client = [
     { name = "authlib" },
     { name = "exceptiongroup" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "mcp" },
     { name = "opentelemetry-api" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
@@ -1236,7 +1237,7 @@ server = [
     { name = "cyclopts" },
     { name = "exceptiongroup" },
     { name = "griffelib" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "joserfc" },
     { name = "jsonref" },
     { name = "jsonschema-path" },
@@ -1460,15 +1461,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
-]
-
-[[package]]
-name = "gprof2dot"
-version = "2025.4.14"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bb/fd/cad13fa1f7a463a607176432c4affa33ea162f02f58cc36de1d40d3e6b48/gprof2dot-2025.4.14.tar.gz", hash = "sha256:35743e2d2ca027bf48fa7cba37021aaf4a27beeae1ae8e05a50b55f1f921a6ce", size = 39536, upload-time = "2025-04-14T07:21:45.76Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/ed/89d760cb25279109b89eb52975a7b5479700d3114a2421ce735bfb2e7513/gprof2dot-2025.4.14-py3-none-any.whl", hash = "sha256:0742e4c0b4409a5e8777e739388a11e1ed3750be86895655312ea7c20bd0090e", size = 37555, upload-time = "2025-04-14T07:21:43.319Z" },
 ]
 
 [[package]]
@@ -1730,6 +1722,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1779,12 +1784,29 @@ http2 = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -1805,20 +1827,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1a/8f/999e4dda11c6187c78f090eac00895a47e11a0049308f07579bcb7aa3aa2/huggingface_hub-1.23.0.tar.gz", hash = "sha256:c04997fb8bbdace1e57b7703d30ed7678af51f70d00d241819ff411b92ae9a88", size = 919163, upload-time = "2026-07-09T14:49:32.315Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/ce/13b2ba57838b8db1e6bd033c1b21ce0b9f6153b87d4e4939f77074e41eb0/huggingface_hub-1.23.0-py3-none-any.whl", hash = "sha256:b1d604788f5adc7f0eb246e03e0ec19011ca06e38400218c347dccc3dffa64a2", size = 770336, upload-time = "2026-07-09T14:49:30.597Z" },
-]
-
-[[package]]
-name = "hydra-core"
-version = "1.3.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "antlr4-python3-runtime", version = "4.9.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "omegaconf" },
-    { name = "packaging" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/10/dd/220f0e91743136725352497e98540772a01fc7c3ab96ff16c3c74424e984/hydra_core-1.3.4.tar.gz", hash = "sha256:ad0f7b05a0242255a8984d5a4ed2f6847f7b783ed727368a2c0155ec52d6c34c", size = 3263348, upload-time = "2026-07-04T16:25:38.891Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/cd/a568610bafe991fdd3f628fb606316b3b2be52ded019284e895d9beb3a1e/hydra_core-1.3.4-py3-none-any.whl", hash = "sha256:e58683692904a09f1fdfffa1a9b86bfd94e215b59f1ee17e7cd7d92738090d33", size = 155478, upload-time = "2026-07-04T16:25:37.291Z" },
 ]
 
 [[package]]
@@ -1884,15 +1892,6 @@ version = "0.1.0"
 source = { editable = "environments/interception" }
 dependencies = [
     { name = "verifiers" },
-]
-
-[[package]]
-name = "itsdangerous"
-version = "2.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
 ]
 
 [[package]]
@@ -2406,15 +2405,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.28.1"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -2424,9 +2423,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
@@ -2683,36 +2695,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nemo-gym"
-version = "0.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp" },
-    { name = "fastapi" },
-    { name = "gprof2dot" },
-    { name = "hydra-core" },
-    { name = "itsdangerous" },
-    { name = "mcp" },
-    { name = "omegaconf" },
-    { name = "openai" },
-    { name = "orjson" },
-    { name = "pandas" },
-    { name = "pydantic" },
-    { name = "pydot" },
-    { name = "ray" },
-    { name = "requests" },
-    { name = "rich" },
-    { name = "typing-extensions" },
-    { name = "uvicorn" },
-    { name = "wandb" },
-    { name = "yappi" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/91/5365cac38f305aad2e00e8ce7295a3ef2e4609878eca4a102f83fb29debf/nemo_gym-0.4.0.tar.gz", hash = "sha256:c24f2624491d85b867681a68dea5bc69a93798d731a00d4f6e24cc49d89c558c", size = 32185869, upload-time = "2026-07-02T19:28:22.846Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/df/05f6db0564cdc434154ed9c29b8ca7599272e5d50e9777184ac41772ae5b/nemo_gym-0.4.0-py3-none-any.whl", hash = "sha256:955f08027a2f01a1c6e0e3c5da0820c330fee0307754d59ba2517f5ad89cea6e", size = 31829166, upload-time = "2026-07-02T19:28:19.735Z" },
-]
-
-[[package]]
 name = "nest-asyncio"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2857,19 +2839,6 @@ wheels = [
 ]
 
 [[package]]
-name = "omegaconf"
-version = "2.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "antlr4-python3-runtime", version = "4.9.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "pyyaml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/3d/e4b57b8d9008c6ebe0d5eff901f91d5700cf7bdb8c8863df817463a7fd5e/omegaconf-2.3.1.tar.gz", hash = "sha256:e5e7de64aeebeddaf8e6d3f7a783b32ac2a01c0fbd9c878012caecb891a1f42a", size = 3298472, upload-time = "2026-06-11T05:05:12.885Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/0e/152509871bf30df6fc38569f52a2db9b55dd41aae957adae50a053ac7778/omegaconf-2.3.1-py3-none-any.whl", hash = "sha256:3d701d14e9a8828f1edd28bb70b725908b34277cdd72cf7d6a83f94dadc6b6a0", size = 79502, upload-time = "2026-06-11T05:05:09.954Z" },
-]
-
-[[package]]
 name = "onnxruntime"
 version = "1.27.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2921,7 +2890,7 @@ wheels = [
 
 [[package]]
 name = "openai-agents"
-version = "0.18.2"
+version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "griffelib" },
@@ -2932,9 +2901,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/0c/52e9aeff5549b225d5666a0eb84a8a22b4c47db08b6f44dbd45876fcfba3/openai_agents-0.18.2.tar.gz", hash = "sha256:9f418bb563eddff1e01f245ae8a4964b7649396f444b569b4113d105e41ca1d3", size = 5546139, upload-time = "2026-07-11T01:08:18.537Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/18/1204bde976436ad85498b759d5297843ebd2e0a214f729eb2dc4423cdfc7/openai_agents-0.20.0.tar.gz", hash = "sha256:a6b37954877868ac233876a27dab1e2a461c53ecbd5fcf6e19e2d276d3e848cd", size = 6146452, upload-time = "2026-08-11T03:12:49.556Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/23/b5b6b80a3e36f021ca2a8c4637684f0d722d646b19d3616768a68802c302/openai_agents-0.18.2-py3-none-any.whl", hash = "sha256:c7aea341b256a90b87b17b7e444bab29a12655864a2f0094f65561223d867185", size = 874310, upload-time = "2026-07-11T01:08:16.851Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/8b/18528f00cb1a5d0b8e00f457f7dc88e7b17439bc520861aae2b638b88710/openai_agents-0.20.0-py3-none-any.whl", hash = "sha256:aaff662b802fa90762ad539e131b9ea387e12e3664b87bc75157ad1b3fc88850", size = 1064338, upload-time = "2026-08-11T03:12:47.615Z" },
 ]
 
 [[package]]
@@ -3782,18 +3751,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydot"
-version = "4.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyparsing" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/50/35/b17cb89ff865484c6a20ef46bf9d95a5f07328292578de0b295f4a6beec2/pydot-4.0.1.tar.gz", hash = "sha256:c2148f681c4a33e08bf0e26a9e5f8e4099a82e0e2a068098f32ce86577364ad5", size = 162594, upload-time = "2025-06-17T20:09:56.454Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/32/a7125fb28c4261a627f999d5fb4afff25b523800faed2c30979949d6facd/pydot-4.0.1-py3-none-any.whl", hash = "sha256:869c0efadd2708c0be1f916eb669f3d664ca684bc57ffb7ecc08e70d5e93fee6", size = 37087, upload-time = "2025-06-17T20:09:55.25Z" },
-]
-
-[[package]]
 name = "pydub"
 version = "0.25.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4122,34 +4079,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/0e/3f0d0d335c6b3abb9b7b723776d0b21fa7f3a6c819a0db6097059aada160/pyzmq-27.1.0-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53b40f8ae006f2734ee7608d59ed661419f087521edbfc2149c3932e9c14808c", size = 567747, upload-time = "2025-09-08T23:09:52.698Z" },
     { url = "https://files.pythonhosted.org/packages/a1/cf/f2b3784d536250ffd4be70e049f3b60981235d70c6e8ce7e3ef21e1adb25/pyzmq-27.1.0-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f605d884e7c8be8fe1aa94e0a783bf3f591b84c24e4bc4f3e7564c82ac25e271", size = 747371, upload-time = "2025-09-08T23:09:54.563Z" },
     { url = "https://files.pythonhosted.org/packages/01/1b/5dbe84eefc86f48473947e2f41711aded97eecef1231f4558f1f02713c12/pyzmq-27.1.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c9f7f6e13dff2e44a6afeaf2cf54cee5929ad64afaf4d40b50f93c58fc687355", size = 544862, upload-time = "2025-09-08T23:09:56.509Z" },
-]
-
-[[package]]
-name = "ray"
-version = "2.56.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "filelock" },
-    { name = "jsonschema" },
-    { name = "msgpack" },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "pyyaml" },
-    { name = "requests" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/f2/2cbbbef7a67adc6555b141c7a67557bd7ce21cfb85b85772627c6a582e97/ray-2.56.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:a9ad4e26941eb2f8dbd494ad07f9f2227143164c6114132b26b23ad4f20b1c6f", size = 66354212, upload-time = "2026-06-29T20:50:37.148Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/69/09c8320519aa4d075bd6ecb1694c28d26b5b07a5b46050703d9ac2c5a9b6/ray-2.56.0-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:aea655831d25084cb343002a8e67a77b6aa552ddb776a65461d49f62884f096a", size = 73299499, upload-time = "2026-06-29T20:50:42.584Z" },
-    { url = "https://files.pythonhosted.org/packages/18/d3/84df370c773a0b853abdba498a6258106cb928d452ff56eec7f86c2f80b4/ray-2.56.0-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:c5bf1a4384c0e2aa4420c95474b734d064cac354b0f00760be02d886afe96ca4", size = 74143858, upload-time = "2026-06-29T20:50:48.228Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/1b/0b4c96879ded375d0b35441c6b3633ccbea7c7c5448335589811fe5f275c/ray-2.56.0-cp311-cp311-win_amd64.whl", hash = "sha256:8e57781685bb4332edf8a7cfb1135ff53d50002b6a0504006e68365bcd26aa7c", size = 28390306, upload-time = "2026-06-29T20:50:53.841Z" },
-    { url = "https://files.pythonhosted.org/packages/05/d2/83777f52c10e04654c162bfa093f4e34cf6decf7a0bb4311e2432bfa8ecb/ray-2.56.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:684a427c50745989e92a332343f0812c93b8506f71c768b95b1eefc113492699", size = 66344824, upload-time = "2026-06-29T20:50:58.367Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/b2/d610ffe2878dae8ab903cfdded883a054c102b0104670bca7b34b662db51/ray-2.56.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:e1fd03c6ecc5fe4c31466569e41ce0a4faf26fb930798c9d1f1eb1f405a687c8", size = 73317367, upload-time = "2026-06-29T20:51:03.893Z" },
-    { url = "https://files.pythonhosted.org/packages/39/d1/8d442116f41e6bebec418d89f1556c67c77d593b55cf59e716503e7a4a17/ray-2.56.0-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:78ef34a71383c1fcf335e531e0e590867857fce9069f06ed351be6ce7a58fc50", size = 74192607, upload-time = "2026-06-29T20:51:09.528Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/9e/cac7454325c79eb32f36f233285d9179858c7073bc27ac91afb74854ff12/ray-2.56.0-cp312-cp312-win_amd64.whl", hash = "sha256:a8fc809dab6fc07cf05d45ea93a776c852c990512eb1fac0e3d15819fe6df10a", size = 28370978, upload-time = "2026-06-29T20:51:14.168Z" },
-    { url = "https://files.pythonhosted.org/packages/65/86/29c9444c9f11f0bf3d4da75d3dc7a27c0fb86f8604beea6513968dc2df26/ray-2.56.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:992047f50473b5bfea74c8f528f999968e0b4bc735af23ad476a0f4e04741aea", size = 66289930, upload-time = "2026-06-29T20:51:20.79Z" },
-    { url = "https://files.pythonhosted.org/packages/59/59/3c4d533a92e99b12b9d2e8690e41d7ace269d77deecb0aef753df7924b9e/ray-2.56.0-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:a0e9cfe92c88ab74abca23923c15a592f49bc7617ffdda4190daca7785a7c4f6", size = 73252460, upload-time = "2026-06-29T20:51:26.216Z" },
-    { url = "https://files.pythonhosted.org/packages/59/ba/285d409253b332af91884daa4b0a3be3ce799682aa2c1e0f8dbbafaf1da4/ray-2.56.0-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:54d2725f8b65d9615c933fec5ec62e54a67b8f2e14286026fb014606253670ef", size = 74130685, upload-time = "2026-06-29T20:51:31.59Z" },
 ]
 
 [[package]]
@@ -4523,19 +4452,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7d/31/f2289ce78b9b473d582568c234e104d2a342fd658cc288a7553d83bb8595/semantic_version-2.10.0.tar.gz", hash = "sha256:bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c", size = 52289, upload-time = "2022-05-26T13:35:23.454Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl", hash = "sha256:de78a3b8e0feda74cabc54aab2da702113e33ac9d9eb9d2389bcf1f58b7d9177", size = 15552, upload-time = "2022-05-26T13:35:21.206Z" },
-]
-
-[[package]]
-name = "sentry-sdk"
-version = "2.65.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f1/1f/ed17a390348156ca99fe622b97cd7d2f1969b5f49df89084b0f28e7953e9/sentry_sdk-2.65.0.tar.gz", hash = "sha256:c94dc945d54bad49d4f20448b1e6b217ca2f92f46d05c3e83d41764af685c3d1", size = 932133, upload-time = "2026-07-13T11:33:19.92Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/3b/326ad4c03b5da89b5124c8890af66e8119c4d2e10abc0619e0d67d9f7c7f/sentry_sdk-2.65.0-py3-none-any.whl", hash = "sha256:3595169677a808e4d0e1ea6ffb89443459549c7a98392ed71c77c847182ab6bf", size = 503869, upload-time = "2026-07-13T11:33:17.71Z" },
 ]
 
 [[package]]
@@ -4964,6 +4880,15 @@ wheels = [
 ]
 
 [[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
 name = "ty"
 version = "0.0.63"
 source = { registry = "https://pypi.org/simple" }
@@ -5053,11 +4978,11 @@ wheels = [
 
 [[package]]
 name = "uncalled-for"
-version = "0.3.2"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/82/345cc927f7fbdae6065e7768759932fcc827fc20b29b45dfbafa2f1f7da4/uncalled_for-0.3.2.tar.gz", hash = "sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2", size = 50032, upload-time = "2026-05-06T13:38:25.204Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/5a/92ce0b3ea5481915f55da994c2c2c5f7a3c09949afde196ee89f8ab961aa/uncalled_for-0.4.0.tar.gz", hash = "sha256:335b95bd2422332ec210d518f314a16e4c640921c39fc8bf2ad095bd3538f4af", size = 56979, upload-time = "2026-08-10T14:51:46.247Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/25/2c87754f3a9e692315f7b811244090e68f362979fc8886b3fbd2985a1d8c/uncalled_for-0.3.2-py3-none-any.whl", hash = "sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e", size = 11444, upload-time = "2026-05-06T13:38:24.025Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/40/97cec87c077eb3291fc7905e6633e08b7ca593c57d30238444bcb6bb3d53/uncalled_for-0.4.0-py3-none-any.whl", hash = "sha256:16c4bb3337532e4bd5569adc192285976f3ad5305402256d34c67a12b5c968bd", size = 15502, upload-time = "2026-08-10T14:51:45.068Z" },
 ]
 
 [[package]]
@@ -5128,6 +5053,7 @@ dependencies = [
     { name = "datasets" },
     { name = "gepa" },
     { name = "httpx" },
+    { name = "httpx2" },
     { name = "loguru" },
     { name = "math-verify" },
     { name = "mcp" },
@@ -5162,13 +5088,11 @@ harbor = [
 modal = [
     { name = "modal" },
 ]
-nemo-gym = [
-    { name = "nemo-gym", marker = "python_full_version >= '3.12'" },
-]
 notebook = [
     { name = "nest-asyncio" },
 ]
 openenv = [
+    { name = "fastmcp" },
     { name = "openenv" },
 ]
 rg = [
@@ -5229,34 +5153,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/34/d9/b477fddb68840b570af8b22afe9b035cbc277b5fb7b33dea390617a8b10f/virtualenv-21.6.1.tar.gz", hash = "sha256:15f978b7cd329f24855ff4a0c4b4899cc7678589f49adbdcbbb4d3232e641128", size = 5526620, upload-time = "2026-07-10T19:33:53.312Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/7c/4e7225d46d634a0d8d534dd8a6ce0c319d09b4d0cf0337eb314ca4789d8c/virtualenv-21.6.1-py3-none-any.whl", hash = "sha256:afe991df855715a2b2f60edfcc0107ef95a79fdfd8cb4cdaa71603d1c12e463b", size = 5506392, upload-time = "2026-07-10T19:33:51.629Z" },
-]
-
-[[package]]
-name = "wandb"
-version = "0.28.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "packaging" },
-    { name = "platformdirs" },
-    { name = "protobuf" },
-    { name = "pydantic" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "sentry-sdk" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/92/fb/8d3f96a8b143060d6fa145462d0785981373e04694e4152555ccb5d23939/wandb-0.28.1.tar.gz", hash = "sha256:870ccb1a01238b0ac07c6fd96a0810a1f79090aba04ea29f4ee012ac8327705d", size = 40578119, upload-time = "2026-07-16T18:47:05.413Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/21/8df50164d07623cfcefec19bbf9327d9be84b637a827cea1f0c06db005fd/wandb-0.28.1-py3-none-macosx_12_0_arm64.whl", hash = "sha256:da909a76e65c64c0d93acc485d2a19f66e336f1e3f725f1c98a070883e084943", size = 24277925, upload-time = "2026-07-16T18:46:42.383Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/18/6c3da7e6cb215ad363324db8dc4d83b93626f5e339822b05b1c38a6097fd/wandb-0.28.1-py3-none-macosx_12_0_x86_64.whl", hash = "sha256:3da3db219c54bfd1082c00e9061c8ea894ba43e42733b5af00bb10c09d7158fe", size = 25480852, upload-time = "2026-07-16T18:46:45.102Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/1a/d15bcfb4417fa69edcaa33db8ea012db733da1057e193b047e3f69fdd671/wandb-0.28.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:ae9ae6fb29e2e2b1d097ed8b75c0c0240c778c2a8cad1d996dee870a1e401c2c", size = 24832138, upload-time = "2026-07-16T18:46:47.433Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/da/49924c7df2952dfd82c86c3779c339c0c3d6f6439387c03d97d0470c3658/wandb-0.28.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:8cfb898b6a6c884d9c9294b02764e88bce65049f027a124d6bee53fe722469b6", size = 26486533, upload-time = "2026-07-16T18:46:49.839Z" },
-    { url = "https://files.pythonhosted.org/packages/11/c0/06b23518e29690784f1b3081e39c7679ca076cb0af094cb9b4bb309150f5/wandb-0.28.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:cf2b1533945395e4fdbe6182b272bb0ca8a02c10b3086a395e2d57686ae3ed0d", size = 25022635, upload-time = "2026-07-16T18:46:52.376Z" },
-    { url = "https://files.pythonhosted.org/packages/23/30/6de2f7995a8a6eecbd03d24c79a139a734c0168f5520cf4c7ccb43c1dbbc/wandb-0.28.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:7233061080507a4b4098bed1ccb381ce6f890c60397cd4153d060285bcb267bd", size = 27008895, upload-time = "2026-07-16T18:46:55.025Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/83/49deab9447687625371435ca21b6da82f223f1c7d014d77386b9cb91833c/wandb-0.28.1-py3-none-win32.whl", hash = "sha256:4bc461cda3ce23a19d8df5e42981a664d95fa3231efb10fd1e85d9d4824c7d29", size = 24418398, upload-time = "2026-07-16T18:46:57.43Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/6f/ed6616b11ea15b8ceabedcaa567286c1c9ec65fa50563230a90bfb627cc5/wandb-0.28.1-py3-none-win_amd64.whl", hash = "sha256:d98a10370162b1e970850237114c56e9c4c58f3cb701e4b8cb38f36f6749fd52", size = 24418404, upload-time = "2026-07-16T18:47:00.427Z" },
-    { url = "https://files.pythonhosted.org/packages/07/78/75b6827a6665337a715c5347c5edbd84eca660f7a0f48d8d6d24d1f66bee/wandb-0.28.1-py3-none-win_arm64.whl", hash = "sha256:4aa07f13dd3bcac2c0524c8d0f49f76e83ab5c1054fd09f3b1a436cfcde146a6", size = 22299006, upload-time = "2026-07-16T18:47:02.71Z" },
 ]
 
 [[package]]
@@ -5506,41 +5402,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/6d/56ed2b6b200f26fb474f3fd387d95d0601efcd5bb33430c90c68924bdd77/xxhash-3.8.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4b512261801b1e5fde7b6ebf2fef7977339c620cbbca88a0040ad9ad134f4d02", size = 38202, upload-time = "2026-07-06T10:49:50.59Z" },
     { url = "https://files.pythonhosted.org/packages/0d/a3/56864d895d1161a9f17502088e9c1fb7c06bde2c2efdde620d22bb7a9c43/xxhash-3.8.1-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:49aa8692507835dcc1e8ad8021f20c74c2dc13d83b5112e87877faa2a0035b20", size = 34448, upload-time = "2026-07-06T10:49:53.242Z" },
     { url = "https://files.pythonhosted.org/packages/6b/57/5c6e0908a47f61dca96d01c8ee6fce01ed1050611eb779083ba8758fed81/xxhash-3.8.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:345b07b78e2bf583d71682aa34ae5b5fab575f7a1cb31e10263ebbc6f89f8c42", size = 32869, upload-time = "2026-07-06T10:49:55.972Z" },
-]
-
-[[package]]
-name = "yappi"
-version = "1.7.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9f/47/f7ec7744dff1104560d6276f951a8182f5b805e8d86ece591aebd0512845/yappi-1.7.6.tar.gz", hash = "sha256:c94281936af77c00c6ac2306a0e7f85a67e354d717120df85fcc5dfb9243d4dd", size = 62639, upload-time = "2026-03-17T22:31:40.928Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/6d/332fb3c5044b029398e82faea2cf0723ba57e26383d5ad461d2e1f6f049e/yappi-1.7.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6d6b52ebe13f05c4845df803aca02ea209cb6de71b5e16a26a938543d9df4342", size = 33037, upload-time = "2026-03-17T22:30:48.93Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/dd/3692268998ebbbfd984ffdea52f56548480626d046eb1e83fb50a7e3e704/yappi-1.7.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a4b62efda1ca0b820985ae31f5081fa8250307f45d5905ba78b19c558fccd9e2", size = 33097, upload-time = "2026-03-17T22:30:50.267Z" },
-    { url = "https://files.pythonhosted.org/packages/15/6a/c4c34f8fb1e683e9cf513f842c5ad1accbdc701b635192a47f701eebfdca/yappi-1.7.6-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8aa1f8983463d064cdd28709f76c5886bc1417607f075fc326e605faa44e7f04", size = 81519, upload-time = "2026-03-17T22:30:51.117Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/08/0dc97e9131004491b55cabc6d8d8b9e498e4e80cfdf5df04d4bf8e5c4829/yappi-1.7.6-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:757199a1d4e8b3f27656b69612d6db99fb06df6e25dc3b37a01b11e564b135fe", size = 80624, upload-time = "2026-03-17T22:30:52.199Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/23/da8868b2654795411026778b45e0a2a72fa75f6aad5c1603263a5ff6e14f/yappi-1.7.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:84fb5444b1e10c66f34fc65fdaa461dbce703865925d5d81604e614e775f9c24", size = 79046, upload-time = "2026-03-17T22:30:53.094Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/4c/da46a83e33a9f20f6f53f675dd3aba433fd989d04c723c1154e7f1485f95/yappi-1.7.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:322bdfe2693492c226c31fcb0c197a203a0ff8e65e0594882c4d6061a1184b49", size = 78629, upload-time = "2026-03-17T22:30:54.052Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/d6/38bdf52d49e3f0349730da50ccf36d83b6d8b107dbdb7ff6e89347bebf8b/yappi-1.7.6-cp311-cp311-win32.whl", hash = "sha256:380d6b49d5d62df60c022c7c510dc56cac688f2329cda07954a0d99edeba644c", size = 32750, upload-time = "2026-03-17T22:30:54.947Z" },
-    { url = "https://files.pythonhosted.org/packages/61/2c/bb70b2af0d684d34c3432f8edd5d526ad45d55f7e4652d7f9d62e7408bb0/yappi-1.7.6-cp311-cp311-win_amd64.whl", hash = "sha256:d8721d2137155880eaf851b0a1bc9ad3e9a3c175e28869a87e8abd22d2b12029", size = 35132, upload-time = "2026-03-17T22:30:55.813Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/0a/aa57e4502235ea3bf837845895f996b94e41fb4a7cf2c98f96d9f98b3634/yappi-1.7.6-cp311-cp311-win_arm64.whl", hash = "sha256:b6a4e5b7c813aa147ddc6a12f660de01829da184d760095dd3609cf1059b64e3", size = 32774, upload-time = "2026-03-17T22:30:56.747Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/0e/948fdb5980494c50fcf4d24cfd1d5c2ea9c48d4dd151e6b9c032d7ac5fed/yappi-1.7.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:56fae31c4e09448a9919c1e6a4f976b2a49aa914f42e6e95355f6329c83003da", size = 33256, upload-time = "2026-03-17T22:30:57.871Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/be/af330ad8ede549ecaa8b29d3a2185e2209b3a87056c05dbaaa7841497c6d/yappi-1.7.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:15ed0d845e30b35952d09dd4f70df81089db05b735d57c75e0924ebacda14a34", size = 33189, upload-time = "2026-03-17T22:30:58.733Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/80/220c5a34e3a4949cea0e0ff1049afab3a67f1bfb348db89a16bb74c77621/yappi-1.7.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e878f63781761db7b62265468d78147b95df9ca2af9bc5140f94ad0faffe11c", size = 82799, upload-time = "2026-03-17T22:30:59.649Z" },
-    { url = "https://files.pythonhosted.org/packages/94/e0/e49b8e12140dba82767ee9fd8de1577be90a09a083aa6e0f02fdfc3e8ee9/yappi-1.7.6-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a88615e2b9817887f6d1addfd12466a8529f25acc58b656205ae3f641cd725b", size = 82322, upload-time = "2026-03-17T22:31:00.524Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/95/fdcabc38a3e70e7c6394d07868ff25c9984a1ea97020cc65d8858c71aa62/yappi-1.7.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:178b23a56a59ddd58a528848e9242040ecad6d2fe0bcfb439455eef02cd43b07", size = 79978, upload-time = "2026-03-17T22:31:01.456Z" },
-    { url = "https://files.pythonhosted.org/packages/83/e6/6e11c44a90725a6f1afa4bc308618b2efc07a90d4c06e1d5a3b0125f8e6c/yappi-1.7.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:62cbb47dffca45b906d52a3c8f02e508f67d657275fb9d897e1e736fe5afe25f", size = 80053, upload-time = "2026-03-17T22:31:02.366Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/79/f056c72ba190d186fe52eb6a9181aab15dbd68a868ab5c7375e3b5796565/yappi-1.7.6-cp312-cp312-win32.whl", hash = "sha256:dbcf79ee2f1a96ec52e8291c07e27c0e38eead61a5c24d57eb467b5d9e6f2f9f", size = 32906, upload-time = "2026-03-17T22:31:03.29Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/89/a9ee11f80482263b7268c8968a4e675393454167b20574831a357610afd4/yappi-1.7.6-cp312-cp312-win_amd64.whl", hash = "sha256:59bd23fb39a7b9027c5eecc94585042849cb36be9af2d35c31812be1408af356", size = 35204, upload-time = "2026-03-17T22:31:04.131Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/72/711a33a5bf45e5af484a48001b75908dade76d4b8ed5d180f89dc62c5a5a/yappi-1.7.6-cp312-cp312-win_arm64.whl", hash = "sha256:0adc831b099a554831335819d7eb1643e189e4f3aa2db873ca5d584bd42dba01", size = 32836, upload-time = "2026-03-17T22:31:05.116Z" },
-    { url = "https://files.pythonhosted.org/packages/15/b0/9a10f3a22290b67e23f339318fd368c173547478e0896f89363fb9cf190b/yappi-1.7.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:072df6fa8b4cfb5159c261dd0df8e8b85de0adbadbc5e953e1183da193674bc4", size = 33299, upload-time = "2026-03-17T22:31:06.04Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/ca/f36ccb82d7c96dee3858d26ed08e67de1767c309f285dbb2f76eceeaba48/yappi-1.7.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e4643d431656ec63e83455605ba29d1609d36b2fe14412e6939a223c323a7aee", size = 33193, upload-time = "2026-03-17T22:31:07.293Z" },
-    { url = "https://files.pythonhosted.org/packages/17/04/078db90359b39496f9192e375cd97831b138794cf456ad43bd8c7b65a4e3/yappi-1.7.6-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b27541c7f77ef2f76b2e0bb5da6dce5dc5fcdc7e500b4756e7a3e077d499ac25", size = 83096, upload-time = "2026-03-17T22:31:08.205Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/52/24e214e5d4093e7b137fac95958afe289d1153ad35e6556be348c55a0b6a/yappi-1.7.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6e100b6c36b922fc407078ed74f08b2463f46efc1fb440387eb493966e4ec434", size = 82639, upload-time = "2026-03-17T22:31:09.121Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/d9/19b43be0e0f2a72518ec4907138614d4f98027839c10cd6b9b3a607cca2a/yappi-1.7.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5beecd15ff133c93fc505669754cb7caadd7fb19e87a71af133dfd1410e17aff", size = 80278, upload-time = "2026-03-17T22:31:10.039Z" },
-    { url = "https://files.pythonhosted.org/packages/68/9e/9fa404fee5eb4942ad36409b5d00e3783bd573982aa84f22c8a2646a7125/yappi-1.7.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f3b5742d39c1ebe8909db0dec4a5b724a5a6167161864280021298f7ef4e76a1", size = 80337, upload-time = "2026-03-17T22:31:11.299Z" },
-    { url = "https://files.pythonhosted.org/packages/92/2a/a42901c467259e10193c66a24bff410f041896ecdd3cb7b42dd515a54b2a/yappi-1.7.6-cp313-cp313-win32.whl", hash = "sha256:c9e3a92a04d9d6199fa0d157139beff1ca7eea7389e0e6b46b1353d8ffeec6a3", size = 32897, upload-time = "2026-03-17T22:31:12.219Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/6c/dede83e0ca33701681acdb06854e492010257ae83bd9dda8e953983fab3a/yappi-1.7.6-cp313-cp313-win_amd64.whl", hash = "sha256:95f9f326483d111b768f630a2d60689de7defff777f016b1f0dab9e93f36beb5", size = 35215, upload-time = "2026-03-17T22:31:13.084Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/b0/dec448196d207b2e3b4e6b27dd74d0f1714b645af4f25cfe7dfd564ec14f/yappi-1.7.6-cp313-cp313-win_arm64.whl", hash = "sha256:4981a243c5dbf105f6e1415197935ca36fde2b28adf26d2feceb95b5f1f77f06", size = 32861, upload-time = "2026-03-17T22:31:14.292Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -5053,7 +5053,6 @@ dependencies = [
     { name = "datasets" },
     { name = "gepa" },
     { name = "httpx" },
-    { name = "httpx2" },
     { name = "loguru" },
     { name = "math-verify" },
     { name = "mcp" },
@@ -5092,7 +5091,6 @@ notebook = [
     { name = "nest-asyncio" },
 ]
 openenv = [
-    { name = "fastmcp" },
     { name = "openenv" },
 ]
 rg = [

--- a/verifiers/legacy/envs/experimental/mcp_env.py
+++ b/verifiers/legacy/envs/experimental/mcp_env.py
@@ -6,7 +6,7 @@ import threading
 from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, cast
 
-from mcp import ClientSession, StdioServerParameters
+from mcp import Client, StdioServerParameters
 from mcp.client.stdio import stdio_client
 from mcp.types import TextContent, Tool as MCPTool
 
@@ -27,7 +27,7 @@ class MCPServerConnection:
     def __init__(self, config: MCPServerConfig, logger: logging.Logger):
         self.config = config
         self.logger = logger
-        self.session: Optional[ClientSession] = None
+        self.client: Optional[Client] = None
         self.tools: Dict[str, MCPTool] = {}
 
         self._connection_task: Optional[asyncio.Task] = None
@@ -54,21 +54,18 @@ class MCPServerConnection:
                 env=self.config.env,
             )
 
-            async with stdio_client(server_params) as (read, write):
-                async with ClientSession(read, write) as session:
-                    self.session = session
+            async with Client(stdio_client(server_params)) as client:
+                self.client = client
 
-                    await session.initialize()
+                tools_response = await client.list_tools()
 
-                    tools_response = await session.list_tools()
+                for tool in tools_response.tools:
+                    self.tools[tool.name] = tool
 
-                    for tool in tools_response.tools:
-                        self.tools[tool.name] = tool
+                self._ready.set()
 
-                    self._ready.set()
-
-                    while True:
-                        await asyncio.sleep(1)
+                while True:
+                    await asyncio.sleep(1)
 
         except asyncio.CancelledError:
             raise
@@ -76,14 +73,14 @@ class MCPServerConnection:
             self._error = e
             self._ready.set()
         finally:
-            self.session = None
+            self.client = None
             self.tools = {}
 
     async def call_tool(self, tool_name: str, arguments: dict) -> str:
-        assert self.session is not None, f"Server '{self.config.name}' not connected"
+        assert self.client is not None, f"Server '{self.config.name}' not connected"
         assert self.loop is not None, "Connection loop not initialized"
         fut = asyncio.run_coroutine_threadsafe(
-            self.session.call_tool(tool_name, arguments=arguments), self.loop
+            self.client.call_tool(tool_name, arguments=arguments), self.loop
         )
         result = await asyncio.wrap_future(fut)
 
@@ -130,7 +127,7 @@ class MCPToolWrapper:
         """Convert the MCP tool metadata directly to vf.Tool."""
         parameters = cast(
             dict[str, object],
-            self.tool.inputSchema or {"type": "object", "properties": {}},
+            self.tool.input_schema or {"type": "object", "properties": {}},
         )
         return Tool(
             name=self.__name__,

--- a/verifiers/v1/harnesses/bash/program.py
+++ b/verifiers/v1/harnesses/bash/program.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["openai", "mcp>=1.24.0,<2", "httpx", "tenacity"]
+# dependencies = ["openai", "mcp==2.0.0", "httpx", "httpx2", "tenacity"]
 # ///
 """Secrets arrive through argv so local tool subprocesses do not inherit them."""
 
@@ -187,12 +187,14 @@ async def chat(
 
 
 @asynccontextmanager
-async def mcp_session(spec: dict):
-    """One fresh streamable-HTTP session to an MCP server, opened and closed within the caller's
-    task so AnyIO cancellation scopes stay correctly nested. A teardown failure after the body
-    completed is swallowed — the result is already in hand, and closing noise must not fail (or
-    replay) an already-answered call."""
-    from mcp import ClientSession
+async def mcp_client(spec: dict):
+    """One fresh MCP client, negotiating the newest protocol and falling back for old servers.
+
+    It is opened and closed within the caller's task so AnyIO cancellation scopes stay correctly
+    nested. Closing noise after a completed body cannot fail or replay an answered call.
+    """
+    import httpx2
+    from mcp import Client
     from mcp.client.streamable_http import (
         create_mcp_http_client,
         streamable_http_client,
@@ -203,22 +205,18 @@ async def mcp_session(spec: dict):
         http_client = await stack.enter_async_context(
             create_mcp_http_client(
                 headers=spec.get("headers") or None,
-                timeout=httpx.Timeout(spec.get("timeout", MCP_TIMEOUT), connect=5.0),
+                timeout=httpx2.Timeout(spec.get("timeout", MCP_TIMEOUT), connect=5.0),
             )
         )
-        read, write, *_ = await stack.enter_async_context(
-            streamable_http_client(spec["url"], http_client=http_client)
-        )
-        session = await stack.enter_async_context(ClientSession(read, write))
-        await session.initialize()
-        yield session
+        transport = streamable_http_client(spec["url"], http_client=http_client)
+        yield await stack.enter_async_context(Client(transport))
     finally:
         with suppress(Exception):
             await stack.aclose()
 
 
 async def with_retry(call):
-    """Run one session-scoped operation, retrying transient failures with backoff. A call whose
+    """Run one client operation, retrying transient failures with backoff. A call whose
     response was lost may be replayed — MCP has no idempotency key, so tools should tolerate
     at-least-once delivery (a tool that fails reports through its result, not an exception)."""
     async for attempt in AsyncRetrying(
@@ -235,7 +233,7 @@ async def connect_mcp(
 ) -> tuple[list[dict], dict, dict]:
     """Enumerate each configured MCP server's tools (a streamable-HTTP `url`); return (tool schemas,
     dispatch mapping `<server>_<tool>` -> (server name, raw tool name), servers mapping name -> spec).
-    No session is held — a stateless-HTTP server is reconnected per call."""
+    No protocol session is held; a fresh client handles each call."""
     tool_schemas: list[dict] = []
     dispatch: dict[str, tuple] = {}
     servers: dict[str, dict] = {}
@@ -243,8 +241,8 @@ async def connect_mcp(
         servers[name] = spec
 
         async def list_tools(spec: dict = spec):
-            async with mcp_session(spec) as session:
-                return (await session.list_tools()).tools
+            async with mcp_client(spec) as client:
+                return (await client.list_tools()).tools
 
         for tool in await with_retry(list_tools):
             # A server named "" (TOOL_PREFIX = None) advertises its tools bare.
@@ -259,7 +257,7 @@ async def connect_mcp(
                     "function": {
                         "name": full,
                         "description": tool.description or "",
-                        "parameters": tool.inputSchema,
+                        "parameters": tool.input_schema,
                     },
                 }
             )
@@ -273,7 +271,7 @@ def mcp_content_to_chat_content(blocks) -> str | list[dict]:
         if block.type == "text":
             parts.append({"type": "text", "text": block.text})
         elif block.type == "image":
-            url = f"data:{block.mimeType};base64,{block.data}"
+            url = f"data:{block.mime_type};base64,{block.data}"
             parts.append({"type": "image_url", "image_url": {"url": url}})
         else:
             parts.append({"type": "text", "text": str(block)})
@@ -287,13 +285,13 @@ def mcp_content_to_chat_content(blocks) -> str | list[dict]:
 async def call_mcp(
     servers: dict, dispatch: dict, name: str, arguments: dict
 ) -> str | list[dict]:
-    """Call a tool on a fresh session per attempt — see `with_retry` for the replay semantics.
+    """Call a tool with a fresh client per attempt — see `with_retry` for replay semantics.
     The result is converted outside the retry so a conversion failure fails once."""
     server_name, raw = dispatch[name]
 
     async def call():
-        async with mcp_session(servers[server_name]) as session:
-            return await session.call_tool(raw, arguments)
+        async with mcp_client(servers[server_name]) as client:
+            return await client.call_tool(raw, arguments)
 
     result = await with_retry(call)
     return mcp_content_to_chat_content(result.content)

--- a/verifiers/v1/harnesses/browser_use/program.py
+++ b/verifiers/v1/harnesses/browser_use/program.py
@@ -1,10 +1,11 @@
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.11"
 # dependencies = [
 #     "browser-harness==0.1.8",
 #     "openai",
-#     "mcp>=1.24.0,<2",
+#     "mcp==2.0.0",
 #     "httpx",
+#     "httpx2",
 #     "tenacity",
 # ]
 # ///
@@ -31,7 +32,6 @@ from pathlib import Path
 from typing import Any, cast
 from urllib.parse import urlsplit
 
-import httpx
 from openai import AsyncOpenAI
 from tenacity import AsyncRetrying, stop_after_attempt, wait_exponential_jitter
 
@@ -188,12 +188,14 @@ async def chat(
 
 
 @asynccontextmanager
-async def mcp_session(spec: dict):
-    """One fresh streamable-HTTP session to an MCP server, opened and closed within the caller's
-    task so AnyIO cancellation scopes stay correctly nested. A teardown failure after the body
-    completed is swallowed — the result is already in hand, and closing noise must not fail (or
-    replay) an already-answered call."""
-    from mcp import ClientSession
+async def mcp_client(spec: dict):
+    """One fresh MCP client, negotiating the newest protocol and falling back for old servers.
+
+    It is opened and closed within the caller's task so AnyIO cancellation scopes stay correctly
+    nested. Closing noise after a completed body cannot fail or replay an answered call.
+    """
+    import httpx2
+    from mcp import Client
     from mcp.client.streamable_http import (
         create_mcp_http_client,
         streamable_http_client,
@@ -204,22 +206,18 @@ async def mcp_session(spec: dict):
         http_client = await stack.enter_async_context(
             create_mcp_http_client(
                 headers=spec.get("headers") or None,
-                timeout=httpx.Timeout(spec.get("timeout", MCP_TIMEOUT), connect=5.0),
+                timeout=httpx2.Timeout(spec.get("timeout", MCP_TIMEOUT), connect=5.0),
             )
         )
-        read, write, *_ = await stack.enter_async_context(
-            streamable_http_client(spec["url"], http_client=http_client)
-        )
-        session = await stack.enter_async_context(ClientSession(read, write))
-        await session.initialize()
-        yield session
+        transport = streamable_http_client(spec["url"], http_client=http_client)
+        yield await stack.enter_async_context(Client(transport))
     finally:
         with suppress(Exception):
             await stack.aclose()
 
 
 async def with_retry(call):
-    """Run one session-scoped operation, retrying transient failures with backoff. A call whose
+    """Run one client operation, retrying transient failures with backoff. A call whose
     response was lost may be replayed — MCP has no idempotency key, so tools should tolerate
     at-least-once delivery (a tool that fails reports through its result, not an exception)."""
     async for attempt in AsyncRetrying(
@@ -236,7 +234,7 @@ async def connect_mcp(
 ) -> tuple[list[dict], dict, dict]:
     """Enumerate each configured MCP server's tools (a streamable-HTTP `url`); return (tool schemas,
     dispatch mapping `<server>_<tool>` -> (server name, raw tool name), servers mapping name -> spec).
-    No session is held — a stateless-HTTP server is reconnected per call."""
+    No protocol session is held; a fresh client handles each call."""
     tool_schemas: list[dict] = []
     dispatch: dict[str, tuple] = {}
     servers: dict[str, dict] = {}
@@ -244,8 +242,8 @@ async def connect_mcp(
         servers[name] = spec
 
         async def list_tools(spec: dict = spec):
-            async with mcp_session(spec) as session:
-                return (await session.list_tools()).tools
+            async with mcp_client(spec) as client:
+                return (await client.list_tools()).tools
 
         for tool in await with_retry(list_tools):
             # A server named "" (TOOL_PREFIX = None) advertises its tools bare.
@@ -260,7 +258,7 @@ async def connect_mcp(
                     "function": {
                         "name": full,
                         "description": tool.description or "",
-                        "parameters": tool.inputSchema,
+                        "parameters": tool.input_schema,
                     },
                 }
             )
@@ -274,7 +272,7 @@ def mcp_content_to_chat_content(blocks) -> str | list[dict]:
         if block.type == "text":
             parts.append({"type": "text", "text": block.text})
         elif block.type == "image":
-            url = f"data:{block.mimeType};base64,{block.data}"
+            url = f"data:{block.mime_type};base64,{block.data}"
             parts.append({"type": "image_url", "image_url": {"url": url}})
         else:
             parts.append({"type": "text", "text": str(block)})
@@ -288,13 +286,13 @@ def mcp_content_to_chat_content(blocks) -> str | list[dict]:
 async def call_mcp(
     servers: dict, dispatch: dict, name: str, arguments: dict
 ) -> str | list[dict]:
-    """Call a tool on a fresh session per attempt — see `with_retry` for the replay semantics.
+    """Call a tool with a fresh client per attempt — see `with_retry` for replay semantics.
     The result is converted outside the retry so a conversion failure fails once."""
     server_name, raw = dispatch[name]
 
     async def call():
-        async with mcp_session(servers[server_name]) as session:
-            return await session.call_tool(raw, arguments)
+        async with mcp_client(servers[server_name]) as client:
+            return await client.call_tool(raw, arguments)
 
     result = await with_retry(call)
     return mcp_content_to_chat_content(result.content)

--- a/verifiers/v1/harnesses/codex/harness.py
+++ b/verifiers/v1/harnesses/codex/harness.py
@@ -138,7 +138,7 @@ class CodexHarness(ACPHarness[CodexHarnessConfig]):
                 f"failed to create Codex home: {created.stderr.strip()[-500:]}"
             )
 
-        mcp_config = (
+        mcp_config = "features={mcp_2026_07_28=true}\n" + (
             "mcp_servers={"
             + ",".join(
                 f"{json.dumps(name, ensure_ascii=False)}="

--- a/verifiers/v1/harnesses/null/program.py
+++ b/verifiers/v1/harnesses/null/program.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.11"
-# dependencies = ["openai", "mcp>=1.24.0,<2", "httpx", "tenacity"]
+# dependencies = ["openai", "mcp==2.0.0", "httpx", "httpx2", "tenacity"]
 # ///
 """The interception endpoint and secret arrive through argv rather than the environment."""
 
@@ -59,12 +59,14 @@ async def chat(
 
 
 @asynccontextmanager
-async def mcp_session(spec: dict):
-    """One fresh streamable-HTTP session to an MCP server, opened and closed within the caller's
-    task so AnyIO cancellation scopes stay correctly nested. A teardown failure after the body
-    completed is swallowed — the result is already in hand, and closing noise must not fail (or
-    replay) an already-answered call."""
-    from mcp import ClientSession
+async def mcp_client(spec: dict):
+    """One fresh MCP client, negotiating the newest protocol and falling back for old servers.
+
+    It is opened and closed within the caller's task so AnyIO cancellation scopes stay correctly
+    nested. Closing noise after a completed body cannot fail or replay an answered call.
+    """
+    import httpx2
+    from mcp import Client
     from mcp.client.streamable_http import (
         create_mcp_http_client,
         streamable_http_client,
@@ -75,22 +77,18 @@ async def mcp_session(spec: dict):
         http_client = await stack.enter_async_context(
             create_mcp_http_client(
                 headers=spec.get("headers") or None,
-                timeout=httpx.Timeout(spec.get("timeout", MCP_TIMEOUT), connect=5.0),
+                timeout=httpx2.Timeout(spec.get("timeout", MCP_TIMEOUT), connect=5.0),
             )
         )
-        read, write, *_ = await stack.enter_async_context(
-            streamable_http_client(spec["url"], http_client=http_client)
-        )
-        session = await stack.enter_async_context(ClientSession(read, write))
-        await session.initialize()
-        yield session
+        transport = streamable_http_client(spec["url"], http_client=http_client)
+        yield await stack.enter_async_context(Client(transport))
     finally:
         with suppress(Exception):
             await stack.aclose()
 
 
 async def with_retry(call):
-    """Run one session-scoped operation, retrying transient failures with backoff. A call whose
+    """Run one client operation, retrying transient failures with backoff. A call whose
     response was lost may be replayed — MCP has no idempotency key, so tools should tolerate
     at-least-once delivery (a tool that fails reports through its result, not an exception)."""
     async for attempt in AsyncRetrying(
@@ -105,7 +103,7 @@ async def with_retry(call):
 async def connect_mcp(config: dict) -> tuple[list[dict], dict, dict]:
     """Enumerate each configured MCP server's tools (a streamable-HTTP `url`); return (tool schemas,
     dispatch mapping advertised name -> (server name, raw tool name), servers mapping name -> spec).
-    No session is held — a stateless-HTTP server is reconnected per call. Tools are advertised as
+    No protocol session is held; a fresh client handles each call. Tools are advertised as
     `<server>_<tool>`; a server named `""` (TOOL_PREFIX = None) advertises its tools bare, so names
     must be unique across the rollout's servers."""
     tool_schemas: list[dict] = []
@@ -115,8 +113,8 @@ async def connect_mcp(config: dict) -> tuple[list[dict], dict, dict]:
         servers[name] = spec
 
         async def list_tools(spec: dict = spec):
-            async with mcp_session(spec) as session:
-                return (await session.list_tools()).tools
+            async with mcp_client(spec) as client:
+                return (await client.list_tools()).tools
 
         for tool in await with_retry(list_tools):
             full = f"{name}_{tool.name}" if name else tool.name
@@ -130,7 +128,7 @@ async def connect_mcp(config: dict) -> tuple[list[dict], dict, dict]:
                     "function": {
                         "name": full,
                         "description": tool.description or "",
-                        "parameters": tool.inputSchema,
+                        "parameters": tool.input_schema,
                     },
                 }
             )
@@ -144,7 +142,7 @@ def mcp_content_to_chat_content(blocks) -> str | list[dict]:
         if block.type == "text":
             parts.append({"type": "text", "text": block.text})
         elif block.type == "image":
-            url = f"data:{block.mimeType};base64,{block.data}"
+            url = f"data:{block.mime_type};base64,{block.data}"
             parts.append({"type": "image_url", "image_url": {"url": url}})
         else:
             parts.append({"type": "text", "text": str(block)})
@@ -158,13 +156,13 @@ def mcp_content_to_chat_content(blocks) -> str | list[dict]:
 async def call_mcp(
     servers: dict, dispatch: dict, name: str, arguments: dict
 ) -> str | list[dict]:
-    """Call a tool on a fresh session per attempt — see `with_retry` for the replay semantics.
+    """Call a tool with a fresh client per attempt — see `with_retry` for replay semantics.
     The result is converted outside the retry so a conversion failure fails once."""
     server_name, raw = dispatch[name]
 
     async def call():
-        async with mcp_session(servers[server_name]) as session:
-            return await session.call_tool(raw, arguments)
+        async with mcp_client(servers[server_name]) as client:
+            return await client.call_tool(raw, arguments)
 
     result = await with_retry(call)
     return mcp_content_to_chat_content(result.content)
@@ -197,7 +195,7 @@ async def main() -> None:
     )
     config = json.loads(args.mcp_config or "{}")
     if config.get("mcpServers"):
-        # Bound only tool enumeration; each session is opened and closed within this task.
+        # Bound only tool enumeration; each client is opened and closed within this task.
         async with asyncio.timeout(60):
             tools, dispatch, servers = await connect_mcp(config)
     else:

--- a/verifiers/v1/mcp/server.py
+++ b/verifiers/v1/mcp/server.py
@@ -10,6 +10,7 @@ import logging
 import os
 from collections.abc import Callable
 from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar
+from urllib.parse import parse_qs
 
 from pydantic import TypeAdapter, ValidationError
 from pydantic_config import BaseConfig
@@ -19,7 +20,7 @@ from verifiers.v1.utils.generic import concrete_type
 
 if TYPE_CHECKING:
     from httpx import AsyncClient, Response
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server.mcpserver import MCPServer
 
 ConfigT = TypeVar("ConfigT", bound=BaseConfig)
 logger = logging.getLogger(__name__)
@@ -95,18 +96,14 @@ def state_signature(secret: str, url: str, route: str) -> str:
 _call_state: contextvars.ContextVar[State | None] = contextvars.ContextVar(
     "vf_call_state", default=None
 )
+_request_query_params: contextvars.ContextVar[dict[str, list[str]] | None] = (
+    contextvars.ContextVar("vf_request_query_params", default=None)
+)
 
 
 def _request_query(name: str) -> str | None:
-    from mcp.server.lowlevel.server import request_ctx
-
-    try:
-        request = request_ctx.get().request
-    except LookupError:
-        return None
-    if request is None:
-        return None
-    values = request.query_params.getlist(name)
+    params = _request_query_params.get()
+    values = params.get(name, []) if params else []
     if len(values) > 1:
         raise ValueError(f"duplicate {name!r} state coordinate")
     return values[0] if values else None
@@ -248,7 +245,7 @@ class ServerBase(Generic[ConfigT, StateT]):
             finally:
                 _call_state.reset(token)
 
-        # FastMCP must advertise the wrapped tool's parameters, not `*args, **kwargs`.
+        # MCPServer must advertise the wrapped tool's parameters, not `*args, **kwargs`.
         wrapper.__signature__ = inspect.signature(fn)  # type: ignore[attr-defined]
         return wrapper
 
@@ -266,7 +263,7 @@ class ServerBase(Generic[ConfigT, StateT]):
     async def setup_task(self, task) -> None:
         """Initialize per-task state; taskset-scoped servers skip this hook."""
 
-    def register(self, mcp: FastMCP) -> None:
+    def register(self, mcp: MCPServer) -> None:
         """Register this server's MCP handlers."""
         raise NotImplementedError
 
@@ -276,7 +273,9 @@ class ServerBase(Generic[ConfigT, StateT]):
         from pathlib import Path
 
         import uvicorn
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server.mcpserver import MCPServer
+
+        from verifiers import __version__
 
         _die_with_parent()
         host = os.environ.get("MCP_HOST", "127.0.0.1")
@@ -306,14 +305,34 @@ class ServerBase(Generic[ConfigT, StateT]):
                     security = TransportSecuritySettings(
                         enable_dns_rebinding_protection=False
                     )
-                    mcp = FastMCP(
-                        self.server_name,
+                    mcp = MCPServer(
+                        self.server_name or type(self).__name__,
+                        version=__version__,
+                    )
+                    self.register(mcp)
+                    # Modern HTTP is inherently sessionless. Keep the legacy leg stateless too so
+                    # older agent clients can use the same reconnect-per-call endpoint.
+                    mcp_app = mcp.streamable_http_app(
                         json_response=True,
                         stateless_http=True,
                         transport_security=security,
                     )
-                    self.register(mcp)
-                    app = mcp.streamable_http_app()
+
+                    async def app(scope, receive, send):
+                        query = (
+                            parse_qs(
+                                scope.get("query_string", b"").decode(),
+                                keep_blank_values=True,
+                            )
+                            if scope["type"] == "http"
+                            else None
+                        )
+                        token = _request_query_params.set(query)
+                        try:
+                            await mcp_app(scope, receive, send)
+                        finally:
+                            _request_query_params.reset(token)
+
                     server = uvicorn.Server(uvicorn.Config(app, log_level="critical"))
                     await server.serve(sockets=[sock])
             finally:

--- a/verifiers/v1/mcp/toolset.py
+++ b/verifiers/v1/mcp/toolset.py
@@ -10,7 +10,7 @@ from verifiers.v1.state import StateT
 from verifiers.v1.utils.decorators import discover_decorated
 
 if TYPE_CHECKING:
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server.mcpserver import MCPServer
 
 
 class ToolsetConfig(BaseConfig):
@@ -25,7 +25,7 @@ class SharedToolsetConfig(BaseConfig):
 
 
 class Toolset(ServerBase[ConfigT, StateT]):
-    def register(self, mcp: FastMCP) -> None:
+    def register(self, mcp: MCPServer) -> None:
         for fn in discover_decorated(self, "tool"):
             mcp.add_tool(
                 self._with_state(fn),

--- a/verifiers/v1/tasksets/nemo_gym/server.py
+++ b/verifiers/v1/tasksets/nemo_gym/server.py
@@ -1,3 +1,33 @@
+# /// script
+# requires-python = ">=3.12,<3.14"
+# dependencies = ["nemo-gym==0.4.0"]
+#
+# [[tool.uv.dependency-metadata]]
+# name = "nemo-gym"
+# version = "0.4.0"
+# requires-python = ">=3.12"
+# requires-dist = [
+#     "aiohttp>=3.14.1",
+#     "fastapi",
+#     "gprof2dot",
+#     "hydra-core",
+#     "itsdangerous",
+#     "mcp>=1.27,<2",
+#     "omegaconf",
+#     "openai>=2.9",
+#     "orjson",
+#     "pandas",
+#     "pydantic",
+#     "pydot",
+#     "ray>=2.55.1",
+#     "requests",
+#     "rich",
+#     "typing-extensions",
+#     "uvicorn",
+#     "wandb",
+#     "yappi",
+# ]
+# ///
 """Serve one resource-server class from the published NeMo Gym package."""
 
 import os

--- a/verifiers/v1/tasksets/nemo_gym/taskset.py
+++ b/verifiers/v1/tasksets/nemo_gym/taskset.py
@@ -135,8 +135,10 @@ class NeMoGymEnv(SingleAgentEnv):
 
         runtime = self._nemo_runtime = make_runtime(SubprocessConfig())
         await runtime.start()
+        server = Path(__file__).with_name("server.py")
+        program = await runtime.prepare_uv_script(server.read_bytes())
         await runtime.run_background(
-            ["uv", "run", str(Path(__file__).with_name("server.py"))],
+            program,
             {"NEMO_GYM_RESOURCE_SERVER": entrypoint},
             "nemo_gym.log",
         )

--- a/verifiers/v1/tasksets/nemo_gym/taskset.py
+++ b/verifiers/v1/tasksets/nemo_gym/taskset.py
@@ -1,9 +1,7 @@
 """NeMo Gym resource-server tasks driven by Verifiers harnesses."""
 
 import asyncio
-import importlib.util
 import json
-import sys
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, ClassVar, cast
@@ -131,11 +129,6 @@ class NeMoGymEnv(SingleAgentEnv):
         config = taskset.config.task
         if config.resources_url is not None:
             return
-        if importlib.util.find_spec("nemo_gym") is None:
-            raise RuntimeError(
-                "Managed NeMo Gym tasksets require the `nemo-gym` extra. "
-                "Install it with: `uv sync --python 3.12 --extra nemo-gym`"
-            )
         entrypoint = taskset.resource_server
         if entrypoint is None:
             raise ValueError("set --env.taskset.task.resources-url")
@@ -143,7 +136,7 @@ class NeMoGymEnv(SingleAgentEnv):
         runtime = self._nemo_runtime = make_runtime(SubprocessConfig())
         await runtime.start()
         await runtime.run_background(
-            [sys.executable, "-m", "verifiers.v1.tasksets.nemo_gym.server"],
+            ["uv", "run", str(Path(__file__).with_name("server.py"))],
             {"NEMO_GYM_RESOURCE_SERVER": entrypoint},
             "nemo_gym.log",
         )

--- a/verifiers/v1/tasksets/nemo_gym/toolset.py
+++ b/verifiers/v1/tasksets/nemo_gym/toolset.py
@@ -5,7 +5,6 @@ from contextlib import AsyncExitStack, asynccontextmanager, suppress
 from typing import Any, cast
 
 import httpx
-import httpx2
 from mcp import Client
 from mcp.client.streamable_http import create_mcp_http_client, streamable_http_client
 from mcp.server.mcpserver import Context, MCPServer
@@ -44,11 +43,9 @@ class NeMoGymState(State):
         stack = AsyncExitStack()
         try:
             http_client = await stack.enter_async_context(
-                create_mcp_http_client(
-                    headers=self.mcp_headers,
-                    timeout=httpx2.Timeout(self.request_timeout),
-                )
+                create_mcp_http_client(headers=self.mcp_headers)
             )
+            http_client.timeout = self.request_timeout
             transport = streamable_http_client(self.mcp_url, http_client=http_client)
             yield await stack.enter_async_context(Client(transport))
         finally:

--- a/verifiers/v1/tasksets/nemo_gym/toolset.py
+++ b/verifiers/v1/tasksets/nemo_gym/toolset.py
@@ -2,15 +2,13 @@
 
 from collections.abc import AsyncIterator
 from contextlib import AsyncExitStack, asynccontextmanager, suppress
-from typing import Any
+from typing import Any, cast
 
 import httpx
-from mcp import ClientSession
-from mcp.client.streamable_http import (
-    create_mcp_http_client,
-    streamable_http_client,
-)
-from mcp.server.fastmcp import FastMCP
+import httpx2
+from mcp import Client
+from mcp.client.streamable_http import create_mcp_http_client, streamable_http_client
+from mcp.server.mcpserver import Context, MCPServer
 from mcp.types import CallToolResult, TextContent, Tool
 from pydantic import Field
 
@@ -40,23 +38,19 @@ class NeMoGymState(State):
             return await client.post(f"{self.resources_url}/{path}", json=body)
 
     @asynccontextmanager
-    async def mcp_session(self) -> AsyncIterator[ClientSession]:
-        """Open an upstream MCP session using this rollout's credentials."""
+    async def mcp_client(self) -> AsyncIterator[Client]:
+        """Open an upstream MCP client using this rollout's credentials."""
         assert self.mcp_url is not None
         stack = AsyncExitStack()
         try:
-            client = await stack.enter_async_context(
+            http_client = await stack.enter_async_context(
                 create_mcp_http_client(
                     headers=self.mcp_headers,
-                    timeout=httpx.Timeout(self.request_timeout),
+                    timeout=httpx2.Timeout(self.request_timeout),
                 )
             )
-            read, write, *_ = await stack.enter_async_context(
-                streamable_http_client(self.mcp_url, http_client=client)
-            )
-            session = await stack.enter_async_context(ClientSession(read, write))
-            await session.initialize()
-            yield session
+            transport = streamable_http_client(self.mcp_url, http_client=http_client)
+            yield await stack.enter_async_context(Client(transport))
         finally:
             with suppress(Exception):
                 await stack.aclose()
@@ -67,31 +61,38 @@ class NeMoGymToolset(Toolset[SharedToolsetConfig, NeMoGymState]):
 
     TOOL_PREFIX = None
 
-    def register(self, mcp: FastMCP) -> None:
-        server = mcp._mcp_server
-        server.list_tools()(self._with_state(self.list_tools))
-        server.call_tool(validate_input=False)(self._with_state(self.call_tool))
+    def register(self, mcp: MCPServer) -> None:
+        # MCPServer's protocol handlers call these public methods, so replacing them keeps the
+        # dynamic, rollout-specific catalog without registering a fake static tool schema.
+        server = cast(Any, mcp)
+        server.list_tools = self._with_state(self.list_tools)
+        server.call_tool = self._with_state(self.call_tool)
 
     async def list_tools(self) -> list[Tool]:
         if self.state.mcp_url is not None:
-            async with self.state.mcp_session() as session:
-                tools = (await session.list_tools()).tools
+            async with self.state.mcp_client() as client:
+                tools = (await client.list_tools()).tools
         else:
             tools = [
                 Tool(
                     name=spec["name"],
                     description=spec.get("description") or None,
-                    inputSchema=spec.get("parameters") or {},
+                    input_schema=spec.get("parameters") or {},
                 )
                 for spec in self.state.direct_tools.values()
             ]
         self.state.tool_names = [tool.name for tool in tools]
         return tools
 
-    async def call_tool(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        context: Context | None = None,
+    ) -> CallToolResult:
         if self.state.mcp_url is not None:
-            async with self.state.mcp_session() as session:
-                return await session.call_tool(name, arguments)
+            async with self.state.mcp_client() as client:
+                return await client.call_tool(name, arguments)
 
         if name not in self.state.direct_tools:
             raise ValueError(f"unknown NeMo Gym tool: {name}")
@@ -99,7 +100,7 @@ class NeMoGymToolset(Toolset[SharedToolsetConfig, NeMoGymState]):
         response = await self.state.post(name, arguments)
         return CallToolResult(
             content=[TextContent(type="text", text=response.text)],
-            isError=not response.is_success,
+            is_error=not response.is_success,
         )
 
 


### PR DESCRIPTION
## Overview

Move Verifiers tool servers and first-party MCP clients to the MCP 2026-07-28 protocol and its stateless HTTP model.

## Details

- Run V1 tool servers on the MCP 2.0 server API with stateless Streamable HTTP.
- Use the MCP 2.0 negotiating client in the Null, Bash, Browser Use, Compact, legacy, and NeMo Gym integrations.
- Enable the new MCP protocol in Codex while allowing clients to negotiate with older servers.
- Isolate NeMo Gym's MCP 1.x dependency in its resource-server subprocess.
- Update the OpenAI Agents and OpenEnv/FastMCP dependency integrations needed by the new protocol.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Major MCP SDK and HTTP stack changes affect every tool call and MCP server path; NeMo Gym’s split subprocess adds a second MCP version boundary that could break if script isolation or negotiation regresses.
> 
> **Overview**
> Upgrades the stack to **MCP 2.0** (`mcp==2.0.0`) and the **2026-07-28** stateless Streamable HTTP model across V1 tool servers, harness MCP clients, and related integrations.
> 
> **Clients** replace `ClientSession` + manual `initialize()` with `mcp.Client` on streamable HTTP transports. Harness programs (null, bash, browser_use, compact) rename `mcp_session` → `mcp_client`, use **`httpx2`** for MCP HTTP timeouts, and read tool metadata via **`input_schema`** / image **`mime_type`**. The legacy experimental MCP env and NeMo Gym bridge follow the same client API.
> 
> **Servers** move from `FastMCP` to **`MCPServer`**, serving **`streamable_http_app(..., stateless_http=True)`** with a small ASGI wrapper so state coordinates still come from query params. Codex config prepends **`features={mcp_2026_07_28=true}`**.
> 
> **Dependencies**: pin MCP 2, bump **`openai-agents>=0.20.0`**, refresh the lockfile (e.g. fastmcp 4.x beta, `httpx2`). **NeMo Gym** no longer pulls MCP 1.x into the main install—the resource server runs as an isolated **uv script** (`server.py`) with its own `mcp>=1.27,<2` metadata, and the optional `nemo-gym` extra no longer declares the package directly in `pyproject.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e25357748a60c1130fea309a11a101c453e9be79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Upgrade MCP client and server to `mcp==2.0.0` (MCP 2026-07-28)
> - Replaces `mcp.ClientSession` with `mcp.Client` using `streamable_http_client` or `stdio_client` and `httpx2` timeouts across all harnesses
> - Migrates the MCP server from `FastMCP` to `MCPServer` using a stateless streamable HTTP app and a contextvar for request query parameters
> - Switches tool schema field from `inputSchema` to `input_schema` and image block field from `mimeType` to `mime_type`
> - Launches the NeMo Gym resource server as a prepared `uv` script in the sandbox, removing `nemo-gym` from harness core dependencies
> - Risk: Pins `mcp` to `==2.0.0` and bumps `openai-agents` to `>=0.20.0`. API changes in `MCPServer` and `mcp.Client` will break existing `FastMCP` server extensions or `ClientSession` callers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e253577.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->