### PR TITLE
bump prime-agent to v0.9.1

### DIFF
--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -19,10 +19,10 @@ logger = logging.getLogger(__name__)
 GITHUB_RELEASE_URL = (
     "https://github.com/PrimeIntellect-ai/prime-agent/releases/download"
 )
-PRIME_AGENT_COMMIT: Literal["514633727bf26d74f39f3119c2b0e31a5ceb2a9d"] = (
-    "514633727bf26d74f39f3119c2b0e31a5ceb2a9d"
+PRIME_AGENT_COMMIT: Literal["81ae3cb34d27d38ee37f9e205a1e73694993b344"] = (
+    "81ae3cb34d27d38ee37f9e205a1e73694993b344"
 )
-PRIME_AGENT_VERSION = "0.8.1"
+PRIME_AGENT_VERSION = "0.9.1"
 PRIME_AGENT_DIR = "/var/tmp/vf-prime-agent"
 STATE_ROOT = "/tmp/vf-prime-agent-runs"
 SKILLS_DIR = ".agents/skills"
@@ -87,7 +87,7 @@ PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL=1 npm install -g \
 
 
 class PrimeAgentHarnessConfig(HarnessConfig):
-    commit: Literal["514633727bf26d74f39f3119c2b0e31a5ceb2a9d"] = PRIME_AGENT_COMMIT
+    commit: Literal["81ae3cb34d27d38ee37f9e205a1e73694993b344"] = PRIME_AGENT_COMMIT
     """Prime Agent main commit to install."""
 
     autonomous: bool = False

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -51,10 +51,10 @@ for tarball in "$agent_tarball" "$ai_tarball" "$core_tarball" "$tui_tarball"; do
         "$release_url/$tarball" -o "$download_dir/$tarball"
 done
 printf '%s  %s\n' \
-    '46c24db1782dd31adc35d5c6cbcc75564faba6ced3bf2ccf03d836ee77134475' "$agent_tarball" \
-    'f6c3bdb6093bc24a327546fe865ef9a4a172c734fcd4c4093e30c19476f0134d' "$ai_tarball" \
-    '0cc3660953545f8ac9a7e704fcb9875f954d58c3085304080ef615c280aa5748' "$core_tarball" \
-    'bd07bccee0ca495565b1d62e9411f3fdebe49e3dfa52870564f08af5e61fde15' "$tui_tarball" \
+    '573bce0cd004fc62052e9a924089941b7f39266ab71e66a94c85a1f9d35835ba' "$agent_tarball" \
+    '11b5b4cf67b6bb2d3420a44fb69181bc9d94d81e69a2b4fde07eb9c99f5faf4f' "$ai_tarball" \
+    'fb6f3a5dcc8b69c5eeb3beff722b5e0f09885c14849db50bc1d7c0f1d064151c' "$core_tarball" \
+    '4f3eaca2814944d3993073e0b88c0bde54a641ddb5132fbe107e392b997e38ec' "$tui_tarball" \
     > "$download_dir/SHA256SUMS"
 (cd "$download_dir" && sha256sum -c SHA256SUMS)
 mkdir "$download_dir/package-root"


### PR DESCRIPTION
Minimal version bump (+8/-8 lines):

- `PRIME_AGENT_VERSION`: `"0.8.1"` → `"0.9.1"`
- `PRIME_AGENT_COMMIT`: SHA updated to `81ae3cb34d27d38ee37f9e205a1e73694993b344` (v0.9.1 release tag)
- SHA256 checksums for all four release tarballs updated to v0.9.1 values

Verified by downloading all four tarballs from GitHub releases and computing SHA256 locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin and install checksum updates only; behavior changes come from the external prime-agent v0.9.1 release, not from harness logic edits.
> 
> **Overview**
> **Bumps the Prime Agent harness** from **0.8.1** to **0.9.1** so verifier runs install and execute the newer release.
> 
> The pinned commit (`PRIME_AGENT_COMMIT`) and `PrimeAgentHarnessConfig.commit` `Literal` default move to `81ae3cb34d27d38ee37f9e205a1e73694993b344`. The embedded install script’s **SHA256 checksums** for the four release tarballs (`prime-agent`, `prime-agent-ai`, `prime-agent-core`, `prime-agent-tui`) are updated to match v0.9.1 artifacts downloaded from GitHub releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3119b161c0e70c90d7c7d0535f4904cd7c83d9a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `PrimeAgentHarnessConfig` to Prime Agent v0.9.1
> Updates the pinned Prime Agent commit to `81ae3cb34d27d38ee37f9e205a1e73694993b344` and release version from 0.8.1 to 0.9.1 in [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2502/files#diff-20ba08f960d62f6e395d3eb05c3a6b051e309727747f31f1a381d7aa7396323b). Replaces SHA-256 checksums for the agent, AI, core, and TUI release tarballs to match the new artifacts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3119b16.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->