### PR TITLE
fix: avoid unused MCP harness imports

### DIFF
--- a/verifiers/v1/harnesses/bash/harness.py
+++ b/verifiers/v1/harnesses/bash/harness.py
@@ -8,6 +8,7 @@ from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.harness import Harness
 from verifiers.v1.harnesses.utils.launch import (
     CHAT_PROGRAM_SOURCE,
+    MCP_CHAT_PROGRAM_SOURCE,
     launch_chat_program,
 )
 from verifiers.v1.runtimes import ProgramResult, Runtime
@@ -121,6 +122,7 @@ class BashHarness(Harness[BashHarnessConfig]):
             mcp_urls,
             system_prompt,
             prompt,
+            source_with_mcp=MCP_CHAT_PROGRAM_SOURCE,
             extra_args=args,
             env=env,
             activate=False,

--- a/verifiers/v1/harnesses/null/harness.py
+++ b/verifiers/v1/harnesses/null/harness.py
@@ -3,6 +3,7 @@ from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.harness import Harness
 from verifiers.v1.harnesses.utils.launch import (
     CHAT_PROGRAM_SOURCE,
+    MCP_CHAT_PROGRAM_SOURCE,
     launch_chat_program,
 )
 from verifiers.v1.runtimes import ProgramResult, Runtime
@@ -46,4 +47,5 @@ class NullHarness(Harness[NullHarnessConfig]):
             mcp_urls,
             system_prompt,
             prompt,
+            source_with_mcp=MCP_CHAT_PROGRAM_SOURCE,
         )

--- a/verifiers/v1/harnesses/utils/launch.py
+++ b/verifiers/v1/harnesses/utils/launch.py
@@ -24,14 +24,13 @@ def bundle_program(program: str, *modules: ModuleType) -> str:
 # The shared Null/Bash chat program is the utils modules themselves: `core` ends with
 # the `__main__` entry point, so the program text is only the script metadata. Secrets
 # use argv so tools do not inherit them.
-CHAT_PROGRAM_SOURCE = bundle_program(
+CHAT_PROGRAM = (
     '# /// script\n# requires-python = ">=3.10"\n'
     '# dependencies = ["openai", "mcp==2.0.0", "httpx", "httpx2", "tenacity"]\n'
-    "# ///\n",
-    mcp,
-    compaction,
-    core,
+    "# ///\n"
 )
+CHAT_PROGRAM_SOURCE = bundle_program(CHAT_PROGRAM, compaction, core)
+MCP_CHAT_PROGRAM_SOURCE = bundle_program(CHAT_PROGRAM, mcp, compaction, core)
 
 
 async def launch_chat_program(
@@ -46,6 +45,7 @@ async def launch_chat_program(
     system_prompt: str | None,
     prompt: str | Messages | None,
     *,
+    source_with_mcp: str | None = None,
     extra_args: Sequence[str] = (),
     env: dict[str, str] | None = None,
     activate: bool = True,
@@ -60,6 +60,7 @@ async def launch_chat_program(
     if system_prompt:
         args.append(f"--system-prompt={system_prompt}")
     if mcp_urls:
+        source = source_with_mcp or source
         args.append(
             "--mcp-config="
             + json.dumps(


### PR DESCRIPTION
## Summary

- keep MCP client code out of null and bash subprocesses when no MCP servers are configured
- select the MCP-enabled chat program only when a rollout has MCP server URLs

## Verification

- `uv run pytest tests/ -n auto` (82 passed, 76 live tests skipped without `PRIME_API_KEY`)
- `uv run pre-commit run --all-files`
- compiled and imported both generated chat program variants
- ran the reverse-text LoRA config for five steps before and after this change

| Metric | `main` (`465552e93`) | This branch (`2ed00310d`) | Change |
| --- | ---: | ---: | ---: |
| Mean harness time, 640 traces | 2.058 s | 0.967 s | -53.0% |
| P90 harness time, 640 traces | 3.513 s | 1.360 s | -61.3% |
| Mean total trace time | 2.605 s | 1.477 s | -43.3% |
| Five-step orchestrator loop | 69.0 s | 47.0 s | -31.9% |
| Process wall time | 176.47 s | 114.40 s | -35.2% |

Benchmark command:

```console
uv run rl @ configs/ci/integration/reverse-text-lora/start.toml --clean --output-dir <output> --run.name <name> --max-steps 5
```


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pass `MCP_CHAT_PROGRAM_SOURCE` to `launch_chat_program` in `BashHarness` and `NullHarness`
> - Splits the bundled chat program into `CHAT_PROGRAM_SOURCE` (core + compaction) and `MCP_CHAT_PROGRAM_SOURCE` (adds MCP modules) in [launch.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2490/files#diff-f00f52fdf451c06e9bd80d3a7b1c0fe095bd3797ca76f6fec3a4cea166504016)
> - Extends `launch_chat_program` with an optional `source_with_mcp` parameter; when `mcp_urls` is non-empty, the function uses `source_with_mcp` if supplied
> - Updates `BashHarness.launch` and `NullHarness.launch` to pass `source_with_mcp=MCP_CHAT_PROGRAM_SOURCE`, resolving previously unused imports
> - Risk: when `mcp_urls` is provided, the launched program now bundles MCP modules instead of the core-only source; callers not passing `source_with_mcp` keep prior behavior
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ed0031.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is gated on non-empty mcp_urls and only affects which bundled script is prepared; MCP rollouts still get the full MCP bundle via source_with_mcp.
> 
> **Overview**
> Rollouts without MCP servers no longer embed the MCP client in the subprocess chat program, which cuts harness overhead roughly in half in the author’s benchmarks.
> 
> **`launch.py`** now builds two bundled programs: **`CHAT_PROGRAM_SOURCE`** (compaction + core) and **`MCP_CHAT_PROGRAM_SOURCE`** (adds the `mcp` module). **`launch_chat_program`** accepts optional **`source_with_mcp`**; when **`mcp_urls`** is non-empty it swaps to that source before writing **`--mcp-config`**.
> 
> **`BashHarness`** and **`NullHarness`** pass **`source_with_mcp=MCP_CHAT_PROGRAM_SOURCE`** while still using the lean source for **`setup`** and the default launch path. MCP-enabled rollouts behave as before; other harnesses that don’t pass **`source_with_mcp`** are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ed00310d9c6a5ab993fd3129c699cd352302ce1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->