### PR TITLE
docs: remove stale legacy references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,4 +25,4 @@
 ## Testing
 
 - **Prefer e2e tests over unit tests**: v1's end-to-end tests are sufficient — extra unit tests clog the repo. Editing existing tests is fine; to check your own work, write a temporary script instead of committing new tests.
-- **Run the contributor checks**: run `uv run pre-commit install` once, then for touched areas `uv run ruff check --fix .`, `uv run pytest tests/`, and `uv run pre-commit run --all-files` (see `docs/legacy/development.md`).
+- **Run the contributor checks**: run `uv run pre-commit install` once, then for touched areas `uv run ruff check --fix .`, `uv run pytest tests/`, and `uv run pre-commit run --all-files`.

--- a/docs/v1/overview.md
+++ b/docs/v1/overview.md
@@ -42,5 +42,3 @@ A trace records the message graph, rewards, metrics, errors, and one per-call re
 - [Harnesses](harnesses.md) — How to build custom harnesses
 - [Agent](agent.md) — How to run standalone agents
 - [Env](env.md) — How to build multi-agent environments
-
-For the documentation for legacy environments, go to [the v0 documentation](../legacy/overview.md).


### PR DESCRIPTION
## Overview

Keep the current documentation and contributor guidance focused on the supported v1 surface.

## Details

- Remove the legacy documentation pointer from the v1 overview.
- Keep the contributor check instructions self-contained.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime, config, or security behavior changes.
> 
> **Overview**
> **Contributor and v1 docs no longer point at legacy material.**
> 
> In `AGENTS.md`, the testing bullet for contributor checks drops the “see `docs/legacy/development.md`” link so the `uv run pre-commit`, ruff, pytest, and pre-commit steps stand on their own.
> 
> In `docs/v1/overview.md`, the closing line that sent readers to `../legacy/overview.md` for v0 documentation is removed so the v1 doc list ends at current topics only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb779b1e64b20588558492213dae44040e7457b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove stale legacy documentation references from `AGENTS.md` and `docs/v1/overview.md`
> Cleans up outdated pointers to legacy docs. Removes the `docs/legacy/development.md` reference in the testing section of [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/pull/2484/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9) and drops the sentence directing readers to v0 legacy documentation at the end of [docs/v1/overview.md](https://github.com/PrimeIntellect-ai/verifiers/pull/2484/files#diff-3f90b7dcac1242e83c61cac02bf2a16838ae5689be635e6d313210b4911c0896).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cb779b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->