### PR TITLE
Clean up empty NeMo Gym extra

### DIFF
--- a/environments/nemo_gym_weather/pyproject.toml
+++ b/environments/nemo_gym_weather/pyproject.toml
@@ -3,7 +3,7 @@ name = "nemo-gym-weather"
 version = "0.1.0"
 description = "NeMo Gym's MCP weather example through the reusable Verifiers v1 taskset."
 requires-python = ">=3.12"
-dependencies = ["verifiers[nemo-gym]"]
+dependencies = ["verifiers"]
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,9 +120,6 @@ notebook = [
 openenv = [
     "openenv>=0.4.1",
 ]
-nemo-gym = [
-    # NeMo Gym currently publishes Python 3.12+ packages; keep core verifiers installable on 3.11.
-]
 [tool.uv]
 preview = true
 required-version = ">=0.11.1"


### PR DESCRIPTION
## Overview

Remove obsolete optional-extra metadata left behind after the NeMo Gym dependency moved into its isolated resource-server script. This is packaging cleanup that aligns declarations with the existing runtime design; no server or evaluation logic changes.

## Details

- Remove the empty `nemo-gym` optional extra from Verifiers.
- Make the bundled weather environment depend on plain `verifiers` instead of the obsolete extra.
- Keep `nemo-gym==0.4.0` and MCP 1.x isolated in the managed server script while the main Verifiers process uses MCP 2.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove empty `nemo-gym` extra from `pyproject.toml`
> Deletes the empty `nemo-gym` optional dependency group from [pyproject.toml](https://github.com/PrimeIntellect-ai/verifiers/pull/2476/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) and updates [environments/nemo_gym_weather/pyproject.toml](https://github.com/PrimeIntellect-ai/verifiers/pull/2476/files#diff-ee5b2924b2552efc7ebbe75f7dce3116b96fe34fedc5fe43bdb7b4cecf65cc7f) to depend on base `verifiers` instead of `verifiers[nemo-gym]`.
> - Risk: `pip install .[nemo-gym]` will no longer work since the extra is removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized be7f8be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->