### PR TITLE
feat: add null harness compaction

### DIFF
--- a/verifiers/v1/harnesses/bash/harness.py
+++ b/verifiers/v1/harnesses/bash/harness.py
@@ -1,13 +1,11 @@
 import os
 
-from pydantic import PositiveInt
-from pydantic_config import BaseConfig
-
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.harness import Harness
 from verifiers.v1.harnesses.utils.launch import (
     CHAT_PROGRAM_SOURCE,
+    CompactionConfig,
     launch_chat_program,
 )
 from verifiers.v1.runtimes import ProgramResult, Runtime
@@ -27,14 +25,6 @@ SEARCH_PROMPT = (
     "You also have a search tool that returns Google results (title, URL, snippet) for a query; "
     "use it to research, and use bash (e.g. curl) to read result pages in full when needed."
 )
-
-
-class CompactionConfig(BaseConfig):
-    """Context compaction policy for the bash agent loop."""
-
-    summarize_at_tokens: PositiveInt | None = None
-    """Compact at this token count. When unset, compact when 16k tokens remain below the
-    model context window when the provider advertises it."""
 
 
 class BashHarnessConfig(HarnessConfig):

--- a/verifiers/v1/harnesses/bash/harness.py
+++ b/verifiers/v1/harnesses/bash/harness.py
@@ -3,9 +3,9 @@ import os
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.harness import Harness
+from verifiers.v1.harnesses.utils.config import CompactionConfig
 from verifiers.v1.harnesses.utils.launch import (
     CHAT_PROGRAM_SOURCE,
-    CompactionConfig,
     launch_chat_program,
 )
 from verifiers.v1.runtimes import ProgramResult, Runtime

--- a/verifiers/v1/harnesses/null/harness.py
+++ b/verifiers/v1/harnesses/null/harness.py
@@ -1,9 +1,9 @@
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.harness import Harness
+from verifiers.v1.harnesses.utils.config import CompactionConfig
 from verifiers.v1.harnesses.utils.launch import (
     CHAT_PROGRAM_SOURCE,
-    CompactionConfig,
     launch_chat_program,
 )
 from verifiers.v1.runtimes import ProgramResult, Runtime

--- a/verifiers/v1/harnesses/null/harness.py
+++ b/verifiers/v1/harnesses/null/harness.py
@@ -3,6 +3,7 @@ from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.harness import Harness
 from verifiers.v1.harnesses.utils.launch import (
     CHAT_PROGRAM_SOURCE,
+    CompactionConfig,
     launch_chat_program,
 )
 from verifiers.v1.runtimes import ProgramResult, Runtime
@@ -11,7 +12,8 @@ from verifiers.v1.trace import Trace
 
 
 class NullHarnessConfig(HarnessConfig):
-    pass
+    compaction: CompactionConfig | None = None
+    """Context compaction policy. Set an empty config to use automatic thresholds."""
 
 
 class NullHarness(Harness[NullHarnessConfig]):
@@ -35,6 +37,12 @@ class NullHarness(Harness[NullHarnessConfig]):
         data: TaskData,
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(data)
+        args = []
+        if self.config.compaction is not None:
+            args.append("--compaction")
+            threshold = self.config.compaction.summarize_at_tokens
+            if threshold is not None:
+                args.append(f"--summarize-at-tokens={threshold}")
         return await launch_chat_program(
             CHAT_PROGRAM_SOURCE,
             self.config,
@@ -46,4 +54,5 @@ class NullHarness(Harness[NullHarnessConfig]):
             mcp_urls,
             system_prompt,
             prompt,
+            extra_args=args,
         )

--- a/verifiers/v1/harnesses/utils/config.py
+++ b/verifiers/v1/harnesses/utils/config.py
@@ -1,0 +1,12 @@
+"""Shared harness configuration."""
+
+from pydantic import PositiveInt
+from pydantic_config import BaseConfig
+
+
+class CompactionConfig(BaseConfig):
+    """Context compaction policy for the shared chat loop."""
+
+    summarize_at_tokens: PositiveInt | None = None
+    """Compact at this token count. When unset, compact when 16k tokens remain below the
+    model context window when the provider advertises it."""

--- a/verifiers/v1/harnesses/utils/core.py
+++ b/verifiers/v1/harnesses/utils/core.py
@@ -230,7 +230,7 @@ async def run_chat_loop(
             # cleanly with what the conversation holds - still a trainable sample.
             return
         except APIStatusError as error:
-            # Null cannot compact, so context exhaustion ends it with the transcript so far.
+            # Null ends unrecoverable context exhaustion with the transcript so far.
             if args.bash or not is_context_overflow(error):
                 raise
             return

--- a/verifiers/v1/harnesses/utils/launch.py
+++ b/verifiers/v1/harnesses/utils/launch.py
@@ -3,9 +3,6 @@ import json
 from collections.abc import Sequence
 from types import ModuleType
 
-from pydantic import PositiveInt
-from pydantic_config import BaseConfig
-
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.dialects.chat import message_to_wire
@@ -15,14 +12,6 @@ from verifiers.v1.trace import Trace
 from verifiers.v1.types import Messages
 
 PEP_723_END = "# ///\n"
-
-
-class CompactionConfig(BaseConfig):
-    """Context compaction policy for the shared chat loop."""
-
-    summarize_at_tokens: PositiveInt | None = None
-    """Compact at this token count. When unset, compact when 16k tokens remain below the
-    model context window when the provider advertises it."""
 
 
 def bundle_program(program: str, *modules: ModuleType) -> str:

--- a/verifiers/v1/harnesses/utils/launch.py
+++ b/verifiers/v1/harnesses/utils/launch.py
@@ -3,6 +3,9 @@ import json
 from collections.abc import Sequence
 from types import ModuleType
 
+from pydantic import PositiveInt
+from pydantic_config import BaseConfig
+
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.dialects.chat import message_to_wire
@@ -12,6 +15,14 @@ from verifiers.v1.trace import Trace
 from verifiers.v1.types import Messages
 
 PEP_723_END = "# ///\n"
+
+
+class CompactionConfig(BaseConfig):
+    """Context compaction policy for the shared chat loop."""
+
+    summarize_at_tokens: PositiveInt | None = None
+    """Compact at this token count. When unset, compact when 16k tokens remain below the
+    model context window when the provider advertises it."""
 
 
 def bundle_program(program: str, *modules: ModuleType) -> str:


### PR DESCRIPTION
## Summary

- add the optional compaction policy to the Null harness
- define `CompactionConfig` in `utils/config.py` and share it between the Null and Bash harnesses
- pass automatic or explicit compaction thresholds to the shared chat program

## Verification

- `uv run pytest tests/` — 82 passed, 76 live tests skipped without `PRIME_API_KEY`
- `uv run pre-commit run --all-files`
- compiled `CHAT_PROGRAM_SOURCE` and checked Null compaction argument forwarding

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add context compaction support to `NullHarness`
> - Moves `CompactionConfig` to the shared [config.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2483/files#diff-72feaa829a9fed2f77155e66916dcc9aa3111030a2cc00404345aa5df5b776f6) module and removes the local copy from the bash harness
> - Adds an optional `compaction` field to `NullHarnessConfig`; when set, `NullHarness.launch` passes `--compaction` and an optional `--summarize-at-tokens` flag to the chat program
> - When `compaction` is `None`, launch behavior is unchanged
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 89886a0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 105dbf14af3ee52606cf2fcdae4229bc967e0a98. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
