### PR TITLE
feat(v1): rlm compaction knob is passthrough, with explicit enabled/max_compactions

### DIFF
--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -47,10 +47,13 @@ class CompactionConfig(BaseConfig):
     summarize_at_tokens: PositiveInt | None = None
     """Compact at this token count. When unset, compact when 16k tokens remain below the
     model context window when the provider advertises it."""
+    max_compactions: PositiveInt | None = None
+    """Compactions per session before the engine stops compacting; `None` =
+    nano-rlm's default."""
 
 
 class RLMHarnessConfig(HarnessConfig):
-    version: str = Field(default="240090d", min_length=1)
+    version: str = Field(default="dd2c04f", min_length=1)
     """Git ref (branch, tag, or commit) of nano-rlm to install. Must know every
     field this harness puts on the wire, i.e. be at least the default ref."""
     max_depth: NonNegativeInt | None = None
@@ -59,8 +62,11 @@ class RLMHarnessConfig(HarnessConfig):
     builtin_skills: list[BuiltinSkill] = Field(default_factory=list)
     """Built-in rlm skills to enable (RLM_SKILLS), e.g. `["edit"]`; empty enables none.
     The tool set is fixed (ipython); the base `skills` field takes SKILL.md paths."""
-    compaction: CompactionConfig | None = None
-    """Context compaction policy. Set an empty config to use automatic thresholds."""
+    compaction: CompactionConfig | bool | None = None
+    """Context compaction: a `[compaction]` section (or `true`) enables it with the
+    given settings, `false` disables it (an overflowing session then fails), and
+    unset defers to nano-rlm's default (on, automatic thresholds, bounded by its
+    default 1M tree-token budget)."""
     max_concurrent_subagents: PositiveInt | None = None
     """Sub-agents running at once per session tree; `None` = nano-rlm's default (4).
     nano-rlm requires it to be at least `max_depth`."""
@@ -146,6 +152,19 @@ class RLMHarness(ACPHarness[RLMHarnessConfig]):
         system_prompt: str | None,
     ) -> JsonObject:
         compaction = self.config.compaction
+        policy_knobs: dict[str, Any] = {
+            "max_depth": self.config.max_depth,
+            "max_concurrent_subagents": self.config.max_concurrent_subagents,
+            "max_total_turns": self.config.max_total_turns,
+            "max_total_tokens": self.config.max_total_tokens,
+            "max_tool_output_bytes": self.config.max_tool_output_bytes,
+        }
+        if isinstance(compaction, bool):
+            policy_knobs["compaction"] = compaction
+        elif compaction is not None:
+            policy_knobs["compaction"] = True
+            policy_knobs["summarize_at_tokens"] = compaction.summarize_at_tokens
+            policy_knobs["max_compactions"] = compaction.max_compactions
         appends = [
             text
             for text in (system_prompt, self.config.append_to_system_prompt)
@@ -161,19 +180,7 @@ class RLMHarness(ACPHarness[RLMHarnessConfig]):
             # None = passthrough: the key stays off the wire and nano-rlm's own
             # default applies.
             "policy": {
-                key: value
-                for key, value in {
-                    "max_depth": self.config.max_depth,
-                    "compaction": compaction is not None,
-                    "summarize_at_tokens": (
-                        compaction.summarize_at_tokens if compaction else None
-                    ),
-                    "max_concurrent_subagents": self.config.max_concurrent_subagents,
-                    "max_total_turns": self.config.max_total_turns,
-                    "max_total_tokens": self.config.max_total_tokens,
-                    "max_tool_output_bytes": self.config.max_tool_output_bytes,
-                }.items()
-                if value is not None
+                key: value for key, value in policy_knobs.items() if value is not None
             },
             "system_prompt_path": None,
             "append_to_system_prompt": "\n\n".join(appends) or None,


### PR DESCRIPTION
Companion to PrimeIntellect-ai/nano-rlm#168 (compaction + 1M tree-token budget on by default, unlimited compactions). The default itself lives in nano-rlm; this PR stops the harness from overriding it, adds the explicit controls, and bumps the default pin to nano-rlm#168's merge commit (`dd2c04f`).

## What changes

- **Unset `compaction` is now passthrough.** The harness used to always send `compaction: false` when the knob was unset, which would silently override nano-rlm's new default on every run. Now the compaction keys stay off the wire entirely and the pinned ref's default applies — same convention as `max_depth` and the other knobs.
- **`compaction = false` is the explicit off-switch** — since "unset" no longer means "off". A `[compaction]` section (or `true`) enables it implicitly with the given settings, per the prime-rl section-presence convention.
- **`CompactionConfig.max_compactions`** — per-session compaction cap override (`None` = nano-rlm's default: unlimited).

## Knob semantics after this PR

| TOML | wire | effect |
|---|---|---|
| *(unset)* | *(no compaction keys)* | nano-rlm's default at the new pin `dd2c04f`: **on** (auto threshold, bounded by nano-rlm's default 1M tree-token budget) |
| `compaction = {}` or `compaction = true` | `compaction: true` | on, auto threshold |
| `compaction.summarize_at_tokens = N` | `compaction: true, summarize_at_tokens: N` | on, fixed threshold |
| `compaction = false` | `compaction: false` | off |

## Validation

Passthrough payload validated against nano-rlm's `runtime-v1` contract at `dd2c04f`: an empty policy resolves to `compaction=True, max_compactions=None, max_total_tokens=1_000_000`; `enabled=false` + `max_compactions` override resolve as sent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default runtime compaction behavior for configs that leave `compaction` unset and alters which policy fields are sent to nano-rlm; incorrect wire semantics could affect long sessions and token budgets.
> 
> **Overview**
> **RLM runtime policy no longer forces compaction off when the harness knob is unset.** Previously unset `compaction` still sent `compaction: false`, overriding nano-rlm’s defaults; now compaction-related keys are omitted from `policy` so the pinned ref’s defaults apply (aligned with `max_depth` and other passthrough knobs).
> 
> **Compaction is configurable as a section, `true`, or `false`.** `RLMHarnessConfig.compaction` accepts `CompactionConfig | bool | None`: a `[compaction]` block (or `true`) enables compaction and can set `summarize_at_tokens` and the new **`max_compactions`** cap; `false` sends an explicit off switch (overflowing sessions fail instead of compacting).
> 
> **Wire encoding in `_runtime_metadata`** builds a `policy_knobs` map: booleans set `compaction` directly; a config object sets `compaction: true` plus optional thresholds; only non-`None` values are included. Default **nano-rlm install ref** bumps from `240090d` to **`dd2c04f`** (companion to nano-rlm compaction defaults).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a9d54bbad640f1b4f4085caaedb1c1c2dc10858. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make RLM compaction a passthrough knob with explicit enabled and `max_compactions`
> - `RLMHarnessConfig.compaction` now accepts booleans in addition to a `CompactionConfig` or null: `true` forces compaction on, `false` explicitly disables it, and unset leaves the nano-rlm default
> - Adds optional `max_compactions` to `CompactionConfig` to cap compactions per session before the engine stops compacting
> - `RLMHarness._runtime_metadata` serializes explicit compaction enablement, `summarize_at_tokens`, and `max_compactions` into the `policy_knobs` payload, and strips null-valued knobs
> - Bumps the default nano-rlm installation ref from `240090d` to `dd2c04f`
> - Risk: harness configs using `compaction: false` now transmit an explicit disablement instead of being treated as unset; verify no existing configs rely on `false` being ignored by [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2493/files#diff-3955da24b5fd88f62482297bbda7ba0936f633927f15576db27fed6e58f668ec)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a9d54b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->