### PR TITLE
fix(v1): resolve RLM concurrency with depth

### DIFF
--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -68,8 +68,8 @@ class RLMHarnessConfig(HarnessConfig):
     unset defers to nano-rlm's default (on, automatic thresholds, bounded by its
     default 1M tree-token budget)."""
     max_concurrent_subagents: PositiveInt | None = None
-    """Sub-agents running at once per session tree; `None` = nano-rlm's default (4).
-    nano-rlm requires it to be at least `max_depth`."""
+    """Sub-agents running at once per session tree; `None` = nano-rlm's default (4),
+    raised to an explicit `max_depth` when needed to keep the policy valid."""
     max_total_turns: PositiveInt | None = None
     """Tree-total turn budget (one turn = one work-loop model call, any engine); every
     engine stops before its next call once spent. `None` = uncapped."""
@@ -152,9 +152,12 @@ class RLMHarness(ACPHarness[RLMHarnessConfig]):
         system_prompt: str | None,
     ) -> JsonObject:
         compaction = self.config.compaction
+        max_concurrent_subagents = self.config.max_concurrent_subagents
+        if max_concurrent_subagents is None and self.config.max_depth is not None:
+            max_concurrent_subagents = max(4, self.config.max_depth)
         policy_knobs: dict[str, Any] = {
             "max_depth": self.config.max_depth,
-            "max_concurrent_subagents": self.config.max_concurrent_subagents,
+            "max_concurrent_subagents": max_concurrent_subagents,
             "max_total_turns": self.config.max_total_turns,
             "max_total_tokens": self.config.max_total_tokens,
             "max_tool_output_bytes": self.config.max_tool_output_bytes,


### PR DESCRIPTION
## Overview

Keeps explicit RLM recursion policies valid when callers configure depth without also setting a concurrency limit.

## Details

- preserves nano-rlm's default concurrency for explicit depths at or below that default
- raises derived concurrency to match deeper explicit recursion depths
- leaves both policy keys absent when neither knob is configured, preserving nano-rlm pass-through defaults

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-to-metadata mapping only; no auth, data, or runtime execution path changes beyond passing valid policy values to nano-rlm.
> 
> **Overview**
> When callers set **`max_depth`** without **`max_concurrent_subagents`**, the RLM harness now **derives** concurrency as `max(4, max_depth)` before building runtime policy metadata, so nano-rlm’s requirement that concurrency is at least depth is met without forcing users to set both knobs.
> 
> Shallow explicit depths (≤4) still use the **same effective limit as nano-rlm’s default (4)**. Deeper depths get concurrency raised to match. If neither field is set, behavior is unchanged—those policy keys stay off the wire and nano-rlm defaults apply.
> 
> The **`max_concurrent_subagents`** field doc is updated to describe this derivation instead of only stating the downstream library rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a3922671fc82e6fc10cb64e8f596f33db3e2780. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix RLM concurrency limit to respect `max_depth` when `max_concurrent_subagents` is unset
> When `max_concurrent_subagents` is not set, `RLMHarness._runtime_metadata` now computes an effective concurrency of `max(4, max_depth)` so the runtime policy can support the configured depth. Explicitly configured concurrency values remain unchanged. Risk: any consumer relying on the unset default staying at exactly 4 will now see a higher value when `max_depth` exceeds 4 — check `RLMHarnessConfig` usage in [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2507/files#diff-3955da24b5fd88f62482297bbda7ba0936f633927f15576db27fed6e58f668ec).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a39226.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->