### PR TITLE
bump prime-agent to v0.9.0

### DIFF
--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -110,10 +110,11 @@ PRIME_AGENT_ACP = ACP()
 
 
 class PrimeAgentHarnessConfig(HarnessConfig):
-    version: str = "0.6.0"
+    version: str = "0.9.0"
     """Prime Agent release to install, pinned for reproducibility.
 
-    0.6.0 is the first release with native ACP mode (`--mode acp`).
+    Bumped from 0.6.0 to 0.9.0. The tarball is published to the R2 release
+    bucket at the same URL pattern.
     """
 
     tarball_url: str | None = None


### PR DESCRIPTION
Minimal version bump: `version: str = "0.6.0"` → `"0.9.0"`.

The tarball exists at the same R2 release URL pattern.
https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/releases/v0.9.0/prime-agent-0.9.0.tgz

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single default version pin for an external agent tarball; no auth or core runtime logic changes.
> 
> **Overview**
> **Pins the Prime Agent harness to release v0.9.0** instead of v0.6.0 by changing the default `PrimeAgentHarnessConfig.version`.
> 
> Install still resolves the npm tarball from the same R2 `RELEASE_BASE_URL` pattern (`.../releases/v{version}/prime-agent-{version}.tgz`), so the next rollout with a new tarball URL will reinstall per the existing stamp logic. The config docstring is updated to document the bump and drops the note that 0.6.0 was the first ACP-native release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit deef759f5119ae780490f016e7ae7f198283ab05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump Prime Agent pinned release to v0.9.0 in `PrimeAgentHarnessConfig`
> Updates the default Prime Agent release from 0.6.0 to 0.9.0 in [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2500/files#diff-20ba08f960d62f6e395d3eb05c3a6b051e309727747f31f1a381d7aa7396323b), along with the adjacent release docs and tarball URL pattern. Autonomous-mode and quality-gate config fields are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized deef759. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->