### PR TITLE
feat(v1): keep credentials out of platform uploads

### DIFF
--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -478,3 +478,105 @@ def test_semantic_edge_set_accepts_deep_acyclic_chain():
     )
 
     assert len(edge_set.edges) == 2_000
+
+
+def test_push_traces_uploads_redacted_projection(monkeypatch):
+    """`--push` drops the config fields that carry credentials and replaces every known
+    secret the agent echoed — including one the harness printed inside a quoted JSON
+    tool result — while the saved record keeps its config and the tokens never touch
+    disk. Ordinary text and short or non-credential values stay as they are."""
+    import httpx
+
+    from verifiers.v1.clients import EvalClientConfig
+    from verifiers.v1.configs.cli.eval import EvalConfig
+    from verifiers.v1.configs.harness import HarnessConfig
+    from verifiers.v1.episode import EnvInfo, Episode
+    from verifiers.v1.utils import platform
+
+    monkeypatch.setenv("PRIME_API_KEY", "prime-platform-key-0001")
+    monkeypatch.setenv("MODEL_API_KEY", "sk-model-key-000000000001")
+    monkeypatch.setenv("HOST_HF_TOKEN", "hf_host_token_00000001")
+    client = EvalClientConfig(
+        base_url="https://models.example/v1",
+        api_key_var="MODEL_API_KEY",
+        headers={"X-Auth": 'he said "hi" 0001', "X-Trace": "plain-header"},
+    )
+    config = EvalConfig(env={"taskset": {"id": "echo-v1"}}, model="m", client=client)
+    secrets = {
+        "prime-platform-key-0001",
+        "sk-model-key-000000000001",
+        "hf_host_token_00000001",
+        'he said "hi" 0001',
+        "hf_harness_token_0001",
+        "intercept-token-0001",
+    }
+    echo = " ".join(sorted(secrets)) + " debug=1 plain-header"
+    tool_result = json.dumps(
+        {"env": {"KEY": 'he said "hi" 0001', "ok": "plain-header"}}
+    )
+    trace = vf.Trace(
+        agent=vf.AgentInfo(
+            config=vf.AgentConfig(
+                client=client,
+                harness=HarnessConfig(
+                    id="bash",
+                    env={"HF_TOKEN": "hf_harness_token_0001", "DEBUG": "1"},
+                    forward_env=["HOME"],
+                ),
+            )
+        ),
+        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="q")),
+        nodes=[
+            MessageNode(parent=None, message=UserMessage(content="q"), sampled=False),
+            MessageNode(parent=0, message=AssistantMessage(content=echo), sampled=True),
+            MessageNode(
+                parent=1, message=UserMessage(content=tool_result), sampled=False
+            ),
+        ],
+        upload_secrets=["intercept-token-0001"],
+    )
+    episode = Episode(
+        env=EnvInfo(id="echo-v1"), task=trace.task, traces=[trace], ok=True
+    )
+
+    posted: dict[str, bytes] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        posted[request.url.path] = request.content
+        if request.url.path.endswith("/environmentshub/resolve"):
+            return httpx.Response(200, json={"data": {"id": "env-1"}})
+        if request.url.path.endswith("/evaluations/"):
+            return httpx.Response(200, json={"evaluation_id": "eval-1"})
+        return httpx.Response(200, json={})
+
+    real_client = httpx.Client
+    monkeypatch.setattr(
+        platform.httpx,
+        "Client",
+        lambda **kw: real_client(transport=httpx.MockTransport(handler), **kw),
+    )
+    url = platform.push_traces([episode], config)
+
+    assert url is not None and url.endswith("/dashboard/evaluations/eval-1")
+    body = posted["/api/v1/evaluations/eval-1/samples"].decode()
+    for secret in secrets:
+        assert secret not in body and secret.replace('"', '\\"') not in body
+    payload = json.loads(body)
+    native = payload["samples"][0]["info"]["native_wrapper"]["traces"][0]
+    assert "headers" not in native["agent"]["config"]["client"]
+    assert "env" not in native["agent"]["config"]["harness"]
+    assert native["agent"]["config"]["harness"]["forward_env"] == ["HOME"]
+    assert "upload_secrets" not in native
+    messages = payload["samples"][0]["completion"]
+    assert messages[1]["content"].endswith("debug=1 plain-header")
+    assert json.loads(messages[2]["content"]) == {
+        "env": {"KEY": "[REDACTED]", "ok": "plain-header"}
+    }
+    # The saved record keeps the run reproducible; only the tokens stay off disk.
+    record = episode.to_record()["traces"][0]
+    assert (
+        record["agent"]["config"]["harness"]["env"]["HF_TOKEN"]
+        == "hf_harness_token_0001"
+    )
+    assert record["agent"]["config"]["client"]["headers"]["X-Trace"] == "plain-header"
+    assert "upload_secrets" not in record

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -7,6 +7,7 @@ import json
 from types import SimpleNamespace
 
 import pytest
+from pydantic import Field
 
 import verifiers.v1 as vf
 from verifiers.v1.agent import Interaction
@@ -31,6 +32,11 @@ class MyTask(vf.TaskData):
 
 class MyState(vf.State):
     score: int = 0
+
+
+class EnvTask(vf.TaskData):
+    verifier_env: dict[str, str] = Field(default_factory=dict)
+    """An environment mapping inside task data, as Harbor's `verifier_env`."""
 
 
 class FailingSegmentRollout:
@@ -510,14 +516,16 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
         "hf_harness_token_0001",
         "intercept-token-0001",
         "hooks/abc/def",
+        "judge-key-000000001",
     }
     echo = " ".join(sorted(secrets)) + " debug=1 plain-header"
-    # A tool result as another encoder would emit it, `/` escaped included.
+    # A tool result as another encoder would emit it, `/` escaped and uppercase hex.
     tool_result = (
         '{"env": {"KEY": "he said \\"hi\\" 0001", "url": "hooks\\/abc\\/def", '
-        '"ok": "plain-header"}}'
+        '"ok": "plain-header", "u": "\\u00FCn\\u00EFcode"}}'
     )
-    trace = vf.Trace(
+    deep = json.dumps({"log": json.dumps({"auth": "hooks/abc/def", "n": 1})})
+    trace = vf.Trace[EnvTask, vf.State](
         agent=vf.AgentInfo(
             config=vf.AgentConfig(
                 client=client,
@@ -528,17 +536,25 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
                 ),
             )
         ),
-        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="q")),
+        task=vf.TraceTask(
+            type="EnvTask",
+            data=EnvTask(
+                idx=0,
+                prompt="q",
+                verifier_env={"JUDGE_API_KEY": "judge-key-000000001", "MODE": "fast"},
+            ),
+        ),
         nodes=[
             MessageNode(parent=None, message=UserMessage(content="q"), sampled=False),
             MessageNode(parent=0, message=AssistantMessage(content=echo), sampled=True),
             MessageNode(
                 parent=1, message=UserMessage(content=tool_result), sampled=False
             ),
+            MessageNode(parent=2, message=UserMessage(content=deep), sampled=False),
         ],
         upload_secrets=["intercept-token-0001", "hooks/abc/def"],
     )
-    episode = Episode(
+    episode = Episode[EnvTask, vf.State](
         env=EnvInfo(id="echo-v1"), task=trace.task, traces=[trace], ok=True
     )
 
@@ -573,7 +589,21 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
     messages = payload["samples"][0]["completion"]
     assert messages[1]["content"].endswith("debug=1 plain-header")
     assert json.loads(messages[2]["content"]) == {
-        "env": {"KEY": "[REDACTED]", "url": "[REDACTED]", "ok": "plain-header"}
+        "env": {
+            "KEY": "[REDACTED]",
+            "url": "[REDACTED]",
+            "ok": "plain-header",
+            "u": "ünïcode",
+        }
+    }
+    assert json.loads(json.loads(messages[3]["content"])["log"]) == {
+        "auth": "[REDACTED]",
+        "n": 1,
+    }
+    # The task's own environment mapping keeps its keys; only credential values go.
+    assert payload["samples"][0]["task"]["verifier_env"] == {
+        "JUDGE_API_KEY": "[REDACTED]",
+        "MODE": "fast",
     }
     # The saved record keeps the run reproducible; only the tokens stay off disk.
     record = episode.to_record()["traces"][0]

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -39,6 +39,8 @@ class EnvTask(vf.TaskData):
     """An environment mapping inside task data, as Harbor's `verifier_env`."""
     verifier: dict = Field(default_factory=dict)
     """A nested block with its own `env`, as Harbor's `verifier.env`."""
+    db_url: str = ""
+    """A connection string outside any environment mapping."""
 
 
 class FailingSegmentRollout:
@@ -527,6 +529,7 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
         "grader-token-0001",
         "retry-token-0001",  # a discarded attempt's token, carried with its errors
         "pg-pass-000001",
+        "task-url-pass-0001",
     }
     echo = " ".join(sorted(secrets)) + " debug=1 plain-header production-realm"
     # A tool result as another encoder would emit it, `/` escaped and uppercase hex.
@@ -557,6 +560,7 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
                     "MODE": "fast",
                 },
                 verifier={"env": {"GRADER_TOKEN": "grader-token-0001", "N": "1"}},
+                db_url="postgres://svc:task-url-pass-0001@db/y",
             ),
         ),
         nodes=[
@@ -600,6 +604,7 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
     for secret in secrets:
         assert secret not in body and secret.replace('"', '\\"') not in body
     payload = json.loads(body)
+    assert "upload_secrets" not in payload["samples"][0]["info"]["native_wrapper"]
     native = payload["samples"][0]["info"]["native_wrapper"]["traces"][0]
     assert "headers" not in native["agent"]["config"]["client"]
     assert (
@@ -633,6 +638,7 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
     assert payload["samples"][0]["task"]["verifier"] == {
         "env": {"GRADER_TOKEN": "[REDACTED]", "N": "1"}
     }
+    assert payload["samples"][0]["task"]["db_url"] == "postgres://svc:[REDACTED]@db/y"
     # The saved record keeps the run reproducible; only the tokens stay off disk.
     record = episode.to_record()["traces"][0]
     assert (

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -517,7 +517,8 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
         "intercept-token-0001",
         "hooks/abc/def",
         "judge-key-000000001",
-        "db-pass-000001",
+        "db%40pass-000001",
+        "db@pass-000001",  # the URL password as a client echoes it
     }
     echo = " ".join(sorted(secrets)) + " debug=1 plain-header"
     # A tool result as another encoder would emit it, `/` escaped and uppercase hex.
@@ -544,7 +545,7 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
                 prompt="q",
                 verifier_env={
                     "JUDGE_API_KEY": "judge-key-000000001",
-                    "DATABASE_URL": "postgres://app:db-pass-000001@db/x",
+                    "DATABASE_URL": "postgres://app:db%40pass-000001@db/x",
                     "MODE": "fast",
                 },
             ),

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -517,6 +517,7 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
         "intercept-token-0001",
         "hooks/abc/def",
         "judge-key-000000001",
+        "db-pass-000001",
     }
     echo = " ".join(sorted(secrets)) + " debug=1 plain-header"
     # A tool result as another encoder would emit it, `/` escaped and uppercase hex.
@@ -541,7 +542,11 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
             data=EnvTask(
                 idx=0,
                 prompt="q",
-                verifier_env={"JUDGE_API_KEY": "judge-key-000000001", "MODE": "fast"},
+                verifier_env={
+                    "JUDGE_API_KEY": "judge-key-000000001",
+                    "DATABASE_URL": "postgres://app:db-pass-000001@db/x",
+                    "MODE": "fast",
+                },
             ),
         ),
         nodes=[
@@ -600,9 +605,11 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
         "auth": "[REDACTED]",
         "n": 1,
     }
-    # The task's own environment mapping keeps its keys; only credential values go.
+    # The task's own environment mapping keeps its keys and URL shape; only the
+    # credential-named values and the URL password go.
     assert payload["samples"][0]["task"]["verifier_env"] == {
         "JUDGE_API_KEY": "[REDACTED]",
+        "DATABASE_URL": "postgres://app:[REDACTED]@db/x",
         "MODE": "fast",
     }
     # The saved record keeps the run reproducible; only the tokens stay off disk.

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -518,6 +518,12 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
     monkeypatch.setenv(
         "SSH_AUTH_SOCK", "/tmp/ssh-agent/agent.123"
     )  # about auth, not auth
+    monkeypatch.setenv(  # a JSON-valued variable is a mapping too
+        "DOCKER_AUTH_CONFIG",
+        json.dumps(
+            {"auths": {"https://index.docker.io/v1/": {"auth": "dXNlcjpwYXNzd29yZA=="}}}
+        ),
+    )
     client = EvalClientConfig(
         base_url="https://svc:url-pass-000001@models.example/v1",
         api_key_var="MODEL_API_KEY",
@@ -554,6 +560,7 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
         "pg-pass-000001",
         "sas-sig-000001",  # a signed URL's signature is its bearer credential
         "ghp_pat_000000000001",
+        "dXNlcjpwYXNzd29yZA==",  # Docker's registry auth, inside a JSON-valued variable
         "task-url-pass-0001",
         "query-token-0001",
         "seat-key-000001",

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -515,6 +515,7 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
     )
     monkeypatch.setenv("GITHUB_PAT", "ghp_pat_000000000001")  # PAT, but PATH is not
     monkeypatch.setenv("PYTHONPATH", "/opt/keep/this/path")
+    monkeypatch.setenv("TOKEN_URL", "https://idp.example/oauth/token")  # about a token
     monkeypatch.setenv(
         "SSH_AUTH_SOCK", "/tmp/ssh-agent/agent.123"
     )  # about auth, not auth
@@ -568,7 +569,7 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
     }
     echo = (
         " ".join(sorted(secrets))
-        + " debug=1 plain-header production-realm /opt/keep/this/path /tmp/ssh-agent/agent.123"
+        + " debug=1 plain-header production-realm /opt/keep/this/path /tmp/ssh-agent/agent.123 https://idp.example/oauth/token"
     )
     # A tool result as another encoder would emit it, `/` escaped and uppercase hex.
     tool_result = (
@@ -666,7 +667,7 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
     assert "upload_secrets" not in native
     messages = payload["samples"][0]["completion"]
     assert messages[1]["content"].endswith(
-        "debug=1 plain-header production-realm /opt/keep/this/path /tmp/ssh-agent/agent.123"
+        "debug=1 plain-header production-realm /opt/keep/this/path /tmp/ssh-agent/agent.123 https://idp.example/oauth/token"
     )
     assert json.loads(messages[2]["content"]) == {
         "env": {

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -515,6 +515,9 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
     )
     monkeypatch.setenv("GITHUB_PAT", "ghp_pat_000000000001")  # PAT, but PATH is not
     monkeypatch.setenv("PYTHONPATH", "/opt/keep/this/path")
+    monkeypatch.setenv(
+        "SSH_AUTH_SOCK", "/tmp/ssh-agent/agent.123"
+    )  # about auth, not auth
     client = EvalClientConfig(
         base_url="https://svc:url-pass-000001@models.example/v1",
         api_key_var="MODEL_API_KEY",
@@ -558,7 +561,7 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
     }
     echo = (
         " ".join(sorted(secrets))
-        + " debug=1 plain-header production-realm /opt/keep/this/path"
+        + " debug=1 plain-header production-realm /opt/keep/this/path /tmp/ssh-agent/agent.123"
     )
     # A tool result as another encoder would emit it, `/` escaped and uppercase hex.
     tool_result = (
@@ -656,7 +659,7 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
     assert "upload_secrets" not in native
     messages = payload["samples"][0]["completion"]
     assert messages[1]["content"].endswith(
-        "debug=1 plain-header production-realm /opt/keep/this/path"
+        "debug=1 plain-header production-realm /opt/keep/this/path /tmp/ssh-agent/agent.123"
     )
     assert json.loads(messages[2]["content"]) == {
         "env": {

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -505,6 +505,7 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
     monkeypatch.setenv("MODEL_API_KEY", "sk-model-key-000000000001")
     monkeypatch.setenv("HOST_HF_TOKEN", "hf_host_token_00000001")
     monkeypatch.setenv("KEYCLOAK_REALM", "production-realm")  # KEYCLOAK is not KEY
+    monkeypatch.setenv("PGPASSWORD", "pg-pass-000001")  # but PGPASSWORD is a password
     client = EvalClientConfig(
         base_url="https://svc:url-pass-000001@models.example/v1",
         api_key_var="MODEL_API_KEY",
@@ -525,6 +526,7 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
         "url-pass-000001",
         "grader-token-0001",
         "retry-token-0001",  # a discarded attempt's token, carried with its errors
+        "pg-pass-000001",
     }
     echo = " ".join(sorted(secrets)) + " debug=1 plain-header production-realm"
     # A tool result as another encoder would emit it, `/` escaped and uppercase hex.

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -509,10 +509,13 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
         'he said "hi" 0001',
         "hf_harness_token_0001",
         "intercept-token-0001",
+        "hooks/abc/def",
     }
     echo = " ".join(sorted(secrets)) + " debug=1 plain-header"
-    tool_result = json.dumps(
-        {"env": {"KEY": 'he said "hi" 0001', "ok": "plain-header"}}
+    # A tool result as another encoder would emit it, `/` escaped included.
+    tool_result = (
+        '{"env": {"KEY": "he said \\"hi\\" 0001", "url": "hooks\\/abc\\/def", '
+        '"ok": "plain-header"}}'
     )
     trace = vf.Trace(
         agent=vf.AgentInfo(
@@ -570,7 +573,7 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
     messages = payload["samples"][0]["completion"]
     assert messages[1]["content"].endswith("debug=1 plain-header")
     assert json.loads(messages[2]["content"]) == {
-        "env": {"KEY": "[REDACTED]", "ok": "plain-header"}
+        "env": {"KEY": "[REDACTED]", "url": "[REDACTED]", "ok": "plain-header"}
     }
     # The saved record keeps the run reproducible; only the tokens stay off disk.
     record = episode.to_record()["traces"][0]

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -544,6 +544,7 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
         "pg-pass-000001",
         "task-url-pass-0001",
         "seat-key-000001",
+        "episode-token-0001",  # only in the episode's own task, not the trace's
     }
     echo = " ".join(sorted(secrets)) + " debug=1 plain-header production-realm"
     # A tool result as another encoder would emit it, `/` escaped and uppercase hex.
@@ -587,9 +588,15 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
         ],
         upload_secrets=["intercept-token-0001", "hooks/abc/def"],
     )
+    # A derived-task env: the episode's task differs from the trace's and is uploaded too.
     episode = Episode[EnvTask, vf.State](
         env=EnvInfo(id="echo-v1"),
-        task=trace.task,
+        task=vf.TraceTask(
+            type="EnvTask",
+            data=EnvTask(
+                idx=0, prompt="q", verifier_env={"ROOT_TOKEN": "episode-token-0001"}
+            ),
+        ),
         traces=[trace],
         ok=True,
         upload_secrets=["retry-token-0001"],
@@ -619,6 +626,9 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
         assert secret not in body and secret.replace('"', '\\"') not in body
     payload = json.loads(body)
     assert "upload_secrets" not in payload["samples"][0]["info"]["native_wrapper"]
+    assert payload["samples"][0]["info"]["native_wrapper"]["task"]["data"][
+        "verifier_env"
+    ] == {"ROOT_TOKEN": "[REDACTED]"}
     native = payload["samples"][0]["info"]["native_wrapper"]["traces"][0]
     assert "headers" not in native["agent"]["config"]["client"]
     assert (

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -504,6 +504,7 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
     monkeypatch.setenv("PRIME_API_KEY", "prime-platform-key-0001")
     monkeypatch.setenv("MODEL_API_KEY", "sk-model-key-000000000001")
     monkeypatch.setenv("HOST_HF_TOKEN", "hf_host_token_00000001")
+    monkeypatch.setenv("KEYCLOAK_REALM", "production-realm")  # KEYCLOAK is not KEY
     client = EvalClientConfig(
         base_url="https://svc:url-pass-000001@models.example/v1",
         api_key_var="MODEL_API_KEY",
@@ -525,7 +526,7 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
         "grader-token-0001",
         "retry-token-0001",  # a discarded attempt's token, carried with its errors
     }
-    echo = " ".join(sorted(secrets)) + " debug=1 plain-header"
+    echo = " ".join(sorted(secrets)) + " debug=1 plain-header production-realm"
     # A tool result as another encoder would emit it, `/` escaped and uppercase hex.
     tool_result = (
         '{"env": {"KEY": "he said \\"hi\\" 0001", "url": "hooks\\/abc\\/def", '
@@ -607,7 +608,7 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
     assert native["agent"]["config"]["harness"]["forward_env"] == ["HOME"]
     assert "upload_secrets" not in native
     messages = payload["samples"][0]["completion"]
-    assert messages[1]["content"].endswith("debug=1 plain-header")
+    assert messages[1]["content"].endswith("debug=1 plain-header production-realm")
     assert json.loads(messages[2]["content"]) == {
         "env": {
             "KEY": "[REDACTED]",

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -510,6 +510,9 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
     monkeypatch.setenv("HOST_HF_TOKEN", "hf_host_token_00000001")
     monkeypatch.setenv("KEYCLOAK_REALM", "production-realm")  # KEYCLOAK is not KEY
     monkeypatch.setenv("PGPASSWORD", "pg-pass-000001")  # but PGPASSWORD is a password
+    monkeypatch.setenv(
+        "SAS_URL", "https://a.blob.core.windows.net/c?sv=2020&sig=sas-sig-000001"
+    )
     client = EvalClientConfig(
         base_url="https://svc:url-pass-000001@models.example/v1",
         api_key_var="MODEL_API_KEY",
@@ -544,6 +547,7 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
         "grader-token-0001",
         "retry-token-0001",  # a discarded attempt's token, carried with its errors
         "pg-pass-000001",
+        "sas-sig-000001",  # a signed URL's signature is its bearer credential
         "task-url-pass-0001",
         "query-token-0001",
         "seat-key-000001",

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -41,6 +41,8 @@ class EnvTask(vf.TaskData):
     """A nested block with its own `env`, as Harbor's `verifier.env`."""
     db_url: str = ""
     """A connection string outside any environment mapping."""
+    ws_url: str = ""
+    """An endpoint authenticated through its query string."""
 
 
 class FailingSegmentRollout:
@@ -543,6 +545,7 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
         "retry-token-0001",  # a discarded attempt's token, carried with its errors
         "pg-pass-000001",
         "task-url-pass-0001",
+        "query-token-0001",
         "seat-key-000001",
         "episode-token-0001",  # only in the episode's own task, not the trace's
     }
@@ -576,6 +579,7 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
                 },
                 verifier={"env": {"GRADER_TOKEN": "grader-token-0001", "N": "1"}},
                 db_url="postgres://svc:task-url-pass-0001@db/y",
+                ws_url="wss://browser.example/devtools?token=query-token-0001&v=2",
             ),
         ),
         nodes=[
@@ -594,7 +598,9 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
         task=vf.TraceTask(
             type="EnvTask",
             data=EnvTask(
-                idx=0, prompt="q", verifier_env={"ROOT_TOKEN": "episode-token-0001"}
+                idx=0,
+                prompt="see ?token=prose-token-0001",
+                verifier_env={"ROOT_TOKEN": "episode-token-0001"},
             ),
         ),
         traces=[trace],
@@ -663,6 +669,14 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
         "env": {"GRADER_TOKEN": "[REDACTED]", "N": "1"}
     }
     assert payload["samples"][0]["task"]["db_url"] == "postgres://svc:[REDACTED]@db/y"
+    assert (
+        payload["samples"][0]["task"]["ws_url"]
+        == "wss://browser.example/devtools?token=[REDACTED]&v=2"
+    )
+    assert (
+        payload["samples"][0]["info"]["native_wrapper"]["task"]["data"]["prompt"]
+        == "see ?token=prose-token-0001"
+    )
     # The saved record keeps the run reproducible; only the tokens stay off disk.
     record = episode.to_record()["traces"][0]
     assert (

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -523,6 +523,7 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
         "db@pass-000001",  # the URL password as a client echoes it
         "url-pass-000001",
         "grader-token-0001",
+        "retry-token-0001",  # a discarded attempt's token, carried with its errors
     }
     echo = " ".join(sorted(secrets)) + " debug=1 plain-header"
     # A tool result as another encoder would emit it, `/` escaped and uppercase hex.
@@ -566,7 +567,11 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
         upload_secrets=["intercept-token-0001", "hooks/abc/def"],
     )
     episode = Episode[EnvTask, vf.State](
-        env=EnvInfo(id="echo-v1"), task=trace.task, traces=[trace], ok=True
+        env=EnvInfo(id="echo-v1"),
+        task=trace.task,
+        traces=[trace],
+        ok=True,
+        upload_secrets=["retry-token-0001"],
     )
 
     posted: dict[str, bytes] = {}
@@ -633,3 +638,4 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
     )
     assert record["agent"]["config"]["client"]["headers"]["X-Trace"] == "plain-header"
     assert "upload_secrets" not in record
+    assert "upload_secrets" not in episode.to_record()

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -37,6 +37,8 @@ class MyState(vf.State):
 class EnvTask(vf.TaskData):
     verifier_env: dict[str, str] = Field(default_factory=dict)
     """An environment mapping inside task data, as Harbor's `verifier_env`."""
+    verifier: dict = Field(default_factory=dict)
+    """A nested block with its own `env`, as Harbor's `verifier.env`."""
 
 
 class FailingSegmentRollout:
@@ -503,7 +505,7 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
     monkeypatch.setenv("MODEL_API_KEY", "sk-model-key-000000000001")
     monkeypatch.setenv("HOST_HF_TOKEN", "hf_host_token_00000001")
     client = EvalClientConfig(
-        base_url="https://models.example/v1",
+        base_url="https://svc:url-pass-000001@models.example/v1",
         api_key_var="MODEL_API_KEY",
         headers={"X-Auth": 'he said "hi" 0001', "X-Trace": "plain-header"},
     )
@@ -519,6 +521,8 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
         "judge-key-000000001",
         "db%40pass-000001",
         "db@pass-000001",  # the URL password as a client echoes it
+        "url-pass-000001",
+        "grader-token-0001",
     }
     echo = " ".join(sorted(secrets)) + " debug=1 plain-header"
     # A tool result as another encoder would emit it, `/` escaped and uppercase hex.
@@ -548,6 +552,7 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
                     "DATABASE_URL": "postgres://app:db%40pass-000001@db/x",
                     "MODE": "fast",
                 },
+                verifier={"env": {"GRADER_TOKEN": "grader-token-0001", "N": "1"}},
             ),
         ),
         nodes=[
@@ -589,6 +594,10 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
     payload = json.loads(body)
     native = payload["samples"][0]["info"]["native_wrapper"]["traces"][0]
     assert "headers" not in native["agent"]["config"]["client"]
+    assert (
+        native["agent"]["config"]["client"]["base_url"]
+        == "https://svc:[REDACTED]@models.example/v1"
+    )
     assert "env" not in native["agent"]["config"]["harness"]
     assert native["agent"]["config"]["harness"]["forward_env"] == ["HOME"]
     assert "upload_secrets" not in native
@@ -612,6 +621,9 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
         "JUDGE_API_KEY": "[REDACTED]",
         "DATABASE_URL": "postgres://app:[REDACTED]@db/x",
         "MODE": "fast",
+    }
+    assert payload["samples"][0]["task"]["verifier"] == {
+        "env": {"GRADER_TOKEN": "[REDACTED]", "N": "1"}
     }
     # The saved record keeps the run reproducible; only the tokens stay off disk.
     record = episode.to_record()["traces"][0]

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -513,6 +513,8 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
     monkeypatch.setenv(
         "SAS_URL", "https://a.blob.core.windows.net/c?sv=2020&sig=sas-sig-000001"
     )
+    monkeypatch.setenv("GITHUB_PAT", "ghp_pat_000000000001")  # PAT, but PATH is not
+    monkeypatch.setenv("PYTHONPATH", "/opt/keep/this/path")
     client = EvalClientConfig(
         base_url="https://svc:url-pass-000001@models.example/v1",
         api_key_var="MODEL_API_KEY",
@@ -548,12 +550,16 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
         "retry-token-0001",  # a discarded attempt's token, carried with its errors
         "pg-pass-000001",
         "sas-sig-000001",  # a signed URL's signature is its bearer credential
+        "ghp_pat_000000000001",
         "task-url-pass-0001",
         "query-token-0001",
         "seat-key-000001",
         "episode-token-0001",  # only in the episode's own task, not the trace's
     }
-    echo = " ".join(sorted(secrets)) + " debug=1 plain-header production-realm"
+    echo = (
+        " ".join(sorted(secrets))
+        + " debug=1 plain-header production-realm /opt/keep/this/path"
+    )
     # A tool result as another encoder would emit it, `/` escaped and uppercase hex.
     tool_result = (
         '{"env": {"KEY": "he said \\"hi\\" 0001", "url": "hooks\\/abc\\/def", '
@@ -649,7 +655,9 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
     assert native["agent"]["config"]["harness"]["forward_env"] == ["HOME"]
     assert "upload_secrets" not in native
     messages = payload["samples"][0]["completion"]
-    assert messages[1]["content"].endswith("debug=1 plain-header production-realm")
+    assert messages[1]["content"].endswith(
+        "debug=1 plain-header production-realm /opt/keep/this/path"
+    )
     assert json.loads(messages[2]["content"]) == {
         "env": {
             "KEY": "[REDACTED]",

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -513,7 +513,20 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
         api_key_var="MODEL_API_KEY",
         headers={"X-Auth": 'he said "hi" 0001', "X-Trace": "plain-header"},
     )
-    config = EvalConfig(env={"taskset": {"id": "echo-v1"}}, model="m", client=client)
+    # The run's env config is known too: a seat's client headers, a task config's headers.
+    config = EvalConfig(
+        env={
+            "taskset": {"id": "echo-v1"},
+            "agent": {
+                "client": {
+                    **client.model_dump(),
+                    "headers": {"X-Api-Key": "seat-key-000001"},
+                }
+            },
+        },
+        model="m",
+        client=client,
+    )
     secrets = {
         "prime-platform-key-0001",
         "sk-model-key-000000000001",
@@ -530,6 +543,7 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
         "retry-token-0001",  # a discarded attempt's token, carried with its errors
         "pg-pass-000001",
         "task-url-pass-0001",
+        "seat-key-000001",
     }
     echo = " ".join(sorted(secrets)) + " debug=1 plain-header production-realm"
     # A tool result as another encoder would emit it, `/` escaped and uppercase hex.

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -521,7 +521,8 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
     )  # about auth, not auth
     monkeypatch.setenv(  # a JSON-valued variable is a mapping too
         "DOCKER_AUTH_CONFIG",
-        json.dumps(
+        " "
+        + json.dumps(  # leading whitespace is valid JSON
             {"auths": {"https://index.docker.io/v1/": {"auth": "dXNlcjpwYXNzd29yZA=="}}}
         ),
     )

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -536,7 +536,7 @@ def test_push_traces_uploads_redacted_projection(monkeypatch):
                 parent=1, message=UserMessage(content=tool_result), sampled=False
             ),
         ],
-        upload_secrets=["intercept-token-0001"],
+        upload_secrets=["intercept-token-0001", "hooks/abc/def"],
     )
     episode = Episode(
         env=EnvInfo(id="echo-v1"), task=trace.task, traces=[trace], ok=True

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -378,6 +378,7 @@ class Agent:
             raise RuntimeError("Agent is closed; create a new agent")
         retry = self.config.retries
         history: list = []
+        history_secrets: list[str] = []
         for attempt in range(retry.max_retries + 1):
             trace = await self._run_once(
                 task, runtime, tools, on_trace, collect_artifacts
@@ -391,6 +392,7 @@ class Agent:
                 )
                 break
             history.extend(trace.errors)
+            history_secrets.extend(trace.upload_secrets)
             delay = backoff(attempt)
             logger.warning(
                 "retrying agent rollout (retry %d/%d) in %.1fs after error: %s",
@@ -402,8 +404,10 @@ class Agent:
             await asyncio.sleep(delay)
         if history:
             # The full history rides the final trace either way; success is the
-            # `ok` stamp, never errors-emptiness.
+            # `ok` stamp, never errors-emptiness. Each attempt's secrets ride with
+            # the errors they may appear in.
             trace.errors = history + trace.errors
+            trace.upload_secrets[:0] = history_secrets
         return trace
 
     async def _run_once(

--- a/verifiers/v1/cli/eval/main.py
+++ b/verifiers/v1/cli/eval/main.py
@@ -24,6 +24,7 @@ from verifiers.v1.cli.resolve import (
     with_positional_taskset,
 )
 from verifiers.v1.configs.cli.eval import EvalConfig
+from verifiers.v1.trace import EXCLUDE_FIELDS
 from verifiers.v1.utils.interrupt import install_interrupt
 from verifiers.v1.utils.logging import setup_logging
 
@@ -145,4 +146,8 @@ def main(argv: list[str] | None = None) -> None:
     ):  # --rich is the whole output; otherwise dump each trace as JSON
         for episode in episodes:
             for trace in episode.traces:
-                print(trace.model_dump_json(indent=2, exclude_none=True))
+                print(
+                    trace.model_dump_json(
+                        indent=2, exclude=EXCLUDE_FIELDS, exclude_none=True
+                    )
+                )

--- a/verifiers/v1/cli/output.py
+++ b/verifiers/v1/cli/output.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from pydantic import BaseModel, TypeAdapter
 
 from verifiers.v1.configs.cli.eval import EvalConfig
-from verifiers.v1.episode import EnvInfo, Episode, WireEpisode
+from verifiers.v1.episode import EPISODE_EXCLUDE_FIELDS, EnvInfo, Episode, WireEpisode
 from verifiers.v1.state import StateT
 from verifiers.v1.task import DataT
 from verifiers.v1.trace import AgentConfigT, Trace
@@ -152,7 +152,9 @@ def write_episode(
 ) -> None:
     """Serialize and append one rollout episode in the worker thread."""
     # Preserve fields declared by typed Trace subclasses nested in the episode.
-    data = type_adapter(type(episode)).dump_json(episode, exclude_none=True)
+    data = type_adapter(type(episode)).dump_json(
+        episode, exclude=EPISODE_EXCLUDE_FIELDS, exclude_none=True
+    )
     with (results_dir / TRACES_FILE).open("ab") as f:
         f.write(data + b"\n")
 

--- a/verifiers/v1/episode.py
+++ b/verifiers/v1/episode.py
@@ -11,8 +11,9 @@ from verifiers.v1.task import DataT, WireTaskData
 from verifiers.v1.trace import EXCLUDE_FIELDS, AgentConfigT, Error, Trace, TraceTask
 from verifiers.v1.types import Usage
 
-EPISODE_EXCLUDE_FIELDS = {"traces": {"__all__": EXCLUDE_FIELDS}}
-"""`EXCLUDE_FIELDS` applied to every trace of an episode dump."""
+EPISODE_EXCLUDE_FIELDS = {"upload_secrets": True, "traces": {"__all__": EXCLUDE_FIELDS}}
+"""Wire-only fields of an episode dump: its own `upload_secrets`, and `EXCLUDE_FIELDS`
+of every trace."""
 
 
 class EnvInfo(BaseModel):
@@ -103,6 +104,9 @@ class Episode(BaseModel, Generic[DataT, StateT, AgentConfigT]):
     """Whether the episode completed successfully."""
     errors: list[Error] = Field(default_factory=list)
     """Every error captured across attempts, oldest to newest."""
+    upload_secrets: list[str] = Field(default_factory=list, repr=False)
+    """Discarded attempts' `Trace.upload_secrets`, kept with the errors they left
+    behind; never written to disk."""
     traces: list[Trace[DataT, StateT, AgentConfigT]] = Field(default_factory=list)
     """Every agent's trace, in completion order."""
 

--- a/verifiers/v1/episode.py
+++ b/verifiers/v1/episode.py
@@ -11,6 +11,9 @@ from verifiers.v1.task import DataT, WireTaskData
 from verifiers.v1.trace import EXCLUDE_FIELDS, AgentConfigT, Error, Trace, TraceTask
 from verifiers.v1.types import Usage
 
+EPISODE_EXCLUDE_FIELDS = {"traces": {"__all__": EXCLUDE_FIELDS}}
+"""`EXCLUDE_FIELDS` applied to every trace of an episode dump."""
+
 
 class EnvInfo(BaseModel):
     """The env that ran the episode, self-describing without the run's config."""
@@ -150,7 +153,7 @@ class Episode(BaseModel, Generic[DataT, StateT, AgentConfigT]):
         """JSON record without raw trace tensors, which remain on the msgpack wire."""
         return self.model_dump(
             mode="json",
-            exclude={"traces": {"__all__": EXCLUDE_FIELDS}},
+            exclude=EPISODE_EXCLUDE_FIELDS,
             exclude_none=True,
         )
 

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -258,6 +258,15 @@ class Rollout:
             )
             self._endpoint = f"{runtime.host_url(base_url)}/v1"
             self._secret = model_secret
+            self.trace.upload_secrets += [
+                model_secret,
+                state_secret,
+                *(
+                    t.state_secret
+                    for t in self._shared_tools.values()
+                    if t.state_secret
+                ),
+            ]
             self._urls = await self._stack.enter_async_context(
                 serve_tools(
                     toolsets,

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -37,7 +37,7 @@ from verifiers.v1.trace import AgentInfo, Trace, TraceTask
 from verifiers.v1.types import Messages, Request, Response, SystemMessage, UserMessage
 from verifiers.v1.utils.artifacts import collect
 from verifiers.v1.utils.decorators import discover_decorated, invoke
-from verifiers.v1.utils.redact import env_credentials
+from verifiers.v1.utils.redact import env_credentials, url_credentials
 
 logger = logging.getLogger(__name__)
 
@@ -298,13 +298,15 @@ class Rollout:
                     state_base=base_url,
                 )
             )
-            # A shared tool's URL carries a per-rollout signature derived from its
-            # secret; matching the secret alone would not recognise it.
+            # Tool URLs are not traced but the harness reads them: a shared tool's URL
+            # carries a per-rollout signature derived from its secret, and an external
+            # tool's URL may carry userinfo credentials.
             self.trace.upload_secrets += [
-                signature
+                secret
                 for url in self._urls.values()
-                for signature in parse_qs(urlsplit(url).query).get(
-                    STATE_SIGNATURE_PARAM, []
+                for secret in (
+                    *parse_qs(urlsplit(url).query).get(STATE_SIGNATURE_PARAM, []),
+                    *url_credentials(url),
                 )
             ]
             # Setup and service provisioning are complete. Apply the runtime's

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -35,7 +35,7 @@ from verifiers.v1.trace import AgentInfo, Trace, TraceTask
 from verifiers.v1.types import Messages, Request, Response, SystemMessage, UserMessage
 from verifiers.v1.utils.artifacts import collect
 from verifiers.v1.utils.decorators import discover_decorated, invoke
-from verifiers.v1.utils.redact import SECRET_NAME
+from verifiers.v1.utils.redact import env_credentials
 
 logger = logging.getLogger(__name__)
 
@@ -206,22 +206,21 @@ class Rollout:
         )
         try:
             runtime_env = dict(self.task.runtime_env())
-            # Credentials as they are while the harness runs: the client key and the
-            # credential-named client header, harness, and task runtime variables. The
-            # upload redactor also reads the current config, but task runtime values are
-            # never traced, and a key rotated since the run would otherwise be missed.
+            # Credentials as they are while the harness runs: the client key and those
+            # in the client headers, harness, and task runtime variables. The upload
+            # redactor also reads the current config, but task runtime values are never
+            # traced, and a key rotated since the run would otherwise be missed.
             client = self.ctx.client
             self.trace.upload_secrets += [
                 resolve_api_key(client),
                 *(
-                    value
+                    credential
                     for mapping in (
                         client.headers,
                         self.harness.config.resolved_env,
                         runtime_env,
                     )
-                    for name, value in mapping.items()
-                    if SECRET_NAME.search(name)
+                    for credential in env_credentials(mapping)
                 ),
             ]
             if self._borrowed_runtime is None:

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -34,6 +34,7 @@ from verifiers.v1.trace import AgentInfo, Trace, TraceTask
 from verifiers.v1.types import Messages, Request, Response, SystemMessage, UserMessage
 from verifiers.v1.utils.artifacts import collect
 from verifiers.v1.utils.decorators import discover_decorated, invoke
+from verifiers.v1.utils.redact import SECRET_NAME
 
 logger = logging.getLogger(__name__)
 
@@ -204,6 +205,11 @@ class Rollout:
         )
         try:
             runtime_env = dict(self.task.runtime_env())
+            # A task resolves these at run time and they are not traced, so the upload
+            # redactor can only learn them here.
+            self.trace.upload_secrets += [
+                value for name, value in runtime_env.items() if SECRET_NAME.search(name)
+            ]
             if self._borrowed_runtime is None:
                 runtime.env = runtime_env
             else:

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.agent import AgentConfig
+from verifiers.v1.configs.client import resolve_api_key
 from verifiers.v1.configs.runtime import NetworkPolicyConfig
 from verifiers.v1.errors import (
     HarnessError,
@@ -205,10 +206,23 @@ class Rollout:
         )
         try:
             runtime_env = dict(self.task.runtime_env())
-            # A task resolves these at run time and they are not traced, so the upload
-            # redactor can only learn them here.
+            # Credentials as they are while the harness runs: the client key and the
+            # credential-named client header, harness, and task runtime variables. The
+            # upload redactor also reads the current config, but task runtime values are
+            # never traced, and a key rotated since the run would otherwise be missed.
+            client = self.ctx.client
             self.trace.upload_secrets += [
-                value for name, value in runtime_env.items() if SECRET_NAME.search(name)
+                resolve_api_key(client),
+                *(
+                    value
+                    for mapping in (
+                        client.headers,
+                        self.harness.config.resolved_env,
+                        runtime_env,
+                    )
+                    for name, value in mapping.items()
+                    if SECRET_NAME.search(name)
+                ),
             ]
             if self._borrowed_runtime is None:
                 runtime.env = runtime_env
@@ -286,6 +300,7 @@ class Rollout:
             # Setup and service provisioning are complete. Apply the runtime's
             # execution policy while preserving the framework routes the agent uses.
             await runtime.prepare_execution([self._endpoint, *self._urls.values()])
+            self.trace.upload_secrets += runtime.secrets
             async with boundary(HarnessError, "opening harness session"):
                 harness_data = self.trace.task.data
                 if (

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -238,6 +238,9 @@ class Rollout:
                 )
             if self._borrowed_runtime is None:
                 await runtime.start()
+            # Credentials the runtime minted at start (the Docker egress proxy token)
+            # reach every process it runs, the setup hooks included: record them first.
+            self.trace.upload_secrets += runtime.secrets
             await runtime.prepare_setup()
             now = time.time()
             self.trace.timing.boot.end = now
@@ -312,7 +315,6 @@ class Rollout:
             # Setup and service provisioning are complete. Apply the runtime's
             # execution policy while preserving the framework routes the agent uses.
             await runtime.prepare_execution([self._endpoint, *self._urls.values()])
-            self.trace.upload_secrets += runtime.secrets
             async with boundary(HarnessError, "opening harness session"):
                 harness_data = self.trace.task.data
                 if (

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -7,6 +7,7 @@ import time
 from collections.abc import Callable
 from contextlib import AsyncExitStack
 from dataclasses import dataclass
+from urllib.parse import parse_qs, urlsplit
 
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.agent import AgentConfig
@@ -22,6 +23,7 @@ from verifiers.v1.errors import (
 from verifiers.v1.harness import Harness, HarnessSession
 from verifiers.v1.interception import Interception, serve_interception
 from verifiers.v1.mcp import SharedToolServer, serve_tools
+from verifiers.v1.mcp.server import STATE_SIGNATURE_PARAM
 from verifiers.v1.runtimes import (
     ModalConfig,
     Runtime,
@@ -296,6 +298,15 @@ class Rollout:
                     state_base=base_url,
                 )
             )
+            # A shared tool's URL carries a per-rollout signature derived from its
+            # secret; matching the secret alone would not recognise it.
+            self.trace.upload_secrets += [
+                signature
+                for url in self._urls.values()
+                for signature in parse_qs(urlsplit(url).query).get(
+                    STATE_SIGNATURE_PARAM, []
+                )
+            ]
             # Setup and service provisioning are complete. Apply the runtime's
             # execution policy while preserving the framework routes the agent uses.
             await runtime.prepare_execution([self._endpoint, *self._urls.values()])

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -148,6 +148,13 @@ class Runtime(ABC):
         """Whether `open_process()` is implemented for this runtime instance."""
         return type(self).open_process is not Runtime.open_process
 
+    @property
+    def secrets(self) -> list[str]:
+        """Credentials this runtime minted for the processes inside it (a policy
+        proxy's token, say). The rollout records them on its trace so an agent that
+        prints its environment cannot leak them through the platform upload."""
+        return []
+
     def __init__(self, name: str | None = None) -> None:
         self.name = name or f"vf-{uuid.uuid4().hex[:12]}"
         # Per-run task values live on the runtime rather than its serializable config/info.

--- a/verifiers/v1/runtimes/docker/__init__.py
+++ b/verifiers/v1/runtimes/docker/__init__.py
@@ -398,6 +398,10 @@ class DockerRuntime(Runtime):
             raise SandboxError(f"docker network cut failed: {cut.stderr.strip()}")
         self._cut = True
 
+    @property
+    def secrets(self) -> list[str]:
+        return [self._proxy.token] if self._proxy is not None else []
+
     def _proxy_env(self) -> dict[str, str]:
         if self._proxy is None:
             return {}

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -445,9 +445,10 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
     """Every error captured across attempts, oldest to newest."""
     timing: Timing = Field(default_factory=Timing)
     upload_secrets: list[str] = Field(default_factory=list, repr=False)
-    """Credentials minted for this rollout (the interception tokens the harness holds).
-    An agent that prints its environment echoes them into the trace, so the platform
-    upload redacts them; never written to disk."""
+    """Credentials that exist only at rollout time: the interception tokens the harness
+    holds and credential-named variables the task resolves into its runtime. An agent
+    that prints its environment echoes them into the trace, so the platform upload
+    redacts them; never written to disk."""
 
     _head_index: dict = PrivateAttr(default_factory=dict)
     """`(parent, msg_hash) -> node_id` for the graph builder."""

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -45,15 +45,17 @@ TRACE_VERSION = 1
 
 
 EXCLUDE_FIELDS: dict = {
+    "upload_secrets": True,
     "nodes": {
         "__all__": {
             "multi_modal_data",
             "routed_experts",
             "sampling_mask",
         }
-    }
+    },
 }
-"""Raw tensor fields kept on the msgpack wire but excluded from disk serialization."""
+"""Fields kept on the msgpack wire but excluded from disk serialization: raw tensors,
+and the rollout's own credentials."""
 
 
 class TimeSpan(BaseModel):
@@ -442,6 +444,10 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
     errors: list[Error] = Field(default_factory=list)
     """Every error captured across attempts, oldest to newest."""
     timing: Timing = Field(default_factory=Timing)
+    upload_secrets: list[str] = Field(default_factory=list, repr=False)
+    """Credentials minted for this rollout (the interception tokens the harness holds).
+    An agent that prints its environment echoes them into the trace, so the platform
+    upload redacts them; never written to disk."""
 
     _head_index: dict = PrivateAttr(default_factory=dict)
     """`(parent, msg_hash) -> node_id` for the graph builder."""

--- a/verifiers/v1/utils/platform.py
+++ b/verifiers/v1/utils/platform.py
@@ -8,17 +8,17 @@ come from `$PRIME_API_KEY` / `~/.prime/config.json`.
 Credentials stay out of the upload two ways. The config fields that hold them (client
 headers, harness env) are dropped from the projection, and every credential value the
 run knows — the clients' API keys, credential-named header / harness / host environment
-values, the rollouts' interception tokens — is replaced with `[REDACTED]` wherever it
-appears in the serialized samples. Redaction is exact-match only: nothing is guessed
-from the shape of the text, so ordinary content is never rewritten. Saved traces are
-unchanged, so a resumed `--push` redacts everything except the earlier attempt's
-interception tokens, which died with its interception server.
+values, whatever each rollout recorded on `Trace.upload_secrets` — is replaced with
+`[REDACTED]` wherever it appears in the serialized samples. Redaction is exact-match
+only: nothing is guessed from the shape of the text, so ordinary content is never
+rewritten. Saved traces are unchanged, so a resumed `--push` redacts everything except
+what the earlier attempt's rollouts recorded: their interception tokens (dead with that
+run's interception server) and task-resolved runtime credentials.
 """
 
 import json
 import logging
 import os
-import re
 from dataclasses import dataclass
 from typing import Any
 
@@ -29,6 +29,7 @@ from verifiers.v1.configs.client import resolve_api_key
 from verifiers.v1.episode import Episode
 from verifiers.v1.trace import EXCLUDE_FIELDS, Trace
 from verifiers.v1.utils.prime import load_prime_config
+from verifiers.v1.utils.redact import MIN_SECRET_LENGTH, SECRET_NAME, Redactor
 
 logger = logging.getLogger(__name__)
 
@@ -49,60 +50,18 @@ UPLOAD_EXCLUDE = {
 """The episode projection uploaded: the disk record minus the config fields that carry
 credentials (`harness.forward_env` names variables without their values and stays)."""
 
-REDACTED = "[REDACTED]"
-MIN_SECRET_LENGTH = 8
-SECRET_NAME = re.compile(
-    r"KEY|TOKEN|SECRET|PASSW|CREDENTIAL|COOKIE|AUTHORIZATION|(?:^|[_-])AUTH(?:[_-]|$)",
-    re.IGNORECASE,
-)
-"""Variable and header names whose values are credentials."""
-JSON_STRING = re.compile(r'"((?:[^"\\]|\\.)*)"')
-
 
 def json_text(value: Any) -> str:
     return json.dumps(value, ensure_ascii=False, separators=(",", ":"), allow_nan=False)
-
-
-class Redactor:
-    """Replaces every occurrence of the secrets inside JSON strings, counting hits."""
-
-    def __init__(self, secrets: set[str]) -> None:
-        # Inside a JSON string a secret is escaped; inside a JSON document quoted within
-        # a string (a tool result) it is escaped twice. Match every spelling.
-        forms = set(secrets)
-        for _ in range(2):
-            forms |= {
-                json.dumps(form, ensure_ascii=escape)[1:-1]
-                for form in list(forms)
-                for escape in (True, False)
-            }
-        alternatives = "|".join(
-            re.escape(form) for form in sorted(forms, key=len, reverse=True)
-        )
-        self.pattern = re.compile(alternatives) if forms else None
-        self.count = 0
-
-    def json(self, text: str) -> str:
-        """Redact one JSON document given as text; structure and non-string values stay."""
-        pattern = self.pattern
-        if pattern is None:
-            return text
-
-        def string(match: re.Match[str]) -> str:
-            inner, hits = pattern.subn(REDACTED, match.group(1))
-            self.count += hits
-            return f'"{inner}"'
-
-        return JSON_STRING.sub(string, text)
 
 
 def known_secrets(
     episodes: list[Episode], config: EvalConfig, *values: str
 ) -> set[str]:
     """Every credential this run could have echoed into a trace: the clients' API keys,
-    credential-named client header / harness / host environment values, the rollouts'
-    interception tokens, and `values`. Values shorter than `MIN_SECRET_LENGTH` are
-    dropped — redacting them would rewrite ordinary text."""
+    credential-named client header / harness / host environment values, what each
+    rollout recorded on `Trace.upload_secrets`, and `values`. Values shorter than
+    `MIN_SECRET_LENGTH` are dropped — redacting them would rewrite ordinary text."""
     traces = [trace for episode in episodes for trace in episode.traces]
     agents = [trace.agent.config for trace in traces]
     clients = [config.client, *(a.client for a in agents if a.client is not None)]

--- a/verifiers/v1/utils/platform.py
+++ b/verifiers/v1/utils/platform.py
@@ -4,19 +4,30 @@ Uploads one sample per v1 `Episode` over the `/evaluations/` API (create -> push
 samples -> finalize). Each sample keeps the complete native Episode as its source
 of truth and includes a flat summary for older Platform consumers. Auth + base URL
 come from `$PRIME_API_KEY` / `~/.prime/config.json`.
+
+Credentials stay out of the upload two ways. The config fields that hold them (client
+headers, harness env) are dropped from the projection, and every credential value the
+run knows — the clients' API keys, credential-named header / harness / host environment
+values, the rollouts' interception tokens — is replaced with `[REDACTED]` wherever it
+appears in the serialized samples. Redaction is exact-match only: nothing is guessed
+from the shape of the text, so ordinary content is never rewritten. Saved traces are
+unchanged, so a resumed `--push` redacts everything except the earlier attempt's
+interception tokens, which died with its interception server.
 """
 
 import json
 import logging
 import os
+import re
 from dataclasses import dataclass
 from typing import Any
 
 import httpx
 
 from verifiers.v1.configs.cli.eval import EvalConfig
+from verifiers.v1.configs.client import resolve_api_key
 from verifiers.v1.episode import Episode
-from verifiers.v1.trace import Trace
+from verifiers.v1.trace import EXCLUDE_FIELDS, Trace
 from verifiers.v1.utils.prime import load_prime_config
 
 logger = logging.getLogger(__name__)
@@ -25,17 +36,93 @@ DEFAULT_API_URL = "https://api.primeintellect.ai"
 DEFAULT_FRONTEND_URL = "https://app.primeintellect.ai"
 # Repeated /samples posts append; match the Prime Evals client's request ceiling.
 _MAX_SAMPLES_PAYLOAD_BYTES = 25 * 1024 * 1024
+_FRAME_BYTES = len('{"samples":[]}')
+
+UPLOAD_EXCLUDE = {
+    "traces": {
+        "__all__": {
+            **EXCLUDE_FIELDS,
+            "agent": {"config": {"client": {"headers"}, "harness": {"env"}}},
+        }
+    }
+}
+"""The episode projection uploaded: the disk record minus the config fields that carry
+credentials (`harness.forward_env` names variables without their values and stays)."""
+
+REDACTED = "[REDACTED]"
+MIN_SECRET_LENGTH = 8
+SECRET_NAME = re.compile(
+    r"KEY|TOKEN|SECRET|PASSW|CREDENTIAL|COOKIE|AUTHORIZATION|(?:^|[_-])AUTH(?:[_-]|$)",
+    re.IGNORECASE,
+)
+"""Variable and header names whose values are credentials."""
+JSON_STRING = re.compile(r'"((?:[^"\\]|\\.)*)"')
 
 
-def json_bytes(value: Any) -> int:
-    return len(
-        json.dumps(
-            value,
-            ensure_ascii=False,
-            separators=(",", ":"),
-            allow_nan=False,
-        ).encode("utf-8")
-    )
+def json_text(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), allow_nan=False)
+
+
+class Redactor:
+    """Replaces every occurrence of the secrets inside JSON strings, counting hits."""
+
+    def __init__(self, secrets: set[str]) -> None:
+        # Inside a JSON string a secret is escaped; inside a JSON document quoted within
+        # a string (a tool result) it is escaped twice. Match every spelling.
+        forms = set(secrets)
+        for _ in range(2):
+            forms |= {
+                json.dumps(form, ensure_ascii=escape)[1:-1]
+                for form in list(forms)
+                for escape in (True, False)
+            }
+        alternatives = "|".join(
+            re.escape(form) for form in sorted(forms, key=len, reverse=True)
+        )
+        self.pattern = re.compile(alternatives) if forms else None
+        self.count = 0
+
+    def json(self, text: str) -> str:
+        """Redact one JSON document given as text; structure and non-string values stay."""
+        pattern = self.pattern
+        if pattern is None:
+            return text
+
+        def string(match: re.Match[str]) -> str:
+            inner, hits = pattern.subn(REDACTED, match.group(1))
+            self.count += hits
+            return f'"{inner}"'
+
+        return JSON_STRING.sub(string, text)
+
+
+def known_secrets(
+    episodes: list[Episode], config: EvalConfig, *values: str
+) -> set[str]:
+    """Every credential this run could have echoed into a trace: the clients' API keys,
+    credential-named client header / harness / host environment values, the rollouts'
+    interception tokens, and `values`. Values shorter than `MIN_SECRET_LENGTH` are
+    dropped — redacting them would rewrite ordinary text."""
+    traces = [trace for episode in episodes for trace in episode.traces]
+    agents = [trace.agent.config for trace in traces]
+    clients = [config.client, *(a.client for a in agents if a.client is not None)]
+    named = [
+        os.environ,
+        *(client.headers for client in clients),
+        *(a.harness.resolved_env for a in agents if a.harness is not None),
+    ]
+    secrets = {
+        *values,
+        *(resolve_api_key(client) for client in clients),
+        *(secret for trace in traces for secret in trace.upload_secrets),
+        *(
+            value
+            for mapping in named
+            for name, value in mapping.items()
+            if SECRET_NAME.search(name)
+        ),
+    }
+    return {secret for secret in secrets if len(secret) >= MIN_SECRET_LENGTH}
 
 
 @dataclass
@@ -160,15 +247,16 @@ def run_metrics(episodes: list[Episode], traces: list[Trace]) -> dict[str, Any]:
     }
 
 
-def build_samples(episodes: list[Episode]) -> list[dict[str, Any]]:
-    """One Platform sample per Episode, with a legacy-compatible trace summary.
+def build_samples(episodes: list[Episode], redactor: Redactor) -> list[str]:
+    """One Platform sample per Episode, serialized and redacted, with a
+    legacy-compatible trace summary.
 
-    The native Episode in `info.native_wrapper` is authoritative and contains every
-    trace. One trainable trace (or the first trace) supplies only the flat summary
-    used by older consumers. `native_trace_index` identifies that summary trace.
+    The Episode projection in `info.native_wrapper` is authoritative and contains
+    every trace. One trainable trace (or the first trace) supplies only the flat
+    summary used by older consumers. `native_trace_index` identifies that summary trace.
     """
     counts: dict[int, int] = {}
-    samples = []
+    rows = []
     for episode in episodes:
         if not episode.traces:
             continue
@@ -187,21 +275,24 @@ def build_samples(episodes: list[Episode]) -> list[dict[str, Any]]:
         sample["sample_id"] = episode.id
         sample["info"] = {
             **(sample["info"] or {}),
-            "native_wrapper": episode.to_record(),
+            "native_wrapper": episode.model_dump(
+                mode="json", exclude=UPLOAD_EXCLUDE, exclude_none=True
+            ),
             "native_trace_index": summary_trace_index,
         }
-        if len(b'{"samples":[]}') + json_bytes(sample) <= _MAX_SAMPLES_PAYLOAD_BYTES:
-            samples.append(sample)
+        row = redactor.json(json_text(sample))
+        if _FRAME_BYTES + len(row.encode()) <= _MAX_SAMPLES_PAYLOAD_BYTES:
+            rows.append(row)
             continue
         logger.warning(
             "Episode %s exceeds the Platform sample limit; uploading projected traces",
             episode.id,
         )
-        samples.extend(
-            trace_to_sample(candidate, number, episode.id)
+        rows.extend(
+            redactor.json(json_text(trace_to_sample(candidate, number, episode.id)))
             for candidate in episode.traces
         )
-    return samples
+    return rows
 
 
 def push_traces(
@@ -247,29 +338,29 @@ def push_traces(
     # The run is done and its results saved; a network blip here must not crash it
     # — log and skip the upload instead.
     try:
-        samples = build_samples(episodes)
-        batches: list[list[dict[str, Any]]] = []
-        batch: list[dict[str, Any]] = []
-        payload_bytes = len(b'{"samples":[]}')
-        for i, sample in enumerate(samples):
-            sample_bytes = json_bytes(sample)
-            sample_payload_bytes = len(b'{"samples":[]}') + sample_bytes
-            if sample_payload_bytes > _MAX_SAMPLES_PAYLOAD_BYTES:
+        redactor = Redactor(known_secrets(episodes, config, api_key))
+        rows = build_samples(episodes, redactor)
+        if redactor.count:
+            logger.warning(
+                "--push: redacted %d occurrence(s) of known secrets from the upload; "
+                "saved traces are unchanged",
+                redactor.count,
+            )
+        # Batch by exact request size; each body is `{"samples":[<row>,<row>,...]}`.
+        batches: list[list[str]] = [[]]
+        size = _FRAME_BYTES
+        for i, row in enumerate(rows):
+            row_bytes = len(row.encode())
+            if _FRAME_BYTES + row_bytes > _MAX_SAMPLES_PAYLOAD_BYTES:
                 raise ValueError(
                     f"sample {i} is too large to upload "
-                    f"({sample_payload_bytes} > "
-                    f"{_MAX_SAMPLES_PAYLOAD_BYTES} bytes)"
+                    f"({_FRAME_BYTES + row_bytes} > {_MAX_SAMPLES_PAYLOAD_BYTES} bytes)"
                 )
-            next_payload_bytes = payload_bytes + (1 if batch else 0) + sample_bytes
-            if batch and next_payload_bytes > _MAX_SAMPLES_PAYLOAD_BYTES:
-                batches.append(batch)
-                batch = []
-                payload_bytes = len(b'{"samples":[]}')
-                next_payload_bytes = payload_bytes + sample_bytes
-            batch.append(sample)
-            payload_bytes = next_payload_bytes
-        if batch or not samples:
-            batches.append(batch)
+            if batches[-1] and size + 1 + row_bytes > _MAX_SAMPLES_PAYLOAD_BYTES:
+                batches.append([])
+                size = _FRAME_BYTES
+            size += row_bytes + (1 if batches[-1] else 0)
+            batches[-1].append(row)
 
         with httpx.Client(headers=headers, timeout=300.0) as client:
 
@@ -296,15 +387,9 @@ def push_traces(
                 },
             )["evaluation_id"]
             for batch in batches:
-                body = json.dumps(
-                    {"samples": batch},
-                    ensure_ascii=False,
-                    separators=(",", ":"),
-                    allow_nan=False,
-                ).encode("utf-8")
                 resp = client.post(
                     f"{api}/evaluations/{eval_id}/samples",
-                    content=body,
+                    content=f'{{"samples":[{",".join(batch)}]}}'.encode(),
                 )
                 resp.raise_for_status()
             post(f"/evaluations/{eval_id}/finalize", {"metrics": metrics})
@@ -313,5 +398,5 @@ def push_traces(
         return finish(error=f"{type(e).__name__}: {e}")
 
     url = f"{frontend}/dashboard/evaluations/{eval_id}"
-    logger.info("--push: uploaded %d samples -> %s", len(samples), url)
+    logger.info("--push: uploaded %d samples -> %s", len(rows), url)
     return finish(url=url)

--- a/verifiers/v1/utils/platform.py
+++ b/verifiers/v1/utils/platform.py
@@ -7,18 +7,19 @@ come from `$PRIME_API_KEY` / `~/.prime/config.json`.
 
 Credentials stay out of the upload two ways. The config fields that hold them (client
 headers, harness env) are dropped from the projection, and every credential value the
-run knows — the clients' API keys, credential-named header / harness / host environment
-values, whatever each rollout recorded on `Trace.upload_secrets` — is replaced with
-`[REDACTED]` wherever it appears in the serialized samples. Redaction is exact-match
-only: nothing is guessed from the shape of the text, so ordinary content is never
-rewritten. Saved traces are unchanged, so a resumed `--push` redacts everything except
-what the earlier attempt's rollouts recorded: their interception tokens (dead with that
-run's interception server) and task-resolved runtime credentials.
+run knows — the clients' API keys, credential-named values from client headers, harness
+and task environments and the host environment, whatever each rollout recorded on
+`Trace.upload_secrets` — is replaced with `[REDACTED]` in every outbound request body.
+Redaction is exact-match only: nothing is guessed from the shape of the text, so
+ordinary content is never rewritten. Saved traces are unchanged, so a resumed `--push`
+redacts everything except the values only the earlier attempt's rollouts knew: their
+interception and runtime tokens (dead with that run) and credentials rotated since.
 """
 
 import json
 import logging
 import os
+import re
 from dataclasses import dataclass
 from typing import Any
 
@@ -50,6 +51,9 @@ UPLOAD_EXCLUDE = {
 """The episode projection uploaded: the disk record minus the config fields that carry
 credentials (`harness.forward_env` names variables without their values and stays)."""
 
+ENV_FIELD = re.compile(r"(?:^|_)env$")
+"""Task-data fields holding an environment mapping (Harbor's `env`, `verifier_env`)."""
+
 
 def json_text(value: Any) -> str:
     return json.dumps(value, ensure_ascii=False, separators=(",", ":"), allow_nan=False)
@@ -58,9 +62,10 @@ def json_text(value: Any) -> str:
 def known_secrets(
     episodes: list[Episode], config: EvalConfig, *values: str
 ) -> set[str]:
-    """Every credential this run could have echoed into a trace: the clients' API keys,
-    credential-named client header / harness / host environment values, what each
-    rollout recorded on `Trace.upload_secrets`, and `values`. Values shorter than
+    """Every credential this run could have put into a trace: the clients' API keys,
+    credential-named values from client headers, harness and task-data environments and
+    the host environment as they are now, what each rollout recorded on
+    `Trace.upload_secrets` as they were then, and `values`. Values shorter than
     `MIN_SECRET_LENGTH` are dropped — redacting them would rewrite ordinary text."""
     traces = [trace for episode in episodes for trace in episode.traces]
     agents = [trace.agent.config for trace in traces]
@@ -69,6 +74,12 @@ def known_secrets(
         os.environ,
         *(client.headers for client in clients),
         *(a.harness.resolved_env for a in agents if a.harness is not None),
+        *(
+            value
+            for trace in traces
+            for name, value in trace.task.data.model_dump(mode="json").items()
+            if ENV_FIELD.search(name) and isinstance(value, dict)
+        ),
     ]
     secrets = {
         *values,
@@ -78,7 +89,7 @@ def known_secrets(
             value
             for mapping in named
             for name, value in mapping.items()
-            if SECRET_NAME.search(name)
+            if isinstance(value, str) and SECRET_NAME.search(name)
         ),
     }
     return {secret for secret in secrets if len(secret) >= MIN_SECRET_LENGTH}
@@ -324,7 +335,9 @@ def push_traces(
         with httpx.Client(headers=headers, timeout=300.0) as client:
 
             def post(path: str, body: dict) -> dict:
-                resp = client.post(f"{api}{path}", json=body)
+                resp = client.post(
+                    f"{api}{path}", content=redactor.json(json_text(body)).encode()
+                )
                 resp.raise_for_status()
                 return resp.json()
 

--- a/verifiers/v1/utils/platform.py
+++ b/verifiers/v1/utils/platform.py
@@ -98,8 +98,8 @@ def known_secrets(
 ) -> set[str]:
     """Every credential this run could have put into a trace: the clients' API keys;
     the credentials in the host environment and in every environment or header mapping
-    of the run's env config, the traced agent configs, and the task data
-    (`env_credentials`); URL credentials anywhere in those configs and task data (a
+    of the run's env config, the traced agent configs, and the trace and episode task
+    data (`env_credentials`); URL credentials anywhere in those configs and task data (a
     client `base_url`, a harness endpoint, a task's connection string); what each
     rollout recorded on
     `Trace.upload_secrets` as it was then (discarded attempts' on
@@ -116,6 +116,7 @@ def known_secrets(
         config.env.model_dump(mode="json"),
         *(trace.agent.config.model_dump(mode="json") for trace in traces),
         *(trace.task.data.model_dump(mode="json") for trace in traces),
+        *(episode.task.data.model_dump(mode="json") for episode in episodes),
     ]
     named = [
         os.environ,

--- a/verifiers/v1/utils/platform.py
+++ b/verifiers/v1/utils/platform.py
@@ -28,7 +28,7 @@ import httpx
 
 from verifiers.v1.configs.cli.eval import EvalConfig
 from verifiers.v1.configs.client import resolve_api_key
-from verifiers.v1.episode import Episode
+from verifiers.v1.episode import EPISODE_EXCLUDE_FIELDS, Episode
 from verifiers.v1.trace import EXCLUDE_FIELDS, Trace
 from verifiers.v1.utils.prime import load_prime_config
 from verifiers.v1.utils.redact import (
@@ -47,12 +47,13 @@ _MAX_SAMPLES_PAYLOAD_BYTES = 25 * 1024 * 1024
 _FRAME_BYTES = len('{"samples":[]}')
 
 UPLOAD_EXCLUDE = {
+    **EPISODE_EXCLUDE_FIELDS,
     "traces": {
         "__all__": {
             **EXCLUDE_FIELDS,
             "agent": {"config": {"client": {"headers"}, "harness": {"env"}}},
         }
-    }
+    },
 }
 """The episode projection uploaded: the disk record minus the config fields that carry
 credentials (`harness.forward_env` names variables without their values and stays)."""
@@ -61,9 +62,21 @@ ENV_FIELD = re.compile(r"(?:^|_)env$")
 """Task-data fields holding an environment mapping (Harbor's `env`, `verifier_env`)."""
 
 
+def strings(value: Any) -> Iterator[str]:
+    """Every string in a JSON tree."""
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for child in value.values():
+            yield from strings(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from strings(child)
+
+
 def env_mappings(value: Any, name: str = "") -> Iterator[dict]:
-    """Environment mappings anywhere in a task-data dump, nested ones included
-    (Harbor's `verifier.env`)."""
+    """Environment mappings anywhere in a JSON tree, nested ones included (a harness
+    config's `env`, Harbor's `verifier.env`)."""
     if isinstance(value, dict):
         if ENV_FIELD.search(name):
             yield value
@@ -81,33 +94,41 @@ def json_text(value: Any) -> str:
 def known_secrets(
     episodes: list[Episode], config: EvalConfig, *values: str
 ) -> set[str]:
-    """Every credential this run could have put into a trace: the clients' API keys and
-    the credentials in their base URLs, the credentials in client headers, harness and
-    task-data environments and the host environment as they are now (`env_credentials`),
-    what each rollout recorded on `Trace.upload_secrets` as they were then (discarded
-    attempts' on `Episode.upload_secrets`), and `values`.
-    Values shorter than `MIN_SECRET_LENGTH` are dropped — redacting them would rewrite
-    ordinary text."""
+    """Every credential this run could have put into a trace: the clients' API keys;
+    the credentials in the host environment, the client headers, and every environment
+    mapping in the traced agent configs and task data (`env_credentials`); URL
+    credentials anywhere in those configs and task data (a client `base_url`, a
+    harness endpoint, a task's connection string); what each rollout recorded on
+    `Trace.upload_secrets` as it was then (discarded attempts' on
+    `Episode.upload_secrets`); and `values`. Values shorter than `MIN_SECRET_LENGTH` are
+    dropped — redacting them would rewrite ordinary text."""
     traces = [trace for episode in episodes for trace in episode.traces]
-    agents = [trace.agent.config for trace in traces]
-    clients = [config.client, *(a.client for a in agents if a.client is not None)]
+    clients = [
+        config.client,
+        *(t.agent.config.client for t in traces if t.agent.config.client is not None),
+    ]
+    dumps = [
+        config.client.model_dump(mode="json"),
+        *(trace.agent.config.model_dump(mode="json") for trace in traces),
+        *(trace.task.data.model_dump(mode="json") for trace in traces),
+    ]
     named = [
         os.environ,
         *(client.headers for client in clients),
-        *(a.harness.resolved_env for a in agents if a.harness is not None),
-        *(
-            mapping
-            for trace in traces
-            for mapping in env_mappings(trace.task.data.model_dump(mode="json"))
-        ),
+        *(mapping for dump in dumps for mapping in env_mappings(dump)),
     ]
     secrets = {
         *values,
         *(resolve_api_key(client) for client in clients),
-        *(c for client in clients for c in url_credentials(client.base_url)),
+        *(credential for mapping in named for credential in env_credentials(mapping)),
+        *(
+            credential
+            for dump in dumps
+            for text in strings(dump)
+            for credential in url_credentials(text)
+        ),
         *(secret for trace in traces for secret in trace.upload_secrets),
         *(secret for episode in episodes for secret in episode.upload_secrets),
-        *(credential for mapping in named for credential in env_credentials(mapping)),
     }
     return {secret for secret in secrets if len(secret) >= MIN_SECRET_LENGTH}
 

--- a/verifiers/v1/utils/platform.py
+++ b/verifiers/v1/utils/platform.py
@@ -61,7 +61,11 @@ credentials (`harness.forward_env` names variables without their values and stay
 
 CREDENTIAL_MAPPING = re.compile(r"(?:^|_)(?:env|headers)$")
 """Config and task-data fields holding an environment or header mapping (a harness
-`env`, Harbor's `verifier_env`, a client's or a task config's `headers`)."""
+`env`, Harbor's `verifier_env`, a client's or a task config's `headers`). Name-based
+discovery stays inside these: applied to every field it would take `api_key_var`'s
+value, the *name* of a variable, for a credential, and keeping it out would need the
+reference-suffix lists this design avoids. A credential stored under a bare task-data
+field (`api_key: ...`) is recognised only through its value's URL shape."""
 
 
 def strings(value: Any) -> Iterator[str]:

--- a/verifiers/v1/utils/platform.py
+++ b/verifiers/v1/utils/platform.py
@@ -33,6 +33,7 @@ from verifiers.v1.trace import EXCLUDE_FIELDS, Trace
 from verifiers.v1.utils.prime import load_prime_config
 from verifiers.v1.utils.redact import (
     MIN_SECRET_LENGTH,
+    REDACTED,
     Redactor,
     env_credentials,
     url_credentials,
@@ -101,7 +102,8 @@ def known_secrets(
     harness endpoint, a task's connection string); what each rollout recorded on
     `Trace.upload_secrets` as it was then (discarded attempts' on
     `Episode.upload_secrets`); and `values`. Values shorter than `MIN_SECRET_LENGTH` are
-    dropped — redacting them would rewrite ordinary text."""
+    dropped — redacting them would rewrite ordinary text — and so are placeholders that
+    sit inside the `[REDACTED]` marker."""
     traces = [trace for episode in episodes for trace in episode.traces]
     clients = [
         config.client,
@@ -130,7 +132,12 @@ def known_secrets(
         *(secret for trace in traces for secret in trace.upload_secrets),
         *(secret for episode in episodes for secret in episode.upload_secrets),
     }
-    return {secret for secret in secrets if len(secret) >= MIN_SECRET_LENGTH}
+    # A value inside the marker (`API_TOKEN=REDACTED`) is a sanitized placeholder.
+    return {
+        secret
+        for secret in secrets
+        if len(secret) >= MIN_SECRET_LENGTH and secret not in REDACTED
+    }
 
 
 @dataclass

--- a/verifiers/v1/utils/platform.py
+++ b/verifiers/v1/utils/platform.py
@@ -59,8 +59,9 @@ UPLOAD_EXCLUDE = {
 """The episode projection uploaded: the disk record minus the config fields that carry
 credentials (`harness.forward_env` names variables without their values and stays)."""
 
-ENV_FIELD = re.compile(r"(?:^|_)env$")
-"""Task-data fields holding an environment mapping (Harbor's `env`, `verifier_env`)."""
+CREDENTIAL_MAPPING = re.compile(r"(?:^|_)(?:env|headers)$")
+"""Config and task-data fields holding an environment or header mapping (a harness
+`env`, Harbor's `verifier_env`, a client's or a task config's `headers`)."""
 
 
 def strings(value: Any) -> Iterator[str]:
@@ -75,17 +76,17 @@ def strings(value: Any) -> Iterator[str]:
             yield from strings(child)
 
 
-def env_mappings(value: Any, name: str = "") -> Iterator[dict]:
-    """Environment mappings anywhere in a JSON tree, nested ones included (a harness
-    config's `env`, Harbor's `verifier.env`)."""
+def credential_mappings(value: Any, name: str = "") -> Iterator[dict]:
+    """Environment and header mappings anywhere in a JSON tree, nested ones included
+    (a harness config's `env`, Harbor's `verifier.env`, a task config's `headers`)."""
     if isinstance(value, dict):
-        if ENV_FIELD.search(name):
+        if CREDENTIAL_MAPPING.search(name):
             yield value
         for key, child in value.items():
-            yield from env_mappings(child, key)
+            yield from credential_mappings(child, key)
     elif isinstance(value, list):
         for child in value:
-            yield from env_mappings(child, name)
+            yield from credential_mappings(child, name)
 
 
 def json_text(value: Any) -> str:
@@ -96,10 +97,11 @@ def known_secrets(
     episodes: list[Episode], config: EvalConfig, *values: str
 ) -> set[str]:
     """Every credential this run could have put into a trace: the clients' API keys;
-    the credentials in the host environment, the client headers, and every environment
-    mapping in the traced agent configs and task data (`env_credentials`); URL
-    credentials anywhere in those configs and task data (a client `base_url`, a
-    harness endpoint, a task's connection string); what each rollout recorded on
+    the credentials in the host environment and in every environment or header mapping
+    of the run's env config, the traced agent configs, and the task data
+    (`env_credentials`); URL credentials anywhere in those configs and task data (a
+    client `base_url`, a harness endpoint, a task's connection string); what each
+    rollout recorded on
     `Trace.upload_secrets` as it was then (discarded attempts' on
     `Episode.upload_secrets`); and `values`. Values shorter than `MIN_SECRET_LENGTH` are
     dropped — redacting them would rewrite ordinary text — and so are placeholders that
@@ -111,13 +113,13 @@ def known_secrets(
     ]
     dumps = [
         config.client.model_dump(mode="json"),
+        config.env.model_dump(mode="json"),
         *(trace.agent.config.model_dump(mode="json") for trace in traces),
         *(trace.task.data.model_dump(mode="json") for trace in traces),
     ]
     named = [
         os.environ,
-        *(client.headers for client in clients),
-        *(mapping for dump in dumps for mapping in env_mappings(dump)),
+        *(mapping for dump in dumps for mapping in credential_mappings(dump)),
     ]
     secrets = {
         *values,

--- a/verifiers/v1/utils/platform.py
+++ b/verifiers/v1/utils/platform.py
@@ -33,9 +33,9 @@ from verifiers.v1.trace import EXCLUDE_FIELDS, Trace
 from verifiers.v1.utils.prime import load_prime_config
 from verifiers.v1.utils.redact import (
     MIN_SECRET_LENGTH,
-    REDACTED,
     Redactor,
     env_credentials,
+    overlaps_marker,
     url_credentials,
 )
 
@@ -105,7 +105,7 @@ def known_secrets(
     `Trace.upload_secrets` as it was then (discarded attempts' on
     `Episode.upload_secrets`); and `values`. Values shorter than `MIN_SECRET_LENGTH` are
     dropped — redacting them would rewrite ordinary text — and so are placeholders that
-    sit inside the `[REDACTED]` marker."""
+    overlap the `[REDACTED]` marker."""
     traces = [trace for episode in episodes for trace in episode.traces]
     clients = [
         config.client,
@@ -135,11 +135,11 @@ def known_secrets(
         *(secret for trace in traces for secret in trace.upload_secrets),
         *(secret for episode in episodes for secret in episode.upload_secrets),
     }
-    # A value inside the marker (`API_TOKEN=REDACTED`) is a sanitized placeholder.
+    # A value overlapping the marker (`API_TOKEN=REDACTED`) is a sanitized placeholder.
     return {
         secret
         for secret in secrets
-        if len(secret) >= MIN_SECRET_LENGTH and secret not in REDACTED
+        if len(secret) >= MIN_SECRET_LENGTH and not overlaps_marker(secret)
     }
 
 

--- a/verifiers/v1/utils/platform.py
+++ b/verifiers/v1/utils/platform.py
@@ -20,6 +20,7 @@ import json
 import logging
 import os
 import re
+from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any
 
@@ -30,7 +31,12 @@ from verifiers.v1.configs.client import resolve_api_key
 from verifiers.v1.episode import Episode
 from verifiers.v1.trace import EXCLUDE_FIELDS, Trace
 from verifiers.v1.utils.prime import load_prime_config
-from verifiers.v1.utils.redact import MIN_SECRET_LENGTH, Redactor, env_credentials
+from verifiers.v1.utils.redact import (
+    MIN_SECRET_LENGTH,
+    Redactor,
+    env_credentials,
+    url_credentials,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +61,19 @@ ENV_FIELD = re.compile(r"(?:^|_)env$")
 """Task-data fields holding an environment mapping (Harbor's `env`, `verifier_env`)."""
 
 
+def env_mappings(value: Any, name: str = "") -> Iterator[dict]:
+    """Environment mappings anywhere in a task-data dump, nested ones included
+    (Harbor's `verifier.env`)."""
+    if isinstance(value, dict):
+        if ENV_FIELD.search(name):
+            yield value
+        for key, child in value.items():
+            yield from env_mappings(child, key)
+    elif isinstance(value, list):
+        for child in value:
+            yield from env_mappings(child, name)
+
+
 def json_text(value: Any) -> str:
     return json.dumps(value, ensure_ascii=False, separators=(",", ":"), allow_nan=False)
 
@@ -62,11 +81,12 @@ def json_text(value: Any) -> str:
 def known_secrets(
     episodes: list[Episode], config: EvalConfig, *values: str
 ) -> set[str]:
-    """Every credential this run could have put into a trace: the clients' API keys,
-    the credentials in client headers, harness and task-data environments and the host
-    environment as they are now (`env_credentials`), what each rollout recorded on
-    `Trace.upload_secrets` as they were then, and `values`. Values shorter than
-    `MIN_SECRET_LENGTH` are dropped — redacting them would rewrite ordinary text."""
+    """Every credential this run could have put into a trace: the clients' API keys and
+    the credentials in their base URLs, the credentials in client headers, harness and
+    task-data environments and the host environment as they are now (`env_credentials`),
+    what each rollout recorded on `Trace.upload_secrets` as they were then, and `values`.
+    Values shorter than `MIN_SECRET_LENGTH` are dropped — redacting them would rewrite
+    ordinary text."""
     traces = [trace for episode in episodes for trace in episode.traces]
     agents = [trace.agent.config for trace in traces]
     clients = [config.client, *(a.client for a in agents if a.client is not None)]
@@ -75,15 +95,15 @@ def known_secrets(
         *(client.headers for client in clients),
         *(a.harness.resolved_env for a in agents if a.harness is not None),
         *(
-            value
+            mapping
             for trace in traces
-            for name, value in trace.task.data.model_dump(mode="json").items()
-            if ENV_FIELD.search(name) and isinstance(value, dict)
+            for mapping in env_mappings(trace.task.data.model_dump(mode="json"))
         ),
     ]
     secrets = {
         *values,
         *(resolve_api_key(client) for client in clients),
+        *(c for client in clients for c in url_credentials(client.base_url)),
         *(secret for trace in traces for secret in trace.upload_secrets),
         *(credential for mapping in named for credential in env_credentials(mapping)),
     }

--- a/verifiers/v1/utils/platform.py
+++ b/verifiers/v1/utils/platform.py
@@ -97,19 +97,24 @@ def json_text(value: Any) -> str:
     return json.dumps(value, ensure_ascii=False, separators=(",", ":"), allow_nan=False)
 
 
+def redactable(secrets: Iterator[str] | list[str] | set[str]) -> set[str]:
+    """Drop what cannot be redacted safely: a value shorter than `MIN_SECRET_LENGTH` would
+    rewrite ordinary text, and one inside the `[REDACTED]` marker (`API_TOKEN=REDACTED`)
+    is a sanitized placeholder."""
+    return {s for s in secrets if len(s) >= MIN_SECRET_LENGTH and s not in REDACTED}
+
+
 def known_secrets(
     episodes: list[Episode], config: EvalConfig, *values: str
 ) -> set[str]:
-    """Every credential this run could have put into a trace: the clients' API keys;
+    """Every run-wide credential that could have reached a trace: the clients' API keys;
     the credentials in the host environment and in every environment or header mapping
     of the run's env config, the traced agent configs, and the trace and episode task
     data (`env_credentials`); URL credentials anywhere in those configs and task data (a
-    client `base_url`, a harness endpoint, a task's connection string); what each
-    rollout recorded on
-    `Trace.upload_secrets` as it was then (discarded attempts' on
-    `Episode.upload_secrets`); and `values`. Values shorter than `MIN_SECRET_LENGTH` are
-    dropped — redacting them would rewrite ordinary text — and so are placeholders that
-    sit inside the `[REDACTED]` marker."""
+    client `base_url`, a harness endpoint, a task's connection string); and `values`.
+    What a rollout recorded on `upload_secrets` is added per episode by `build_samples`,
+    so the pattern every string is searched with stays small however many rollouts a run
+    has."""
     traces = [trace for episode in episodes for trace in episode.traces]
     clients = [
         config.client,
@@ -136,16 +141,8 @@ def known_secrets(
             for text in strings(dump)
             for credential in url_credentials(text)
         ),
-        *(secret for trace in traces for secret in trace.upload_secrets),
-        *(secret for episode in episodes for secret in episode.upload_secrets),
     }
-    # A value inside the marker (`API_TOKEN=REDACTED`) is a sanitized placeholder; one
-    # that merely contains or borders the marker is a credential and stays.
-    return {
-        secret
-        for secret in secrets
-        if len(secret) >= MIN_SECRET_LENGTH and secret not in REDACTED
-    }
+    return redactable(secrets)
 
 
 @dataclass
@@ -270,19 +267,31 @@ def run_metrics(episodes: list[Episode], traces: list[Trace]) -> dict[str, Any]:
     }
 
 
-def build_samples(episodes: list[Episode], redactor: Redactor) -> list[str]:
+def build_samples(episodes: list[Episode], secrets: set[str]) -> tuple[list[str], int]:
     """One Platform sample per Episode, serialized and redacted, with a
-    legacy-compatible trace summary.
+    legacy-compatible trace summary; also the number of redactions made.
 
     The Episode projection in `info.native_wrapper` is authoritative and contains
     every trace. One trainable trace (or the first trace) supplies only the flat
     summary used by older consumers. `native_trace_index` identifies that summary trace.
+    Each sample is redacted with the run-wide `secrets` plus what its own rollouts
+    recorded (`upload_secrets`): a rollout's tokens can appear only in its own episode.
     """
     counts: dict[int, int] = {}
     rows = []
+    redacted = 0
     for episode in episodes:
         if not episode.traces:
             continue
+        redactor = Redactor(
+            secrets
+            | redactable(
+                [
+                    *episode.upload_secrets,
+                    *(s for trace in episode.traces for s in trace.upload_secrets),
+                ]
+            )
+        )
         summary_trace_index = next(
             (
                 index
@@ -306,16 +315,17 @@ def build_samples(episodes: list[Episode], redactor: Redactor) -> list[str]:
         row = redactor.json(json_text(sample))
         if _FRAME_BYTES + len(row.encode()) <= _MAX_SAMPLES_PAYLOAD_BYTES:
             rows.append(row)
-            continue
-        logger.warning(
-            "Episode %s exceeds the Platform sample limit; uploading projected traces",
-            episode.id,
-        )
-        rows.extend(
-            redactor.json(json_text(trace_to_sample(candidate, number, episode.id)))
-            for candidate in episode.traces
-        )
-    return rows
+        else:
+            logger.warning(
+                "Episode %s exceeds the Platform sample limit; uploading projected traces",
+                episode.id,
+            )
+            rows.extend(
+                redactor.json(json_text(trace_to_sample(candidate, number, episode.id)))
+                for candidate in episode.traces
+            )
+        redacted += redactor.count
+    return rows, redacted
 
 
 def push_traces(
@@ -361,13 +371,14 @@ def push_traces(
     # The run is done and its results saved; a network blip here must not crash it
     # — log and skip the upload instead.
     try:
-        redactor = Redactor(known_secrets(episodes, config, api_key))
-        rows = build_samples(episodes, redactor)
-        if redactor.count:
+        secrets = known_secrets(episodes, config, api_key)
+        redactor = Redactor(secrets)  # for the request bodies below
+        rows, redacted = build_samples(episodes, secrets)
+        if redacted:
             logger.warning(
                 "--push: redacted %d occurrence(s) of known secrets from the upload; "
                 "saved traces are unchanged",
-                redactor.count,
+                redacted,
             )
         # Batch by exact request size; each body is `{"samples":[<row>,<row>,...]}`.
         batches: list[list[str]] = [[]]

--- a/verifiers/v1/utils/platform.py
+++ b/verifiers/v1/utils/platform.py
@@ -84,7 +84,8 @@ def known_secrets(
     """Every credential this run could have put into a trace: the clients' API keys and
     the credentials in their base URLs, the credentials in client headers, harness and
     task-data environments and the host environment as they are now (`env_credentials`),
-    what each rollout recorded on `Trace.upload_secrets` as they were then, and `values`.
+    what each rollout recorded on `Trace.upload_secrets` as they were then (discarded
+    attempts' on `Episode.upload_secrets`), and `values`.
     Values shorter than `MIN_SECRET_LENGTH` are dropped — redacting them would rewrite
     ordinary text."""
     traces = [trace for episode in episodes for trace in episode.traces]
@@ -105,6 +106,7 @@ def known_secrets(
         *(resolve_api_key(client) for client in clients),
         *(c for client in clients for c in url_credentials(client.base_url)),
         *(secret for trace in traces for secret in trace.upload_secrets),
+        *(secret for episode in episodes for secret in episode.upload_secrets),
         *(credential for mapping in named for credential in env_credentials(mapping)),
     }
     return {secret for secret in secrets if len(secret) >= MIN_SECRET_LENGTH}

--- a/verifiers/v1/utils/platform.py
+++ b/verifiers/v1/utils/platform.py
@@ -30,7 +30,7 @@ from verifiers.v1.configs.client import resolve_api_key
 from verifiers.v1.episode import Episode
 from verifiers.v1.trace import EXCLUDE_FIELDS, Trace
 from verifiers.v1.utils.prime import load_prime_config
-from verifiers.v1.utils.redact import MIN_SECRET_LENGTH, SECRET_NAME, Redactor
+from verifiers.v1.utils.redact import MIN_SECRET_LENGTH, Redactor, env_credentials
 
 logger = logging.getLogger(__name__)
 
@@ -63,8 +63,8 @@ def known_secrets(
     episodes: list[Episode], config: EvalConfig, *values: str
 ) -> set[str]:
     """Every credential this run could have put into a trace: the clients' API keys,
-    credential-named values from client headers, harness and task-data environments and
-    the host environment as they are now, what each rollout recorded on
+    the credentials in client headers, harness and task-data environments and the host
+    environment as they are now (`env_credentials`), what each rollout recorded on
     `Trace.upload_secrets` as they were then, and `values`. Values shorter than
     `MIN_SECRET_LENGTH` are dropped — redacting them would rewrite ordinary text."""
     traces = [trace for episode in episodes for trace in episode.traces]
@@ -85,12 +85,7 @@ def known_secrets(
         *values,
         *(resolve_api_key(client) for client in clients),
         *(secret for trace in traces for secret in trace.upload_secrets),
-        *(
-            value
-            for mapping in named
-            for name, value in mapping.items()
-            if isinstance(value, str) and SECRET_NAME.search(name)
-        ),
+        *(credential for mapping in named for credential in env_credentials(mapping)),
     }
     return {secret for secret in secrets if len(secret) >= MIN_SECRET_LENGTH}
 

--- a/verifiers/v1/utils/platform.py
+++ b/verifiers/v1/utils/platform.py
@@ -33,9 +33,9 @@ from verifiers.v1.trace import EXCLUDE_FIELDS, Trace
 from verifiers.v1.utils.prime import load_prime_config
 from verifiers.v1.utils.redact import (
     MIN_SECRET_LENGTH,
+    REDACTED,
     Redactor,
     env_credentials,
-    overlaps_marker,
     url_credentials,
 )
 
@@ -109,7 +109,7 @@ def known_secrets(
     `Trace.upload_secrets` as it was then (discarded attempts' on
     `Episode.upload_secrets`); and `values`. Values shorter than `MIN_SECRET_LENGTH` are
     dropped — redacting them would rewrite ordinary text — and so are placeholders that
-    overlap the `[REDACTED]` marker."""
+    sit inside the `[REDACTED]` marker."""
     traces = [trace for episode in episodes for trace in episode.traces]
     clients = [
         config.client,
@@ -139,11 +139,12 @@ def known_secrets(
         *(secret for trace in traces for secret in trace.upload_secrets),
         *(secret for episode in episodes for secret in episode.upload_secrets),
     }
-    # A value overlapping the marker (`API_TOKEN=REDACTED`) is a sanitized placeholder.
+    # A value inside the marker (`API_TOKEN=REDACTED`) is a sanitized placeholder; one
+    # that merely contains or borders the marker is a credential and stays.
     return {
         secret
         for secret in secrets
-        if len(secret) >= MIN_SECRET_LENGTH and not overlaps_marker(secret)
+        if len(secret) >= MIN_SECRET_LENGTH and secret not in REDACTED
     }
 
 

--- a/verifiers/v1/utils/redact.py
+++ b/verifiers/v1/utils/redact.py
@@ -21,29 +21,34 @@ SECRET_NAME = re.compile(
 JSON_STRING = re.compile(r'"(?:[^"\\]|\\.)*"')
 
 
+def url_credentials(value: str) -> Iterator[str]:
+    """The password — or the bare user token — inside a `scheme://user:password@host`
+    value, as written and percent-decoded the way a client uses it. A username next to a
+    password is a name, not a secret (`postgres`, the egress proxy's `verifiers`), so a
+    token placed there beside a dummy password (GitHub's legacy `token:x-oauth-basic`)
+    is not recognised."""
+    try:
+        parts = urlsplit(value)
+    except ValueError:
+        return
+    if "@" not in parts.netloc:
+        return
+    # With a password slot, even an empty one, the username is a name, not a token.
+    userinfo = parts.username if parts.password is None else parts.password
+    if userinfo:
+        yield from {userinfo, unquote(userinfo)}
+
+
 def env_credentials(mapping: Mapping[str, object]) -> Iterator[str]:
     """The credentials in an environment-like mapping (variables, headers): every value
-    under a credential-like name, and the password — or the bare user token — inside a
-    `scheme://user:password@host` value whatever its name (`DATABASE_URL`, `HTTP_PROXY`),
-    as written and percent-decoded the way a client uses it. A username next to a
-    password is a name, not a secret (`postgres`, the egress proxy's
-    `verifiers`), so a token placed there beside a dummy password (GitHub's legacy
-    `token:x-oauth-basic`) is not recognised."""
+    under a credential-like name, and the URL credentials in any value whatever its name
+    (`DATABASE_URL`, `HTTP_PROXY`)."""
     for name, value in mapping.items():
         if not isinstance(value, str):
             continue
         if SECRET_NAME.search(name):
             yield value
-        try:
-            parts = urlsplit(value)
-        except ValueError:
-            continue
-        if "@" not in parts.netloc:
-            continue
-        # With a password slot, even an empty one, the username is a name, not a token.
-        userinfo = parts.username if parts.password is None else parts.password
-        if userinfo:
-            yield from {userinfo, unquote(userinfo)}
+        yield from url_credentials(value)
 
 
 class Redactor:

--- a/verifiers/v1/utils/redact.py
+++ b/verifiers/v1/utils/redact.py
@@ -53,14 +53,25 @@ def url_credentials(value: str) -> Iterator[str]:
 
 def env_credentials(mapping: Mapping[str, object]) -> Iterator[str]:
     """The credentials in an environment-like mapping (variables, headers): every value
-    under a credential-like name, and the URL credentials in any value whatever its name
-    (`DATABASE_URL`, `HTTP_PROXY`)."""
+    under a credential-like name, the URL credentials in any value whatever its name
+    (`DATABASE_URL`, `HTTP_PROXY`), and the same again inside a value that is a JSON
+    object (`DOCKER_AUTH_CONFIG`, a service-account blob), which is a mapping too."""
     for name, value in mapping.items():
+        if isinstance(value, Mapping):
+            yield from env_credentials(value)
+            continue
         if not isinstance(value, str):
             continue
         if SECRET_NAME.search(name):
             yield value
         yield from url_credentials(value)
+        if value.startswith("{"):
+            try:
+                nested = json.loads(value)
+            except ValueError:
+                continue
+            if isinstance(nested, Mapping):
+                yield from env_credentials(nested)
 
 
 class Redactor:

--- a/verifiers/v1/utils/redact.py
+++ b/verifiers/v1/utils/redact.py
@@ -15,16 +15,20 @@ from urllib.parse import unquote, unquote_plus, urlsplit
 REDACTED = "[REDACTED]"
 MIN_SECRET_LENGTH = 8
 SECRET_NAME = re.compile(
-    r"(?:(?<![A-Za-z0-9])(?:API_?KEYS?|KEYS?|CREDENTIALS?|COOKIES?|AUTHORIZATION|SIGNATURES?|SIG|PATS?)"
+    r"(?:(?<![A-Za-z0-9])"
+    r"(?:API_?KEYS?|KEYS?|CREDENTIALS?|COOKIES?|AUTHORIZATION|AUTH|SIGNATURES?|SIG|PATS?)"
     r"|TOKENS?|SECRETS?|PASSW(?:OR)?DS?)"
-    r"(?![A-Za-z0-9])"
-    r"|(?<![A-Za-z0-9])AUTH$",
+    r"(?:[_-][0-9]+)?$",
     re.IGNORECASE,
 )
-"""Variable and header names whose values are credentials: a credential word as a whole
-segment (`HF_TOKEN`, `X-Api-Key`, a signed URL's `sig`/`X-Amz-Signature`, `GITHUB_PAT`), so `KEYCLOAK_REALM`, `OAUTH_CLIENT_ID`, or
-`TOKENIZERS_PARALLELISM` is not one. AUTH counts only as the last segment (`BASIC_AUTH`, `X-Auth`): elsewhere it says what a variable is about, not what it holds (`AUTH_TYPE`, `SSH_AUTH_SOCK`). No other word ends in TOKEN, SECRET, or PASSWORD,
-so those may also end a segment (`PGPASSWORD`, `ACCESSTOKEN`)."""
+"""Variable and header names whose values are credentials: the name's last word is a
+credential word (`HF_TOKEN`, `X-Api-Key`, `PGPASSWORD`), optionally numbered
+(`API_KEY_2`). Compound names are head-final, so `TOKEN_URL`, `COOKIE_DOMAIN`,
+`KEY_FILE`, `AUTHORIZATION_URL`, and `SSH_AUTH_SOCK` name metadata about a credential
+rather than one, and `KEYCLOAK_REALM` or `TOKENIZERS_PARALLELISM` never named one. A
+name whose head word is not a credential word (`SECRET_KEY_BASE`) is missed on
+purpose. No other word ends in TOKEN, SECRET, or PASSWORD, so those may also end a
+segment (`PGPASSWORD`, `ACCESSTOKEN`)."""
 JSON_STRING = re.compile(r'"(?:[^"\\]|\\.)*"')
 
 

--- a/verifiers/v1/utils/redact.py
+++ b/verifiers/v1/utils/redact.py
@@ -51,12 +51,17 @@ def url_credentials(value: str) -> Iterator[str]:
 
 
 def overlaps_marker(secret: str) -> bool:
-    """Whether replacing with the marker could leave or form `secret`: it sits inside
-    `[REDACTED]`, or begins with the marker's tail (`]bar`) or ends with its head
-    (`foo[`). Such a value is a placeholder or a pathological input, never a credential."""
-    return secret in REDACTED or any(
-        secret.startswith(REDACTED[-n:]) or secret.endswith(REDACTED[:n])
-        for n in range(1, len(REDACTED) + 1)
+    """Whether replacing with the marker could leave or form `secret`: one sits inside the
+    other (`REDACTED`, `foo[REDACTED]bar`), or `secret` begins with the marker's tail
+    (`]bar`) or ends with its head (`foo[`). Such a value is a placeholder or a
+    pathological input, never a credential."""
+    return (
+        secret in REDACTED
+        or REDACTED in secret
+        or any(
+            secret.startswith(REDACTED[-n:]) or secret.endswith(REDACTED[:n])
+            for n in range(1, len(REDACTED) + 1)
+        )
     )
 
 

--- a/verifiers/v1/utils/redact.py
+++ b/verifiers/v1/utils/redact.py
@@ -14,14 +14,15 @@ from urllib.parse import unquote, urlsplit
 REDACTED = "[REDACTED]"
 MIN_SECRET_LENGTH = 8
 SECRET_NAME = re.compile(
-    r"(?<![A-Za-z0-9])"
-    r"(?:API_?KEYS?|KEYS?|TOKENS?|SECRETS?|PASSW(?:OR)?DS?|CREDENTIALS?|COOKIES?|AUTHORIZATION|AUTH)"
+    r"(?:(?<![A-Za-z0-9])(?:API_?KEYS?|KEYS?|CREDENTIALS?|COOKIES?|AUTHORIZATION|AUTH)"
+    r"|TOKENS?|SECRETS?|PASSW(?:OR)?DS?)"
     r"(?![A-Za-z0-9])",
     re.IGNORECASE,
 )
 """Variable and header names whose values are credentials: a credential word as a whole
-segment (`HF_TOKEN`, `X-Api-Key`), so `KEYCLOAK_REALM` or `TOKENIZERS_PARALLELISM` is
-not one."""
+segment (`HF_TOKEN`, `X-Api-Key`), so `KEYCLOAK_REALM`, `OAUTH_CLIENT_ID`, or
+`TOKENIZERS_PARALLELISM` is not one. No other word ends in TOKEN, SECRET, or PASSWORD,
+so those may also end a segment (`PGPASSWORD`, `ACCESSTOKEN`)."""
 JSON_STRING = re.compile(r'"(?:[^"\\]|\\.)*"')
 
 

--- a/verifiers/v1/utils/redact.py
+++ b/verifiers/v1/utils/redact.py
@@ -1,0 +1,54 @@
+"""Keep known secret values out of uploads.
+
+Redaction is exact-match only: a known value is replaced with `[REDACTED]` wherever it
+appears inside a JSON string, and nothing is guessed from the shape of the text, so
+ordinary content is never rewritten. The prime CLI carries the same redactor
+(`prime_cli/utils/redact.py`) and owns user-supplied `--secret` values.
+"""
+
+import json
+import re
+
+REDACTED = "[REDACTED]"
+MIN_SECRET_LENGTH = 8
+SECRET_NAME = re.compile(
+    r"KEY|TOKEN|SECRET|PASSW|CREDENTIAL|COOKIE|AUTHORIZATION|(?:^|[_-])AUTH(?:[_-]|$)",
+    re.IGNORECASE,
+)
+"""Variable and header names whose values are credentials."""
+JSON_STRING = re.compile(r'"((?:[^"\\]|\\.)*)"')
+
+
+class Redactor:
+    """Replaces every occurrence of the secrets inside JSON strings, counting hits."""
+
+    def __init__(self, secrets: set[str]) -> None:
+        # Inside a JSON string a secret is escaped; inside a JSON document quoted within
+        # a string (a tool result) it is escaped twice. Encoders other than Python's
+        # also escape `/`. Match every spelling.
+        forms = set(secrets)
+        forms |= {form.replace("/", r"\/") for form in forms}
+        for _ in range(2):
+            forms |= {
+                json.dumps(form, ensure_ascii=escape)[1:-1]
+                for form in list(forms)
+                for escape in (True, False)
+            }
+        alternatives = "|".join(
+            re.escape(form) for form in sorted(forms, key=len, reverse=True)
+        )
+        self.pattern = re.compile(alternatives) if forms else None
+        self.count = 0
+
+    def json(self, text: str) -> str:
+        """Redact one JSON document given as text; structure and non-string values stay."""
+        pattern = self.pattern
+        if pattern is None:
+            return text
+
+        def string(match: re.Match[str]) -> str:
+            inner, hits = pattern.subn(REDACTED, match.group(1))
+            self.count += hits
+            return f'"{inner}"'
+
+        return JSON_STRING.sub(string, text)

--- a/verifiers/v1/utils/redact.py
+++ b/verifiers/v1/utils/redact.py
@@ -8,6 +8,8 @@ ordinary content is never rewritten. The prime CLI carries the same redactor
 
 import json
 import re
+from collections.abc import Iterator, Mapping
+from urllib.parse import urlsplit
 
 REDACTED = "[REDACTED]"
 MIN_SECRET_LENGTH = 8
@@ -17,6 +19,23 @@ SECRET_NAME = re.compile(
 )
 """Variable and header names whose values are credentials."""
 JSON_STRING = re.compile(r'"(?:[^"\\]|\\.)*"')
+
+
+def env_credentials(mapping: Mapping[str, object]) -> Iterator[str]:
+    """The credentials in an environment-like mapping (variables, headers): every value
+    under a credential-like name, and the password — or the bare user token — inside a
+    `scheme://user:password@host` value whatever its name (`DATABASE_URL`, `HTTP_PROXY`)."""
+    for name, value in mapping.items():
+        if not isinstance(value, str):
+            continue
+        if SECRET_NAME.search(name):
+            yield value
+        try:
+            parts = urlsplit(value)
+        except ValueError:
+            continue
+        if "@" in parts.netloc and (userinfo := parts.password or parts.username):
+            yield userinfo
 
 
 class Redactor:

--- a/verifiers/v1/utils/redact.py
+++ b/verifiers/v1/utils/redact.py
@@ -24,7 +24,10 @@ JSON_STRING = re.compile(r'"(?:[^"\\]|\\.)*"')
 def env_credentials(mapping: Mapping[str, object]) -> Iterator[str]:
     """The credentials in an environment-like mapping (variables, headers): every value
     under a credential-like name, and the password — or the bare user token — inside a
-    `scheme://user:password@host` value whatever its name (`DATABASE_URL`, `HTTP_PROXY`)."""
+    `scheme://user:password@host` value whatever its name (`DATABASE_URL`, `HTTP_PROXY`).
+    A username next to a password is a name, not a secret (`postgres`, the egress proxy's
+    `verifiers`), so a token placed there beside a dummy password (GitHub's legacy
+    `token:x-oauth-basic`) is not recognised."""
     for name, value in mapping.items():
         if not isinstance(value, str):
             continue

--- a/verifiers/v1/utils/redact.py
+++ b/verifiers/v1/utils/redact.py
@@ -9,7 +9,7 @@ ordinary content is never rewritten. The prime CLI carries the same redactor
 import json
 import re
 from collections.abc import Iterator, Mapping
-from urllib.parse import urlsplit
+from urllib.parse import unquote, urlsplit
 
 REDACTED = "[REDACTED]"
 MIN_SECRET_LENGTH = 8
@@ -24,8 +24,9 @@ JSON_STRING = re.compile(r'"(?:[^"\\]|\\.)*"')
 def env_credentials(mapping: Mapping[str, object]) -> Iterator[str]:
     """The credentials in an environment-like mapping (variables, headers): every value
     under a credential-like name, and the password — or the bare user token — inside a
-    `scheme://user:password@host` value whatever its name (`DATABASE_URL`, `HTTP_PROXY`).
-    A username next to a password is a name, not a secret (`postgres`, the egress proxy's
+    `scheme://user:password@host` value whatever its name (`DATABASE_URL`, `HTTP_PROXY`),
+    as written and percent-decoded the way a client uses it. A username next to a
+    password is a name, not a secret (`postgres`, the egress proxy's
     `verifiers`), so a token placed there beside a dummy password (GitHub's legacy
     `token:x-oauth-basic`) is not recognised."""
     for name, value in mapping.items():
@@ -38,7 +39,7 @@ def env_credentials(mapping: Mapping[str, object]) -> Iterator[str]:
         except ValueError:
             continue
         if "@" in parts.netloc and (userinfo := parts.password or parts.username):
-            yield userinfo
+            yield from {userinfo, unquote(userinfo)}
 
 
 class Redactor:

--- a/verifiers/v1/utils/redact.py
+++ b/verifiers/v1/utils/redact.py
@@ -16,16 +16,16 @@ SECRET_NAME = re.compile(
     re.IGNORECASE,
 )
 """Variable and header names whose values are credentials."""
-JSON_STRING = re.compile(r'"((?:[^"\\]|\\.)*)"')
+JSON_STRING = re.compile(r'"(?:[^"\\]|\\.)*"')
 
 
 class Redactor:
     """Replaces every occurrence of the secrets inside JSON strings, counting hits."""
 
     def __init__(self, secrets: set[str]) -> None:
-        # Inside a JSON string a secret is escaped; inside a JSON document quoted within
-        # a string (a tool result) it is escaped twice. Encoders other than Python's
-        # also escape `/`. Match every spelling.
+        # The string itself is decoded before matching. A JSON document quoted inside it
+        # (a tool result) is escaped once per nesting level, by an encoder that may also
+        # escape `/`: match those spellings too.
         forms = set(secrets)
         forms |= {form.replace("/", r"\/") for form in forms}
         for _ in range(2):
@@ -41,14 +41,18 @@ class Redactor:
         self.count = 0
 
     def json(self, text: str) -> str:
-        """Redact one JSON document given as text; structure and non-string values stay."""
+        """Redact one JSON document given as text; structure and non-string values stay,
+        and so do the bytes of every string without a hit."""
         pattern = self.pattern
         if pattern is None:
             return text
 
         def string(match: re.Match[str]) -> str:
-            inner, hits = pattern.subn(REDACTED, match.group(1))
+            token = match.group(0)
+            redacted, hits = pattern.subn(REDACTED, json.loads(token))
+            if not hits:
+                return token
             self.count += hits
-            return f'"{inner}"'
+            return json.dumps(redacted, ensure_ascii=token.isascii())
 
         return JSON_STRING.sub(string, text)

--- a/verifiers/v1/utils/redact.py
+++ b/verifiers/v1/utils/redact.py
@@ -14,13 +14,13 @@ from urllib.parse import unquote, unquote_plus, urlsplit
 REDACTED = "[REDACTED]"
 MIN_SECRET_LENGTH = 8
 SECRET_NAME = re.compile(
-    r"(?:(?<![A-Za-z0-9])(?:API_?KEYS?|KEYS?|CREDENTIALS?|COOKIES?|AUTHORIZATION|AUTH)"
+    r"(?:(?<![A-Za-z0-9])(?:API_?KEYS?|KEYS?|CREDENTIALS?|COOKIES?|AUTHORIZATION|AUTH|SIGNATURES?|SIG)"
     r"|TOKENS?|SECRETS?|PASSW(?:OR)?DS?)"
     r"(?![A-Za-z0-9])",
     re.IGNORECASE,
 )
 """Variable and header names whose values are credentials: a credential word as a whole
-segment (`HF_TOKEN`, `X-Api-Key`), so `KEYCLOAK_REALM`, `OAUTH_CLIENT_ID`, or
+segment (`HF_TOKEN`, `X-Api-Key`, a signed URL's `sig`/`X-Amz-Signature`), so `KEYCLOAK_REALM`, `OAUTH_CLIENT_ID`, or
 `TOKENIZERS_PARALLELISM` is not one. No other word ends in TOKEN, SECRET, or PASSWORD,
 so those may also end a segment (`PGPASSWORD`, `ACCESSTOKEN`)."""
 JSON_STRING = re.compile(r'"(?:[^"\\]|\\.)*"')

--- a/verifiers/v1/utils/redact.py
+++ b/verifiers/v1/utils/redact.py
@@ -38,7 +38,11 @@ def env_credentials(mapping: Mapping[str, object]) -> Iterator[str]:
             parts = urlsplit(value)
         except ValueError:
             continue
-        if "@" in parts.netloc and (userinfo := parts.password or parts.username):
+        if "@" not in parts.netloc:
+            continue
+        # With a password slot, even an empty one, the username is a name, not a token.
+        userinfo = parts.username if parts.password is None else parts.password
+        if userinfo:
             yield from {userinfo, unquote(userinfo)}
 
 

--- a/verifiers/v1/utils/redact.py
+++ b/verifiers/v1/utils/redact.py
@@ -9,7 +9,7 @@ ordinary content is never rewritten. The prime CLI carries the same redactor
 import json
 import re
 from collections.abc import Iterator, Mapping
-from urllib.parse import unquote, urlsplit
+from urllib.parse import unquote, unquote_plus, urlsplit
 
 REDACTED = "[REDACTED]"
 MIN_SECRET_LENGTH = 8
@@ -47,7 +47,17 @@ def url_credentials(value: str) -> Iterator[str]:
     for pair in parts.query.split("&"):
         name, _, raw = pair.partition("=")
         if raw and SECRET_NAME.search(unquote(name)):
-            yield from {raw, unquote(raw)}
+            yield from {raw, unquote(raw), unquote_plus(raw)}
+
+
+def overlaps_marker(secret: str) -> bool:
+    """Whether replacing with the marker could leave or form `secret`: it sits inside
+    `[REDACTED]`, or begins with the marker's tail (`]bar`) or ends with its head
+    (`foo[`). Such a value is a placeholder or a pathological input, never a credential."""
+    return secret in REDACTED or any(
+        secret.startswith(REDACTED[-n:]) or secret.endswith(REDACTED[:n])
+        for n in range(1, len(REDACTED) + 1)
+    )
 
 
 def env_credentials(mapping: Mapping[str, object]) -> Iterator[str]:

--- a/verifiers/v1/utils/redact.py
+++ b/verifiers/v1/utils/redact.py
@@ -50,21 +50,6 @@ def url_credentials(value: str) -> Iterator[str]:
             yield from {raw, unquote(raw), unquote_plus(raw)}
 
 
-def overlaps_marker(secret: str) -> bool:
-    """Whether replacing with the marker could leave or form `secret`: one sits inside the
-    other (`REDACTED`, `foo[REDACTED]bar`), or `secret` begins with the marker's tail
-    (`]bar`) or ends with its head (`foo[`). Such a value is a placeholder or a
-    pathological input, never a credential."""
-    return (
-        secret in REDACTED
-        or REDACTED in secret
-        or any(
-            secret.startswith(REDACTED[-n:]) or secret.endswith(REDACTED[:n])
-            for n in range(1, len(REDACTED) + 1)
-        )
-    )
-
-
 def env_credentials(mapping: Mapping[str, object]) -> Iterator[str]:
     """The credentials in an environment-like mapping (variables, headers): every value
     under a credential-like name, and the URL credentials in any value whatever its name

--- a/verifiers/v1/utils/redact.py
+++ b/verifiers/v1/utils/redact.py
@@ -46,7 +46,7 @@ def url_credentials(value: str) -> Iterator[str]:
             yield from {userinfo, unquote(userinfo)}
     for pair in parts.query.split("&"):
         name, _, raw = pair.partition("=")
-        if raw and SECRET_NAME.search(name):
+        if raw and SECRET_NAME.search(unquote(name)):
             yield from {raw, unquote(raw)}
 
 

--- a/verifiers/v1/utils/redact.py
+++ b/verifiers/v1/utils/redact.py
@@ -14,14 +14,15 @@ from urllib.parse import unquote, unquote_plus, urlsplit
 REDACTED = "[REDACTED]"
 MIN_SECRET_LENGTH = 8
 SECRET_NAME = re.compile(
-    r"(?:(?<![A-Za-z0-9])(?:API_?KEYS?|KEYS?|CREDENTIALS?|COOKIES?|AUTHORIZATION|AUTH|SIGNATURES?|SIG|PATS?)"
+    r"(?:(?<![A-Za-z0-9])(?:API_?KEYS?|KEYS?|CREDENTIALS?|COOKIES?|AUTHORIZATION|SIGNATURES?|SIG|PATS?)"
     r"|TOKENS?|SECRETS?|PASSW(?:OR)?DS?)"
-    r"(?![A-Za-z0-9])",
+    r"(?![A-Za-z0-9])"
+    r"|(?<![A-Za-z0-9])AUTH$",
     re.IGNORECASE,
 )
 """Variable and header names whose values are credentials: a credential word as a whole
 segment (`HF_TOKEN`, `X-Api-Key`, a signed URL's `sig`/`X-Amz-Signature`, `GITHUB_PAT`), so `KEYCLOAK_REALM`, `OAUTH_CLIENT_ID`, or
-`TOKENIZERS_PARALLELISM` is not one. No other word ends in TOKEN, SECRET, or PASSWORD,
+`TOKENIZERS_PARALLELISM` is not one. AUTH counts only as the last segment (`BASIC_AUTH`, `X-Auth`): elsewhere it says what a variable is about, not what it holds (`AUTH_TYPE`, `SSH_AUTH_SOCK`). No other word ends in TOKEN, SECRET, or PASSWORD,
 so those may also end a segment (`PGPASSWORD`, `ACCESSTOKEN`)."""
 JSON_STRING = re.compile(r'"(?:[^"\\]|\\.)*"')
 

--- a/verifiers/v1/utils/redact.py
+++ b/verifiers/v1/utils/redact.py
@@ -14,10 +14,14 @@ from urllib.parse import unquote, urlsplit
 REDACTED = "[REDACTED]"
 MIN_SECRET_LENGTH = 8
 SECRET_NAME = re.compile(
-    r"KEY|TOKEN|SECRET|PASSW|CREDENTIAL|COOKIE|AUTHORIZATION|(?:^|[_-])AUTH(?:[_-]|$)",
+    r"(?<![A-Za-z0-9])"
+    r"(?:API_?KEYS?|KEYS?|TOKENS?|SECRETS?|PASSW(?:OR)?DS?|CREDENTIALS?|COOKIES?|AUTHORIZATION|AUTH)"
+    r"(?![A-Za-z0-9])",
     re.IGNORECASE,
 )
-"""Variable and header names whose values are credentials."""
+"""Variable and header names whose values are credentials: a credential word as a whole
+segment (`HF_TOKEN`, `X-Api-Key`), so `KEYCLOAK_REALM` or `TOKENIZERS_PARALLELISM` is
+not one."""
 JSON_STRING = re.compile(r'"(?:[^"\\]|\\.)*"')
 
 

--- a/verifiers/v1/utils/redact.py
+++ b/verifiers/v1/utils/redact.py
@@ -70,7 +70,7 @@ def env_credentials(mapping: Mapping[Any, Any]) -> Iterator[str]:
         if SECRET_NAME.search(name):
             yield value
         yield from url_credentials(value)
-        if value.startswith("{"):
+        if value.lstrip().startswith("{"):
             try:
                 nested = json.loads(value)
             except ValueError:

--- a/verifiers/v1/utils/redact.py
+++ b/verifiers/v1/utils/redact.py
@@ -14,13 +14,13 @@ from urllib.parse import unquote, unquote_plus, urlsplit
 REDACTED = "[REDACTED]"
 MIN_SECRET_LENGTH = 8
 SECRET_NAME = re.compile(
-    r"(?:(?<![A-Za-z0-9])(?:API_?KEYS?|KEYS?|CREDENTIALS?|COOKIES?|AUTHORIZATION|AUTH|SIGNATURES?|SIG)"
+    r"(?:(?<![A-Za-z0-9])(?:API_?KEYS?|KEYS?|CREDENTIALS?|COOKIES?|AUTHORIZATION|AUTH|SIGNATURES?|SIG|PATS?)"
     r"|TOKENS?|SECRETS?|PASSW(?:OR)?DS?)"
     r"(?![A-Za-z0-9])",
     re.IGNORECASE,
 )
 """Variable and header names whose values are credentials: a credential word as a whole
-segment (`HF_TOKEN`, `X-Api-Key`, a signed URL's `sig`/`X-Amz-Signature`), so `KEYCLOAK_REALM`, `OAUTH_CLIENT_ID`, or
+segment (`HF_TOKEN`, `X-Api-Key`, a signed URL's `sig`/`X-Amz-Signature`, `GITHUB_PAT`), so `KEYCLOAK_REALM`, `OAUTH_CLIENT_ID`, or
 `TOKENIZERS_PARALLELISM` is not one. No other word ends in TOKEN, SECRET, or PASSWORD,
 so those may also end a segment (`PGPASSWORD`, `ACCESSTOKEN`)."""
 JSON_STRING = re.compile(r'"(?:[^"\\]|\\.)*"')

--- a/verifiers/v1/utils/redact.py
+++ b/verifiers/v1/utils/redact.py
@@ -27,21 +27,27 @@ JSON_STRING = re.compile(r'"(?:[^"\\]|\\.)*"')
 
 
 def url_credentials(value: str) -> Iterator[str]:
-    """The password — or the bare user token — inside a `scheme://user:password@host`
-    value, as written and percent-decoded the way a client uses it. A username next to a
-    password is a name, not a secret (`postgres`, the egress proxy's `verifiers`), so a
-    token placed there beside a dummy password (GitHub's legacy `token:x-oauth-basic`)
-    is not recognised."""
+    """The credentials inside a URL, as written and percent-decoded the way a client uses
+    them: the password — or the bare user token — of `scheme://user:password@host`, and
+    credential-named query values (`?token=…`). A username next to a password is a name,
+    not a secret (`postgres`), so a token placed there beside a dummy password (GitHub's
+    legacy `token:x-oauth-basic`) is not recognised. Prose is never a URL here: the
+    value must start with `scheme://host`."""
     try:
         parts = urlsplit(value)
     except ValueError:
         return
-    if "@" not in parts.netloc:
+    if not (parts.scheme and parts.netloc):
         return
-    # With a password slot, even an empty one, the username is a name, not a token.
-    userinfo = parts.username if parts.password is None else parts.password
-    if userinfo:
-        yield from {userinfo, unquote(userinfo)}
+    if "@" in parts.netloc:
+        # With a password slot, even an empty one, the username is a name, not a token.
+        userinfo = parts.username if parts.password is None else parts.password
+        if userinfo:
+            yield from {userinfo, unquote(userinfo)}
+    for pair in parts.query.split("&"):
+        name, _, raw = pair.partition("=")
+        if raw and SECRET_NAME.search(name):
+            yield from {raw, unquote(raw)}
 
 
 def env_credentials(mapping: Mapping[str, object]) -> Iterator[str]:

--- a/verifiers/v1/utils/redact.py
+++ b/verifiers/v1/utils/redact.py
@@ -9,6 +9,7 @@ ordinary content is never rewritten. The prime CLI carries the same redactor
 import json
 import re
 from collections.abc import Iterator, Mapping
+from typing import Any
 from urllib.parse import unquote, unquote_plus, urlsplit
 
 REDACTED = "[REDACTED]"
@@ -51,7 +52,7 @@ def url_credentials(value: str) -> Iterator[str]:
             yield from {raw, unquote(raw), unquote_plus(raw)}
 
 
-def env_credentials(mapping: Mapping[str, object]) -> Iterator[str]:
+def env_credentials(mapping: Mapping[Any, Any]) -> Iterator[str]:
     """The credentials in an environment-like mapping (variables, headers): every value
     under a credential-like name, the URL credentials in any value whatever its name
     (`DATABASE_URL`, `HTTP_PROXY`), and the same again inside a value that is a JSON

--- a/verifiers/v1/utils/redact.py
+++ b/verifiers/v1/utils/redact.py
@@ -23,34 +23,29 @@ class Redactor:
     """Replaces every occurrence of the secrets inside JSON strings, counting hits."""
 
     def __init__(self, secrets: set[str]) -> None:
-        # The string itself is decoded before matching. A JSON document quoted inside it
-        # (a tool result) is escaped once per nesting level, by an encoder that may also
-        # escape `/`: match those spellings too.
-        forms = set(secrets)
-        forms |= {form.replace("/", r"\/") for form in forms}
-        for _ in range(2):
-            forms |= {
-                json.dumps(form, ensure_ascii=escape)[1:-1]
-                for form in list(forms)
-                for escape in (True, False)
-            }
         alternatives = "|".join(
-            re.escape(form) for form in sorted(forms, key=len, reverse=True)
+            re.escape(secret) for secret in sorted(secrets, key=len, reverse=True)
         )
-        self.pattern = re.compile(alternatives) if forms else None
+        self.pattern = re.compile(alternatives) if secrets else None
         self.count = 0
 
     def json(self, text: str) -> str:
         """Redact one JSON document given as text; structure and non-string values stay,
-        and so do the bytes of every string without a hit."""
+        and so do the bytes of every string without a hit. Each string is decoded before
+        matching and searched again for quoted JSON inside it (a tool result), so every
+        escape spelling at every nesting depth is matched."""
         pattern = self.pattern
         if pattern is None:
             return text
 
         def string(match: re.Match[str]) -> str:
             token = match.group(0)
-            redacted, hits = pattern.subn(REDACTED, json.loads(token))
-            if not hits:
+            try:
+                value = json.loads(token)
+            except ValueError:  # quotes in prose, not a JSON string
+                return token
+            redacted, hits = pattern.subn(REDACTED, self.json(value))
+            if redacted == value:
                 return token
             self.count += hits
             return json.dumps(redacted, ensure_ascii=token.isascii())

--- a/verifiers/v1/utils/retries.py
+++ b/verifiers/v1/utils/retries.py
@@ -113,6 +113,7 @@ async def run_episode_with_retry(
     attempts' errors are prepended so the episode shows the full history; a final
     good attempt returns clean."""
     history: list = []
+    history_secrets: list[str] = []
     for attempt in range(retry.max_retries + 1):
         final = await run()
         if attempt == retry.max_retries or not episode_should_retry(final, retry):
@@ -121,8 +122,10 @@ async def run_episode_with_retry(
             (t.last_error for t in final.traces if t.last_error), None
         )
         history.extend(final.errors)
+        history_secrets.extend(final.upload_secrets)
         for trace in final.traces:
             history.extend(trace.errors)
+            history_secrets.extend(trace.upload_secrets)
         delay = backoff(attempt)
         logger.warning(
             "retrying episode %s (retry %d/%d) in %.1fs after error: %s",
@@ -136,6 +139,8 @@ async def run_episode_with_retry(
     if history:
         # The full history rides the final episode either way; success is the
         # `ok` stamp, never errors-emptiness. In place: the envelope, the stamp,
-        # and every consumer share this one list.
+        # and every consumer share this one list. Each attempt's secrets ride with
+        # the errors they may appear in.
         final.errors[:0] = history
+        final.upload_secrets[:0] = history_secrets
     return final


### PR DESCRIPTION
## Overview

Replaces #2475 with a from-scratch, minimal implementation of the same goal: credentials never reach the Platform. No `prime-evals` dependency, no release ordering, no sidecar files.

## What `--push` does now

**Structural.** The uploaded episode projection (`UPLOAD_EXCLUDE`) is the disk record minus the two config fields that hold credentials: `client.headers` and `harness.env`. `harness.forward_env` only names variables and stays.

**By value.** Every credential the run knows is replaced with `[REDACTED]` in every outbound request body:
- the run's and each agent's resolved client API key
- the credentials in the host environment and in every environment or header mapping (`env`, `*_env`, `headers`) anywhere in the run's env config, the traced agent configs, and the task data (a client's headers, a harness `env`, a task config's `headers`, Harbor's `verifier_env` and nested `verifier.env`) — values under credential-like names (`KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|COOKIE|AUTHORIZATION|AUTH|SIGNATURE|SIG|PAT` as the name's last word, optionally numbered — compound names are head-final, so `HF_TOKEN`, `X-Api-Key`, `PGPASSWORD`, `API_KEY_2` are credentials while `TOKEN_URL`, `COOKIE_DOMAIN`, `KEY_FILE`, `SSH_AUTH_SOCK`, `KEYCLOAK_REALM` are not); plus URL credentials anywhere in the traced agent configs and task data (a client `base_url`, a harness `cdp_url`, a task's connection string), plus, for any value that is a URL (`scheme://host…`, never prose), the password (or bare user token) of its userinfo and its credential-named query values (`DATABASE_URL`, an authenticated `HTTP_PROXY`, `wss://…?token=…`); a value that is a JSON object is a mapping too and gets the same rules inside it (`DOCKER_AUTH_CONFIG`, a service-account blob); 8+ chars
- everything a rollout records on the new `Trace.upload_secrets` (rides the eval wire, excluded from disk and stdout like the raw tensors): its interception tokens, the shared-tool URL signatures and any external tool URL's credentials (tool endpoints are not traced), credentials the runtime minted (`Runtime.secrets`, e.g. the Docker egress proxy token), and the client key plus credential-named header, harness, and task runtime variables as they were while the harness ran, so a key rotated before `--push` is still redacted. A retried attempt's secrets ride with the errors it leaves behind (`Agent.run`, `run_episode_with_retry` via `Episode.upload_secrets`)

Redaction is exact-match only, over the serialized JSON text: each JSON string is decoded and then searched again for quoted JSON inside it, recursively, so any escape spelling at any nesting depth is matched. Only JSON strings are touched, so numbers and structure cannot be corrupted, and a string without a hit keeps its exact bytes. Nothing is guessed from the shape of the text, so ordinary content is never rewritten.

Each sample is redacted with the small run-wide set plus its own rollout's `upload_secrets`, so the pattern every string is searched with does not grow with the number of rollouts. Saved traces are unchanged, so the run stays reproducible from its output dir. The log reports how many occurrences were redacted.

## Deliberately not carried over from #2475

- **Shape-based credential detection.** Every review round on #2475 / prime#882 added another pattern (cookie pairs, Digest auth, `apiKeys`, escaped quotes, …) and another false-positive guard (`token_usage`, `oauth`, schema context). That is a scanner's job; we redact what we *know*. [pi-share-hf](https://github.com/badlogic/pi-share-hf) takes the same position and leaves generic detection to trufflehog.
- **The fingerprint sidecar for resume.** A resumed `--push` redacts everything except the values only the earlier attempt's rollouts knew: its interception and runtime tokens (dead with that run) and credentials rotated since; the module docstring says so.
- `resolve_headers` / team-id relocation, the `prime-evals` client, `run_shielded` call-site moves: unrelated to keeping secrets out.

## Split with the prime CLI

Verifiers redacts what only it knows (its config, its tokens). User-supplied values live in the prime CLI: the companion PR PrimeIntellect-ai/prime#888 adds `--secret` to `prime traces upload` and `prime eval push`, plus the same environment scan, using the same ~40-line redactor. The two copies are intentionally independent so neither repo waits on the other's release.

## Test

`test_push_traces_uploads_redacted_projection` drives `push_traces` against a mock transport: headers/env dropped, every known secret gone from the body (echoed plainly, inside a quoted tool result with `\/` and uppercase-hex escapes, and two documents deep), a credential inside the task's `verifier_env` replaced while its key and non-credential neighbours stay, ordinary and short values kept, disk record untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the security boundary for eval uploads; missed or incorrect redaction could still expose secrets in platform payloads, and secrets shorter than 8 characters are intentionally not redacted.
> 
> **Overview**
> **Platform `--push` no longer ships raw credentials.** Uploads use a stricter episode projection (drops `client.headers` and `harness.env`) and run every outbound JSON body through exact-match redaction to `[REDACTED]`, including secrets nested inside quoted tool-result strings.
> 
> **Rollouts now record what to scrub.** `Trace.upload_secrets` (and `Episode.upload_secrets` on retries) captures API keys, env/header/task runtime credentials, interception and tool URL tokens, and runtime-minted secrets (e.g. Docker egress proxy). Those lists ride the eval wire but are stripped from disk, `traces.jsonl`, and CLI JSON via `EXCLUDE_FIELDS` / `EPISODE_EXCLUDE_FIELDS`.
> 
> **New `verifiers/v1/utils/redact.py`** discovers credential values from env-like maps and URLs, then `Redactor` rewrites only JSON string leaves. A large integration test asserts the mock upload body is clean while local `to_record()` stays full-fidelity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41205cfd738351939b5f7ebdcf45b017ac5f5b14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Redact credentials from platform upload bodies and exclude secrets from saved records
> - Collects credential values (API keys, environment/header mappings, URL userinfo/query params, runtime secrets, tool URL signatures) during rollout startup and service provisioning into per-trace and per-episode `upload_secrets` lists retained in memory
> - Adds a `Redactor` in [redact.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2508/files#diff-a231dc46c3b94587f0f3bac0bb3fd6d65029b8f8021d1205e0a2b1f852966fae) that replaces known secret occurrences inside JSON string tokens at any nesting depth, preserving structure and non-matching content
> - Gathers a run-wide secret set in [platform.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2508/files#diff-8644072f827be448db5b0010e0969c6c86d9bbf07191ca00a993f416d123235f) from explicit values, clients, host env, environment/header-like mappings, and URL credentials, then runs all platform request bodies through the `Redactor` before upload
> - Adds shared exclusion policies (`EXCLUDE_FIELDS`, `EPISODE_EXCLUDE_FIELDS`, `UPLOAD_EXCLUDE`) so `Trace.to_record`, `Episode.to_record`, episode-file serialization, and CLI trace output omit `upload_secrets`, client headers, harness environments, and raw node fields from saved/disk records
> - Aggregates `upload_secrets` from discarded retry attempts into the final episode via [retries.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2508/files#diff-4fd4916191300939b5f48317db0b7957d414c54402780c71a0ef9085e53d809c) and [agent.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2508/files#diff-f719e773e216506045964fdfb9fad948b7b504ea092359ced06c928ab5148ea2)
> - Risk: `Redactor.json` in [redact.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2508/files#diff-a231dc46c3b94587f0f3bac0bb3fd6d65029b8f8021d1205e0a2b1f852966fae) rejects non-finite numbers; any code path that previously uploaded JSON containing `NaN`/`Infinity` will now raise. Oversized serialized samples are rejected against the configured request limit in `push_traces`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 41205cf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->