### PR TITLE
bump prime-agent to v0.9.0

### DIFF
--- a/verifiers/v1/harnesses/__init__.py
+++ b/verifiers/v1/harnesses/__init__.py
@@ -21,6 +21,10 @@ from verifiers.v1.harnesses.null import NullHarness, NullHarnessConfig
 from verifiers.v1.harnesses.openclaw import OpenClawHarness, OpenClawHarnessConfig
 from verifiers.v1.harnesses.pi import PiHarness, PiHarnessConfig
 from verifiers.v1.harnesses.pool import PoolHarness, PoolHarnessConfig
+from verifiers.v1.harnesses.prime_agent import (
+    PrimeAgentHarness,
+    PrimeAgentHarnessConfig,
+)
 from verifiers.v1.harnesses.rlm import RLMHarness, RLMHarnessConfig
 from verifiers.v1.harnesses.terminus_2 import Terminus2Harness, Terminus2HarnessConfig
 
@@ -47,6 +51,8 @@ __all__ = [
     "PiHarnessConfig",
     "PoolHarness",
     "PoolHarnessConfig",
+    "PrimeAgentHarness",
+    "PrimeAgentHarnessConfig",
     "RLMHarness",
     "RLMHarnessConfig",
     "Terminus2Harness",

--- a/verifiers/v1/harnesses/prime_agent/__init__.py
+++ b/verifiers/v1/harnesses/prime_agent/__init__.py
@@ -1,0 +1,6 @@
+from verifiers.v1.harnesses.prime_agent.harness import (
+    PrimeAgentHarness,
+    PrimeAgentHarnessConfig,
+)
+
+__all__ = ["PrimeAgentHarness", "PrimeAgentHarnessConfig"]

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -107,7 +107,12 @@ class PrimeAgentHarnessConfig(HarnessConfig):
 
 class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
     APPENDS_SYSTEM_PROMPT = True
-    SUPPORTS_MCP = True
+    # prime-agent's ACP mode ignores the `mcpServers` of `session/new`, and its own
+    # MCP integrations are authored Python-backed skills the model imports in its
+    # kernel, not tools an ACP client can inject. Claiming support would let a
+    # tool-bearing taskset run with its tools silently absent, so declare it false
+    # and let `validate_pairing` reject that pairing up front.
+    SUPPORTS_MCP = False
     SUPPORTS_RESUME = True
     SUPPORTS_SKILLS = True
 
@@ -252,6 +257,5 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
             env,
             ["sh", "-c", f'exec "$PWD/{wrapper}"'],
             prompt,
-            mcp_urls=mcp_urls,
             system_prompt=system_prompt,
         )

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -53,11 +53,22 @@ if [ -f /etc/alpine-release ]; then
     fi
     node_bin="$(dirname "$(command -v node)")"
 else
-    command -v curl >/dev/null 2>&1 \
-        || { apt-get update -qq && apt-get install -y -qq curl ca-certificates >/dev/null; }
+    if ! command -v curl >/dev/null 2>&1; then
+        # Only Debian-family images are provisioned here; say so instead of
+        # failing with "apt-get: not found" on a distro this cannot bootstrap.
+        command -v apt-get >/dev/null 2>&1 \
+            || { echo "prime-agent setup needs curl, or apt-get to install it" >&2; exit 1; }
+        apt-get update -qq && apt-get install -y -qq curl ca-certificates >/dev/null
+    fi
     case "$(uname -s)" in Linux) node_os=linux ;; Darwin) node_os=darwin ;; *) echo "unsupported os: $(uname -s)" >&2; exit 1 ;; esac
     if [ ! -x "$node/bin/node" ] || [ "$("$node/bin/node" --version 2>/dev/null)" != "v$VF_PRIME_AGENT_NODE_VERSION" ]; then
-        case "$(uname -m)" in aarch64|arm64) node_arch=arm64 ;; *) node_arch=x64 ;; esac
+        # Reject an unknown machine like the OS check does: guessing x64 would
+        # download an archive whose node cannot exec, failing much later.
+        case "$(uname -m)" in
+            aarch64|arm64) node_arch=arm64 ;;
+            x86_64|amd64) node_arch=x64 ;;
+            *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+        esac
         rm -rf "$node"
         mkdir -p "$node"
         curl -fsSL "https://nodejs.org/dist/v$VF_PRIME_AGENT_NODE_VERSION/node-v$VF_PRIME_AGENT_NODE_VERSION-${node_os}-${node_arch}.tar.gz" \
@@ -246,10 +257,16 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
                 f'export {ENV_AGENT_DIR} HOME="${ENV_AGENT_DIR}"\n'
                 # Substitute the bearer token into models.json here, so the plaintext
                 # credential is only readable by this rollout's own agent process.
+                # Node rewrites the parsed document rather than a text substitution:
+                # a token carrying a backslash, quote, or `sed` metacharacter would
+                # otherwise corrupt the key or abort the wrapper before exec.
                 f'models="${ENV_AGENT_DIR}/models.json"\n'
                 f"umask 077\n"
-                f'sed "s|{APIKEY_PLACEHOLDER}|${KEY_VAR}|" "$models" > "$models.tmp"\n'
-                f'mv "$models.tmp" "$models"\n'
+                "node -e '"
+                'const fs=require("fs"),p=process.argv[1],'
+                'c=JSON.parse(fs.readFileSync(p,"utf8"));'
+                f'c.providers["{PROVIDER}"].apiKey=process.env.{KEY_VAR}||"";'
+                'fs.writeFileSync(p,JSON.stringify(c))\' "$models"\n'
                 f'exec {shlex.join(args)} "$@"\n'
             ).encode(),
         )

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -1,0 +1,187 @@
+"""Prime Agent harness driving prime-agent's native ACP mode."""
+
+import json
+import logging
+import shlex
+
+from pydantic import Field
+
+from verifiers.v1.acp import ACP
+from verifiers.v1.clients import ModelContext
+from verifiers.v1.configs.harness import HarnessConfig
+from verifiers.v1.harness import Harness
+from verifiers.v1.runtimes import ProgramResult, Runtime
+from verifiers.v1.task import TaskData
+from verifiers.v1.trace import Trace
+
+logger = logging.getLogger(__name__)
+
+# Model traffic is routed through the interception endpoint, which prime-agent
+# sees as an ordinary OpenAI-compatible provider.
+PROVIDER = "intercept"
+KEY_VAR = "PRIME_AGENT_INTERCEPT_KEY"
+
+PRIME_AGENT_DIR = "/tmp/vf-prime-agent"
+PRIME_AGENT_BIN = f"{PRIME_AGENT_DIR}/node_modules/.bin/prime-agent"
+SKILLS_DIR = ".agents/skills"
+INSTALLER_URL = "https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/install.sh"
+
+INSTALL = r"""
+set -e
+if [ -x "$VF_PRIME_AGENT_BIN" ]; then
+    exit 0
+fi
+mkdir -p "$VF_PRIME_AGENT_DIR"
+cd "$VF_PRIME_AGENT_DIR"
+# The published release tarball is a plain npm package, so install it directly
+# instead of running the interactive installer script.
+npm install --no-audit --no-fund --prefix "$VF_PRIME_AGENT_DIR" \
+    "$VF_PRIME_AGENT_TARBALL"
+"""
+
+PRIME_AGENT_ACP = ACP()
+
+
+class PrimeAgentHarnessConfig(HarnessConfig):
+    version: str = "0.5.1"
+    """Prime Agent release to install, pinned for reproducibility."""
+
+    tarball_url: str | None = None
+    """Override the release tarball URL (defaults to the pinned public release)."""
+
+    autonomous: bool = False
+    """Run with `--autonomous`, so the agent continues until its limits or gates stop it."""
+
+    gates: list[str] = Field(default_factory=list)
+    """Autonomous quality-gate commands. Requires `autonomous`."""
+
+
+class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
+    APPENDS_SYSTEM_PROMPT = True
+    SUPPORTS_MCP = True
+    SUPPORTS_RESUME = True
+    SUPPORTS_SKILLS = True
+
+    def _tarball(self) -> str:
+        if self.config.tarball_url:
+            return self.config.tarball_url
+        version = self.config.version
+        base = INSTALLER_URL.rsplit("/", 1)[0]
+        return f"{base}/releases/v{version}/prime-agent-{version}.tgz"
+
+    async def setup(self, runtime: Runtime) -> None:
+        await self.install_skills(runtime, SKILLS_DIR)
+        logger.info("prime-agent: ensuring %s is installed", self.config.version)
+        lock = f"{PRIME_AGENT_DIR}/install.lock"
+        # Concurrent rollouts share one runtime; serialize the install like the
+        # other node-based harnesses do.
+        guarded = (
+            f"mkdir -p {PRIME_AGENT_DIR} && "
+            f'"$(command -v flock || command -v lockf)" {lock} '
+            f"sh -c {shlex.quote(INSTALL)}"
+        )
+        install = await runtime.run(
+            ["sh", "-c", guarded],
+            {
+                "VF_PRIME_AGENT_DIR": PRIME_AGENT_DIR,
+                "VF_PRIME_AGENT_BIN": PRIME_AGENT_BIN,
+                "VF_PRIME_AGENT_TARBALL": self._tarball(),
+            },
+        )
+        if install.exit_code != 0:
+            raise RuntimeError(
+                f"prime-agent install failed: {install.stderr.strip()[-500:]}"
+            )
+        await PRIME_AGENT_ACP.setup(self, runtime)
+
+    async def launch(
+        self,
+        ctx: ModelContext,
+        trace: Trace,
+        runtime: Runtime,
+        endpoint: str,
+        secret: str,
+        mcp_urls: dict[str, str],
+        data: TaskData,
+    ) -> ProgramResult:
+        system_prompt, prompt = self.resolve_prompt(data)
+        agent_dir = f".vf-prime-agent-{trace.id}"
+        reasoning = ctx.sampling.reasoning_effort not in (
+            None,
+            "none",
+        ) or ctx.model.rsplit("/", 1)[-1].startswith(("gpt-5", "o1", "o3", "o4"))
+        models = {
+            "providers": {
+                PROVIDER: {
+                    "baseUrl": endpoint,
+                    "api": "openai-completions",
+                    "apiKey": f"${KEY_VAR}",
+                    "models": [
+                        {
+                            "id": ctx.model,
+                            "reasoning": reasoning,
+                            "input": ["text", "image"],
+                        }
+                    ],
+                }
+            }
+        }
+        await runtime.write(f"{agent_dir}/models.json", json.dumps(models).encode())
+
+        env = {
+            **self.config.resolved_env,
+            KEY_VAR: secret,
+            "PI_CODING_AGENT_DIR": agent_dir,
+            "PI_OFFLINE": "1",
+            "PI_TELEMETRY": "0",
+        }
+
+        args = [
+            PRIME_AGENT_BIN,
+            "--mode",
+            "acp",
+            "--provider",
+            PROVIDER,
+            "--model",
+            ctx.model,
+        ]
+        for skill in self.config.skills:
+            # Resolve like `install_skills` so the path matches what it wrote.
+            args += ["--skill", f"{SKILLS_DIR}/{skill.resolve().name}"]
+        if self.config.disabled_tools:
+            raise ValueError(
+                "prime-agent has no per-tool disable flag; its model-facing tool is "
+                "ipython. Use --no-builtin-tools upstream if that is ever needed."
+            )
+        if self.config.autonomous:
+            args.append("--autonomous")
+            for gate in self.config.gates:
+                args += ["--autonomous-gate", gate]
+        elif self.config.gates:
+            raise ValueError("prime-agent gates require autonomous=true")
+        if system_prompt:
+            args += ["--append-system-prompt", system_prompt]
+
+        # ACP owns stdout, so the agent must be exec'd directly with HOME pinned
+        # to the per-trace agent dir: prime-agent writes sessions and kernel state
+        # under it, and rollouts must not share either.
+        wrapper = f"{agent_dir}/prime-agent"
+        await runtime.write(
+            wrapper,
+            (
+                "#!/bin/sh\n"
+                'PI_CODING_AGENT_DIR="$PWD/$PI_CODING_AGENT_DIR"\n'
+                'export PI_CODING_AGENT_DIR HOME="$PI_CODING_AGENT_DIR"\n'
+                f'exec {shlex.join(args)} "$@"\n'
+            ).encode(),
+        )
+        await runtime.run(["chmod", "+x", wrapper], {})
+
+        return await PRIME_AGENT_ACP.run(
+            runtime,
+            env,
+            ["sh", "-c", f'exec "$PWD/{wrapper}"'],
+            prompt,
+            mcp_urls=mcp_urls,
+            system_prompt=system_prompt,
+        )

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -18,6 +18,11 @@ logger = logging.getLogger(__name__)
 
 # Model traffic is routed through the interception endpoint, which prime-agent
 # sees as an ordinary OpenAI-compatible provider.
+#
+# The agent-dir env var is derived from the package's own piConfig name, so the
+# published prime-agent release reads PRIME_AGENT_CODING_AGENT_DIR, not the
+# upstream PI_ prefix.
+ENV_AGENT_DIR = "PRIME_AGENT_CODING_AGENT_DIR"
 PROVIDER = "intercept"
 KEY_VAR = "PRIME_AGENT_INTERCEPT_KEY"
 
@@ -25,18 +30,43 @@ PRIME_AGENT_DIR = "/tmp/vf-prime-agent"
 PRIME_AGENT_BIN = f"{PRIME_AGENT_DIR}/node_modules/.bin/prime-agent"
 SKILLS_DIR = ".agents/skills"
 INSTALLER_URL = "https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/install.sh"
+NODE_VERSION = "22.19.0"
+NODE_BIN = f"{PRIME_AGENT_DIR}/node/bin"
 
 INSTALL = r"""
 set -e
+node="$VF_PRIME_AGENT_DIR/node"
+node_ok() { node -e 'const [a,b]=process.versions.node.split(".").map(Number); process.exit(a>22 || a===22 && b>=8 ? 0 : 1)'; }
+
+# Containers do not ship Node, and prime-agent requires >=22.8. Prefer the
+# distro package, otherwise fetch the pinned official build.
+if [ -f /etc/alpine-release ]; then
+    apk add --no-cache curl ca-certificates nodejs-current npm >/dev/null
+    node_bin="$(dirname "$(command -v node)")"
+else
+    command -v curl >/dev/null 2>&1 \
+        || { apt-get update -qq && apt-get install -y -qq curl ca-certificates >/dev/null; }
+    case "$(uname -s)" in Linux) node_os=linux ;; Darwin) node_os=darwin ;; *) echo "unsupported os: $(uname -s)" >&2; exit 1 ;; esac
+    if [ ! -x "$node/bin/node" ] || [ "$("$node/bin/node" --version 2>/dev/null)" != "v$VF_PRIME_AGENT_NODE_VERSION" ]; then
+        case "$(uname -m)" in aarch64|arm64) node_arch=arm64 ;; *) node_arch=x64 ;; esac
+        rm -rf "$node"
+        mkdir -p "$node"
+        curl -fsSL "https://nodejs.org/dist/v$VF_PRIME_AGENT_NODE_VERSION/node-v$VF_PRIME_AGENT_NODE_VERSION-${node_os}-${node_arch}.tar.gz" \
+            | tar -xz -C "$node" --strip-components=1
+    fi
+    node_bin="$node/bin"
+fi
+export PATH="$node_bin:$PATH"
+node_ok || { echo "prime-agent requires Node.js 22.8 or newer" >&2; exit 1; }
+
 if [ -x "$VF_PRIME_AGENT_BIN" ]; then
     exit 0
 fi
 mkdir -p "$VF_PRIME_AGENT_DIR"
-cd "$VF_PRIME_AGENT_DIR"
 # The published release tarball is a plain npm package, so install it directly
 # instead of running the interactive installer script.
 npm install --no-audit --no-fund --prefix "$VF_PRIME_AGENT_DIR" \
-    "$VF_PRIME_AGENT_TARBALL"
+    "$VF_PRIME_AGENT_TARBALL" >/dev/null
 """
 
 PRIME_AGENT_ACP = ACP()
@@ -89,6 +119,7 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
                 "VF_PRIME_AGENT_DIR": PRIME_AGENT_DIR,
                 "VF_PRIME_AGENT_BIN": PRIME_AGENT_BIN,
                 "VF_PRIME_AGENT_TARBALL": self._tarball(),
+                "VF_PRIME_AGENT_NODE_VERSION": NODE_VERSION,
             },
         )
         if install.exit_code != 0:
@@ -118,7 +149,10 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
                 PROVIDER: {
                     "baseUrl": endpoint,
                     "api": "openai-completions",
-                    "apiKey": f"${KEY_VAR}",
+                    # prime-agent does NOT expand "$VAR" in models.json: it sends the
+                    # literal string as the bearer token (verified against a capturing
+                    # server). Inline the secret instead of the pi-style indirection.
+                    "apiKey": secret,
                     "models": [
                         {
                             "id": ctx.model,
@@ -134,9 +168,9 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
         env = {
             **self.config.resolved_env,
             KEY_VAR: secret,
-            "PI_CODING_AGENT_DIR": agent_dir,
-            "PI_OFFLINE": "1",
-            "PI_TELEMETRY": "0",
+            ENV_AGENT_DIR: agent_dir,
+            "PRIME_AGENT_OFFLINE": "1",
+            "PRIME_AGENT_TELEMETRY": "0",
         }
 
         args = [
@@ -173,8 +207,10 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
             wrapper,
             (
                 "#!/bin/sh\n"
-                'PI_CODING_AGENT_DIR="$PWD/$PI_CODING_AGENT_DIR"\n'
-                'export PI_CODING_AGENT_DIR HOME="$PI_CODING_AGENT_DIR"\n'
+                # The bundled Node lives beside the install, not on the container PATH.
+                f'export PATH="{NODE_BIN}:$PATH"\n'
+                f'{ENV_AGENT_DIR}="$PWD/${ENV_AGENT_DIR}"\n'
+                f'export {ENV_AGENT_DIR} HOME="${ENV_AGENT_DIR}"\n'
                 f'exec {shlex.join(args)} "$@"\n'
             ).encode(),
         )

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -160,6 +160,12 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
         data: TaskData,
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(data)
+        # A resumed segment replays the accreted conversation, and the ACP runner
+        # renders that transcript into the prompt — including the `[system]` block
+        # it rendered on the first segment. Re-emitting the system prompt here
+        # would hand the model the same instructions twice.
+        if trace.branches and trace.branches[-1].messages:
+            system_prompt = None
         agent_dir = f".vf-prime-agent-{trace.id}"
         reasoning = ctx.sampling.reasoning_effort not in (
             None,

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -31,7 +31,17 @@ KEY_VAR = "PRIME_AGENT_INTERCEPT_KEY"
 PRIME_AGENT_DIR = "/tmp/vf-prime-agent"
 PRIME_AGENT_BIN = f"{PRIME_AGENT_DIR}/node_modules/.bin/prime-agent"
 SKILLS_DIR = ".agents/skills"
-INSTALLER_URL = "https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/install.sh"
+# Release artifacts live under this base; `latest.json` at the root records the
+# current version and each tarball's sha256.
+#
+# This is the artifact base, which is not the same as the user-facing installer at
+# https://app.primeintellect.ai/prime-agent/install.sh. That script is a thin
+# front end: it resolves versions and downloads tarballs from this base, defaulting
+# to it in its own `prime_agent_base_url` and honoring PRIME_AGENT_DOWNLOAD_BASE_URL.
+# The same value is the prime-agent repo's R2_PUBLIC_BASE_URL variable, which its
+# release workflow publishes to. This harness installs the npm tarball directly
+# rather than running that script, so it needs the artifact base.
+RELEASE_BASE_URL = "https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev"
 NODE_VERSION = "22.19.0"
 NODE_BIN = f"{PRIME_AGENT_DIR}/node/bin"
 
@@ -131,8 +141,7 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
         if self.config.tarball_url:
             return self.config.tarball_url
         version = self.config.version
-        base = INSTALLER_URL.rsplit("/", 1)[0]
-        return f"{base}/releases/v{version}/prime-agent-{version}.tgz"
+        return f"{RELEASE_BASE_URL}/releases/v{version}/prime-agent-{version}.tgz"
 
     async def setup(self, runtime: Runtime) -> None:
         await self.install_skills(runtime, SKILLS_DIR)

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -43,8 +43,11 @@ PRIME_AGENT_ACP = ACP()
 
 
 class PrimeAgentHarnessConfig(HarnessConfig):
-    version: str = "0.5.1"
-    """Prime Agent release to install, pinned for reproducibility."""
+    version: str = "0.6.0"
+    """Prime Agent release to install, pinned for reproducibility.
+
+    0.6.0 is the first release with native ACP mode (`--mode acp`).
+    """
 
     tarball_url: str | None = None
     """Override the release tarball URL (defaults to the pinned public release)."""

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -44,6 +44,13 @@ node_ok() { node -e 'const [a,b]=process.versions.node.split(".").map(Number); p
 # distro package, otherwise fetch the pinned official build.
 if [ -f /etc/alpine-release ]; then
     apk add --no-cache curl ca-certificates nodejs-current npm >/dev/null
+    if ! node_ok; then
+        # The official Node build is glibc-only, so an Alpine whose own
+        # nodejs-current is too old has to move its repos forward and retry.
+        sed -E -i 's/v[0-9]+\.[0-9]+/v3.22/g' /etc/apk/repositories
+        apk upgrade --available --no-cache >/dev/null
+        apk add --no-cache nodejs-current npm >/dev/null
+    fi
     node_bin="$(dirname "$(command -v node)")"
 else
     command -v curl >/dev/null 2>&1 \
@@ -61,14 +68,21 @@ fi
 export PATH="$node_bin:$PATH"
 node_ok || { echo "prime-agent requires Node.js 22.8 or newer" >&2; exit 1; }
 
-if [ -x "$VF_PRIME_AGENT_BIN" ]; then
+# Concurrent rollouts share the install, so it is keyed on the requested
+# tarball: a changed `version` or `tarball_url` must reinstall rather than
+# silently reuse whatever an earlier rollout left in the shared directory.
+stamp="$VF_PRIME_AGENT_DIR/.installed"
+if [ -x "$VF_PRIME_AGENT_BIN" ] && [ "$(cat "$stamp" 2>/dev/null)" = "$VF_PRIME_AGENT_TARBALL" ]; then
     exit 0
 fi
 mkdir -p "$VF_PRIME_AGENT_DIR"
+# Drop the stamp first so a failed install is never mistaken for a good one.
+rm -f "$stamp"
 # The published release tarball is a plain npm package, so install it directly
 # instead of running the interactive installer script.
 npm install --no-audit --no-fund --prefix "$VF_PRIME_AGENT_DIR" \
     "$VF_PRIME_AGENT_TARBALL" >/dev/null
+printf %s "$VF_PRIME_AGENT_TARBALL" > "$stamp"
 """
 
 PRIME_AGENT_ACP = ACP()

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -110,10 +110,11 @@ PRIME_AGENT_ACP = ACP()
 
 
 class PrimeAgentHarnessConfig(HarnessConfig):
-    version: str = "0.6.0"
+    version: str = "0.9.0"
     """Prime Agent release to install, pinned for reproducibility.
 
-    0.6.0 is the first release with native ACP mode (`--mode acp`).
+    0.6.0 was the first release with native ACP mode (`--mode acp`). v0.9.0
+    includes MCP tool server support and improved install reliability.
     """
 
     tarball_url: str | None = None

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -24,6 +24,8 @@ logger = logging.getLogger(__name__)
 # upstream PI_ prefix.
 ENV_AGENT_DIR = "PRIME_AGENT_CODING_AGENT_DIR"
 PROVIDER = "intercept"
+# Stand-in written to models.json; the launch wrapper swaps in the real secret.
+APIKEY_PLACEHOLDER = "__VF_PRIME_AGENT_KEY__"
 KEY_VAR = "PRIME_AGENT_INTERCEPT_KEY"
 
 PRIME_AGENT_DIR = "/tmp/vf-prime-agent"
@@ -149,10 +151,14 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
                 PROVIDER: {
                     "baseUrl": endpoint,
                     "api": "openai-completions",
-                    # prime-agent does NOT expand "$VAR" in models.json: it sends the
+                    # prime-agent does not expand "$VAR" in models.json: it sends the
                     # literal string as the bearer token (verified against a capturing
-                    # server). Inline the secret instead of the pi-style indirection.
-                    "apiKey": secret,
+                    # server), so the pi-style indirection cannot be used here. The
+                    # secret is substituted by the launch wrapper at exec time instead
+                    # of being written to disk, because concurrent rollouts share a
+                    # runtime and model-executed code could otherwise read another
+                    # rollout's credential out of its models.json.
+                    "apiKey": APIKEY_PLACEHOLDER,
                     "models": [
                         {
                             "id": ctx.model,
@@ -163,7 +169,8 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
                 }
             }
         }
-        await runtime.write(f"{agent_dir}/models.json", json.dumps(models).encode())
+        models_path = f"{agent_dir}/models.json"
+        await runtime.write(models_path, json.dumps(models).encode())
 
         env = {
             **self.config.resolved_env,
@@ -196,8 +203,8 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
                 args += ["--autonomous-gate", gate]
         elif self.config.gates:
             raise ValueError("prime-agent gates require autonomous=true")
-        if system_prompt:
-            args += ["--append-system-prompt", system_prompt]
+        # The ACP runner seeds the system prompt into the conversation itself, so
+        # passing --append-system-prompt as well would apply it twice.
 
         # ACP owns stdout, so the agent must be exec'd directly with HOME pinned
         # to the per-trace agent dir: prime-agent writes sessions and kernel state
@@ -207,14 +214,24 @@ class PrimeAgentHarness(Harness[PrimeAgentHarnessConfig]):
             wrapper,
             (
                 "#!/bin/sh\n"
+                "set -e\n"
                 # The bundled Node lives beside the install, not on the container PATH.
                 f'export PATH="{NODE_BIN}:$PATH"\n'
                 f'{ENV_AGENT_DIR}="$PWD/${ENV_AGENT_DIR}"\n'
                 f'export {ENV_AGENT_DIR} HOME="${ENV_AGENT_DIR}"\n'
+                # Substitute the bearer token into models.json here, so the plaintext
+                # credential is only readable by this rollout's own agent process.
+                f'models="${ENV_AGENT_DIR}/models.json"\n'
+                f"umask 077\n"
+                f'sed "s|{APIKEY_PLACEHOLDER}|${KEY_VAR}|" "$models" > "$models.tmp"\n'
+                f'mv "$models.tmp" "$models"\n'
                 f'exec {shlex.join(args)} "$@"\n'
             ).encode(),
         )
         await runtime.run(["chmod", "+x", wrapper], {})
+        # models.json is world-readable as written; restrict it before it holds a secret.
+        await runtime.run(["chmod", "700", agent_dir], {})
+        await runtime.run(["chmod", "600", models_path], {})
 
         return await PRIME_AGENT_ACP.run(
             runtime,


### PR DESCRIPTION
Bump the pinned prime-agent version from 0.6.0 to 0.9.0 in the prime-agent harness.

v0.9.0 includes MCP tool server support and improved install reliability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Installs and executes remote npm artifacts plus bootstrap shell in shared runtimes, and handles intercept API secrets via per-rollout wrappers—credential and supply-chain sensitive, though isolated per trace.
> 
> **Overview**
> Adds a new **`PrimeAgentHarness`** and exports it from the harness registry so rollouts can run **prime-agent** in native **`--mode acp`** instead of going through the Pi adapter stack.
> 
> **Setup** installs a pinned release tarball (default **v0.9.0**, overridable via `version` / `tarball_url`) from the public R2 artifact base, bootstrapping **Node ≥22.8** on Alpine/Debian/macOS with a **flock**-guarded shared install under `/tmp/vf-prime-agent`, and wires up the shared **ACP** helper like other agent harnesses.
> 
> **Launch** routes the model through the **intercept** OpenAI-compatible endpoint, writes per-trace `models.json` with a placeholder API key, and uses a small shell wrapper to inject the real bearer token at exec time (JSON rewrite, tight permissions) while pinning **`HOME`** to an isolated `.vf-prime-agent-{trace.id}` directory. It supports **skills**, **resume** (skips duplicate system prompt on continuation), optional **`--autonomous`** / gate flags, declares **`SUPPORTS_MCP = false`** so MCP tasksets fail pairing validation, and rejects **`disabled_tools`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit beae7eddedfb3b988d918e012cad204814fe3ffc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `PrimeAgentHarness` for Prime Agent v0.9.0 with ACP launch and setup
> - Introduces `PrimeAgentHarness` and `PrimeAgentHarnessConfig` in [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2498/files#diff-20ba08f960d62f6e395d3eb05c3a6b051e309727747f31f1a381d7aa7396323b), exported from [__init__.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2498/files#diff-a3e2276a4733d094107ba89dae94cac82f1f87a650e7b7046e6885e51b8b42fd) and the parent harnesses package.
> - `PrimeAgentHarnessConfig` defaults `release_version` to `0.9.0`, supports an optional tarball URL override, autonomous execution mode, and autonomous quality-gate commands.
> - `setup` provisions a pinned Node.js environment for Alpine or Debian-family OS, installs the selected npm tarball (or reuses a previously installed one), installs configured skills under a runtime lock, and raises `RuntimeError` on installation failure before initializing ACP.
> - `launch` runs Prime Agent in ACP mode against the supplied interception endpoint and model, handles resume without duplicating the system prompt, passes skills and autonomous gates, and rejects unsupported disabled-tool or invalid gate configurations.
> - Risk: new harness with no existing callers; installation procedure in `setup` shells out to provision Node.js and install npm packages, so review the OS/arch validation and tarball URL construction in `_tarball` and `setup` for environment safety.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized beae7ed. 3 files reviewed, 3 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->