### PR TITLE
bump prime-agent to v0.9.1

### DIFF
--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -110,10 +110,10 @@ PRIME_AGENT_ACP = ACP()
 
 
 class PrimeAgentHarnessConfig(HarnessConfig):
-    version: str = "0.9.0"
+    version: str = "0.9.1"
     """Prime Agent release to install, pinned for reproducibility.
 
-    Bumped from 0.6.0 to 0.9.0. The tarball is published to the R2 release
+    Bumped from 0.6.0 to 0.9.1. The tarball is published to the R2 release
     bucket at the same URL pattern.
     """
 

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -110,10 +110,11 @@ PRIME_AGENT_ACP = ACP()
 
 
 class PrimeAgentHarnessConfig(HarnessConfig):
-    version: str = "0.6.0"
+    version: str = "0.9.0"
     """Prime Agent release to install, pinned for reproducibility.
 
-    0.6.0 is the first release with native ACP mode (`--mode acp`).
+    Bumped from 0.6.0 to 0.9.0. The tarball is published to the R2 release
+    bucket at the same URL pattern.
     """
 
     tarball_url: str | None = None


### PR DESCRIPTION
Minimal version bump: `version: str = "0.6.0"` → `"0.9.1"`.

The tarball exists at the same R2 release URL pattern.
https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/releases/v0.9.1/prime-agent-0.9.1.tgz

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single default version pin and documentation change; install URL construction already follows `config.version`.
> 
> **Overview**
> Updates the **Prime Agent harness** pinned default from `0.6.0` to **`0.9.1`**, so rollouts install the newer release tarball from the same R2 URL pattern (`releases/v{version}/prime-agent-{version}.tgz`).
> 
> The install stamp logic is unchanged: a version bump still triggers reinstall when the shared install dir is reused. The config docstring now records the bump and that artifacts stay on the existing release bucket.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd34cdf543ef47ce5ad21e431ccab4d118facad0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump pinned Prime Agent release from `0.6.0` to `0.9.1` in `PrimeAgentHarnessConfig`
> Updates the default release tarball URL in [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2501/files#diff-20ba08f960d62f6e395d3eb05c3a6b051e309727747f31f1a381d7aa7396323b) to select Prime Agent 0.9.1 instead of 0.6.0. The tarball URL pattern itself is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized deef759. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->