### PR TITLE
feat(v1): record pluggable judge requests

### DIFF
--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -712,7 +712,11 @@ async def test_replay_round_trip(run_v1, tmp_path):
         {
             "name": "source-judge",
             "request": {"model": "source-model", "messages": []},
-            "response": {"text": "stale", "parsed": None, "usage": None},
+            "response": {
+                "message": {"role": "assistant", "content": "stale"},
+                "parsed": None,
+                "usage": None,
+            },
         }
     ]
     stream.write_text(json.dumps(record) + "\n")

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -404,7 +404,7 @@ async def test_rubric_judge(run_v1, tmp_path):
     assert trace.ok
     assert trace.rewards["rubric"].score > 0  # the judge's verdict landed in the reward
     assert trace.metrics["rubric/always_yes"] == 1.0
-    assert trace.info["judge"]  # the call was recorded onto the trace
+    assert trace.info["judge_calls"]  # the call was recorded onto the trace
 
 
 @pytest.mark.e2e
@@ -701,11 +701,25 @@ async def test_replay_round_trip(run_v1, tmp_path):
     assert source.ok
     assert "lcs" in source.rewards
 
+    # Replay must not mix the source run's judge transcript into newly computed
+    # judge calls. Seed a saved call directly because this task scores without a
+    # judge; cleanup happens before task scoring and therefore does not inspect it.
+    import json
+
+    stream = run_dir / "traces.jsonl"
+    record = json.loads(stream.read_text())
+    record["traces"][0]["info"]["judge_calls"] = [
+        {
+            "name": "source-judge",
+            "request": {"model": "source-model", "messages": []},
+            "response": {"text": "stale", "parsed": None, "usage": None},
+        }
+    ]
+    stream.write_text(json.dumps(record) + "\n")
+
     async def replay(source_dir: Path, out: Path):
         # The CLI's layering, minus the argv plumbing: the saved run's config is the base
         # (`ReplayConfig` ignores its eval-only keys), the source's output_dir is dropped.
-        import json
-
         data = json.loads(saved_config_path(source_dir).read_text())
         data.pop("output_dir", None)
         config = ReplayConfig(**{**data, "rich": False})
@@ -720,6 +734,7 @@ async def test_replay_round_trip(run_v1, tmp_path):
         # and recomputed the same value.
         assert replayed.rewards.keys() == source.rewards.keys()
         assert replayed.reward == pytest.approx(source.reward)
+        assert "judge_calls" not in replayed.info
     # The wire task keeps its taskset-specific fields in the replay's own output.
     raw = (tmp_path / "replay2" / "traces.jsonl").read_text()
     assert '"answer"' in raw

--- a/tests/v1/test_judges.py
+++ b/tests/v1/test_judges.py
@@ -92,7 +92,20 @@ def fake_judge_model(monkeypatch):
         if parse is not None:
             response.parsed = parse(response)
         if trace is not None:
-            trace.record_judge(response)
+            from verifiers.v1.dialects.chat import message_to_wire
+
+            wire = (
+                [{"role": "user", "content": messages}]
+                if isinstance(messages, str)
+                else [message_to_wire(message) for message in messages]
+            )
+            kwargs = {"model": self.config.model, "messages": wire}
+            kwargs.update(sampling)
+            trace.record_judge_call(
+                name=self.reward_name,
+                request={"model": kwargs["model"], "messages": kwargs["messages"]},
+                response=response,
+            )
         return response
 
     monkeypatch.setattr(Judge, "complete", fake_complete)
@@ -225,7 +238,21 @@ async def test_reference_score(fake_judge_model):
     assert (
         "Capital of France?" in fake_judge_model[0]
     )  # the task prompt is in the judge prompt
-    assert len(trace.info["judge"]) == 1  # the call is recorded onto the trace
+    assert len(trace.info["judge_calls"]) == 1  # the call is recorded onto the trace
+    judge_record = trace.info["judge_calls"][0]
+    assert judge_record["name"] == "reference"
+    assert judge_record["request"]["model"] == "openai/gpt-5.4-nano"
+    assert "Capital of France?" in judge_record["request"]["messages"][0]["content"]
+    assert judge_record["response"]["parsed"] == 1.0
+
+    override_trace = make_trace()
+    await vf.ReferenceJudge().complete(
+        "Judge this response.", trace=override_trace, model="openai/gpt-5.4-mini"
+    )
+    assert (
+        override_trace.info["judge_calls"][0]["request"]["model"]
+        == "openai/gpt-5.4-mini"
+    )
 
     trace = make_trace(reply="It is Rome.")
     assert await vf.ReferenceJudge().score(trace.task.data, trace) == 0.0
@@ -446,7 +473,14 @@ async def test_error_attribution(monkeypatch, tmp_path):
             return response
         finally:
             if trace is not None:
-                trace.record_judge(response)
+                trace.record_judge_call(
+                    name=self.reward_name,
+                    request={
+                        "model": self.config.model,
+                        "messages": [{"role": "user", "content": messages}],
+                    },
+                    response=response,
+                )
 
     monkeypatch.setattr(Judge, "complete", gibberish_judge)
     taskset = JudgedTaskset(
@@ -463,7 +497,7 @@ async def test_error_attribution(monkeypatch, tmp_path):
             trace, runtime=None
         )
     assert trace.rewards["reference"] is None  # seeded: expected but never scored
-    assert len(trace.info["judge"]) == 1  # the billed call is still recorded
+    assert len(trace.info["judge_calls"]) == 1  # the billed call is still recorded
 
 
 # --- rubric --------------------------------------------------------------------------------
@@ -542,7 +576,7 @@ async def test_rubric_score(tmp_path, fake_judge_model):
     trace = make_trace()
     assert await judge.score(trace.task.data, trace) == 0.75
     assert trace.metrics == {"rubric/mentions_paris": 1.0, "rubric/is_polite": 0.0}
-    assert len(trace.info["judge"]) == 1  # one call for the whole rubric
+    assert len(trace.info["judge_calls"]) == 1  # one call for the whole rubric
 
 
 async def test_rubric_verdict_mismatch_raises(tmp_path, monkeypatch):
@@ -652,7 +686,7 @@ async def test_task_score_runs_plugged_judges(tmp_path, fake_judge_model):
         trace.rewards["quality"].score == 0.75
     )  # the rubric's aggregate, under its `name`
     assert (
-        len(trace.info["judge"]) == 2
+        len(trace.info["judge_calls"]) == 2
     )  # every judge call recorded (rubric = one call)
 
 

--- a/tests/v1/test_judges.py
+++ b/tests/v1/test_judges.py
@@ -243,6 +243,13 @@ async def test_reference_score(fake_judge_model):
     assert judge_record["name"] == "reference"
     assert judge_record["request"]["model"] == "openai/gpt-5.4-nano"
     assert "Capital of France?" in judge_record["request"]["messages"][0]["content"]
+    assert judge_record["response"]["message"] == {
+        "role": "assistant",
+        "content": "yes",
+        "reasoning_content": None,
+        "tool_calls": None,
+        "provider_state": None,
+    }
     assert judge_record["response"]["parsed"] == 1.0
 
     override_trace = make_trace()

--- a/tests/v1/test_judges.py
+++ b/tests/v1/test_judges.py
@@ -252,6 +252,21 @@ async def test_reference_score(fake_judge_model):
     }
     assert judge_record["response"]["parsed"] == 1.0
 
+    request_messages = [{"role": "user", "content": "original"}]
+    request = {
+        "model": "openai/gpt-5.4-nano",
+        "messages": request_messages,
+    }
+    trace.record_judge_call(
+        name="snapshot",
+        request=request,
+        response=JudgeResponse(text="yes"),
+    )
+    request_messages[0]["content"] = "mutated"
+    assert (
+        trace.info["judge_calls"][-1]["request"]["messages"][0]["content"] == "original"
+    )
+
     override_trace = make_trace()
     await vf.ReferenceJudge().complete(
         "Judge this response.", trace=override_trace, model="openai/gpt-5.4-mini"

--- a/verifiers/v1/cli/replay.py
+++ b/verifiers/v1/cli/replay.py
@@ -156,7 +156,7 @@ async def run_replay(config: ReplayConfig, source: Path, out: Path) -> list[Trac
             else:
                 st.state = "running"
                 # Clear the recorded scores; only offline-recomputable ones come back.
-                trace.info.pop("judge", None)
+                trace.info.pop("judge_calls", None)
                 trace.rewards, trace.metrics, trace.extra_usage = {}, {}, []
                 # The declared Task for a rebuilt row, the base Task for the
                 # WireTaskData fallback.

--- a/verifiers/v1/judge.py
+++ b/verifiers/v1/judge.py
@@ -32,7 +32,8 @@ in which case `JudgeResponse.parsed` is the validated pydantic object.
 A judge is cheap to construct (the HTTP client is opened per call, inside `complete`, and
 closed when the call returns), so build it where you use it.
 
-Passing `trace=` records the call onto it — a typed record appended to `trace.info["judge"]` and
+Passing `trace=` records the call onto it — a request/response record appended to
+`trace.info["judge_calls"]` and
 the call's tokens + cost added to `trace.extra_usage` (kept separate from the agent's `trace.usage`),
 so judge behaviour and spend are no longer invisible. The record lands even if the judge refuses, an
 empty structured output comes back, or `parse` raises (the request was already billed). Omit `trace`
@@ -210,7 +211,14 @@ class Judge(Generic[ParsedT, ConfigT]):
             return response
         finally:
             if trace is not None and response is not None:
-                trace.record_judge(response)
+                trace.record_judge_call(
+                    name=self.reward_name,
+                    request={
+                        "model": kwargs["model"],
+                        "messages": kwargs["messages"],
+                    },
+                    response=response,
+                )
 
     async def evaluate(
         self, *, trace: Trace | None = None, **fields: Any

--- a/verifiers/v1/judges/rubric.py
+++ b/verifiers/v1/judges/rubric.py
@@ -24,7 +24,7 @@ RUBRIC_PROMPT = (Path(__file__).resolve().parent / "rubric.txt").read_text(
 
 # Appended to the prompt when `structured_output` is off, so the reply is JSON we can parse. Each
 # criterion carries a one-sentence `reason` written *before* the verdict (chain-of-thought), so the
-# verdict follows from it and the reasoning is auditable in `trace.info["judge"]`.
+# verdict follows from it and the reasoning is auditable in `trace.info["judge_calls"]`.
 JSON_SUFFIX = (
     "\n\nRespond with ONLY a JSON object and nothing else, in exactly this shape:\n"
     '{"verdicts": [{"name": "<criterion name>", "reason": "<one sentence citing specific '

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -680,11 +680,16 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
         response: JudgeResponse,
     ) -> None:
         """Record one complete judge request/response exchange."""
+        response_record = response.model_dump()
+        message = AssistantMessage(content=response_record.pop("text"))
         self.info.setdefault("judge_calls", []).append(
             {
                 "name": name,
                 "request": dict(request),
-                "response": response.model_dump(),
+                "response": {
+                    "message": message.model_dump(),
+                    **response_record,
+                },
             }
         )
         if response.usage is not None:

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import time
 import traceback
 import uuid
@@ -685,7 +686,7 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
         self.info.setdefault("judge_calls", []).append(
             {
                 "name": name,
-                "request": dict(request),
+                "request": copy.deepcopy(dict(request)),
                 "response": {
                     "message": message.model_dump(),
                     **response_record,

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -672,8 +672,21 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
         reward = Reward(score=float(value), weight=float(weight))
         self.rewards[name] = reward
 
-    def record_judge(self, response: JudgeResponse) -> None:
-        self.info.setdefault("judge", []).append(response.model_dump())
+    def record_judge_call(
+        self,
+        *,
+        name: str,
+        request: Mapping[str, Any],
+        response: JudgeResponse,
+    ) -> None:
+        """Record one complete judge request/response exchange."""
+        self.info.setdefault("judge_calls", []).append(
+            {
+                "name": name,
+                "request": dict(request),
+                "response": response.model_dump(),
+            }
+        )
         if response.usage is not None:
             self.extra_usage.append(response.usage)
 


### PR DESCRIPTION
## Summary

- persist every pluggable judge exchange under `trace.info["judge_calls"]`
- make `Trace.record_judge_call(...)` require the judge name, effective request, and response
- store one consistent nested `{name, request, response}` record rather than optional metadata mixed into the response
- preserve the generated reply as a standard `AssistantMessage`, with the parsed verdict and usage alongside it
- snapshot the effective model and messages so later caller mutations cannot rewrite recorded evidence

## Contract

```json
{
  "name": "reference",
  "request": {
    "model": "openai/gpt-5.4-nano",
    "messages": [{"role": "user", "content": "..."}]
  },
  "response": {
    "message": {"role": "assistant", "content": "..."},
    "parsed": 1.0,
    "usage": {"prompt_tokens": 52, "completion_tokens": 12}
  }
}
```

This intentionally replaces `trace.info["judge"]` and `Trace.record_judge(response)`; there is no compatibility shape or optional prompt metadata.

## Tests

- `uv run pytest tests/` (82 passed, 76 credential-gated skips)
- `uv run pre-commit run --all-files`
- explicit coverage for per-call model overrides, immutable request snapshots, the persisted assistant message, and replay cleanup

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API change: `Trace.record_judge` and `trace.info["judge"]` are removed; out-of-tree callers must migrate. Replay behavior intentionally drops saved judge calls before rescore, which is correct but changes persisted replay output.
> 
> **Overview**
> **Judge exchanges are now stored as full request/response records under `trace.info["judge_calls"]`**, replacing the response-only `trace.info["judge"]` list and **`Trace.record_judge`**.
> 
> Each entry is `{name, request, response}`: the judge name, the effective **model** and **messages** (including per-call overrides), and a **response** block with a structured **`AssistantMessage`**, **`parsed`**, and **`usage`**. Requests are **deep-copied** so later mutations do not alter persisted traces.
> 
> **`Judge.complete`** records via **`record_judge_call`** in its **`finally`** block so billed calls are kept even when parsing fails. **Replay rescoring** pops **`judge_calls`** from the source trace before offline scoring so stale judge transcripts are not carried into replayed runs; new judge calls during replay are still recorded.
> 
> Tests and e2e replay coverage assert the new shape, snapshot stability, and empty **`judge_calls`** on replayed traces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 442c9c8e89596b921105b09b119a77283802730d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Record pluggable judge request/response exchanges in `trace.info["judge_calls"]`
> - Replaces the response-only `Trace.record_judge` method with `record_judge_call`, which appends a full named record (judge name, request messages, model, and parsed response) to `info["judge_calls"]` and still accounts usage in `extra_usage`.
> - `Judge.complete` now calls `record_judge_call` in its `finally` block, so the exchange is recorded even when response parsing raises.
> - `run_replay.rescore` strips the source trace's `judge_calls` before offline scoring, so replayed traces start clean while any new judge calls during replay are still captured.
> - Updates all judge and e2e tests to assert against the renamed collection and the richer record fields.
> - Risk: `Trace.record_judge` is removed; any out-of-tree callers must migrate to `record_judge_call`. The old `trace.info["judge"]` response-only key is no longer written.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #2497 opened
>
> - Changed judge call response recording format in `Trace.record_judge_call` method from storing a flat `text` field to storing a structured `message` object containing an `AssistantMessage` with role, content, reasoning_content, tool_calls, and provider_state fields, alongside `parsed` and `usage` fields in the response dictionary [f42923c]
> - Modified `Trace.record_judge_call` method to deep-copy request objects using `copy.deepcopy` instead of shallow dictionary conversion [442c9c8]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 597d92f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
