### PR TITLE
Support OpenClaw 2.0 in the v1 harness

### DIFF
--- a/verifiers/v1/harnesses/openclaw/harness.py
+++ b/verifiers/v1/harnesses/openclaw/harness.py
@@ -20,10 +20,48 @@ logger = logging.getLogger(__name__)
 # OpenClaw and its bundled Node runtime exceed the small /tmp tmpfs in some VMs.
 OPENCLAW_DIR = "/var/tmp/vf-openclaw-{version}"
 OPENCLAW_BIN = f"{OPENCLAW_DIR}/bin/openclaw"
-INSTALL = r"""
+SETUP = r"""
 set -e
-command -v curl >/dev/null || (apt-get update -qq && apt-get install -y -qq curl ca-certificates >/dev/null)
-curl -fsSL --proto '=https' --tlsv1.2 https://openclaw.ai/install-cli.sh | bash -s -- --prefix {dir} --version {version} --no-onboard
+if [ ! -x "$VF_OPENCLAW_BIN" ]; then
+    command -v curl >/dev/null || (apt-get update -qq && apt-get install -y -qq curl ca-certificates >/dev/null)
+    curl -fsSL --proto '=https' --tlsv1.2 https://openclaw.ai/install-cli.sh \
+        | bash -s -- --prefix "$VF_OPENCLAW_DIR" --version "$VF_OPENCLAW_VERSION" --no-onboard
+fi
+set -- $(find "$VF_OPENCLAW_DIR/tools" -type f -path '*/openclaw/dist/session-accessor.sqlite-transcript-store-*.js')
+[ "$#" -eq 1 ] || { echo "could not locate OpenClaw's transcript sanitizer for replay patch" >&2; exit 1; }
+"$VF_OPENCLAW_DIR/tools/node/bin/node" - "$1" <<'NODE'
+const fs = require("node:fs");
+const file = process.argv[2];
+const stat = fs.statSync(file);
+if (stat.size > 1_000_000) {
+    throw new Error("OpenClaw's transcript sanitizer exceeds the replay patch size limit");
+}
+const source = fs.readFileSync(file, "utf8");
+const patches = [
+    [
+        "const OPAQUE_REPLAY_TOKEN_RE = /^[A-Za-z0-9+/_-]+={0,2}$/;",
+        "const OPAQUE_REPLAY_TOKEN_RE = /^[A-Za-z0-9+/_-]+={0,2}(?:[.][A-Za-z0-9+/_-]+={0,2})*$/;",
+    ],
+    ["\t\tsummary: [],", "\t\tsummary: parsed.summary ?? [],"],
+];
+let patched = source;
+for (const [before, after] of patches) {
+    patched = patched.replaceAll(before, after);
+}
+if (!patches.every(([, after]) => patched.includes(after))) {
+    throw new Error("OpenClaw's transcript sanitizer does not match the replay patch");
+}
+if (patched !== source) {
+    const temporary = `${file}.${process.pid}.tmp`;
+    try {
+        // Publish complete bytes at once so live and concurrent setups never see a partial bundle.
+        fs.writeFileSync(temporary, patched, { mode: stat.mode });
+        fs.renameSync(temporary, file);
+    } finally {
+        fs.rmSync(temporary, { force: true });
+    }
+}
+NODE
 """
 
 OPENCLAW_COMMAND = [
@@ -82,7 +120,7 @@ wait "$acp_pid"
 
 
 class OpenClawHarnessConfig(HarnessConfig):
-    version: str = Field(default="2026.7.1-2", pattern=r"^[A-Za-z0-9._+-]+$")
+    version: str = Field(default="2026.8.1", pattern=r"^[A-Za-z0-9._+-]+$")
     """OpenClaw release to install, pinned for reproducibility."""
     use_bundled_skill: bool = True
     """Enable OpenClaw's bundled skill catalog in addition to uploaded harness skills."""
@@ -117,20 +155,27 @@ class OpenClawHarness(ACPHarness[OpenClawHarnessConfig]):
                     await runtime.write(ready_path, b"")
         directory = OPENCLAW_DIR.format(version=self.config.version)
         binary = OPENCLAW_BIN.format(version=self.config.version)
-        script = INSTALL.replace("{version}", self.config.version).replace(
-            "{dir}", directory
-        )
-        ensure = shlex.quote(f"[ -x {binary} ] || ({script})")
+        # Borrowed runtimes can share this cache, so one filesystem lock owns both
+        # installation and the transcript adjustment.
         guarded = (
-            f"mkdir -p {directory} && "
-            f'"$(command -v flock || command -v lockf)" {directory}/install.lock '
-            f"bash -o pipefail -c {ensure}"
+            f"mkdir -p {shlex.quote(directory)} && "
+            f'"$(command -v flock || command -v lockf)" '
+            f"{shlex.quote(f'{directory}/install.lock')} "
+            f"bash -o pipefail -c {shlex.quote(SETUP)}"
         )
         logger.info("openclaw: ensuring OpenClaw %s is installed", self.config.version)
-        result = await runtime.run(["sh", "-c", guarded], self.config.resolved_env)
+        result = await runtime.run(
+            ["sh", "-c", guarded],
+            {
+                **self.config.resolved_env,
+                "VF_OPENCLAW_BIN": binary,
+                "VF_OPENCLAW_DIR": directory,
+                "VF_OPENCLAW_VERSION": self.config.version,
+            },
+        )
         if result.exit_code != 0:
             detail = (result.stderr or result.stdout).strip()[-500:]
-            raise RuntimeError(f"OpenClaw install failed: {detail}")
+            raise RuntimeError(f"OpenClaw setup failed: {detail}")
         await super().setup(runtime)
 
     async def prepare_acp(
@@ -149,8 +194,6 @@ class OpenClawHarness(ACPHarness[OpenClawHarnessConfig]):
         config_path = f"{state_dir}/openclaw.json"
         skills_dir = f"{state_dir}/skills"
         config = {
-            # Provider state must remain byte-exact within this isolated rollout.
-            "logging": {"redactSensitive": "off"},
             "gateway": {
                 "mode": "local",
                 "bind": "loopback",
@@ -180,6 +223,7 @@ class OpenClawHarness(ACPHarness[OpenClawHarnessConfig]):
                     provider: {
                         "baseUrl": endpoint,
                         "apiKey": "${OPENCLAW_INTERCEPT_KEY}",
+                        "request": {"allowPrivateNetwork": True},
                     }
                 },
             },


### PR DESCRIPTION
## Summary

This updates the v1 OpenClaw harness to use OpenClaw 2.0 while keeping OpenClaw’s automatic model discovery by model name.

## What changed and why

- **Use OpenClaw 2026.8.1 by default.** This is the OpenClaw 2.0 release, so the harness now installs the new version without extra configuration.
- **Allow the configured inference provider to use private-network addresses.** Verifiers sends model requests through a rollout-owned local endpoint. OpenClaw 2.0 blocks that endpoint unless the provider explicitly allows private-network requests.
- **Keep Responses replay tokens and reasoning summaries unchanged when a conversation resumes.** OpenClaw 2.0 otherwise rewrites this saved state. That can make the next model request fail or make one conversation appear as multiple trace branches.
- **Remove the old logging redaction setting.** OpenClaw 2.0 no longer accepts this setting. OpenClaw’s normal redaction behavior still applies to unrelated data.
- **Apply the replay-state adjustment to any configured OpenClaw version.** The harness checks for the expected code and stops with a clear error if OpenClaw changes it in a future release.
- **Keep installation and the replay-state adjustment under the same filesystem lock.** Multiple agents can share one borrowed runtime, so their setup work must not change the same OpenClaw files at the same time.
- **Replace the adjusted file atomically.** The harness writes a complete temporary file and renames it into place, so a running or concurrent setup can never read a partially written OpenClaw bundle.

The harness does not add a custom model list or special-case model names. OpenClaw continues to choose the provider and API format from its native model catalog.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Harness setup now mutates OpenClaw’s installed bundle and hard-fails on sanitizer layout or pattern drift, which affects every OpenClaw rollout but stays scoped to this harness path.
> 
> **Overview**
> Updates the v1 **OpenClaw** harness for **OpenClaw 2.0** by defaulting to **`2026.8.1`** and extending setup beyond a plain CLI install.
> 
> **Setup** now runs under the existing install lock on every ensure: install if the binary is missing, then locate OpenClaw’s bundled **transcript sanitizer** JS and apply two targeted edits so resumed sessions keep **Responses replay tokens** and **reasoning summaries** intact (wider replay-token regex and `summary: parsed.summary ?? []`). Setup fails clearly if the file isn’t unique or the expected strings aren’t present. Install paths are passed via **`VF_OPENCLAW_*`** env vars instead of templating the shell script.
> 
> **ACP config** drops the removed **`logging.redactSensitive`** override and sets **`request.allowPrivateNetwork: true`** on the intercepted provider so rollout-local model endpoints still work under 2.0’s private-network checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc057e079f9e65c2d8d338444c1554cfae197e3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support OpenClaw 2.0 in v1 harness with new setup script and config changes
> - Replaces the inline `INSTALL` script in [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2485/files#diff-d7278b9055ef0f18d323c2ac3010b475bc2122a03e99b44977384fab44c24362) with a `SETUP` script that conditionally installs OpenClaw (only if `VF_OPENCLAW_BIN` is not executable), then patches the bundled transcript sanitizer JS to accept dot-separated opaque replay tokens and default missing summaries to an empty array. Patching fails hard if the sanitizer file exceeds a size threshold or expected patch targets are absent; writes are atomic via temp-file + rename.
> - Bumps default `OpenClawHarnessConfig` version from `2026.7.1-2` to `2026.8.1`.
> - Reworks `OpenClawHarness.setup` to run the `SETUP` script under a single filesystem lock covering both installation and patching, passing `VF_OPENCLAW_BIN`, `VF_OPENCLAW_DIR`, and `VF_OPENCLAW_VERSION` into the environment. Failure message changes from 'OpenClaw install failed' to 'OpenClaw setup failed'.
> - Updates `prepare_acp` to remove `logging.redactSensitive` from the generated config and add `request.allowPrivateNetwork: true` under each model provider.
> - Risk: The sanitizer patch targets specific string patterns in OpenClaw's JS; future OpenClaw releases may shift those patterns and cause setup to fail with an explicit error. The removal of `logging.redactSensitive` means transcripts may no longer be redacted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fc057e0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->