### PR TITLE
feat(v1): bump rlm pin to nano-rlm main, expose guardrail and role-append knobs

### DIFF
--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -5,7 +5,14 @@ import logging
 import shlex
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, PositiveInt, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    NonNegativeInt,
+    PositiveInt,
+    model_validator,
+)
 from pydantic_config import BaseConfig
 
 from verifiers.v1.acp import ACPConfig, ACPHarness, ACPTurn, JsonObject
@@ -17,7 +24,7 @@ from verifiers.v1.trace import Trace
 
 logger = logging.getLogger(__name__)
 
-BuiltinSkill = Literal["edit", "search"]
+BuiltinSkill = Literal["bash", "edit", "fetch", "search"]
 
 RLM_REPO = "github.com/PrimeIntellect-ai/nano-rlm.git"
 RLM_CACHE_DIR = "/tmp/vf-rlm"
@@ -43,15 +50,36 @@ class CompactionConfig(BaseConfig):
 
 
 class RLMHarnessConfig(HarnessConfig):
-    version: str = Field(default="4ef3438", min_length=1)
-    """Git ref (branch, tag, or commit) of nano-rlm to install."""
-    max_depth: int = 0
-    """Recursion depth RLM may spawn sub-harnesses to."""
+    version: str = Field(default="240090d", min_length=1)
+    """Git ref (branch, tag, or commit) of nano-rlm to install. Must know every
+    field this harness puts on the wire, i.e. be at least the default ref."""
+    max_depth: NonNegativeInt | None = None
+    """Recursion depth RLM may spawn sub-agents to; `None` = nano-rlm's default (1).
+    Set 0 to disable recursion."""
     builtin_skills: list[BuiltinSkill] = Field(default_factory=list)
     """Built-in rlm skills to enable (RLM_SKILLS), e.g. `["edit"]`; empty enables none.
     The tool set is fixed (ipython); the base `skills` field takes SKILL.md paths."""
     compaction: CompactionConfig | None = None
     """Context compaction policy. Set an empty config to use automatic thresholds."""
+    max_concurrent_subagents: PositiveInt | None = None
+    """Sub-agents running at once per session tree; `None` = nano-rlm's default (4).
+    nano-rlm requires it to be at least `max_depth`."""
+    max_total_turns: PositiveInt | None = None
+    """Tree-total turn budget (one turn = one work-loop model call, any engine); every
+    engine stops before its next call once spent. `None` = uncapped."""
+    max_total_tokens: PositiveInt | None = None
+    """Tree-total budget of NEW tokens (completion + uncached prompt) across the session
+    tree; once spent every engine stops and no further sub-agents spawn. `None` = unbounded."""
+    max_tool_output_bytes: PositiveInt | None = None
+    """Byte budget for a single tool result entering the conversation (middle truncation);
+    overrides rlm's built-in 20KB default in either direction."""
+    append_to_system_prompt: str | None = None
+    """Appended to the root engine's system prompt, after the taskset's system prompt."""
+    subagent_append_to_system_prompt: str | None = None
+    """Append for sub-agent engines that can still delegate (depth >= 1, below
+    `max_depth`); unset falls back to `append_to_system_prompt`."""
+    leaf_append_to_system_prompt: str | None = None
+    """Append for depth-capped leaf engines; unset falls back to the sub-agent append."""
 
     @model_validator(mode="after")
     def reject_disabled_tools(self) -> "RLMHarnessConfig":
@@ -59,6 +87,15 @@ class RLMHarnessConfig(HarnessConfig):
             raise ValueError(
                 "the rlm harness has a fixed tool set (ipython) and does not support "
                 "`disabled_tools`; use `builtin_skills` to enable built-in skills instead."
+            )
+        if (
+            self.max_depth is not None
+            and self.max_concurrent_subagents is not None
+            and self.max_concurrent_subagents < self.max_depth
+        ):
+            raise ValueError(
+                "`max_concurrent_subagents` must be at least `max_depth` "
+                "(nano-rlm rejects the policy otherwise)."
             )
         return self
 
@@ -109,6 +146,11 @@ class RLMHarness(ACPHarness[RLMHarnessConfig]):
         system_prompt: str | None,
     ) -> JsonObject:
         compaction = self.config.compaction
+        appends = [
+            text
+            for text in (system_prompt, self.config.append_to_system_prompt)
+            if text
+        ]
         payload = {
             "session_id": trace.id,
             "model": ctx.model,
@@ -116,16 +158,29 @@ class RLMHarness(ACPHarness[RLMHarnessConfig]):
                 "base_url": endpoint,
                 "api_key": secret,
             },
+            # None = passthrough: the key stays off the wire and nano-rlm's own
+            # default applies.
             "policy": {
-                "max_depth": self.config.max_depth,
-                "compaction": compaction is not None,
-                "summarize_at_tokens": (
-                    compaction.summarize_at_tokens if compaction else None
-                ),
-                "max_concurrent_subagents": max(4, self.config.max_depth),
+                key: value
+                for key, value in {
+                    "max_depth": self.config.max_depth,
+                    "compaction": compaction is not None,
+                    "summarize_at_tokens": (
+                        compaction.summarize_at_tokens if compaction else None
+                    ),
+                    "max_concurrent_subagents": self.config.max_concurrent_subagents,
+                    "max_total_turns": self.config.max_total_turns,
+                    "max_total_tokens": self.config.max_total_tokens,
+                    "max_tool_output_bytes": self.config.max_tool_output_bytes,
+                }.items()
+                if value is not None
             },
             "system_prompt_path": None,
-            "append_to_system_prompt": system_prompt,
+            "append_to_system_prompt": "\n\n".join(appends) or None,
+            "subagent_append_to_system_prompt": (
+                self.config.subagent_append_to_system_prompt
+            ),
+            "leaf_append_to_system_prompt": self.config.leaf_append_to_system_prompt,
             "skills": list(self.config.builtin_skills),
             "kernel_env": runtime.env,
             "search_api_key": self.config.resolved_env.get("SERPER_API_KEY"),


### PR DESCRIPTION
Companion to the recently merged nano-rlm work. Two parts:

## Pin bump: `4ef3438` → `240090d`

The new default picks up everything merged to nano-rlm main since the compaction pin:

- **PrimeIntellect-ai/nano-rlm#158 — execution guardrails**: tree-total `max_total_turns` / `max_total_tokens` budgets (tokens counted as *new* work: completion + uncached prompt; every engine stops gracefully once spent), and `max_tool_output_bytes` overriding the built-in 20KB per-tool-result truncation.
- **PrimeIntellect-ai/nano-rlm#151 + PrimeIntellect-ai/nano-rlm#166 — role-aware sub-agent prompting**: depth-gated built-in sub-agent contract, per-tier system-prompt appends on the contract (`subagent_…`/`leaf_…` with leaf → subagent → root fallback), plus root-prompt clarity fixes. Validated on a 3-model, 32-task SWE-bench Pro before/after (never worse, slightly cheaper on every model).
- PrimeIntellect-ai/nano-rlm#162 (vLLM overflow phrasing), PrimeIntellect-ai/nano-rlm#156 (bash tool binary-output fix), PrimeIntellect-ai/nano-rlm#153 (semantic lineage edges — the session snapshot already tolerated new fields via `extra="ignore"`).

## New harness config knobs

| knob | maps to | default |
|---|---|---|
| `max_total_turns` | `policy.max_total_turns` | None (uncapped) |
| `max_total_tokens` | `policy.max_total_tokens` | None (unbounded) |
| `max_tool_output_bytes` | `policy.max_tool_output_bytes` | None (rlm's 20KB) |
| `max_concurrent_subagents` | `policy.max_concurrent_subagents` | None → `max(4, max_depth)` |
| `append_to_system_prompt` | contract root append (joined after the taskset system prompt) | None |
| `subagent_append_to_system_prompt` | contract node append | None |
| `leaf_append_to_system_prompt` | contract leaf append | None |
| `builtin_skills` | now also accepts `"bash"`, `"fetch"` | unchanged |

Compatibility: the payload always carries the full field set of the `runtime-v1` contract at the default pin (unset knobs go as explicit `None`), validated against nano-rlm's contract models. The harness was already unconditionally sending post-compaction fields, so the effective rule stays what it was: `version` must be at least the default ref — pinning older refs than the harness's contract era is unsupported.

Related: #2487 (builtin **tools** passthrough, `RLM_BUILTIN_TOOLS`) stays separate — this PR only widens the *skills* literal.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `RLMHarnessConfig` rlm pin to `240090d` and add guardrail and prompt-append knobs
> - Bumps the default `version` from `4ef3438` to `240090d` and expands `BuiltinSkill` to include `"bash"` and `"fetch"`.
> - Adds optional config fields `max_concurrent_subagents`, `max_total_turns`, `max_total_tokens`, `max_tool_output_bytes`, and three `append_to_system_prompt` variants (global, subagent, leaf) with precedence/fallback semantics.
> - `max_depth` type changes from `int` (default `0`) to `Optional[NonNegativeInt]` (default `None`): `None` defers to nano-rlm's default of `1`, `0` disables recursion.
> - `_runtime_metadata` now conditionally includes policy keys only when configured and no longer forces `max_concurrent_subagents` to `max(4, max_depth)`.
> - Risk: a new cross-field validator rejects configs where `max_concurrent_subagents` is set lower than `max_depth`; previous consumers relying on the hardcoded concurrent-subagent floor will now get nano-rlm defaults or `None` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a201007.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default recursion/concurrency behavior when configs omit fields, and wires new execution budgets into the nano-rlm runtime contract.
> 
> **Overview**
> Bumps the default **nano-rlm** install ref from `4ef3438` to `240090d` and widens **`builtin_skills`** to allow `bash` and `fetch` in addition to `edit` and `search`.
> 
> **`RLMHarnessConfig`** gains optional knobs that map into the runtime `policy` and prompt contract: tree-wide **`max_total_turns`** / **`max_total_tokens`**, per-tool **`max_tool_output_bytes`**, **`max_concurrent_subagents`**, plus root/sub-agent/leaf **`append_to_system_prompt`** fields. **`max_depth`** is now `NonNegativeInt | None` (unset defers to nano-rlm’s default instead of hard-coding `0`), with validation that **`max_concurrent_subagents` ≥ `max_depth`** when both are set.
> 
> **`_runtime_metadata`** merges the taskset system prompt with **`append_to_system_prompt`**, forwards the new sub-agent/leaf append fields, and **omits policy keys whose values are `None`** so nano-rlm defaults apply—replacing the prior always-sent **`max_depth`** and computed **`max(4, max_depth)`** for concurrency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a201007124b373e70de9e2b5f0891a76545e97b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->