### PR TITLE
refactor(v1): share the dialects' content walker, mediation and preamble

### DIFF
--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -17,7 +17,7 @@ from verifiers.v1.clients.base import build_async_openai
 from verifiers.v1.clients.client import SESSION_ID_HEADER, Client
 from verifiers.v1.configs.client import TrainClientConfig
 from verifiers.v1.dialects import FINISH_REASONS, ChatDialect, Dialect, parse_tools
-from verifiers.v1.dialects.chat import message_to_wire
+from verifiers.v1.dialects.chat import message_to_wire, tool_calls_to_wire
 from verifiers.v1.errors import ProviderError, model_error
 from verifiers.v1.graph import PendingTurn
 from verifiers.v1.types import (
@@ -55,17 +55,7 @@ def serialize_completion(response: Response, model: str) -> dict:
     if response.message.reasoning_content is not None:
         message["reasoning_content"] = response.message.reasoning_content
     if response.message.tool_calls:
-        message["tool_calls"] = [
-            {
-                "id": c.id,
-                "type": c.type,
-                c.type: {
-                    "name": c.name,
-                    "input" if c.type == "custom" else "arguments": c.arguments,
-                },
-            }
-            for c in response.message.tool_calls
-        ]
+        message["tool_calls"] = tool_calls_to_wire(response.message.tool_calls)
     usage: dict | None = None
     if response.usage:
         # Usage is validated earlier in the pipeline; building its wire dict directly saves time.

--- a/verifiers/v1/dialects/anthropic.py
+++ b/verifiers/v1/dialects/anthropic.py
@@ -20,9 +20,12 @@ from verifiers.v1.dialects.base import (
     RawRequest,
     StreamParser,
     append_user_notice,
+    blocked_path,
     blocked_url,
+    mediate_parts,
     parse_sse_event,
     provider_allowed_domains,
+    user_and_tool_messages,
 )
 from verifiers.v1.types import (
     AssistantMessage,
@@ -129,20 +132,11 @@ def parse_content(content) -> str | list[ContentPart]:
 
 
 def blocked_content_path(value, path: str, policy: NetworkPolicyConfig) -> str | None:
-    if isinstance(value, list):
-        for index, item in enumerate(value):
-            if blocked := blocked_content_path(item, f"{path}[{index}]", policy):
-                return blocked
-        return None
-    if not isinstance(value, dict):
-        return None
+    return blocked_path(value, path, policy, _blocked_block)
 
+
+def _blocked_block(value: dict, path: str, policy: NetworkPolicyConfig) -> str | None:
     kind = value.get("type")
-    caller = value.get("caller")
-    if caller is not None and not (
-        isinstance(caller, dict) and caller.get("type") == "direct"
-    ):
-        return f"{path}.caller.type"
     if kind in ("image", "document"):
         source_path = f"{path}.source"
         source = value.get("source") or {}
@@ -178,31 +172,7 @@ def blocked_content_path(value, path: str, policy: NetworkPolicyConfig) -> str |
 
 
 def mediate_content(value, path: str, policy: NetworkPolicyConfig):
-    if not isinstance(value, list):
-        blocked = blocked_content_path(value, path, policy)
-        return ("", [blocked]) if blocked else (value, [])
-
-    mediated = []
-    capabilities = []
-    for index, block in enumerate(value):
-        item_path = f"{path}[{index}]"
-        if isinstance(block, dict) and block.get("type") in _CONTENT_WRAPPERS:
-            if blocked := blocked_content_path(
-                {**block, "content": []}, item_path, policy
-            ):
-                capabilities.append(blocked)
-                continue
-            content, removed = mediate_content(
-                block.get("content"), f"{item_path}.content", policy
-            )
-            if removed:
-                block["content"] = content or ""
-                capabilities.extend(removed)
-        elif blocked := blocked_content_path(block, item_path, policy):
-            capabilities.append(blocked)
-            continue
-        mediated.append(block)
-    return mediated, capabilities
+    return mediate_parts(value, path, policy, blocked_content_path, _CONTENT_WRAPPERS)
 
 
 def content_to_wire(content) -> str | list[dict]:
@@ -577,12 +547,8 @@ class AnthropicDialect(Dialect[AnthropicMessage]):
         return response_from_wire(response)
 
     def rewrite_request(self, body: dict, before: Request, after: Request) -> None:
-        original = [
-            m for m in before.messages if isinstance(m, (UserMessage, ToolMessage))
-        ]
-        rewritten = [
-            m for m in after.messages if isinstance(m, (UserMessage, ToolMessage))
-        ]
+        original = user_and_tool_messages(before)
+        rewritten = user_and_tool_messages(after)
         targets: list[tuple[dict, dict | None]] = []
         for native in body.get("messages", []):
             if native.get("role") == "assistant":

--- a/verifiers/v1/dialects/base.py
+++ b/verifiers/v1/dialects/base.py
@@ -22,7 +22,14 @@ from pydantic import AnyHttpUrl, BaseModel, ValidationError
 from pydantic_core import from_json
 
 from verifiers.v1.configs.runtime import NetworkPolicyConfig
-from verifiers.v1.types import Request, Response, Sampling, SamplingConfig
+from verifiers.v1.types import (
+    Request,
+    Response,
+    Sampling,
+    SamplingConfig,
+    ToolMessage,
+    UserMessage,
+)
 
 RespT = TypeVar("RespT", bound=BaseModel)
 RawRequest = dict[str, Any]
@@ -47,6 +54,70 @@ def blocked_url(value: str, policy: NetworkPolicyConfig) -> bool:
         return True
     host = url.host.lower().rstrip(".").strip("[]")
     return not policy.permits(url.scheme, host, url.port)
+
+
+def blocked_path(
+    value,
+    path: str,
+    policy: NetworkPolicyConfig,
+    blocked_item: Callable[[dict, str, NetworkPolicyConfig], str | None],
+) -> str | None:
+    """The first policy-blocked path under `value`, or None. Lists recurse per index,
+    non-dicts pass, a non-`direct` `caller` is blocked in every format, and `blocked_item`
+    applies the format's own rules to each dict."""
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            if blocked := blocked_path(item, f"{path}[{index}]", policy, blocked_item):
+                return blocked
+        return None
+    if not isinstance(value, dict):
+        return None
+    caller = value.get("caller")
+    if caller is not None and not (
+        isinstance(caller, dict) and caller.get("type") == "direct"
+    ):
+        return f"{path}.caller.type"
+    return blocked_item(value, path, policy)
+
+
+def mediate_parts(
+    value,
+    path: str,
+    policy: NetworkPolicyConfig,
+    blocked: Callable[[Any, str, NetworkPolicyConfig], str | None],
+    wrappers: tuple[str, ...] = (),
+) -> tuple[Any, list[str]]:
+    """Drop the policy-blocked parts of a content list and report their paths; a non-list
+    value is kept whole or replaced by "". A part whose type is in `wrappers` is checked
+    without its content, then its content is mediated in place."""
+    if not isinstance(value, list):
+        blocked_at = blocked(value, path, policy)
+        return ("", [blocked_at]) if blocked_at else (value, [])
+
+    mediated = []
+    capabilities = []
+    for index, part in enumerate(value):
+        item_path = f"{path}[{index}]"
+        if isinstance(part, dict) and part.get("type") in wrappers:
+            if blocked_at := blocked({**part, "content": []}, item_path, policy):
+                capabilities.append(blocked_at)
+                continue
+            content, removed = mediate_parts(
+                part.get("content"), f"{item_path}.content", policy, blocked, wrappers
+            )
+            if removed:
+                part["content"] = content or ""
+                capabilities.extend(removed)
+        elif blocked_at := blocked(part, item_path, policy):
+            capabilities.append(blocked_at)
+            continue
+        mediated.append(part)
+    return mediated, capabilities
+
+
+def user_and_tool_messages(request: Request) -> list[UserMessage | ToolMessage]:
+    """The rewritable messages of a request, in order."""
+    return [m for m in request.messages if isinstance(m, (UserMessage, ToolMessage))]
 
 
 def provider_allowed_domains(

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -159,6 +159,20 @@ def _content_to_wire(content):
     return [part.model_dump() for part in content]
 
 
+def tool_calls_to_wire(tool_calls: list[ToolCall]) -> list[dict]:
+    return [
+        {
+            "id": call.id,
+            "type": call.type,
+            call.type: {
+                "name": call.name,
+                "input" if call.type == "custom" else "arguments": call.arguments,
+            },
+        }
+        for call in tool_calls
+    ]
+
+
 def message_to_wire(message: Message) -> dict:
     if message.role == "assistant":
         # Strict providers reject `content: null` without tool calls.
@@ -171,19 +185,7 @@ def message_to_wire(message: Message) -> dict:
         elif message.reasoning_content is not None:
             wire["reasoning_content"] = message.reasoning_content
         if message.tool_calls:
-            wire["tool_calls"] = [
-                {
-                    "id": call.id,
-                    "type": call.type,
-                    call.type: {
-                        "name": call.name,
-                        "input"
-                        if call.type == "custom"
-                        else "arguments": call.arguments,
-                    },
-                }
-                for call in message.tool_calls
-            ]
+            wire["tool_calls"] = tool_calls_to_wire(message.tool_calls)
         return wire
     if message.role == "tool":
         wire = {

--- a/verifiers/v1/dialects/responses.py
+++ b/verifiers/v1/dialects/responses.py
@@ -24,9 +24,12 @@ from verifiers.v1.dialects.base import (
     RawRequest,
     StreamParser,
     append_user_notice,
+    blocked_path,
     blocked_url,
+    mediate_parts,
     parse_sse_event,
     provider_allowed_domains,
+    user_and_tool_messages,
 )
 from verifiers.v1.errors import model_error
 from verifiers.v1.types import (
@@ -145,6 +148,18 @@ def parse_content(content) -> str | list[ContentPart]:
     return parts
 
 
+def _content_to_input(content) -> str | list[dict]:
+    """Typed text/image content in Responses' native input shape."""
+    if isinstance(content, str):
+        return content
+    return [
+        {"type": "input_text", "text": part.text}
+        if isinstance(part, TextContentPart)
+        else {"type": "input_image", "image_url": part.image_url.url}
+        for part in content
+    ]
+
+
 def mediate_tools(
     tools, path: str, policy: NetworkPolicyConfig
 ) -> tuple[list[dict], list[str]]:
@@ -199,20 +214,11 @@ def mediate_tools(
 
 
 def blocked_content_path(value, path: str, policy: NetworkPolicyConfig) -> str | None:
-    if isinstance(value, list):
-        for index, item in enumerate(value):
-            if blocked := blocked_content_path(item, f"{path}[{index}]", policy):
-                return blocked
-        return None
-    if not isinstance(value, dict):
-        return None
+    return blocked_path(value, path, policy, _blocked_item)
 
+
+def _blocked_item(value: dict, path: str, policy: NetworkPolicyConfig) -> str | None:
     kind = value.get("type")
-    caller = value.get("caller")
-    if caller is not None and not (
-        isinstance(caller, dict) and caller.get("type") == "direct"
-    ):
-        return f"{path}.caller.type"
     if kind == "input_file":
         if value.get("file_id"):
             return f"{path}.file_id"
@@ -260,18 +266,7 @@ def blocked_content_path(value, path: str, policy: NetworkPolicyConfig) -> str |
 
 
 def mediate_content(value, path: str, policy: NetworkPolicyConfig):
-    if not isinstance(value, list):
-        blocked = blocked_content_path(value, path, policy)
-        return ("", [blocked]) if blocked else (value, [])
-
-    mediated = []
-    capabilities = []
-    for index, part in enumerate(value):
-        if blocked := blocked_content_path(part, f"{path}[{index}]", policy):
-            capabilities.append(blocked)
-            continue
-        mediated.append(part)
-    return mediated, capabilities
+    return mediate_parts(value, path, policy, blocked_content_path)
 
 
 def fold_assistant(items: list[dict] | None) -> AssistantMessage:
@@ -602,29 +597,12 @@ class ResponsesDialect(Dialect[OpenAIResponse]):
         return response_from_wire(response)
 
     def rewrite_request(self, body: dict, before: Request, after: Request) -> None:
-        original = [
-            m for m in before.messages if isinstance(m, (UserMessage, ToolMessage))
-        ]
-        rewritten = [
-            m for m in after.messages if isinstance(m, (UserMessage, ToolMessage))
-        ]
+        original = user_and_tool_messages(before)
+        rewritten = user_and_tool_messages(after)
         items = body.get("input")
         if isinstance(items, str):
             if original != rewritten:
-                message = rewritten[0]
-                content = (
-                    message.content
-                    if isinstance(message.content, str)
-                    else [
-                        {"type": "input_text", "text": part.text}
-                        if isinstance(part, TextContentPart)
-                        else {
-                            "type": "input_image",
-                            "image_url": part.image_url.url,
-                        }
-                        for part in message.content
-                    ]
-                )
+                content = _content_to_input(rewritten[0].content)
                 body["input"] = (
                     content
                     if isinstance(content, str)
@@ -645,19 +623,7 @@ class ResponsesDialect(Dialect[OpenAIResponse]):
         for item, old, new in zip(targets, original, rewritten, strict=True):
             if old == new:
                 continue
-            content = (
-                new.content
-                if isinstance(new.content, str)
-                else [
-                    {"type": "input_text", "text": part.text}
-                    if isinstance(part, TextContentPart)
-                    else {
-                        "type": "input_image",
-                        "image_url": part.image_url.url,
-                    }
-                    for part in new.content
-                ]
-            )
+            content = _content_to_input(new.content)
             item["output" if isinstance(new, ToolMessage) else "content"] = content
 
     def rewrite_response(self, raw: dict, text: str) -> None:


### PR DESCRIPTION
Stacked on #2503 (which is stacked on #2496). Behaviour-preserving; see the equivalence check at the bottom.

The Anthropic and Responses dialects each carried their own copy of the same three pieces, and two other exact twins sat in `responses.py` and between `chat.py` and `clients/train.py`.

**Now shared in `dialects/base.py`**
- `blocked_path(value, path, policy, blocked_item)`: the list walk, non-dict pass-through and non-`direct` `caller` gate that both `blocked_content_path` functions started with verbatim. Each dialect keeps its `blocked_content_path` name and its own per-item rules (`_blocked_block` / `_blocked_item`), so every call site and the recursion through nested content are unchanged.
- `mediate_parts(value, path, policy, blocked, wrappers=())`: the list mediation both `mediate_content` functions implemented. Anthropic's extra branch (check a wrapper block without its content, then mediate its content in place) is the `wrappers` parameter; Responses passes none, which is exactly its old body.
- `user_and_tool_messages(request)`: the two list comprehensions both `rewrite_request` methods opened with.

**Exact twins removed**
- `responses.py`: the content → `input_text`/`input_image` conversion appeared twice inside `rewrite_request`; it is `_content_to_input` now.
- `chat.message_to_wire` and `clients/train.serialize_completion` had the same tool-call comprehension. It is `tool_calls_to_wire` in `chat.py`, which `train.py` already imported from. Only that comprehension is shared: `serialize_completion` keeps its own `content` and `reasoning_content` handling, because it deliberately differs from `message_to_wire` (`content: null` stays `null`, `provider_state` is not consulted).

Net lines are roughly flat (+121 / −126): the shared functions carry docstrings. The point is one implementation of each rule instead of two.

**Equivalence check.** With no dedicated dialect tests, I ran the same 81 inputs through the base branch and this branch and diffed the JSON output: `mediate_content` and `blocked_content_path` for both dialects across three network policies and nested/wrapper/caller/file/url cases, `rewrite_request` for both dialects with string and list inputs (changed and unchanged), `message_to_wire` for assistant/tool/user messages including `content=None` with and without tool calls, and `serialize_completion` with and without usage. Identical. Also `ruff check`, `ruff format --check`, `ty check verifiers`, `pytest tests/v1 -m "not e2e"` (82 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extract shared content walker, mediation, and message selectors into `base` dialect
> - Adds shared helpers to [base.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2505/files#diff-10ccce5f7f0d991c33492a01e73014e10883deb74f7006253f1c690422d841bd): `blocked_path` for recursive policy-path traversal, `mediate_parts` for content mediation, and `user_and_tool_messages` for selecting `UserMessage`/`ToolMessage` instances
> - Updates [anthropic.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2505/files#diff-abc86b3ad07c2d6ab09cd923f50271c4f6c4cb928a9bb82c12f6e97aac17b04d), [responses.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2505/files#diff-73f89a1b25536fd7a806555e765120f5189cb934eff813f4c7900838efa56b5a), and [chat.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2505/files#diff-5d2fcbf59a03489b63b0626038a853eee89543b591074597161ee29aab901280) to call these shared helpers, passing provider-specific block checks and wrapper types as callbacks
> - Replaces inline tool-call wire-dictionary construction in [train.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2505/files#diff-c9bcd6c691890b1de6942fe012d2e74678460b22bf335721a8bba5e939d139c3) and [chat.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2505/files#diff-5d2fcbf59a03489b63b0626038a853eee89543b591074597161ee29aab901280) with the shared `tool_calls_to_wire` serializer
> - Extracts Responses typed-content conversion into `_content_to_input` to remove duplication in request rewriting
> - Risk: provider-specific block callbacks (`_blocked_block`, `_blocked_item`) must preserve their original checks exactly; any missed condition changes what content gets blocked or removed at runtime
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dfa7ec3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only move network-policy blocking and content mediation into shared code; a regression in the dialect-specific block callbacks could alter what provider capabilities are stripped at runtime.
> 
> **Overview**
> **Behavior-preserving deduplication** across Anthropic, Responses, chat, and the train client—no intended runtime changes.
> 
> New shared helpers in `dialects/base.py`: **`blocked_path`** (recursive policy traversal plus non-`direct` `caller` gate), **`mediate_parts`** (strip blocked content parts; Anthropic passes `_CONTENT_WRAPPERS`), and **`user_and_tool_messages`** for `rewrite_request` alignment.
> 
> Anthropic and Responses keep their own `blocked_content_path` / `mediate_content` entry points but delegate to those helpers via **`_blocked_block`** / **`_blocked_item`**. Responses also adds **`_content_to_input`** so typed content → `input_text`/`input_image` isn’t duplicated in `rewrite_request`.
> 
> **`tool_calls_to_wire`** in `chat.py` replaces identical comprehensions in `message_to_wire` and `train.serialize_completion`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfa7ec3303c38c65d48dd4659457a35598ec0193. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->