### PR TITLE
fix(v1): reconcile concurrent graph commits

### DIFF
--- a/tests/v1/test_graph.py
+++ b/tests/v1/test_graph.py
@@ -167,6 +167,98 @@ def test_reasoning_content_participates_in_graph_prefix_matching():
     assert len(tool_call_nodes) == 2
 
 
+def test_parallel_commits_reconcile_shared_prompt_prefix():
+    """Two requests prepared from the same graph snapshot share any common prompt prefix that
+    the first response commits while the second is in flight. A later turn must keep following
+    its original child path rather than re-rooting through the sibling and stranding an orphan."""
+    trace = vf.Trace(
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
+        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="root")),
+    )
+    system = vf.SystemMessage(content="shared")
+    user_a = vf.UserMessage(content="child A")
+    user_b = vf.UserMessage(content="child B")
+    assistant_a = vf.AssistantMessage(content="A1")
+
+    # Both model requests leave before either response has committed its prompt.
+    pending_a = graph.prepare_turn(trace, [system, user_a])
+    pending_b = graph.prepare_turn(trace, [system, user_b])
+    assistant_a_id = pending_a.commit(_response(assistant_a))
+    pending_b.commit(_response(vf.AssistantMessage(content="B1")))
+
+    graph.prepare_turn(
+        trace,
+        [
+            system,
+            user_a,
+            assistant_a,
+            vf.ToolMessage(content="tool A", tool_call_id="call_a"),
+        ],
+    ).commit(_response(vf.AssistantMessage(content="A2")))
+
+    roots = [node for node in trace.nodes if node.parent is None]
+    identities = [
+        (node.parent, graph.message_hash(node.message)) for node in trace.nodes
+    ]
+    assert len(roots) == 1
+    assert len(identities) == len(set(identities))
+    assert trace.num_branches == 2
+    assert assistant_a_id not in graph.leaves(trace)
+
+
+def test_parallel_commit_reconciles_only_token_identical_prefixes():
+    """Content-equivalent prompt nodes share exact physical variants and retain token forks."""
+    trace = vf.Trace(
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
+        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="root")),
+    )
+    system = vf.SystemMessage(content="shared")
+
+    first = graph.prepare_turn(trace, [system])
+    second = graph.prepare_turn(trace, [system])
+    third = graph.prepare_turn(trace, [system])
+    first.commit(
+        vf.Response(
+            id="a",
+            created=0,
+            model="test",
+            message=vf.AssistantMessage(content="A"),
+            finish_reason="stop",
+            tokens=TurnTokens(
+                prompt_ids=[1, 2], completion_ids=[3], message_spans=[(0, 2)]
+            ),
+        )
+    )
+    second.commit(
+        vf.Response(
+            id="b",
+            created=0,
+            model="test",
+            message=vf.AssistantMessage(content="B"),
+            finish_reason="stop",
+            tokens=TurnTokens(
+                prompt_ids=[1, 2], completion_ids=[4], message_spans=[(0, 2)]
+            ),
+        )
+    )
+    third.commit(
+        vf.Response(
+            id="c",
+            created=0,
+            model="test",
+            message=vf.AssistantMessage(content="C"),
+            finish_reason="stop",
+            tokens=TurnTokens(
+                prompt_ids=[1, 99], completion_ids=[5], message_spans=[(0, 2)]
+            ),
+        )
+    )
+
+    roots = [node for node in trace.nodes if node.parent is None]
+    assert [node.token_ids for node in roots] == [[1, 2], [1, 99]]
+    assert trace.num_branches == 3
+
+
 def test_renderer_level_break_forks_by_token_id():
     """Two turns with the *same* message sequence and identical message hashes, but the prior
     assistant turn is retokenized (renderer drift — e.g. a chat template dropping a `<think>`

--- a/tests/v1/test_graph.py
+++ b/tests/v1/test_graph.py
@@ -259,6 +259,50 @@ def test_parallel_commit_reconciles_only_token_identical_prefixes():
     assert trace.num_branches == 3
 
 
+def test_parallel_commit_reconciles_unspanned_assistant_tokens():
+    """A concurrently committed sampled assistant can be unspanned when it reappears in a
+    prompt. Its stored physical tokens still delimit that message and must not shift onto the
+    following input node."""
+    trace = vf.Trace(
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
+        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="root")),
+    )
+    user = vf.UserMessage(content="question")
+    assistant = vf.AssistantMessage(content="answer")
+    follow_up = vf.UserMessage(content="follow up")
+
+    pending = graph.prepare_turn(trace, [user, assistant, follow_up])
+    graph.prepare_turn(trace, [user]).commit(
+        vf.Response(
+            id="first",
+            created=0,
+            model="test",
+            message=assistant,
+            finish_reason="stop",
+            tokens=TurnTokens(
+                prompt_ids=[1], completion_ids=[2, 3], message_spans=[(0, 1)]
+            ),
+        )
+    )
+    pending.commit(
+        vf.Response(
+            id="second",
+            created=0,
+            model="test",
+            message=vf.AssistantMessage(content="done"),
+            finish_reason="stop",
+            tokens=TurnTokens(
+                prompt_ids=[1, 2, 3, 4],
+                completion_ids=[5],
+                message_spans=[(0, 1), None, (3, 4)],
+            ),
+        )
+    )
+
+    assert trace.num_branches == 1
+    assert [node.token_ids for node in trace.nodes] == [[1], [2, 3], [4], [5]]
+
+
 def test_renderer_level_break_forks_by_token_id():
     """Two turns with the *same* message sequence and identical message hashes, but the prior
     assistant turn is retokenized (renderer drift — e.g. a chat template dropping a `<think>`

--- a/tests/v1/test_graph.py
+++ b/tests/v1/test_graph.py
@@ -303,6 +303,64 @@ def test_parallel_commit_reconciles_unspanned_assistant_tokens():
     assert [node.token_ids for node in trace.nodes] == [[1], [2, 3], [4], [5]]
 
 
+def test_unspanned_reconciliation_stops_at_next_message_boundary():
+    """A longer sampled variant may share the prompt's token prefix only by consuming the next
+    message. Reconciliation must choose the variant ending before that attributed boundary."""
+    trace = vf.Trace(
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
+        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="root")),
+    )
+    user = vf.UserMessage(content="question")
+    assistant = vf.AssistantMessage(content="answer")
+    follow_up = vf.UserMessage(content="follow up")
+
+    pending = graph.prepare_turn(trace, [user, assistant, follow_up])
+    first = graph.prepare_turn(trace, [user])
+    second = graph.prepare_turn(trace, [user])
+    first.commit(
+        vf.Response(
+            id="short",
+            created=0,
+            model="test",
+            message=assistant,
+            finish_reason="stop",
+            tokens=TurnTokens(
+                prompt_ids=[1], completion_ids=[2, 3], message_spans=[(0, 1)]
+            ),
+        )
+    )
+    second.commit(
+        vf.Response(
+            id="long",
+            created=0,
+            model="test",
+            message=assistant,
+            finish_reason="stop",
+            tokens=TurnTokens(
+                prompt_ids=[1], completion_ids=[2, 3, 4], message_spans=[(0, 1)]
+            ),
+        )
+    )
+    pending.commit(
+        vf.Response(
+            id="continued",
+            created=0,
+            model="test",
+            message=vf.AssistantMessage(content="done"),
+            finish_reason="stop",
+            tokens=TurnTokens(
+                prompt_ids=[1, 2, 3, 4],
+                completion_ids=[5],
+                message_spans=[(0, 1), None, (3, 4)],
+            ),
+        )
+    )
+
+    follow_up_node = next(node for node in trace.nodes if node.message == follow_up)
+    assert follow_up_node.token_ids == [4]
+    assert trace.nodes[follow_up_node.parent].token_ids == [2, 3]
+
+
 def test_renderer_level_break_forks_by_token_id():
     """Two turns with the *same* message sequence and identical message hashes, but the prior
     assistant turn is retokenized (renderer drift — e.g. a chat template dropping a `<think>`

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -351,12 +351,14 @@ def _matching_prefix_node(
     message: Message,
     prompt_ids: list[int],
     start: int,
+    stop: int,
 ) -> int | None:
-    """Find the longest content-equivalent child whose tokens match at `start`.
+    """Find the longest content-equivalent child matching inside `[start, stop]`.
 
     Renderers may leave a prompt-supplied assistant unattributed (`message_spans[i] is None`).
     Its existing sampled node still owns physical tokens, so use those tokens to recover the
-    otherwise-missing message boundary without consuming any unmatched prompt suffix.
+    otherwise-missing message boundary. The next attributed message's start bounds the match:
+    a sampled variant must never consume tokens that the renderer assigned to that message.
     """
     key = (parent, message_hash(message))
     indexed = _head_index(trace).get(key)
@@ -373,7 +375,8 @@ def _matching_prefix_node(
     matches = [
         node_id
         for node_id in candidates
-        if prompt_ids[start : start + len(trace.nodes[node_id].token_ids)]
+        if start + len(trace.nodes[node_id].token_ids) <= stop
+        and prompt_ids[start : start + len(trace.nodes[node_id].token_ids)]
         == trace.nodes[node_id].token_ids
     ]
     return max(
@@ -661,8 +664,16 @@ def _commit_turn(turn: PendingTurn, response: Response) -> int:
         end = span[1] if span else path_len
         parent = prefix[-1] if prefix else None
         if tokens is not None and span is None:
+            next_start = next(
+                (
+                    later_span[0]
+                    for later_span in (spans[i + 1 :] if spans else [])
+                    if later_span is not None
+                ),
+                len(prompt_ids),
+            )
             existing = _matching_prefix_node(
-                trace, parent, prompt[i], prompt_ids, path_len
+                trace, parent, prompt[i], prompt_ids, path_len, next_start
             )
             if existing is not None:
                 end += len(trace.nodes[existing].token_ids)

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -312,13 +312,46 @@ def _head_index(trace: Trace) -> dict[tuple[int | None, str], int]:
     return trace._head_index
 
 
+def _matching_node(
+    trace: Trace,
+    parent: int | None,
+    message: Message,
+    token_ids: list[int] | None = None,
+) -> int | None:
+    """Find an existing child, optionally requiring its exact physical token span.
+
+    The head index deliberately points at only the latest content-equivalent child. Token-level
+    prefix breaks can leave older physical variants under the same key, so a token mismatch falls
+    back to a reverse scan rather than materializing a duplicate of an already-existing variant.
+    """
+    key = (parent, message_hash(message))
+    indexed = _head_index(trace).get(key)
+    if indexed is not None and (
+        token_ids is None or trace.nodes[indexed].token_ids == token_ids
+    ):
+        return indexed
+    if token_ids is None:
+        return indexed
+    for node_id in range(len(trace.nodes) - 1, -1, -1):
+        if node_id == indexed:
+            continue
+        node = trace.nodes[node_id]
+        if (
+            node.parent == parent
+            and node.token_ids == token_ids
+            and message_hash(node.message) == key[1]
+        ):
+            return node_id
+    return None
+
+
 @dataclass(frozen=True)
 class PendingTurn:
     """A resolved prompt waiting on model inference.
 
-    `prepare_turn` does the one canonical graph prefix walk. Training clients use the resolved
-    prefix for renderer bridging before inference, and `commit` uses the same prefix after
-    inference to add only the prompt tail plus the sampled assistant response.
+    `prepare_turn` resolves the graph prefix used for renderer bridging before inference. `commit`
+    preserves that inference-producing prefix, extends it with any matching nodes committed while
+    inference was in flight, then adds only the remaining prompt tail and sampled response.
     """
 
     trace: Trace
@@ -390,6 +423,10 @@ class PendingTurn:
         parent = self.prefix_node_ids[-1] if self.prefix_node_ids else None
         index = _head_index(self.trace)
         for message in self.tail:
+            existing = _matching_node(self.trace, parent, message)
+            if existing is not None:
+                parent = existing
+                continue
             previous = parent
             self.trace.nodes.append(MessageNode(parent=parent, message=message))
             parent = len(self.trace.nodes) - 1
@@ -575,6 +612,29 @@ def _commit_turn(turn: PendingTurn, response: Response) -> int:
             keep += 1
         prefix = prefix[:keep]
         path_len = off
+
+    # A parallel request may have committed more of this prompt after `prepare_turn` resolved
+    # the inference prefix. Reconcile that still-uncommitted tail now, one whole message at a
+    # time. Exact token-span equality preserves intentional renderer-level forks; tokenless relay
+    # turns use message identity. Because commit is synchronous, once this loop stops the rest of
+    # the tail can be appended without another request interleaving.
+    prefix = list(prefix)
+    while len(prefix) < len(prompt):
+        i = len(prefix)
+        span = spans[i] if spans and i < len(spans) else None
+        end = span[1] if span else path_len
+        node_tokens = prompt_ids[path_len:end]
+        existing = _matching_node(
+            trace,
+            prefix[-1] if prefix else None,
+            prompt[i],
+            node_tokens if tokens is not None else None,
+        )
+        if existing is None:
+            break
+        prefix.append(existing)
+        path_len = end
+
     num_reused = len(prefix)
     parent = prefix[-1] if prefix else None
     # cursor: in prompt_ids, the end of the previous *new* message's tokens

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -345,6 +345,42 @@ def _matching_node(
     return None
 
 
+def _matching_prefix_node(
+    trace: Trace,
+    parent: int | None,
+    message: Message,
+    prompt_ids: list[int],
+    start: int,
+) -> int | None:
+    """Find the longest content-equivalent child whose tokens match at `start`.
+
+    Renderers may leave a prompt-supplied assistant unattributed (`message_spans[i] is None`).
+    Its existing sampled node still owns physical tokens, so use those tokens to recover the
+    otherwise-missing message boundary without consuming any unmatched prompt suffix.
+    """
+    key = (parent, message_hash(message))
+    indexed = _head_index(trace).get(key)
+    candidates: list[int] = []
+    if indexed is not None:
+        candidates.append(indexed)
+    candidates.extend(
+        node_id
+        for node_id in range(len(trace.nodes) - 1, -1, -1)
+        if node_id != indexed
+        and trace.nodes[node_id].parent == parent
+        and message_hash(trace.nodes[node_id].message) == key[1]
+    )
+    matches = [
+        node_id
+        for node_id in candidates
+        if prompt_ids[start : start + len(trace.nodes[node_id].token_ids)]
+        == trace.nodes[node_id].token_ids
+    ]
+    return max(
+        matches, key=lambda node_id: len(trace.nodes[node_id].token_ids), default=None
+    )
+
+
 @dataclass(frozen=True)
 class PendingTurn:
     """A resolved prompt waiting on model inference.
@@ -623,13 +659,21 @@ def _commit_turn(turn: PendingTurn, response: Response) -> int:
         i = len(prefix)
         span = spans[i] if spans and i < len(spans) else None
         end = span[1] if span else path_len
-        node_tokens = prompt_ids[path_len:end]
-        existing = _matching_node(
-            trace,
-            prefix[-1] if prefix else None,
-            prompt[i],
-            node_tokens if tokens is not None else None,
-        )
+        parent = prefix[-1] if prefix else None
+        if tokens is not None and span is None:
+            existing = _matching_prefix_node(
+                trace, parent, prompt[i], prompt_ids, path_len
+            )
+            if existing is not None:
+                end += len(trace.nodes[existing].token_ids)
+        else:
+            node_tokens = prompt_ids[path_len:end]
+            existing = _matching_node(
+                trace,
+                parent,
+                prompt[i],
+                node_tokens if tokens is not None else None,
+            )
         if existing is None:
             break
         prefix.append(existing)


### PR DESCRIPTION
## Summary

- reconcile prompt nodes against the current graph when a model call commits, closing the race between concurrent `prepare_turn` and `commit` operations
- preserve exact token-span identity for training graphs while sharing content-identical tokenless prefixes in eval graphs
- retain hidden physical token variants instead of allowing index collisions to make them unreachable
- correctly reuse unspanned prompt nodes without consuming tokens attributed to the next message

This is a generic `main` graph fix. The ACP semantic-edge work remains separate in [#2449](https://github.com/PrimeIntellect-ai/verifiers/pull/2449).

## Reproduction

With two concurrent nano-RLM children, both first requests prepared before either committed. The second commit created a duplicate system root and overwrote the lookup entry; the first child later re-rooted through the second root, leaving an orphan leaf.

Before the fix:

- 2 child calls
- 4 physical branches instead of `2 + 1`
- 3 roots
- 1 duplicate `(parent, message_hash)` identity

[Before-fix live trace](https://app.primeintellect.ai/dashboard/evaluations/ekmqkxqmdgtsyjk7akofl4yp)

## Post-fix stress run

DeepSeek continued spawning children until the 30-minute rollout timeout, producing a stronger concurrency test:

- 328 model calls and 658 message nodes
- 15 child-session user roots under one shared child system node
- exactly 15 child leaves plus 1 top-level leaf = 16 physical branches
- 2 roots total: the top-level system and the shared child system
- 0 duplicate `(parent, message_hash)` identities

The timeout made final ACP metrics unavailable, but the interception trace was sealed and retained the complete physical graph.

[Post-fix live trace](https://app.primeintellect.ai/dashboard/evaluations/uzex4d5bdt8ua7ik363njpis)

## Validation

- `uv run pytest -q tests/v1/test_graph.py`: 10 passed
- full `tests/` suite passed before the final boundary-only regression; credential-gated cases skipped
- Ruff, formatting, Ty, commit hooks, and push hooks pass
- CI is green on Python 3.11, 3.12, and 3.13, including the live V1 E2E
