### PR TITLE
feat(v1): round per-token floats in JSON records

### DIFF
--- a/verifiers/v1/episode.py
+++ b/verifiers/v1/episode.py
@@ -6,6 +6,7 @@ from typing import Annotated, Any, Generic, Literal, Self
 from pydantic import BaseModel, Field, model_validator
 
 from verifiers.v1.configs.agent import WireAgentConfig
+from verifiers.v1.graph import RECORD_FLOAT_DECIMALS
 from verifiers.v1.state import State, StateT
 from verifiers.v1.task import DataT, WireTaskData
 from verifiers.v1.trace import EXCLUDE_FIELDS, AgentConfigT, Error, Trace, TraceTask
@@ -146,12 +147,16 @@ class Episode(BaseModel, Generic[DataT, StateT, AgentConfigT]):
             grouped.setdefault(trace.agent.name, []).append(trace)
         return grouped
 
-    def to_record(self) -> dict[str, Any]:
-        """JSON record without raw trace tensors, which remain on the msgpack wire."""
+    def to_record(
+        self, float_decimals: int | None = RECORD_FLOAT_DECIMALS
+    ) -> dict[str, Any]:
+        """JSON record without raw trace tensors, which remain on the msgpack wire.
+        Per-token float streams are rounded to `float_decimals` (`None` keeps every digit)."""
         return self.model_dump(
             mode="json",
             exclude={"traces": {"__all__": EXCLUDE_FIELDS}},
             exclude_none=True,
+            context={"float_decimals": float_decimals},
         )
 
 

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -65,6 +65,13 @@ def _decode_ndarray(d: dict) -> np.ndarray:
     return np.frombuffer(d["data"], dtype=np.dtype(d["dtype"])).reshape(d["shape"])
 
 
+RECORD_FLOAT_DECIMALS = 4
+"""Precision of per-token float streams in JSON records (`to_record`). Full-precision
+digits are noise to every record reader and the least compressible bytes of a trace; four
+decimals leave a logprob within 1e-4 of what the trainer saw. The msgpack wire
+(`mode="python"`) keeps full precision — training never reads the record."""
+
+
 class MessageNode(BaseModel):
     """One message in the graph: a message plus the tokens it adds to the cumulative
     sequence. Concatenating a root→leaf path's nodes reconstructs that branch's full token
@@ -149,6 +156,19 @@ class MessageNode(BaseModel):
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    @field_serializer(
+        "logprobs",
+        "advantages",
+        "reference_logprobs",
+        "trainer_logprobs",
+        "entropies",
+        when_used="json",
+    )
+    def serialize_record_floats(self, values: list[float] | None) -> list[float] | None:
+        if values is None:
+            return None
+        return [round(value, RECORD_FLOAT_DECIMALS) for value in values]
 
     @field_serializer("multi_modal_data")
     def serialize_multi_modal_data(self, mmd: MultiModalData | None) -> dict | None:

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -28,7 +28,14 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    FieldSerializationInfo,
+    field_serializer,
+    field_validator,
+)
 from pydantic.json_schema import SkipJsonSchema
 from renderers.base import MultiModalData, PlaceholderRange, RenderedTokens
 
@@ -66,10 +73,11 @@ def _decode_ndarray(d: dict) -> np.ndarray:
 
 
 RECORD_FLOAT_DECIMALS = 4
-"""Precision of per-token float streams in JSON records (`to_record`). Full-precision
+"""Default precision of per-token float streams in JSON records (`to_record`). Full-precision
 digits are noise to every record reader and the least compressible bytes of a trace; four
-decimals leave a logprob within 1e-4 of what the trainer saw. The msgpack wire
-(`mode="python"`) keeps full precision — training never reads the record."""
+decimals leave a logprob within 1e-4 of what the trainer saw. `to_record(float_decimals=...)`
+overrides it per dump (`None` keeps every digit). The msgpack wire (`mode="python"`) keeps
+full precision — training never reads the record."""
 
 
 class MessageNode(BaseModel):
@@ -165,10 +173,13 @@ class MessageNode(BaseModel):
         "entropies",
         when_used="json",
     )
-    def serialize_record_floats(self, values: list[float] | None) -> list[float] | None:
-        if values is None:
-            return None
-        return [round(value, RECORD_FLOAT_DECIMALS) for value in values]
+    def serialize_record_floats(
+        self, values: list[float] | None, info: FieldSerializationInfo
+    ) -> list[float] | None:
+        decimals = (info.context or {}).get("float_decimals", RECORD_FLOAT_DECIMALS)
+        if values is None or decimals is None:
+            return values
+        return [round(value, decimals) for value in values]
 
     @field_serializer("multi_modal_data")
     def serialize_multi_modal_data(self, mmd: MultiModalData | None) -> dict | None:

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 from verifiers.v1 import graph
 from verifiers.v1.configs.agent import AgentConfig, WireAgentConfig
 from verifiers.v1.errors import ProviderError
-from verifiers.v1.graph import MessageNode
+from verifiers.v1.graph import RECORD_FLOAT_DECIMALS, MessageNode
 from verifiers.v1.runtimes import RuntimeInfo
 from verifiers.v1.semantic import (
     ACPInfo,
@@ -709,9 +709,16 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
         self.ok = False
         self.stop("error")
 
-    def to_record(self) -> dict[str, Any]:
-        """JSON record without raw tensors, which remain available on the msgpack wire."""
-        return self.model_dump(mode="json", exclude=EXCLUDE_FIELDS)
+    def to_record(
+        self, float_decimals: int | None = RECORD_FLOAT_DECIMALS
+    ) -> dict[str, Any]:
+        """JSON record without raw tensors, which remain available on the msgpack wire.
+        Per-token float streams are rounded to `float_decimals` (`None` keeps every digit)."""
+        return self.model_dump(
+            mode="json",
+            exclude=EXCLUDE_FIELDS,
+            context={"float_decimals": float_decimals},
+        )
 
 
 WireTrace = Trace[WireTaskData, State, WireAgentConfig]


### PR DESCRIPTION
## Summary

- `MessageNode` serializes `logprobs`, `advantages`, `reference_logprobs`, `trainer_logprobs` and `entropies` with a fixed number of decimals in JSON-mode dumps, via a `when_used="json"` field serializer that reads the dump context.
- `Trace.to_record(float_decimals=...)` and `Episode.to_record(float_decimals=...)` set the precision per dump; `None` keeps every digit. `RECORD_FLOAT_DECIMALS = 4` is the default.
- The msgpack wire (`mode="python"`) is untouched: the env server packs episodes with `mode="python"`, so a trainer's importance ratio still sees full-precision inference logprobs. Only the on-disk record changes.

Measured on a 15.17 GB, 33K-episode scaleswe trace stream: per-token floats are 23% of a record's bytes and the least compressible part. Rounding to 4 decimals shrinks the plain records 1.20x; combined with zstd on the prime-rl side it lifts the total from 6.9x to 11.0x (1.38 GB on disk). Companion: PrimeIntellect-ai/prime-rl#3465, which exposes the precision as `monitors.file.float_decimals`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Serialization-only change scoped to JSON `to_record` dumps; training wire path keeps full precision, with minor impact on consumers that read rounded floats from stored records.
> 
> **Overview**
> JSON **on-disk records** now round per-token float streams (`logprobs`, `advantages`, `reference_logprobs`, `trainer_logprobs`, `entropies`) instead of dumping full IEEE precision. **`MessageNode`** applies a `when_used="json"` serializer that reads **`float_decimals`** from the Pydantic dump context; **`Trace.to_record`** and **`Episode.to_record`** accept **`float_decimals`** (default **`RECORD_FLOAT_DECIMALS` = 4**, **`None`** preserves every digit).
> 
> **Msgpack / `mode="python"`** serialization is unchanged, so env-server wire traffic and trainer importance ratios still see full-precision inference logprobs—only JSON record dumps shrink and compress better.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1154aba45e4d02ffcae3cc395a4e330a02dfbb9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 4-decimal rounding for per-token floats in v1 JSON records
> - Adds the `RECORD_FLOAT_DECIMALS` constant (default 4) in [graph.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2495/files#diff-64c9d635eb215902a512c9e8ab316fd9b9967c36db03d4049aacc812cdfbd740) and a `serialize_record_floats` serializer on `MessageNode` that rounds `logprobs`, `advantages`, `reference_logprobs`, and `trainer_logprobs` during JSON serialization.
> - `Episode.to_record()` and `Trace.to_record()` pass `float_decimals` through Pydantic serialization context; callers can override the precision or pass `None` for full precision.
> - The serializer only applies to JSON records; msgpack and Python serialization paths retain full precision.
> - Behavioral Change: JSON records now round the four per-token float streams to 4 decimals by default instead of emitting full-precision values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1154aba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->