### PR TITLE
fix: require aiohttp 3.14 or newer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "aiolimiter>=1.2.1",
     "setproctitle>=1.3.0",
     "httpx>=0.27.0",
-    "aiohttp>=3.9.0",
+    "aiohttp>=3.14.0",
     "prime-pydantic-config[toml]>=0.4.3",
     "uvloop>=0.21.0; sys_platform != 'win32' and sys_platform != 'cygwin' and platform_python_implementation != 'PyPy'",
     "loguru>=0.7.0",


### PR DESCRIPTION
## Summary

- Require `aiohttp>=3.14.0`, the first release that provides `web.RequestKey`.
- Prevent Verifiers v1 imports from failing when a resolver selects an older aiohttp release.

## Verification

Before this change, aiohttp 3.13.5 does not provide `web.RequestKey`. Importing `verifiers.v1` fails in `interception/server.py`.

After this change, package resolution requires aiohttp 3.14.0 or newer. The Verifiers test suite passes with its locked aiohttp 3.14.3 release.

- `uv lock --check`
- `uv run ruff check --fix .`
- `uv run pytest tests/` (`864 passed, 76 skipped`)
- `uv run pre-commit run --files pyproject.toml`
- `uv run pre-commit run --all-files` reports the existing MD033 inline-HTML errors in `verifiers/legacy/envs/experimental/composable/tasksets/swe/README.md`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require `aiohttp>=3.14.0` in project dependencies
> Updates the dependency constraint in [pyproject.toml](https://github.com/PrimeIntellect-ai/verifiers/pull/2479/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) from `>=3.9.0` to `>=3.14.0`. This raises the minimum supported version of aiohttp for all installations.
>
> Risk: environments pinned to aiohttp versions between 3.9.0 and 3.13.x will fail to install or upgrade until aiohttp is updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e41311.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency floor change with no runtime logic edits; only affects environments still pinned below aiohttp 3.14.
> 
> **Overview**
> Raises the minimum **aiohttp** version in `pyproject.toml` from `>=3.9.0` to **`>=3.14.0`**, matching the first release that exposes `web.RequestKey`.
> 
> That API is used in v1 interception (e.g. `verifiers/v1/interception/server.py`); with older aiohttp, importing `verifiers.v1` could fail at import time. Installers and lockfiles will no longer resolve aiohttp 3.9–3.13.x for this package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e41311dd514af09344e6cb23ccf32877ad33c67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->