### PR TITLE
refactor(v1): one install-under-lock helper for the harnesses

### DIFF
--- a/verifiers/v1/configs/harness.py
+++ b/verifiers/v1/configs/harness.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import Annotated
 
 from pydantic import ConfigDict, Field, FiniteFloat
 from pydantic_config import BaseConfig
 
 from verifiers.v1.types import ID
+
+PinnedVersion = Annotated[str, Field(pattern=r"^[A-Za-z0-9._+-]+$")]
+"""A release/tag a harness pins its program install to."""
 
 
 class HarnessConfig(BaseConfig):

--- a/verifiers/v1/harnesses/claude_code/harness.py
+++ b/verifiers/v1/harnesses/claude_code/harness.py
@@ -1,13 +1,10 @@
 """Run Claude Code through the Claude Agent SDK ACP adapter."""
 
-import shlex
-
-from pydantic import Field
-
 from verifiers.v1.acp import ACPConfig, ACPHarness
 from verifiers.v1.clients import ModelContext
-from verifiers.v1.configs.harness import HarnessConfig
+from verifiers.v1.configs.harness import HarnessConfig, PinnedVersion
 from verifiers.v1.harnesses.node import NODE_BIN_DIR, ensure_node
+from verifiers.v1.harnesses.utils.install import ensure_installed, remove_dir
 from verifiers.v1.runtimes import Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
@@ -32,7 +29,7 @@ touch {ready}
 
 
 class ClaudeCodeHarnessConfig(HarnessConfig):
-    version: str = Field(default="2.1.232", pattern=r"^[A-Za-z0-9._+-]+$")
+    version: PinnedVersion = "2.1.232"
     """Claude Code release to install, pinned for reproducibility."""
 
 
@@ -51,25 +48,18 @@ class ClaudeCodeHarness(ACPHarness[ClaudeCodeHarnessConfig]):
         acp_bin = ACP_BIN.format(**versions)
         ready = f"{directory}/.ready"
         script = ACP_INSTALL.replace("{packages}", packages).replace("{ready}", ready)
-        ensure = shlex.quote(
-            f"[ -f {ready} ] && [ -x {claude_bin} ] && [ -x {acp_bin} ] || ({script})"
-        )
-        acp_guarded = (
-            f"mkdir -p {directory} && "
-            f'"$(command -v flock || command -v lockf)" {directory}/install.lock '
-            f"sh -c {ensure}"
-        )
-        acp_result = await runtime.run(
-            ["sh", "-c", acp_guarded],
-            {
+        await ensure_installed(
+            runtime,
+            directory=directory,
+            ready=f"[ -f {ready} ] && [ -x {claude_bin} ] && [ -x {acp_bin} ]",
+            install=script,
+            env={
                 **self.config.resolved_env,
                 "VF_CLAUDE_CODE_VERSION": self.config.version,
                 "VF_CLAUDE_ACP_VERSION": ACP_VERSION,
             },
+            label="Claude Agent ACP",
         )
-        if acp_result.exit_code != 0:
-            detail = (acp_result.stderr or acp_result.stdout).strip()[-500:]
-            raise RuntimeError(f"Claude Agent ACP install failed: {detail}")
         await super().setup(runtime)
 
     async def prepare_acp(
@@ -113,11 +103,7 @@ class ClaudeCodeHarness(ACPHarness[ClaudeCodeHarnessConfig]):
         )
 
     async def cleanup(self, trace: Trace, runtime: Runtime) -> None:
-        result = await runtime.run(["rm", "-rf", self.config_dir(trace)], {})
-        if result.exit_code != 0:
-            raise RuntimeError(
-                f"failed to clean up Claude config: {result.stderr.strip()[-500:]}"
-            )
+        await remove_dir(runtime, self.config_dir(trace), "Claude config")
 
     @staticmethod
     def config_dir(trace: Trace) -> str:

--- a/verifiers/v1/harnesses/codex/harness.py
+++ b/verifiers/v1/harnesses/codex/harness.py
@@ -4,15 +4,13 @@ import hashlib
 import json
 import logging
 import re
-import shlex
 from collections import Counter
-
-from pydantic import Field
 
 from verifiers.v1.acp import ACPConfig, ACPHarness
 from verifiers.v1.clients import ModelContext
-from verifiers.v1.configs.harness import HarnessConfig
+from verifiers.v1.configs.harness import HarnessConfig, PinnedVersion
 from verifiers.v1.harnesses.node import NODE_BIN_DIR, ensure_node
+from verifiers.v1.harnesses.utils.install import ensure_installed, remove_dir
 from verifiers.v1.runtimes import Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
@@ -38,7 +36,7 @@ touch {ready}
 
 
 class CodexHarnessConfig(HarnessConfig):
-    version: str = Field(default="0.147.0", pattern=r"^[A-Za-z0-9._+-]+$")
+    version: PinnedVersion = "0.147.0"
     """Codex release to install, pinned for reproducibility."""
     multi_agent: bool = False
     """Enable Codex's native multi-agent v2 tools."""
@@ -64,24 +62,18 @@ class CodexHarness(ACPHarness[CodexHarnessConfig]):
         acp_bin = ACP_BIN.format(**versions)
         ready = f"{directory}/.ready"
         script = INSTALL.replace("{packages}", packages).replace("{ready}", ready)
-        ensure = shlex.quote(
-            f"[ -f {ready} ] && [ -x {codex_bin} ] && [ -x {acp_bin} ] || ({script})"
-        )
-        guarded = (
-            f"mkdir -p {directory} && "
-            f'"$(command -v flock || command -v lockf)" {directory}/install.lock '
-            f"sh -c {ensure}"
-        )
-        install = await runtime.run(
-            ["sh", "-c", guarded],
-            {
+        await ensure_installed(
+            runtime,
+            directory=directory,
+            ready=f"[ -f {ready} ] && [ -x {codex_bin} ] && [ -x {acp_bin} ]",
+            install=script,
+            env={
                 **self.config.resolved_env,
                 "VF_CODEX_VERSION": self.config.version,
                 "VF_CODEX_ACP_VERSION": ACP_VERSION,
             },
+            label="codex",
         )
-        if install.exit_code != 0:
-            raise RuntimeError(f"codex install failed: {install.stderr.strip()[-500:]}")
         await super().setup(runtime)
 
     async def prepare_acp(
@@ -112,11 +104,7 @@ class CodexHarness(ACPHarness[CodexHarnessConfig]):
         )
 
     async def cleanup(self, trace: Trace, runtime: Runtime) -> None:
-        result = await runtime.run(["rm", "-rf", self.trace_home(trace)], {})
-        if result.exit_code != 0:
-            raise RuntimeError(
-                f"failed to clean up Codex home: {result.stderr.strip()[-500:]}"
-            )
+        await remove_dir(runtime, self.trace_home(trace), "Codex home")
 
     @staticmethod
     def trace_home(trace: Trace) -> str:

--- a/verifiers/v1/harnesses/hermes_agent/harness.py
+++ b/verifiers/v1/harnesses/hermes_agent/harness.py
@@ -3,11 +3,10 @@
 import json
 from pathlib import Path
 
-from pydantic import Field
-
 from verifiers.v1.acp import ACPConfig, ACPHarness
 from verifiers.v1.clients import ModelContext
-from verifiers.v1.configs.harness import HarnessConfig
+from verifiers.v1.configs.harness import HarnessConfig, PinnedVersion
+from verifiers.v1.harnesses.utils.install import remove_dir
 from verifiers.v1.runtimes import Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
@@ -16,7 +15,7 @@ PROGRAM_SOURCE = (Path(__file__).resolve().parent / "program.py").read_text()
 
 
 class HermesAgentHarnessConfig(HarnessConfig):
-    version: str = Field(default="0.19.0", pattern=r"^[A-Za-z0-9._+-]+$")
+    version: PinnedVersion = "0.19.0"
     """Hermes Agent release to install, pinned for reproducibility."""
     use_bundled_skill: bool = False
     """Enable Hermes Agent's bundled skill catalog in addition to uploaded skills."""
@@ -96,8 +95,4 @@ class HermesAgentHarness(ACPHarness[HermesAgentHarnessConfig]):
         )
 
     async def cleanup(self, trace: Trace, runtime: Runtime) -> None:
-        result = await runtime.run(["rm", "-rf", f"/tmp/vf-hermes/{trace.id}"], {})
-        if result.exit_code:
-            raise RuntimeError(
-                f"failed to clean up Hermes home: {result.stderr.strip()[-500:]}"
-            )
+        await remove_dir(runtime, f"/tmp/vf-hermes/{trace.id}", "Hermes home")

--- a/verifiers/v1/harnesses/kimi_code/harness.py
+++ b/verifiers/v1/harnesses/kimi_code/harness.py
@@ -1,15 +1,14 @@
 """Run Kimi Code's native ACP server against interception."""
 
 import logging
-import shlex
 from typing import Literal
 
 import tomli_w
-from pydantic import Field
 
 from verifiers.v1.acp import ACPConfig, ACPHarness
 from verifiers.v1.clients import ModelContext
-from verifiers.v1.configs.harness import HarnessConfig
+from verifiers.v1.configs.harness import HarnessConfig, PinnedVersion
+from verifiers.v1.harnesses.utils.install import ensure_installed
 from verifiers.v1.runtimes import Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
@@ -39,7 +38,7 @@ env \
 
 
 class KimiCodeHarnessConfig(HarnessConfig):
-    version: str = Field(default="0.36.0", pattern=r"^[A-Za-z0-9._+-]+$")
+    version: PinnedVersion = "0.36.0"
     """Kimi Code release to install, pinned for reproducibility."""
     transport: Literal["chat_completions", "responses", "anthropic_messages"] = (
         "chat_completions"
@@ -58,16 +57,13 @@ class KimiCodeHarness(ACPHarness[KimiCodeHarnessConfig]):
             "kimi-code: ensuring Kimi Code %s is installed", self.config.version
         )
         script = INSTALL.replace("{version}", self.config.version)
-        guarded = (
-            "mkdir -p /tmp/vf-kimi-code && "
-            '"$(command -v flock || command -v lockf)" '
-            f"/tmp/vf-kimi-code/install.lock sh -c {shlex.quote(script)}"
+        await ensure_installed(
+            runtime,
+            directory="/tmp/vf-kimi-code",
+            install=script,
+            env={},
+            label="Kimi Code",
         )
-        install = await runtime.run(["sh", "-c", guarded], {})
-        if install.exit_code != 0:
-            raise RuntimeError(
-                f"Kimi Code install failed: {install.stderr.strip()[-500:]}"
-            )
         await super().setup(runtime)
 
     async def prepare_acp(

--- a/verifiers/v1/harnesses/mini_swe_agent/harness.py
+++ b/verifiers/v1/harnesses/mini_swe_agent/harness.py
@@ -1,9 +1,7 @@
 from pathlib import Path
 
-from pydantic import Field
-
 from verifiers.v1.clients import ModelContext
-from verifiers.v1.configs.harness import HarnessConfig
+from verifiers.v1.configs.harness import HarnessConfig, PinnedVersion
 from verifiers.v1.harness import Harness
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.task import TaskData
@@ -13,7 +11,7 @@ PROGRAM_SOURCE = (Path(__file__).resolve().parent / "program.py").read_text()
 
 
 class MiniSWEAgentHarnessConfig(HarnessConfig):
-    version: str = Field(default="2.4.6", pattern=r"^[A-Za-z0-9._+-]+$")
+    version: PinnedVersion = "2.4.6"
     """mini-swe-agent release to install, pinned for reproducibility."""
 
 

--- a/verifiers/v1/harnesses/node.py
+++ b/verifiers/v1/harnesses/node.py
@@ -1,5 +1,4 @@
-import shlex
-
+from verifiers.v1.harnesses.utils.install import ensure_installed
 from verifiers.v1.runtimes import Runtime
 
 NODE_DIR = "/var/tmp/vf-node"
@@ -39,16 +38,12 @@ node_ok || { echo "ACP adapters require Node.js 22.19 or newer" >&2; exit 1; }
 
 async def ensure_node(runtime: Runtime) -> None:
     """Install the shared Node runtime used by ACP adapter harnesses."""
-    lock = f"{NODE_DIR}.install.lock"
-    guarded = (
-        f'until ln -s "$$" {lock} 2>/dev/null; do '
-        f"owner=$(readlink {lock}); "
-        f'if ! kill -0 "$owner" 2>/dev/null; then '
-        f'[ "$(readlink {lock})" != "$owner" ] || rm -f {lock}; fi; '
-        f"sleep 0.1; done; "
-        f'trap \'[ "$(readlink {lock})" != "$$" ] || rm -f {lock}\' EXIT; '
-        f"sh -c {shlex.quote(INSTALL)}"
+    # The install replaces NODE_DIR wholesale, so the lock lives beside it.
+    await ensure_installed(
+        runtime,
+        directory=NODE_DIR,
+        lock=f"{NODE_DIR}.install.lock",
+        install=INSTALL,
+        env={"VF_NODE_VERSION": NODE_VERSION},
+        label="Node.js",
     )
-    result = await runtime.run(["sh", "-c", guarded], {"VF_NODE_VERSION": NODE_VERSION})
-    if result.exit_code != 0:
-        raise RuntimeError(f"Node.js install failed: {result.stderr.strip()[-500:]}")

--- a/verifiers/v1/harnesses/openclaw/harness.py
+++ b/verifiers/v1/harnesses/openclaw/harness.py
@@ -4,13 +4,11 @@ import asyncio
 import json
 import logging
 import secrets
-import shlex
-
-from pydantic import Field
 
 from verifiers.v1.acp import ACPConfig, ACPHarness
 from verifiers.v1.clients import ModelContext
-from verifiers.v1.configs.harness import HarnessConfig
+from verifiers.v1.configs.harness import HarnessConfig, PinnedVersion
+from verifiers.v1.harnesses.utils.install import ensure_installed, remove_dir
 from verifiers.v1.runtimes import Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
@@ -120,7 +118,7 @@ wait "$acp_pid"
 
 
 class OpenClawHarnessConfig(HarnessConfig):
-    version: str = Field(default="2026.8.1", pattern=r"^[A-Za-z0-9._+-]+$")
+    version: PinnedVersion = "2026.8.1"
     """OpenClaw release to install, pinned for reproducibility."""
     use_bundled_skill: bool = True
     """Enable OpenClaw's bundled skill catalog in addition to uploaded harness skills."""
@@ -143,39 +141,29 @@ class OpenClawHarness(ACPHarness[OpenClawHarnessConfig]):
                 ready_path = f"{self._staged_skills_dir}/.ready"
                 ready = await runtime.run(["test", "-f", ready_path], {})
                 if ready.exit_code != 0:
-                    cleared = await runtime.run(
-                        ["rm", "-rf", self._staged_skills_dir], {}
+                    await remove_dir(
+                        runtime, self._staged_skills_dir, "OpenClaw skills"
                     )
-                    if cleared.exit_code != 0:
-                        raise RuntimeError(
-                            "failed to clear OpenClaw skills: "
-                            f"{cleared.stderr.strip()[-500:]}"
-                        )
                     await self.install_skills(runtime, self._staged_skills_dir)
                     await runtime.write(ready_path, b"")
         directory = OPENCLAW_DIR.format(version=self.config.version)
         binary = OPENCLAW_BIN.format(version=self.config.version)
+        logger.info("openclaw: ensuring OpenClaw %s is installed", self.config.version)
         # Borrowed runtimes can share this cache, so one filesystem lock owns both
         # installation and the transcript adjustment.
-        guarded = (
-            f"mkdir -p {shlex.quote(directory)} && "
-            f'"$(command -v flock || command -v lockf)" '
-            f"{shlex.quote(f'{directory}/install.lock')} "
-            f"bash -o pipefail -c {shlex.quote(SETUP)}"
-        )
-        logger.info("openclaw: ensuring OpenClaw %s is installed", self.config.version)
-        result = await runtime.run(
-            ["sh", "-c", guarded],
-            {
+        await ensure_installed(
+            runtime,
+            directory=directory,
+            install=SETUP,
+            env={
                 **self.config.resolved_env,
                 "VF_OPENCLAW_BIN": binary,
                 "VF_OPENCLAW_DIR": directory,
                 "VF_OPENCLAW_VERSION": self.config.version,
             },
+            label="OpenClaw",
+            shell=("bash", "-o", "pipefail", "-c"),
         )
-        if result.exit_code != 0:
-            detail = (result.stderr or result.stdout).strip()[-500:]
-            raise RuntimeError(f"OpenClaw setup failed: {detail}")
         await super().setup(runtime)
 
     async def prepare_acp(
@@ -277,8 +265,4 @@ class OpenClawHarness(ACPHarness[OpenClawHarnessConfig]):
 
     async def cleanup(self, trace: Trace, runtime: Runtime) -> None:
         state_dir = f".vf-openclaw/{trace.id}"
-        result = await runtime.run(["rm", "-rf", state_dir], {})
-        if result.exit_code != 0:
-            raise RuntimeError(
-                f"failed to clean up OpenClaw state: {result.stderr.strip()[-500:]}"
-            )
+        await remove_dir(runtime, state_dir, "OpenClaw state")

--- a/verifiers/v1/harnesses/pi/harness.py
+++ b/verifiers/v1/harnesses/pi/harness.py
@@ -5,12 +5,11 @@ import logging
 import shlex
 from typing import Literal
 
-from pydantic import Field
-
 from verifiers.v1.acp import ACPConfig, ACPHarness
 from verifiers.v1.clients import ModelContext
-from verifiers.v1.configs.harness import HarnessConfig
+from verifiers.v1.configs.harness import HarnessConfig, PinnedVersion
 from verifiers.v1.harnesses.node import NODE_BIN_DIR, ensure_node
+from verifiers.v1.harnesses.utils.install import ensure_installed
 from verifiers.v1.runtimes import Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
@@ -46,7 +45,7 @@ fi
 
 
 class PiHarnessConfig(HarnessConfig):
-    version: str = Field(default="0.84.1", pattern=r"^[A-Za-z0-9._+-]+$")
+    version: PinnedVersion = "0.84.1"
     """Pi release to install, pinned for reproducibility."""
     transport: Literal["chat_completions", "responses", "anthropic_messages"] = (
         "chat_completions"
@@ -69,27 +68,17 @@ class PiHarness(ACPHarness[PiHarnessConfig]):
             self.config.version,
             ACP_VERSION,
         )
-        lock = f"{PI_DIR}/install.lock"
-        guarded = (
-            f"mkdir -p {PI_DIR} && "
-            f'until ln -s "$$" {lock} 2>/dev/null; do '
-            f"owner=$(readlink {lock}); "
-            f'if ! kill -0 "$owner" 2>/dev/null; then '
-            f'[ "$(readlink {lock})" != "$owner" ] || rm -f {lock}; fi; '
-            f"sleep 0.1; done; "
-            f'trap \'[ "$(readlink {lock})" != "$$" ] || rm -f {lock}\' EXIT; '
-            f"sh -c {shlex.quote(INSTALL)}"
-        )
-        install = await runtime.run(
-            ["sh", "-c", guarded],
-            {
+        await ensure_installed(
+            runtime,
+            directory=PI_DIR,
+            install=INSTALL,
+            env={
                 "VF_PI_VERSION": self.config.version,
                 "VF_PI_MCP_VERSION": MCP_VERSION,
                 "VF_PI_ACP_VERSION": ACP_VERSION,
             },
+            label="pi",
         )
-        if install.exit_code != 0:
-            raise RuntimeError(f"pi install failed: {install.stderr.strip()[-500:]}")
         await super().setup(runtime)
 
     async def prepare_acp(

--- a/verifiers/v1/harnesses/pool/harness.py
+++ b/verifiers/v1/harnesses/pool/harness.py
@@ -3,11 +3,10 @@
 import json
 import shlex
 
-from pydantic import Field
-
 from verifiers.v1.acp import ACPConfig, ACPHarness
 from verifiers.v1.clients import ModelContext
-from verifiers.v1.configs.harness import HarnessConfig
+from verifiers.v1.configs.harness import HarnessConfig, PinnedVersion
+from verifiers.v1.harnesses.utils.install import ensure_installed
 from verifiers.v1.runtimes import Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
@@ -28,7 +27,7 @@ chmod +x "{dir}/pool"
 
 
 class PoolHarnessConfig(HarnessConfig):
-    version: str = Field(default="1.0.15", pattern=r"^[A-Za-z0-9._+-]+$")
+    version: PinnedVersion = "1.0.15"
     """Pool release to install, pinned for reproducibility."""
 
 
@@ -44,17 +43,15 @@ class PoolHarness(ACPHarness[PoolHarnessConfig]):
         script = INSTALL.replace("{version}", self.config.version).replace(
             "{dir}", directory
         )
-        ensure = shlex.quote(f"[ -x {binary} ] || ({script})")
-        # Cache the pinned binary across local rollouts; Linux has flock, macOS has lockf.
-        guarded = (
-            f"mkdir -p {directory} && "
-            f'"$(command -v flock || command -v lockf)" {directory}/install.lock '
-            f"bash -o pipefail -c {ensure}"
+        await ensure_installed(
+            runtime,
+            directory=directory,
+            ready=f"[ -x {binary} ]",
+            install=script,
+            env=self.config.resolved_env,
+            label="Pool",
+            shell=("bash", "-o", "pipefail", "-c"),
         )
-        result = await runtime.run(["sh", "-c", guarded], self.config.resolved_env)
-        if result.exit_code != 0:
-            detail = (result.stderr or result.stdout).strip()[-500:]
-            raise RuntimeError(f"Pool install failed: {detail}")
         await super().setup(runtime)
 
     async def prepare_acp(

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -10,6 +10,7 @@ from verifiers.v1.acp import ACPConfig, ACPHarness, ACPTurn
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.harnesses.node import NODE_BIN_DIR, ensure_node
+from verifiers.v1.harnesses.utils.install import ensure_installed, remove_dir
 from verifiers.v1.runtimes import Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
@@ -157,26 +158,19 @@ class PrimeAgentHarness(ACPHarness[PrimeAgentHarnessConfig]):
         await self.install_skills(runtime, SKILLS_DIR)
         await ensure_node(runtime)
         logger.info("prime-agent: ensuring commit %s is installed", self.config.commit)
-        lock = f"{PRIME_AGENT_DIR}/install.lock"
-        guarded = (
-            f"mkdir -p {PRIME_AGENT_DIR} && "
-            f'"$(command -v flock || command -v lockf)" {lock} '
-            f"sh -c {shlex.quote(INSTALL)}"
-        )
-        result = await runtime.run(
-            ["sh", "-c", guarded],
-            {
+        await ensure_installed(
+            runtime,
+            directory=PRIME_AGENT_DIR,
+            install=INSTALL,
+            env={
                 **self.config.resolved_env,
                 "VF_PRIME_AGENT_DIR": PRIME_AGENT_DIR,
                 "VF_PRIME_AGENT_GITHUB_RELEASE_URL": GITHUB_RELEASE_URL,
                 "PRIME_AGENT_COMMIT": self.config.commit,
                 "PRIME_AGENT_RELEASE_VERSION": PRIME_AGENT_VERSION,
             },
+            label="prime-agent",
         )
-        if result.exit_code != 0:
-            raise RuntimeError(
-                f"prime-agent install failed: {result.stderr.strip()[-500:]}"
-            )
         await super().setup(runtime)
 
     async def prepare_acp(
@@ -285,11 +279,7 @@ class PrimeAgentHarness(ACPHarness[PrimeAgentHarnessConfig]):
 
     async def cleanup(self, trace: Trace, runtime: Runtime) -> None:
         root = self._root(trace)
-        removed = await runtime.run(["rm", "-rf", root], {})
-        if removed.exit_code != 0:
-            raise RuntimeError(
-                f"prime-agent state cleanup failed: {removed.stderr.strip()[-500:]}"
-            )
+        await remove_dir(runtime, root, "prime-agent state")
 
     def _bin(self) -> str:
         return f"{PRIME_AGENT_DIR}/{self.config.commit}/bin/prime-agent"

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -18,6 +18,7 @@ from pydantic_config import BaseConfig
 from verifiers.v1.acp import ACPConfig, ACPHarness, ACPTurn, JsonObject
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
+from verifiers.v1.harnesses.utils.install import ensure_installed
 from verifiers.v1.runtimes import Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
@@ -130,16 +131,17 @@ class RLMHarness(ACPHarness[RLMHarnessConfig]):
             f"touch {ready})"
         )
         logger.info("rlm: ensuring rlm is installed (version=%s)", self.config.version)
-        ensure = shlex.quote(f"[ -f {ready} ] && [ -x {binary} ] || ({install})")
-        guarded = (
-            f"mkdir -p {directory} && flock {directory}/install.lock sh -c {ensure}"
-        )
         env = self.config.resolved_env.copy()
         extra_uv_args = env.get("RLM_EXTRA_UV_ARGS", "")
         env["RLM_EXTRA_UV_ARGS"] = f"{extra_uv_args} --with mcp~=1.28".strip()
-        result = await runtime.run(["sh", "-c", guarded], env)
-        if result.exit_code != 0:
-            raise RuntimeError(f"rlm install failed: {result.stderr.strip()[-500:]}")
+        await ensure_installed(
+            runtime,
+            directory=directory,
+            ready=f"[ -f {ready} ] && [ -x {binary} ]",
+            install=install,
+            env=env,
+            label="rlm",
+        )
         await super().setup(runtime)
 
     def _runtime_metadata(

--- a/verifiers/v1/harnesses/terminus_2/harness.py
+++ b/verifiers/v1/harnesses/terminus_2/harness.py
@@ -1,10 +1,8 @@
 import logging
 from pathlib import Path
 
-from pydantic import Field
-
 from verifiers.v1.clients import ModelContext
-from verifiers.v1.configs.harness import HarnessConfig
+from verifiers.v1.configs.harness import HarnessConfig, PinnedVersion
 from verifiers.v1.harness import Harness
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.task import TaskData
@@ -15,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 class Terminus2HarnessConfig(HarnessConfig):
-    version: str = Field(default="0.21.0", pattern=r"^[A-Za-z0-9._+-]+$")
+    version: PinnedVersion = "0.21.0"
     """Harbor release to install, pinned for reproducibility."""
 
 

--- a/verifiers/v1/harnesses/utils/install.py
+++ b/verifiers/v1/harnesses/utils/install.py
@@ -4,9 +4,6 @@ import shlex
 
 from verifiers.v1.runtimes import Runtime
 
-# Linux has flock, macOS/BSD has lockf; either releases the lock when its holder dies.
-_LOCKER = '"$(command -v flock || command -v lockf)"'
-
 
 async def ensure_installed(
     runtime: Runtime,
@@ -23,12 +20,25 @@ async def ensure_installed(
     install once and the rest wait. `ready` is a shell test that skips the install when it
     already holds. The lock is `directory/install.lock` unless the install replaces
     `directory` itself, in which case pass a `lock` path beside it. `shell` runs the script
-    (e.g. `bash -o pipefail -c` for pipelines)."""
-    lock = lock or f"{directory}/install.lock"
+    (e.g. `bash -o pipefail -c` for pipelines).
+
+    The lock is `flock` (Linux, busybox) or `lockf` (macOS/BSD), both released when the holder
+    dies; an image with neither falls back to a symlink spinlock that reaps a dead owner."""
+    lock = shlex.quote(lock or f"{directory}/install.lock")
     script = f"{ready} || ({install})" if ready else install
+    run = f"{shlex.join(shell)} {shlex.quote(script)}"
+    # A lock that is not a symlink (left behind by flock/lockf) or whose owner pid is gone
+    # is stale and reaped. `kill -0 ""` succeeds under busybox ash, hence the explicit -z.
+    spinlock = (
+        f'until ln -s "$$" {lock} 2>/dev/null; do owner=$(readlink {lock} 2>/dev/null); '
+        f'if [ -z "$owner" ] || ! kill -0 "$owner" 2>/dev/null; then '
+        f'[ "$(readlink {lock} 2>/dev/null)" != "$owner" ] || rm -f {lock}; fi; '
+        f"sleep 0.1; done; "
+        f'trap \'[ "$(readlink {lock} 2>/dev/null)" != "$$" ] || rm -f {lock}\' EXIT; {run}'
+    )
     guarded = (
-        f"mkdir -p {shlex.quote(directory)} && {_LOCKER} {shlex.quote(lock)} "
-        f"{shlex.join(shell)} {shlex.quote(script)}"
+        f"mkdir -p {shlex.quote(directory)} && "
+        f'if l=$(command -v flock || command -v lockf); then "$l" {lock} {run}; else {spinlock}; fi'
     )
     result = await runtime.run(["sh", "-c", guarded], env)
     if result.exit_code != 0:

--- a/verifiers/v1/harnesses/utils/install.py
+++ b/verifiers/v1/harnesses/utils/install.py
@@ -1,0 +1,45 @@
+"""Host-side helpers for installing a harness's program into a runtime."""
+
+import shlex
+
+from verifiers.v1.runtimes import Runtime
+
+# Linux has flock, macOS/BSD has lockf; either releases the lock when its holder dies.
+_LOCKER = '"$(command -v flock || command -v lockf)"'
+
+
+async def ensure_installed(
+    runtime: Runtime,
+    *,
+    directory: str,
+    install: str,
+    env: dict[str, str],
+    label: str,
+    ready: str | None = None,
+    lock: str | None = None,
+    shell: tuple[str, ...] = ("sh", "-c"),
+) -> None:
+    """Run `install` in `runtime` under a lock, so concurrent rollouts sharing the runtime
+    install once and the rest wait. `ready` is a shell test that skips the install when it
+    already holds. The lock is `directory/install.lock` unless the install replaces
+    `directory` itself, in which case pass a `lock` path beside it. `shell` runs the script
+    (e.g. `bash -o pipefail -c` for pipelines)."""
+    lock = lock or f"{directory}/install.lock"
+    script = f"{ready} || ({install})" if ready else install
+    guarded = (
+        f"mkdir -p {shlex.quote(directory)} && {_LOCKER} {shlex.quote(lock)} "
+        f"{shlex.join(shell)} {shlex.quote(script)}"
+    )
+    result = await runtime.run(["sh", "-c", guarded], env)
+    if result.exit_code != 0:
+        detail = (result.stderr or result.stdout).strip()[-500:]
+        raise RuntimeError(f"{label} install failed: {detail}")
+
+
+async def remove_dir(runtime: Runtime, path: str, label: str) -> None:
+    """Delete `path` in `runtime`; a failure names `label` (what the path held)."""
+    result = await runtime.run(["rm", "-rf", path], {})
+    if result.exit_code != 0:
+        raise RuntimeError(
+            f"failed to clean up {label}: {result.stderr.strip()[-500:]}"
+        )

--- a/verifiers/v1/harnesses/utils/install.py
+++ b/verifiers/v1/harnesses/utils/install.py
@@ -23,18 +23,28 @@ async def ensure_installed(
     (e.g. `bash -o pipefail -c` for pipelines).
 
     The lock is `flock` (Linux, busybox) or `lockf` (macOS/BSD), both released when the holder
-    dies; an image with neither falls back to a symlink spinlock that reaps a dead owner."""
+    dies; an image with neither falls back to a symlink spinlock whose owner is recorded as
+    `pid:starttime` so a dead holder is reaped even if its pid was reused."""
     lock = shlex.quote(lock or f"{directory}/install.lock")
     script = f"{ready} || ({install})" if ready else install
     run = f"{shlex.join(shell)} {shlex.quote(script)}"
-    # A lock that is not a symlink (left behind by flock/lockf) or whose owner pid is gone
-    # is stale and reaped. `kill -0 ""` succeeds under busybox ash, hence the explicit -z.
+    # The owner token is pid:starttime (starttime from /proc where readable), so a reused pid
+    # does not pass as the live holder. A lock that is not a symlink (left behind by
+    # flock/lockf) or whose owner is gone is stale and reaped; `kill -0 ""` succeeds under
+    # busybox ash, hence the explicit -z.
+    ident = (
+        'ident() { if [ -r "/proc/$1/stat" ] && s=$(sed "s/^.*) //" "/proc/$1/stat" '
+        '| cut -d" " -f20) && [ -n "$s" ]; then echo "$1:$s"; else echo "$1"; fi; }; '
+        "me=$(ident $$); "
+    )
     spinlock = (
-        f'until ln -s "$$" {lock} 2>/dev/null; do owner=$(readlink {lock} 2>/dev/null); '
-        f'if [ -z "$owner" ] || ! kill -0 "$owner" 2>/dev/null; then '
+        f"{ident}"
+        f'until ln -s "$me" {lock} 2>/dev/null; do owner=$(readlink {lock} 2>/dev/null); '
+        f'pid=${{owner%%:*}}; if [ -z "$owner" ] || ! kill -0 "$pid" 2>/dev/null '
+        f'|| [ "$(ident "$pid")" != "$owner" ]; then '
         f'[ "$(readlink {lock} 2>/dev/null)" != "$owner" ] || rm -f {lock}; fi; '
         f"sleep 0.1; done; "
-        f'trap \'[ "$(readlink {lock} 2>/dev/null)" != "$$" ] || rm -f {lock}\' EXIT; {run}'
+        f'trap \'[ "$(readlink {lock} 2>/dev/null)" != "$me" ] || rm -f {lock}\' EXIT; {run}'
     )
     guarded = (
         f"mkdir -p {shlex.quote(directory)} && "
@@ -42,7 +52,7 @@ async def ensure_installed(
     )
     result = await runtime.run(["sh", "-c", guarded], env)
     if result.exit_code != 0:
-        detail = (result.stderr or result.stdout).strip()[-500:]
+        detail = (result.stderr.strip() or result.stdout.strip())[-500:]
         raise RuntimeError(f"{label} install failed: {detail}")
 
 


### PR DESCRIPTION
Stacked on #2505 → #2503 → #2496.

Every third-party harness installed its program with the same routine: `mkdir -p <dir>`, take a lock on `<dir>/install.lock`, run `[ ready ] || ( install )`, raise `RuntimeError("<name> install failed: " + stderr[-500:])`. Nine copies, and they had drifted into three different locks:

| lock | harnesses |
|---|---|
| `"$(command -v flock \|\| command -v lockf)"` | claude_code, codex, kimi_code, openclaw, pool, prime_agent |
| hand-rolled symlink spinlock with dead-owner check + `EXIT` trap | pi, `node.py` (shared Node install) |
| bare `flock` | rlm |

Around it: the `version: str = Field(default=..., pattern=...)` field nine times, and an `rm -rf` + raise cleanup six times.

**After this PR**
- `harnesses/utils/install.py`: `ensure_installed(runtime, directory=, install=, env=, label=, ready=None, lock=None, shell=("sh","-c"))` and `remove_dir(runtime, path, label)`. `ready` is the optional skip test (openclaw passes none: its `SETUP` script from #2485 self-guards and must always run the transcript patch), `lock` lets the Node installer keep its lock beside the directory it replaces, `shell` lets pool and openclaw keep `bash -o pipefail`. Directory and lock paths are `shlex.quote`d, as #2485 started doing for openclaw.
- `configs/harness.py`: `PinnedVersion = Annotated[str, Field(pattern=r"^[A-Za-z0-9._+-]+$")]`; the nine configs declare `version: PinnedVersion = "<default>"` and keep their own docstrings. rlm keeps its git-ref field.
- claude_code, codex, kimi_code, pool, openclaw, prime_agent, pi, rlm and `ensure_node` install through the helper; claude_code, codex, openclaw, prime_agent and hermes_agent clean up through it. hermes_agent, terminus_2 and mini_swe_agent install via `prepare_uv_script` and only pick up `PinnedVersion`.

**Intended behaviour changes** (all in the lock and error path, none in install scripts):
1. Every harness locks with `flock || lockf` when one is present (they release on holder death natively; every common base image ships one, Alpine via busybox) and falls back to the symlink spinlock that pi and the Node installer used before when neither is. The fallback records its owner as `pid:starttime` (from `/proc`, pid alone where unreadable) so a reused pid is not mistaken for the live holder, and reaps a lock that is a regular file or whose owner is gone; the original spinlock spun forever on a regular lock file because `kill -0 ""` succeeds under busybox ash, and would wait on a reused pid until that process exited (e19f2c84c).
2. rlm gains the lockf fallback it lacked.
3. Install failures report stdout when stderr is empty or whitespace-only (three harnesses already did the former). Cleanup failures share one phrasing, `failed to clean up <label>: …`.
4. `mkdir -p /var/tmp/vf-node` now precedes the Node install; its script creates the directory itself anyway.

Rebased onto main after #2496 merged; the OpenClaw 2.0 (#2485), RLM (#2507) and prime-agent (#2502) changes on main are preserved.

**Verification.** I replayed `setup()` and `cleanup()` for all nine harnesses plus `ensure_node` against a recording fake runtime on the base branch and this branch and diffed every command and environment. Against the rebased base, 17 of 23 replays are byte-identical (openclaw included, since #2485 already uses `flock || lockf`); the six that differ (the four Node installs, pi, rlm) differ only in the lock prefix and are identical from `sh -c` onward. `PinnedVersion` rejects `""`, `"a/b"` and `"bad version!"` and accepts `"0.147.0"`. Also `ruff check`, `ruff format --check`, `ty check verifiers`, `pytest tests/v1 -m "not e2e"` (82 passed). Both lock branches were exercised on `alpine:latest`: two concurrent installs serialize, the install's exit code propagates, a dead-owner symlink, a leftover regular lock file and a live process holding a lock with a stale identity (pid reuse) are reaped, a live owner with its true identity is waited on (a4f4ea500). The docker e2e job runs on this PR as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate harness install-lock and cleanup into shared helpers
> - Adds `ensure_installed` and `remove_dir` to [install.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2506/files#diff-5ddaf01b8cbb0ded4d3d42b42549b45ad9866136f071e72e14cde15c105d8417); `ensure_installed` handles directory creation, optional readiness checks, `flock`/`lockf` serialization with a PID/start-time symlink fallback, stale-owner cleanup, and label-specific errors.
> - Adds a shared `PinnedVersion` type alias in [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2506/files#diff-c5b409466f272f39cbab9228a91d9b6de6c8a0cdd33ad73f05e7fd690966e478) and replaces inline version field declarations across all harness config classes.
> - Migrates `setup` installers and `cleanup` handlers in the Claude Code, Codex, Hermes, Kimi Code, Node, OpenClaw, Pi, Pool, Prime Agent, and RLM harnesses to the shared helpers, passing through their existing scripts, environments, and labels.
> - Risk: all harnesses now share one locking and removal implementation; verify per-harness lock paths and readiness conditions passed to `ensure_installed`, especially `ensure_node` in [node.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2506/files#diff-4117aae0a7b4023c32f09206611f0bf2149b2a51e264157bd24339df2166dfa8) where the lock lives outside the installed directory.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 93a2100.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> All harness program installs and several cleanups now share one locking and error path; lock location and readiness checks (especially Node’s external lock) affect every concurrent rollout on a shared runtime.
> 
> **Overview**
> Introduces **`ensure_installed`** and **`remove_dir`** in `harnesses/utils/install.py` and routes harness `setup`/`cleanup` through them instead of nine copy-pasted `mkdir`, lock, `[ ready ] || install`, and `rm -rf` blocks.
> 
> **`ensure_installed`** centralizes concurrent install serialization (`flock` / `lockf`, with an improved symlink spinlock fallback using `pid:starttime`), optional readiness skips, configurable shell (`bash -o pipefail` where needed), and consistent install failure messages (stderr or stdout). **`remove_dir`** standardizes cleanup errors as `failed to clean up <label>: …`.
> 
> Harness configs that pin npm/release versions now use shared **`PinnedVersion`** in `configs/harness.py` instead of repeated `Field(..., pattern=...)` declarations (RLM keeps its git-ref field).
> 
> Migrated installers: Claude Code, Codex, Kimi Code, Pool, OpenClaw, Prime Agent, Pi, RLM, and shared **`ensure_node`**. Cleanup via **`remove_dir`**: Claude Code, Codex, Hermes, OpenClaw, Prime Agent (plus OpenClaw staged-skills clear). Hermes, mini-swe-agent, and Terminus 2 only pick up **`PinnedVersion`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93a21004fe5ae10547bab54679faa809dacaad29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


