### PR TITLE
feat(v1): Podman and Apptainer runtimes, private container networking

### DIFF
--- a/docs/v1/architecture.md
+++ b/docs/v1/architecture.md
@@ -6,10 +6,12 @@ A server-backed evaluation or prime-rl **orchestrator** creates worker processes
 
 The orchestrator and workers are managed by verifiers and prime-rl themselves and thus offer few configurable knobs.
 
-The **rollout** is the executable combination of one loaded task, the harness, and any tools. Each rollout has an independent trace and runtime state. verifiers has three different runtimes which you can use for most tasksets:
+The **rollout** is the executable combination of one loaded task, the harness, and any tools. Each rollout has an independent trace and runtime state. verifiers has several runtimes which you can use for most tasksets:
 
 - The `subprocess` runtime runs the rollouts in Python subprocesses locally. Thus, it is meant for debugging purposes, as there might be side effects during runtime, such as one subprocess altering the config files of the harness, which then affects the other subprocesses.
 - The `docker` runtime runs the rollouts in docker containers on your local machine.
+- The `podman` runtime is the same implementation driving the Podman CLI, for hosts without Docker.
+- The `apptainer` runtime runs the rollouts in unprivileged Apptainer instances on the host network, as on HPC clusters. It has no egress policy.
 - Sandbox runtimes, such as `prime` or `modal`, are meant for production, especially for training or higher concurrency evaluation. These runtimes run remotely.
 
 The harness runs inside the rollout runtime to interact with the taskset. The harness does _not_ call the provider endpoint directly. Instead, model traffic goes through an **interception server** over a local connection or [Prime Tunnel](https://docs.primeintellect.ai/sandboxes/tunnel).

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -73,7 +73,9 @@ from verifiers.v1.mcp import (
     ToolsetConfig,
 )
 from verifiers.v1.runtimes import (
+    ApptainerConfig,
     DockerConfig,
+    PodmanConfig,
     PrimeConfig,
     ProgramResult,
     Runtime,
@@ -301,6 +303,8 @@ __all__ = [  # noqa: RUF022 - grouped by public API area
     "ProgramResult",
     "SubprocessConfig",
     "DockerConfig",
+    "PodmanConfig",
+    "ApptainerConfig",
     "PrimeConfig",
     "Env",
     "SingleAgentEnv",

--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -268,7 +268,7 @@ async def serve_in_runtime(
         # Keep provider temp files in the runtime workdir so cleanup removes them.
         assert runtime.info.id is not None
         env["TMPDIR"] = runtime.info.id
-    if runtime.published_port is not None:
+    if exposed and runtime.published_port is not None:
         env["MCP_HOST"] = "0.0.0.0"
     fixed = runtime.published_port if exposed else None
     port_file = None
@@ -322,17 +322,18 @@ async def reachable_url(
     runtime; `consumer_is_local` = the consumer can use a host-local URL without a tunnel.
 
     - `colocated` -> localhost (same runtime, in-sandbox or host loopback);
-    - the server runs in a remote sandbox -> its own published URL (`expose`), reachable anywhere;
-    - else it's host-local -> localhost to a local consumer, a host tunnel to a remote one."""
+    - else the runtime publishes the port (`expose`): a remote sandbox's URL is reachable
+      anywhere, a host-local URL directly by a local consumer and through a host tunnel
+      by a remote one."""
     if colocated:
         yield f"http://127.0.0.1:{port}"
-    elif not service.is_local:  # in a remote sandbox → it publishes its own port
-        yield await service.expose(port)
-    elif consumer_is_local:  # local consumer → localhost, no public tunnel
-        yield f"http://127.0.0.1:{port}"
-    else:  # remote consumer → a host tunnel publishes the port outward
-        async with PrimeTunnel().expose(port) as url:
-            yield url
+        return
+    url = await service.expose(port)
+    if service.is_local and not consumer_is_local:
+        async with PrimeTunnel().expose(urlsplit(url).port or 80) as public:
+            yield public
+    else:
+        yield url
 
 
 @dataclass(frozen=True)

--- a/verifiers/v1/runtimes/__init__.py
+++ b/verifiers/v1/runtimes/__init__.py
@@ -5,6 +5,11 @@ from typing import Annotated
 from pydantic import Field
 
 from verifiers.v1.configs.runtime import NetworkPolicyConfig
+from verifiers.v1.runtimes.apptainer import (
+    ApptainerConfig,
+    ApptainerRuntime,
+    ApptainerRuntimeInfo,
+)
 from verifiers.v1.runtimes.base import (
     BaseRuntimeInfo,
     ProgramResult,
@@ -12,7 +17,14 @@ from verifiers.v1.runtimes.base import (
     RuntimeProcess,
     register,
 )
-from verifiers.v1.runtimes.docker import DockerConfig, DockerRuntime, DockerRuntimeInfo
+from verifiers.v1.runtimes.docker import (
+    DockerConfig,
+    DockerRuntime,
+    DockerRuntimeInfo,
+    PodmanConfig,
+    PodmanRuntime,
+    PodmanRuntimeInfo,
+)
 from verifiers.v1.runtimes.modal import ModalConfig, ModalRuntime, ModalRuntimeInfo
 from verifiers.v1.runtimes.prime import (
     PrimeConfig,
@@ -27,24 +39,35 @@ from verifiers.v1.runtimes.subprocess import (
 )
 
 RuntimeConfig = Annotated[
-    SubprocessConfig | DockerConfig | PrimeConfig | ModalConfig,
+    SubprocessConfig
+    | DockerConfig
+    | PodmanConfig
+    | ApptainerConfig
+    | PrimeConfig
+    | ModalConfig,
     Field(discriminator="type"),
 ]
 
 RuntimeInfo = Annotated[
-    SubprocessRuntimeInfo | DockerRuntimeInfo | PrimeRuntimeInfo | ModalRuntimeInfo,
+    SubprocessRuntimeInfo
+    | DockerRuntimeInfo
+    | PodmanRuntimeInfo
+    | ApptainerRuntimeInfo
+    | PrimeRuntimeInfo
+    | ModalRuntimeInfo,
     Field(discriminator="type"),
 ]
 
 
 def _runtime_cls(config: RuntimeConfig) -> type[Runtime]:
-    if isinstance(config, PrimeConfig):
-        return PrimeRuntime
-    if isinstance(config, ModalConfig):
-        return ModalRuntime
-    if isinstance(config, DockerConfig):
-        return DockerRuntime
-    return SubprocessRuntime
+    return {
+        "subprocess": SubprocessRuntime,
+        "docker": DockerRuntime,
+        "podman": PodmanRuntime,
+        "apptainer": ApptainerRuntime,
+        "prime": PrimeRuntime,
+        "modal": ModalRuntime,
+    }[config.type]
 
 
 def make_runtime(config: RuntimeConfig, name: str | None = None) -> Runtime:
@@ -79,6 +102,9 @@ def runtime_is_local(config: RuntimeConfig) -> bool:
 
 
 __all__ = [
+    "ApptainerConfig",
+    "ApptainerRuntime",
+    "ApptainerRuntimeInfo",
     "BaseRuntimeInfo",
     "DockerConfig",
     "DockerRuntime",
@@ -87,6 +113,9 @@ __all__ = [
     "ModalRuntime",
     "ModalRuntimeInfo",
     "NetworkPolicyConfig",
+    "PodmanConfig",
+    "PodmanRuntime",
+    "PodmanRuntimeInfo",
     "PrimeConfig",
     "PrimeRuntime",
     "PrimeRuntimeInfo",

--- a/verifiers/v1/runtimes/apptainer.py
+++ b/verifiers/v1/runtimes/apptainer.py
@@ -1,0 +1,142 @@
+"""Local Apptainer runtime: an unprivileged instance sharing the host network."""
+
+import asyncio
+import contextlib
+import hashlib
+import logging
+import shutil
+import subprocess
+import uuid
+from pathlib import Path
+from typing import ClassVar, Literal
+
+from verifiers.v1.errors import SandboxError
+from verifiers.v1.runtimes.base import BaseRuntimeInfo, parse_gpu
+from verifiers.v1.runtimes.container import ContainerConfig, ContainerRuntime, cli
+from verifiers.v1.utils.paths import CACHE_DIR
+
+logger = logging.getLogger(__name__)
+
+_ROOT = CACHE_DIR / "runtimes" / "apptainer"
+
+
+class ApptainerConfig(ContainerConfig):
+    type: Literal["apptainer"] = "apptainer"
+    """Apptainer has no egress policy: instances run unprivileged on the host network,
+    as on HPC clusters without Docker. `image` is a Docker reference (pulled to a SIF
+    once per reference), any `scheme://` URI Apptainer can pull, or a local SIF path."""
+
+
+class ApptainerRuntimeInfo(ApptainerConfig, BaseRuntimeInfo):
+    pass
+
+
+class ApptainerRuntime(ContainerRuntime):
+    _pulls: ClassVar[dict[str, asyncio.Lock]] = {}
+
+    def __init__(self, config: ApptainerConfig, name: str | None = None) -> None:
+        super().__init__(name)
+        self.config = config
+        self.info = ApptainerRuntimeInfo(**config.model_dump())
+        self._dir: Path | None = None  # host backing for the workspace, /tmp and $HOME
+        self._stopped = False
+
+    async def _exec(self, env: dict[str, str], *, stdin: bool = False) -> list[str]:
+        # `--env` is a comma-separated map flag, so values pass through `env` inside.
+        return [
+            "apptainer",
+            "exec",
+            "--cleanenv",
+            "--no-eval",
+            "--cwd",
+            self.config.workdir,
+            f"instance://{self.name}",
+            "env",
+            *(f"{key}={value}" for key, value in env.items()),
+        ]
+
+    async def start(self) -> None:
+        try:
+            version = await cli("apptainer", "version")
+        except FileNotFoundError as e:
+            raise RuntimeError(
+                "apptainer runtime selected but the `apptainer` CLI is not installed"
+            ) from e
+        if version.exit_code != 0:
+            detail = (version.stderr or version.stdout).strip()
+            raise RuntimeError(
+                f"apptainer runtime selected but Apptainer is not usable: {detail}"
+            )
+        self._dir = _ROOT / "instances" / self.name
+        (self._dir / "workspace").mkdir(parents=True)
+        (self._dir / "session").mkdir()
+        limits: list[str] = []
+        if self.config.cpu is not None:
+            limits += ["--cpus", str(self.config.cpu)]
+        if self.config.memory is not None:
+            limits += ["--memory", f"{self.config.memory}g"]
+        if parse_gpu(self.config.gpu)[1]:
+            limits += ["--nv"]
+        started = await cli(
+            "apptainer",
+            "instance",
+            "start",
+            "--cleanenv",
+            "--containall",
+            "--no-eval",
+            # A contained /tmp and $HOME live in tmpfs unless a workdir backs them.
+            "--workdir",
+            str(self._dir / "session"),
+            "--writable-tmpfs",
+            "--bind",
+            f"{self._dir / 'workspace'}:{self.config.workdir}",
+            *limits,
+            await self._image(),
+            self.name,
+        )
+        if started.exit_code != 0:
+            raise SandboxError(
+                f"apptainer instance start failed: {started.stderr.strip()}"
+            )
+        self.info.id = self.name
+        logger.info(
+            "apptainer: started instance %s (image=%s)", self.name, self.config.image
+        )
+
+    async def _image(self) -> str:
+        """The SIF to run: a local file as is, else the reference pulled once into the
+        cache, like a container engine keeping a pulled image."""
+        local = Path(self.config.image).expanduser()
+        if local.is_file():
+            return str(local)
+        image = self.config.image
+        ref = image if "://" in image else f"docker://{image}"
+        sif = _ROOT / "images" / f"{hashlib.sha256(ref.encode()).hexdigest()}.sif"
+        async with self._pulls.setdefault(ref, asyncio.Lock()):
+            if not sif.exists():
+                sif.parent.mkdir(parents=True, exist_ok=True)
+                # Pull to a unique path and publish it atomically, so concurrent
+                # workers never read a half-written SIF.
+                tmp = sif.with_name(f"{uuid.uuid4().hex}.sif")
+                pulled = await cli("apptainer", "pull", str(tmp), ref)
+                if pulled.exit_code != 0:
+                    raise SandboxError(
+                        f"apptainer pull {ref} failed: {pulled.stderr.strip()}"
+                    )
+                tmp.replace(sif)
+        return str(sif)
+
+    def cleanup(self) -> None:
+        if self._dir is None or self._stopped:
+            return
+        self._stopped = True
+        logger.debug("apptainer: stopping instance %s", self.name)
+        with contextlib.suppress(Exception):
+            subprocess.run(
+                ["apptainer", "instance", "stop", "--force", self.name],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=30,
+                check=False,
+            )
+        shutil.rmtree(self._dir, ignore_errors=True)

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -43,9 +43,9 @@ _ENSURE_UV = (
     f"|| {{ {_INSTALL_CURL}; {_DOWNLOAD_UV}; }}"
 )
 
-# The single port a self-publishing runtime (modal/prime) forwards to a public URL for a server
-# hosted in its sandbox. A server placed in such a runtime binds this (on 0.0.0.0) and is reached
-# at the runtime's public URL.
+# The single port a sandbox runtime forwards out for a server hosted in it: a public URL on
+# modal/prime, a host loopback port on the local container engines. A server placed in such
+# a runtime binds this (on 0.0.0.0) and is reached at the URL `expose` returns.
 SERVICE_PORT = 8000
 
 
@@ -134,8 +134,8 @@ class Runtime(ABC):
 
     is_local: ClassVar[bool] = True
     """Whether this runtime exchanges host-local URLs without a public tunnel. True for
-    subprocess and Docker (directly or through Docker's policy proxy); remote runtimes
-    override to False and use a host `Tunnel` inward plus `expose` outward."""
+    subprocess and the local container runtimes; remote runtimes override to False and
+    use a host `Tunnel` inward plus `expose` outward."""
 
     scripts_dir: ClassVar[str] = "/tmp/vf-scripts"
     """Digest-keyed PEP 723 scripts inside the runtime. Sandboxes own their `/tmp`;
@@ -383,13 +383,14 @@ class Runtime(ABC):
         """A fixed port this runtime exposes to the outside at startup, declared up front to the
         provider (Modal forwards only ports named at `Sandbox.create`). When set, a server placed
         here binds it instead of a host-chosen free port, and `expose` returns its public URL.
-        `None` for local runtimes (subprocess/docker), which pick a free port."""
+        `None` for runtimes whose services already sit on host loopback (subprocess,
+        apptainer), which pick a free port."""
         return None
 
-    async def expose(self, port: int) -> str | None:
-        """Publish a port running *inside this runtime* to a URL reachable from the host/outside,
-        or None when local. A remote runtime overrides this with the provider's native port
-        exposure (modal `tunnels()`, prime `client.expose`), torn down with the sandbox in
-        `stop()`. The reverse of a host `Tunnel` (interception.tunnel, which reaches a host
-        port from inside a runtime)."""
-        return None
+    async def expose(self, port: int) -> str:
+        """Publish a port running *inside this runtime* to a URL reachable from the host/outside.
+        A runtime on the host network is reached at host loopback as is; a sandbox overrides
+        this with its port exposure (modal `tunnels()`, prime `client.expose`, a container
+        engine's published port), torn down with the sandbox in `stop()`. The reverse of a
+        host `Tunnel` (interception.tunnel, which reaches a host port from inside a runtime)."""
+        return f"http://127.0.0.1:{port}"

--- a/verifiers/v1/runtimes/container.py
+++ b/verifiers/v1/runtimes/container.py
@@ -1,0 +1,232 @@
+"""Shared machinery for local container runtimes driven through a CLI `exec`."""
+
+import asyncio
+import contextlib
+import shlex
+import uuid
+from pathlib import PurePosixPath
+
+from pydantic_config import BaseConfig
+
+from verifiers.v1.errors import SandboxError
+from verifiers.v1.runtimes.base import ProgramResult, Runtime, RuntimeProcess
+from verifiers.v1.runtimes.subprocess import read_stream
+from verifiers.v1.utils.aio import run_shielded
+
+
+class ContainerConfig(BaseConfig):
+    image: str = "python:3.11-slim"
+    workdir: str = "/app"
+    # TaskData.resources uses these units; non-default runtime config values take precedence.
+    cpu: float | None = None
+    """Pin the container to this many CPU cores. None = unlimited."""
+    memory: float | None = None
+    """Hard memory limit in GB. None = unlimited."""
+    gpu: str | None = None
+    """GPU spec, e.g. "A100" or "2". Docker exposes that many GPUs (needs the nvidia
+    container toolkit); Podman and Apptainer expose every GPU on the host, so the count
+    is advisory there. None = none."""
+    disk: float | None = None
+    """Advisory disk request in GB. Local containers have no portable per-container size
+    limit, so this is accepted (so a task can declare it without a warning) but not
+    enforced."""
+
+
+async def _communicate(
+    *argv: str, input: bytes | None = None
+) -> tuple[int, bytes, bytes]:
+    """Run a host command to completion; a cancelled await kills it first."""
+    proc = await asyncio.create_subprocess_exec(
+        *argv,
+        stdin=asyncio.subprocess.PIPE
+        if input is not None
+        else asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await proc.communicate(input)
+    except BaseException:
+        if proc.returncode is None:
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
+        await run_shielded(proc.communicate())
+        raise
+    return proc.returncode or 0, stdout, stderr
+
+
+async def cli(*argv: str, input: bytes | None = None) -> ProgramResult:
+    code, stdout, stderr = await _communicate(*argv, input=input)
+    return ProgramResult(
+        code, stdout.decode(errors="replace"), stderr.decode(errors="replace")
+    )
+
+
+class ContainerProcess(RuntimeProcess):
+    """A process attached through the CLI client. The client does not forward signals,
+    so `exec` (the argv prefix that runs a command inside the container) delivers them."""
+
+    def __init__(
+        self, process: asyncio.subprocess.Process, exec: list[str], pid: int
+    ) -> None:
+        self._process = process
+        self._exec = exec
+        self._pid = pid
+        assert process.stdin is not None
+        assert process.stdout is not None
+        assert process.stderr is not None
+        self._stdin = process.stdin
+        self.stdout = read_stream(process.stdout)
+        self.stderr = read_stream(process.stderr)
+
+    async def write(self, data: bytes) -> None:
+        self._stdin.write(data)
+        await self._stdin.drain()
+
+    async def wait(self) -> int:
+        return await self._process.wait()
+
+    async def terminate(self) -> None:
+        await self._signal("TERM")
+
+    async def kill(self) -> None:
+        await self._signal("KILL")
+
+    async def _signal(self, signal: str) -> None:
+        if self._process.returncode is not None:
+            return
+        result = await cli(
+            *self._exec,
+            "sh",
+            "-c",
+            'kill -"$1" "-$2" 2>/dev/null || kill -"$1" "$2"',
+            "vf-signal",
+            signal,
+            str(self._pid),
+        )
+        if result.exit_code != 0 and self._process.returncode is None:
+            raise SandboxError(
+                f"container process signal failed: {result.stderr.strip()}"
+            )
+
+
+async def _abort_process_startup(
+    proc: asyncio.subprocess.Process, exec: list[str], pidfile: str
+) -> str:
+    """Kill a partially opened container process and reap its local CLI client."""
+    # The target normally writes its PID immediately, but cancellation can win
+    # that race. Wait briefly for the file before signalling the process group.
+    cleanup = (
+        'i=0; while [ "$i" -lt 20 ]; do '
+        'if [ -s "$1" ]; then pid=$(cat "$1"); '
+        'kill -KILL "-$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null || true; '
+        'rm -f "$1"; exit 0; fi; '
+        "i=$((i + 1)); sleep 0.05; done; exit 1"
+    )
+    try:
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(
+                cli(*exec, "sh", "-c", cleanup, "vf-process-cleanup", pidfile),
+                timeout=2,
+            )
+    finally:
+        if proc.returncode is None:
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
+        _, stderr = await proc.communicate()
+    return stderr.decode(errors="replace").strip()
+
+
+class ContainerRuntime(Runtime):
+    """A local container reached through its CLI: every operation is an `exec` into it.
+    Subclasses provision the container (`start` / `cleanup`) and describe the exec."""
+
+    config: ContainerConfig
+
+    async def _exec(self, env: dict[str, str], *, stdin: bool = False) -> list[str]:
+        """Host argv that runs a command inside the container, in the workdir, with
+        `env` in its environment; `stdin` keeps the caller's stdin attached. Async so
+        a runtime can finish per-exec preparation first."""
+        raise NotImplementedError
+
+    async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
+        return await cli(*await self._exec(self.process_env(env)), *argv)
+
+    async def open_process(
+        self, argv: list[str], env: dict[str, str]
+    ) -> RuntimeProcess:
+        pidfile = f"/tmp/vf-process-{uuid.uuid4().hex}.pid"
+        # Give the target its own process group when `setsid -w` is available so
+        # terminate()/kill() reap its descendants while the CLI client remains
+        # attached if setsid needs to fork. The inner shell records the
+        # post-setsid PID before exec preserves it as the target PID.
+        wrapper = (
+            "if setsid -w true >/dev/null 2>&1; then "
+            'exec setsid -w sh -c \'echo $$ > "$1"; shift; exec "$@"\' '
+            'vf-process "$@"; '
+            'fi; echo $$ > "$1"; shift; exec "$@"'
+        )
+        proc = await asyncio.create_subprocess_exec(
+            *await self._exec(self.process_env(env), stdin=True),
+            "sh",
+            "-c",
+            wrapper,
+            "vf-process",
+            pidfile,
+            *argv,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        control = await self._exec({})
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + 5
+        try:
+            while True:
+                ready = await cli(*control, "cat", pidfile)
+                if ready.exit_code == 0 and ready.stdout.strip().isdigit():
+                    return ContainerProcess(proc, control, int(ready.stdout.strip()))
+                if proc.returncode is not None or loop.time() >= deadline:
+                    break
+                await asyncio.sleep(0.05)
+        except BaseException:
+            await run_shielded(_abort_process_startup(proc, control, pidfile))
+            raise
+
+        stderr = await run_shielded(_abort_process_startup(proc, control, pidfile))
+        detail = stderr or ready.stderr.strip()
+        raise SandboxError(
+            f"container live process failed to start: {detail or 'PID unavailable'}"
+        )
+
+    async def run_background(
+        self, argv: list[str], env: dict[str, str], log: str
+    ) -> None:
+        # Backgrounded inside the container, so it outlives this exec and lives until
+        # the container is removed in stop().
+        script = f"{shlex.join(argv)} > {shlex.quote(log)} 2>&1 < /dev/null &"
+        result = await cli(*await self._exec(self.process_env(env)), "sh", "-c", script)
+        if result.exit_code != 0:
+            raise SandboxError(
+                f"container background process failed: {result.stderr.strip()}"
+            )
+
+    async def _read(self, path: str) -> bytes:
+        code, data, stderr = await _communicate(*await self._exec({}), "cat", path)
+        if code != 0:
+            raise SandboxError(
+                f"read {path!r}: {stderr.decode(errors='replace').strip()}"
+            )
+        return data
+
+    async def write(self, path: str, data: bytes) -> None:
+        parent = shlex.quote(str(PurePosixPath(path).parent))
+        result = await cli(
+            *await self._exec({}, stdin=True),
+            "sh",
+            "-c",
+            f"mkdir -p {parent} && cat > {shlex.quote(path)}",
+            input=data,
+        )
+        if result.exit_code != 0:
+            raise SandboxError(f"write {path!r}: {result.stderr.strip()}")

--- a/verifiers/v1/runtimes/container.py
+++ b/verifiers/v1/runtimes/container.py
@@ -181,13 +181,16 @@ class ContainerRuntime(Runtime):
         control = await self._exec({})
         loop = asyncio.get_running_loop()
         deadline = loop.time() + 5
+        exited = False
         try:
             while True:
                 ready = await cli(*control, "cat", pidfile)
                 if ready.exit_code == 0 and ready.stdout.strip().isdigit():
                     return ContainerProcess(proc, control, int(ready.stdout.strip()))
-                if proc.returncode is not None or loop.time() >= deadline:
+                # A target that already exited still left its pidfile: poll once more.
+                if exited or loop.time() >= deadline:
                     break
+                exited = proc.returncode is not None
                 await asyncio.sleep(0.05)
         except BaseException:
             await run_shielded(_abort_process_startup(proc, control, pidfile))

--- a/verifiers/v1/runtimes/container.py
+++ b/verifiers/v1/runtimes/container.py
@@ -166,6 +166,7 @@ class ContainerRuntime(Runtime):
             'vf-process "$@"; '
             'fi; echo $$ > "$1"; shift; exec "$@"'
         )
+        control = await self._exec({})
         proc = await asyncio.create_subprocess_exec(
             *await self._exec(self.process_env(env), stdin=True),
             "sh",
@@ -178,7 +179,6 @@ class ContainerRuntime(Runtime):
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-        control = await self._exec({})
         loop = asyncio.get_running_loop()
         deadline = loop.time() + 5
         exited = False

--- a/verifiers/v1/runtimes/docker/__init__.py
+++ b/verifiers/v1/runtimes/docker/__init__.py
@@ -1,197 +1,109 @@
-"""Local Docker runtime with optional execution-time URL filtering."""
+"""Local Docker runtime with optional execution-time URL filtering. Podman drives the same
+CLI surface (and aliases `host.docker.internal`), so it reuses the whole implementation.
+
+Containers get the engine's private network, so a task's ports never collide with the
+host's. Host loopback stays reachable from inside at its own port: on Linux through a
+listener planted on the container's loopback and relayed here (a "door"), off Linux
+through the engine's host alias. A service hosted in the container is published the
+other way, to a host loopback port."""
 
 import array
 import asyncio
 import contextlib
+import functools
 import logging
-import shlex
 import socket
 import subprocess
 import sys
 import tempfile
-import uuid
-from collections.abc import AsyncIterator
-from pathlib import PurePosixPath
-from typing import Literal
+from typing import ClassVar, Literal
 from urllib.parse import urlsplit
 
 from verifiers.v1.configs.runtime import NetworkPolicyConfig
 from verifiers.v1.errors import SandboxError
-from verifiers.v1.runtimes.base import (
-    BaseRuntimeInfo,
-    ProgramResult,
-    Runtime,
-    RuntimeProcess,
-    parse_gpu,
-)
-from verifiers.v1.runtimes.docker.egress import HOST_ALIAS, EgressProxy, NetworkPolicy
-from verifiers.v1.utils.aio import run_shielded
+from verifiers.v1.runtimes.base import SERVICE_PORT, BaseRuntimeInfo, parse_gpu
+from verifiers.v1.runtimes.container import ContainerConfig, ContainerRuntime, cli
+from verifiers.v1.runtimes.docker.egress import EgressProxy, NetworkPolicy, relay
 
 logger = logging.getLogger(__name__)
 
 
-class DockerConfig(NetworkPolicyConfig):
+class DockerConfig(ContainerConfig, NetworkPolicyConfig):
     type: Literal["docker"] = "docker"
-    image: str = "python:3.11-slim"
-    workdir: str = "/app"
-    # TaskData.resources uses these units; non-default runtime config values take precedence.
-    cpu: float | None = None
-    """Pin the container to this many CPU cores (docker `--cpus`). None = unlimited."""
-    memory: float | None = None
-    """Hard memory limit in GB (docker `--memory`). None = unlimited."""
-    gpu: str | None = None
-    """GPU spec, e.g. "A100" or "2" (docker `--gpus` uses the count; needs the nvidia
-    container toolkit). None = none."""
-    disk: float | None = None
-    """Advisory disk request in GB. Docker has no portable per-container size limit, so
-    this is accepted (so a task can declare it without a warning) but not enforced."""
+
+
+class PodmanConfig(ContainerConfig, NetworkPolicyConfig):
+    type: Literal["podman"] = "podman"
 
 
 class DockerRuntimeInfo(DockerConfig, BaseRuntimeInfo):
     pass
 
 
-async def _read_stream(reader: asyncio.StreamReader) -> AsyncIterator[bytes]:
-    while chunk := await reader.read(64 * 1024):
-        yield chunk
+class PodmanRuntimeInfo(PodmanConfig, BaseRuntimeInfo):
+    pass
 
 
-class DockerProcess(RuntimeProcess):
-    def __init__(
-        self,
-        process: asyncio.subprocess.Process,
-        container: str,
-        pid: int,
-    ) -> None:
-        self._process = process
-        self._container = container
-        self._pid = pid
-        assert process.stdin is not None
-        assert process.stdout is not None
-        assert process.stderr is not None
-        self._stdin = process.stdin
-        self.stdout = _read_stream(process.stdout)
-        self.stderr = _read_stream(process.stderr)
-
-    async def write(self, data: bytes) -> None:
-        self._stdin.write(data)
-        await self._stdin.drain()
-
-    async def wait(self) -> int:
-        return await self._process.wait()
-
-    async def terminate(self) -> None:
-        await self._signal("TERM")
-
-    async def kill(self) -> None:
-        await self._signal("KILL")
-
-    async def _signal(self, signal: str) -> None:
-        if self._process.returncode is not None:
-            return
-        result = await docker(
-            "exec",
-            self._container,
-            "sh",
-            "-c",
-            'kill -"$1" "-$2" 2>/dev/null || kill -"$1" "$2"',
-            "vf-signal",
-            signal,
-            str(self._pid),
-        )
-        if result.exit_code != 0 and self._process.returncode is None:
-            raise SandboxError(
-                f"docker exec process signal failed: {result.stderr.strip()}"
-            )
-
-
-async def docker(*args: str) -> ProgramResult:
-    proc = await asyncio.create_subprocess_exec(
-        "docker",
-        *args,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    try:
-        stdout, stderr = await proc.communicate()
-    except BaseException:
-        if proc.returncode is None:
-            with contextlib.suppress(ProcessLookupError):
-                proc.kill()
-        await run_shielded(proc.communicate())
-        raise
-    return ProgramResult(
-        exit_code=proc.returncode or 0,
-        stdout=stdout.decode(errors="replace"),
-        stderr=stderr.decode(errors="replace"),
-    )
-
-
-async def _abort_process_startup(
-    proc: asyncio.subprocess.Process, container: str, pidfile: str
-) -> str:
-    """Kill a partially opened container process and reap its local docker client."""
-    # The target normally writes its PID immediately, but cancellation can win
-    # that race. Wait briefly for the file before signalling the process group.
-    cleanup = (
-        'i=0; while [ "$i" -lt 20 ]; do '
-        'if [ -s "$1" ]; then pid=$(cat "$1"); '
-        'kill -KILL "-$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null || true; '
-        'rm -f "$1"; exit 0; fi; '
-        "i=$((i + 1)); sleep 0.05; done; exit 1"
-    )
-    try:
-        with contextlib.suppress(Exception):
-            await asyncio.wait_for(
-                docker(
-                    "exec",
-                    container,
-                    "sh",
-                    "-c",
-                    cleanup,
-                    "vf-process-cleanup",
-                    pidfile,
-                ),
-                timeout=2,
-            )
-    finally:
-        if proc.returncode is None:
-            with contextlib.suppress(ProcessLookupError):
-                proc.kill()
-        _, stderr = await proc.communicate()
-    return stderr.decode(errors="replace").strip()
-
-
-_PROXY_HOST = "host.docker.internal"
-_PASS_LISTENER = r"""
-import array, socket
+_HOST_ALIAS = "host.docker.internal"
+_NO_PROXY = f"localhost,127.0.0.1,{_HOST_ALIAS}"
+_PLANT_LISTENERS = r"""
+import array, socket, sys
 control = socket.socket(socket.AF_UNIX)
 control.connect("/run/vf/control.sock")
-listener = socket.socket()
-listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-listener.bind(("127.0.0.1", 0))
-listener.listen()
-control.sendmsg([b"listener"], [(socket.SOL_SOCKET, socket.SCM_RIGHTS, array.array("i", [listener.fileno()]))])
+listeners = []
+for port in sys.argv[1:]:
+    listener = socket.socket()
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", int(port)))
+    listener.listen()
+    listeners.append(listener)
+fds = array.array("i", [listener.fileno() for listener in listeners])
+control.sendmsg([b"listeners"], [(socket.SOL_SOCKET, socket.SCM_RIGHTS, fds)])
 """
 
 
-class DockerRuntime(Runtime):
-    def __init__(self, config: DockerConfig, name: str | None = None) -> None:
+async def _door(
+    port: int, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+) -> None:
+    """Relay a connection accepted on the container's loopback to the host's."""
+    try:
+        upstream = await asyncio.open_connection("127.0.0.1", port)
+    except OSError:
+        writer.close()
+        return
+    await relay(reader, writer, *upstream, timeout=None)
+
+
+class DockerRuntime(ContainerRuntime):
+    engine: ClassVar[str] = "docker"
+    """The CLI binary; Podman's is a drop-in for every command used here."""
+    info_cls: ClassVar[type[BaseRuntimeInfo]] = DockerRuntimeInfo
+
+    def __init__(
+        self, config: DockerConfig | PodmanConfig, name: str | None = None
+    ) -> None:
         super().__init__(name)
         self.config = config
-        self.info = DockerRuntimeInfo(**config.model_dump())
+        self.info = self.info_cls(**config.model_dump())
         self._container: str | None = None  # our `--name` (used for exec/rm)
+        self._service_url: str | None = None
         self._proxy: EgressProxy | None = None
-        self._proxy_host_ip: str | None = None
+        # Host loopback port -> the door serving it inside; None until the next exec.
+        self._doors: dict[int, asyncio.Server | None] = {}
+        self._doors_lock = asyncio.Lock()
         self._stopped = False
         self._cut = False
 
+    @property
+    def published_port(self) -> int:
+        return SERVICE_PORT
+
     async def start(self) -> None:
         try:
-            version = await docker("version", "--format", "{{.Server.Version}}")
+            version = await cli(self.engine, "version")
         except FileNotFoundError as e:
             raise RuntimeError(
-                "docker runtime selected but the `docker` CLI is not installed"
+                f"{self.engine} runtime selected but the `{self.engine}` CLI is not installed"
             ) from e
         if version.exit_code != 0:
             detail = (version.stderr or version.stdout).strip()
@@ -203,22 +115,23 @@ class DockerRuntime(Runtime):
                     "`sudo usermod -aG docker $USER` and start a new login shell."
                 )
             raise RuntimeError(
-                f"docker runtime selected but the Docker daemon is not reachable: {detail}{hint}"
+                f"{self.engine} runtime selected but the engine is not reachable: {detail}{hint}"
             )
         self._container = self.name
-        limits: list[str] = []
+        # The engine's NAT'd bridge: a private namespace with `eth0`, which the cut relies
+        # on (rootless Podman would otherwise default to pasta).
+        options = ["--network", "bridge", "--publish", f"127.0.0.1::{SERVICE_PORT}"]
         if self.config.cpu is not None:
-            limits += ["--cpus", str(self.config.cpu)]
+            options += ["--cpus", str(self.config.cpu)]
         if self.config.memory is not None:
-            limits += ["--memory", f"{self.config.memory}g"]
+            options += ["--memory", f"{self.config.memory}g"]
         _, gpu_count = parse_gpu(self.config.gpu)
         if gpu_count:
-            limits += ["--gpus", str(gpu_count)]
+            # Docker takes a device count; Podman takes `all` or a device id.
+            options += ["--gpus", str(gpu_count) if self.engine == "docker" else "all"]
         restricted = self.network_restricted
         if restricted:
-            network = [
-                "--network",
-                "bridge",
+            options += [
                 "--cap-drop",
                 "NET_ADMIN",
                 "--cap-drop",
@@ -228,23 +141,19 @@ class DockerRuntime(Runtime):
                 "--sysctl",
                 "net.ipv6.conf.all.disable_ipv6=1",
             ]
-            if sys.platform != "linux":
-                network += ["--add-host", f"{_PROXY_HOST}:host-gateway"]
-        else:
-            network = ["--network", "host"]
+        if sys.platform != "linux":
+            options += ["--add-host", f"{_HOST_ALIAS}:host-gateway"]
         env_args = [
             arg
             for key, value in self.env.items()
             for arg in ("--env", f"{key}={value}")
         ]
-        run = await docker(
+        run = await cli(
+            self.engine,
             "run",
             "--detach",
-            *network,
-            *limits,
+            *options,
             *env_args,
-            "--workdir",
-            self.config.workdir,
             "--entrypoint",
             "sleep",
             "--name",
@@ -253,102 +162,118 @@ class DockerRuntime(Runtime):
             "infinity",
         )
         if run.exit_code != 0:
-            raise SandboxError(f"docker run failed: {run.stderr.strip()}")
-        self.info.id = run.stdout.strip()[
-            :12
-        ]  # `docker run -d` prints the container id
+            raise SandboxError(f"{self.engine} run failed: {run.stderr.strip()}")
+        self.info.id = run.stdout.strip()[:12]  # `run -d` prints the container id
+        # Docker creates a missing `--workdir` for `exec`; Podman refuses one.
+        made = await cli(
+            self.engine, "exec", self._container, "mkdir", "-p", self.config.workdir
+        )
+        if made.exit_code != 0:
+            raise SandboxError(
+                f"{self.engine} workdir setup failed: {made.stderr.strip()}"
+            )
+        published = await cli(
+            self.engine, "port", self._container, f"{SERVICE_PORT}/tcp"
+        )
+        host_port = (published.stdout.split() or [""])[0].rpartition(":")[2]
+        if published.exit_code != 0 or not host_port.isdigit():
+            detail = (published.stderr or published.stdout).strip()
+            raise SandboxError(
+                f"{self.engine} did not publish the service port: {detail}"
+            )
+        self._service_url = f"http://127.0.0.1:{host_port}"
         if restricted:
             # Setup is trusted; colocated servers fetch their task from host interception
             # before the final framework routes are known.
             self._proxy = EgressProxy(
-                NetworkPolicy(
-                    NetworkPolicyConfig(), [HOST_ALIAS], allow_non_global=True
-                )
+                NetworkPolicy(NetworkPolicyConfig(), [], allow_non_global=True)
             )
-            if sys.platform == "linux":
-                await self._proxy.start(listener=await self._container_listener())
-            else:
-                host = await docker(
-                    "exec",
-                    self._container,
-                    "sh",
-                    "-c",
-                    f"awk '$2 == \"{_PROXY_HOST}\" {{ print $1; exit }}' /etc/hosts",
-                )
-                self._proxy_host_ip = host.stdout.strip()
-                if host.exit_code != 0 or not self._proxy_host_ip:
-                    raise SandboxError(
-                        f"could not resolve {_PROXY_HOST} in Docker: {host.stderr.strip()}"
-                    )
-                await self._proxy.start("127.0.0.1")
+            await self._proxy.start("127.0.0.1")
         logger.info(
-            "docker: started container %s (image=%s)",
+            "%s: started container %s (image=%s)",
+            self.engine,
             self._container,
             self.config.image,
         )
 
-    async def _container_listener(self) -> socket.socket:
-        """Create the proxy listener inside the container netns, serviced here."""
-        with tempfile.TemporaryDirectory(prefix="vf-proxy-") as directory:
-            path = f"{directory}/control.sock"
-            with socket.socket(socket.AF_UNIX) as control:
-                control.bind(path)
-                control.listen(1)
-                helper = await docker(
-                    "run",
-                    "--rm",
-                    "--network",
-                    f"container:{self._container}",
-                    "--cap-drop",
-                    "ALL",
-                    "--cap-add",
-                    "DAC_OVERRIDE",
-                    "--security-opt",
-                    "no-new-privileges",
-                    "--mount",
-                    f"type=bind,source={directory},target=/run/vf",
-                    "python:3.11-alpine",
-                    "python3",
-                    "-c",
-                    _PASS_LISTENER,
-                )
-                if helper.exit_code != 0:
-                    raise SandboxError(
-                        f"docker proxy listener failed: {helper.stderr.strip()}"
-                    )
-                connection, _ = control.accept()
-                with connection:
-                    _, ancillary, *_ = connection.recvmsg(
-                        64, socket.CMSG_SPACE(array.array("i").itemsize)
-                    )
-        descriptor = array.array("i")
-        descriptor.frombytes(ancillary[0][2][: descriptor.itemsize])
-        listener = socket.socket(fileno=descriptor[0])
-        listener.setblocking(False)
-        return listener
-
     def host_url(self, url: str) -> str:
-        host = urlsplit(url).hostname
-        # Keep numeric loopback container-local; the proxy maps this reserved name to
-        # the Verifiers process's loopback for interception and host-local MCP routes.
-        if self.network_restricted and host in ("127.0.0.1", "localhost"):
-            return url.replace(host, HOST_ALIAS, 1)
-        if (
-            not self.network_restricted
-            and sys.platform != "linux"
-            and host in ("127.0.0.1", "localhost")
-        ):
-            return url.replace(host, "host.docker.internal", 1)
+        parts = urlsplit(url)
+        if parts.hostname not in ("127.0.0.1", "localhost"):
+            return url
+        if sys.platform != "linux":
+            return url.replace(parts.hostname, _HOST_ALIAS, 1)
+        # Same address inside: the next exec opens a door at this port.
+        self._doors.setdefault(parts.port or 80, None)
         return url
 
+    async def expose(self, port: int) -> str:
+        if port != SERVICE_PORT or self._service_url is None:
+            raise SandboxError(
+                f"{self.engine} publishes only port {SERVICE_PORT}, not {port}"
+            )
+        return self._service_url
+
+    async def _open_doors(self) -> None:
+        async with self._doors_lock:
+            ports = [port for port, door in self._doors.items() if door is None]
+            if not ports:
+                return
+            for port, listener in zip(ports, await self._plant_listeners(ports)):
+                self._doors[port] = await asyncio.start_server(
+                    functools.partial(_door, port), sock=listener
+                )
+
+    async def _plant_listeners(self, ports: list[int]) -> list[socket.socket]:
+        """Bind listeners at `ports` on the container's loopback, serviced here: a helper
+        sharing the container's network namespace binds them and passes them back."""
+        with (
+            tempfile.TemporaryDirectory(prefix="vf-door-") as directory,
+            socket.socket(socket.AF_UNIX) as control,
+        ):
+            control.bind(f"{directory}/control.sock")
+            control.listen(1)
+            helper = await cli(
+                self.engine,
+                "run",
+                "--rm",
+                "--network",
+                f"container:{self._container}",
+                "--cap-drop",
+                "ALL",
+                "--cap-add",
+                "DAC_OVERRIDE",
+                "--security-opt",
+                "no-new-privileges",
+                "--volume",
+                f"{directory}:/run/vf:Z",
+                "docker.io/library/python:3.11-alpine",
+                "python3",
+                "-c",
+                _PLANT_LISTENERS,
+                *map(str, ports),
+            )
+            if helper.exit_code != 0:
+                raise SandboxError(
+                    f"{self.engine} loopback listener failed: {helper.stderr.strip()}"
+                )
+            connection, _ = control.accept()
+            with connection:
+                _, ancillary, *_ = connection.recvmsg(
+                    64, socket.CMSG_SPACE(len(ports) * array.array("i").itemsize)
+                )
+        descriptors = array.array("i")
+        descriptors.frombytes(ancillary[0][2][: len(ports) * descriptors.itemsize])
+        return [socket.socket(fileno=fd) for fd in descriptors]
+
     async def prepare_execution(self, routes: list[str] | None) -> None:
-        """Allow the declared framework routes, then leave the proxy as the only route."""
+        """Allow the declared framework routes, then leave them and the proxy as the
+        only ways out."""
         if not self.network_restricted:
             return
         assert self._proxy is not None
         if routes is None:
             self._proxy.policy = NetworkPolicy(
-                NetworkPolicyConfig(), [HOST_ALIAS], allow_non_global=True
+                NetworkPolicyConfig(), [], allow_non_global=True
             )
             return
         framework = [
@@ -358,9 +283,26 @@ class DockerRuntime(Runtime):
         self._proxy.policy = NetworkPolicy(self.config, framework)
         if self._cut:
             return
+        # Off Linux the host is a real address reached through the engine's gateway,
+        # so the cut keeps a route to it open on the framework and proxy ports only.
+        host = ""
+        if sys.platform != "linux":
+            found = await cli(
+                self.engine,
+                "exec",
+                self._container,
+                "sh",
+                "-c",
+                f"awk '$2 == \"{_HOST_ALIAS}\" {{ print $1; exit }}' /etc/hosts",
+            )
+            host = found.stdout.strip()
+            if found.exit_code != 0 or not host:
+                raise SandboxError(
+                    f"could not resolve {_HOST_ALIAS} in {self.engine}: {found.stderr.strip()}"
+                )
+        ports = {urlsplit(url).port or 80 for url in routes} | {self._proxy.port}
         script = (
-            "set -eu; HOST=$1; "
-            "PORT=$2; "
+            "set -eu; HOST=$1; shift; "
             'if [ -n "$HOST" ]; then apk add --no-cache iptables >/dev/null; fi; '
             "GW=$(ip route show default | awk '/^default via/{print $3; exit}'); "
             "SUBNET=$(ip route show | awk '/scope link/{print $1; exit}'); "
@@ -374,10 +316,12 @@ class DockerRuntime(Runtime):
             "ip route add blackhole 127.0.0.11/32 table local; "
             'if [ -n "$HOST" ]; then iptables -F OUTPUT; '
             "iptables -A OUTPUT -o lo -j ACCEPT; "
-            'iptables -A OUTPUT -d "$HOST" -p tcp --dport "$PORT" -j ACCEPT; '
+            'for PORT in "$@"; do '
+            'iptables -A OUTPUT -d "$HOST" -p tcp --dport "$PORT" -j ACCEPT; done; '
             "iptables -A OUTPUT -j REJECT; fi"
         )
-        cut = await docker(
+        cut = await cli(
+            self.engine,
             "run",
             "--rm",
             "--network",
@@ -386,166 +330,56 @@ class DockerRuntime(Runtime):
             "ALL",
             "--cap-add",
             "NET_ADMIN",
-            "alpine:3.22",
+            "docker.io/library/alpine:3.22",
             "sh",
             "-c",
             script,
             "cut",
-            self._proxy_host_ip or "",
-            str(self._proxy.port),
+            host,
+            *map(str, sorted(ports)),
         )
         if cut.exit_code != 0:
-            raise SandboxError(f"docker network cut failed: {cut.stderr.strip()}")
+            raise SandboxError(
+                f"{self.engine} network cut failed: {cut.stderr.strip()}"
+            )
         self._cut = True
 
     def _proxy_env(self) -> dict[str, str]:
-        if self._proxy is None:
-            return {}
-        host = "127.0.0.1" if sys.platform == "linux" else _PROXY_HOST
-        proxy = f"http://verifiers:{self._proxy.token}@{host}:{self._proxy.port}"
+        assert self._proxy is not None
+        proxy = self.host_url(
+            f"http://verifiers:{self._proxy.token}@127.0.0.1:{self._proxy.port}"
+        )
         return {
             "HTTP_PROXY": proxy,
             "HTTPS_PROXY": proxy,
             "http_proxy": proxy,
             "https_proxy": proxy,
-            "NO_PROXY": "localhost,127.0.0.1",
-            "no_proxy": "localhost,127.0.0.1",
+            "NO_PROXY": _NO_PROXY,
+            "no_proxy": _NO_PROXY,
         }
 
     async def teardown(self) -> None:
+        for door in self._doors.values():
+            if door is not None:
+                door.close()
         if self._proxy is not None:
             await self._proxy.stop()
         await super().teardown()
 
-    async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
-        env = {**self.process_env(env), **(self._proxy_env() if self._cut else {})}
-        env_args = [arg for k, v in env.items() for arg in ("--env", f"{k}={v}")]
-        return await docker(
-            "exec", *env_args, "--workdir", self.config.workdir, self._container, *argv
-        )
-
-    async def open_process(
-        self, argv: list[str], env: dict[str, str]
-    ) -> RuntimeProcess:
+    async def _exec(self, env: dict[str, str], *, stdin: bool = False) -> list[str]:
         assert self._container is not None
-        env = {**self.process_env(env), **(self._proxy_env() if self._cut else {})}
-        env_args = [
-            arg for key, value in env.items() for arg in ("--env", f"{key}={value}")
+        if self._proxy is not None:
+            env = {**env, **self._proxy_env()}
+        await self._open_doors()
+        return [
+            self.engine,
+            "exec",
+            *(("-i",) if stdin else ()),
+            *(arg for key, value in env.items() for arg in ("--env", f"{key}={value}")),
+            "--workdir",
+            self.config.workdir,
+            self._container,
         ]
-        pidfile = f"/tmp/vf-process-{uuid.uuid4().hex}.pid"
-        # Give the target its own process group when `setsid -w` is available so
-        # terminate()/kill() reap its descendants while docker exec remains
-        # attached if setsid needs to fork. The inner shell records the
-        # post-setsid PID before exec preserves it as the target PID.
-        wrapper = (
-            "if setsid -w true >/dev/null 2>&1; then "
-            'exec setsid -w sh -c \'echo $$ > "$1"; shift; exec "$@"\' '
-            'vf-process "$@"; '
-            'fi; echo $$ > "$1"; shift; exec "$@"'
-        )
-        proc = await asyncio.create_subprocess_exec(
-            "docker",
-            "exec",
-            "-i",
-            *env_args,
-            "--workdir",
-            self.config.workdir,
-            self._container,
-            "sh",
-            "-c",
-            wrapper,
-            "vf-process",
-            pidfile,
-            *argv,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        loop = asyncio.get_running_loop()
-        deadline = loop.time() + 5
-        try:
-            while True:
-                ready = await docker("exec", self._container, "cat", pidfile)
-                if ready.exit_code == 0 and ready.stdout.strip().isdigit():
-                    return DockerProcess(
-                        proc, self._container, int(ready.stdout.strip())
-                    )
-                if proc.returncode is not None or loop.time() >= deadline:
-                    break
-                await asyncio.sleep(0.05)
-        except BaseException:
-            await run_shielded(_abort_process_startup(proc, self._container, pidfile))
-            raise
-
-        stderr = await run_shielded(
-            _abort_process_startup(proc, self._container, pidfile)
-        )
-        detail = stderr or ready.stderr.strip()
-        raise SandboxError(
-            f"docker live process failed to start: {detail or 'PID unavailable'}"
-        )
-
-    async def run_background(
-        self, argv: list[str], env: dict[str, str], log: str
-    ) -> None:
-        # Detached servers survive the cut, so they need the initially permissive proxy.
-        env = {**self.process_env(env), **self._proxy_env()}
-        env_args = [arg for k, v in env.items() for arg in ("--env", f"{k}={v}")]
-        inner = f"{' '.join(shlex.quote(a) for a in argv)} > {shlex.quote(log)} 2>&1"
-        run = await docker(
-            "exec",
-            "--detach",
-            *env_args,
-            "--workdir",
-            self.config.workdir,
-            self._container,
-            "sh",
-            "-c",
-            inner,
-        )  # detached → lives in the container until it's removed in stop()
-        if run.exit_code != 0:
-            raise SandboxError(f"docker exec -d failed: {run.stderr.strip()}")
-
-    async def _read(self, path: str) -> bytes:
-        proc = await asyncio.create_subprocess_exec(
-            "docker",
-            "exec",
-            "--workdir",
-            self.config.workdir,
-            self._container,
-            "cat",
-            path,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        stdout, stderr = await proc.communicate()
-        if proc.returncode != 0:
-            raise SandboxError(
-                f"read {path!r}: {stderr.decode(errors='replace').strip()}"
-            )
-        return stdout
-
-    async def write(self, path: str, data: bytes) -> None:
-        parent = shlex.quote(str(PurePosixPath(path).parent))
-        proc = await asyncio.create_subprocess_exec(
-            "docker",
-            "exec",
-            "-i",
-            "--workdir",
-            self.config.workdir,
-            self._container,
-            "sh",
-            "-c",
-            f"mkdir -p {parent} && cat > {shlex.quote(path)}",
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        _, stderr = await proc.communicate(input=data)
-        if proc.returncode != 0:
-            raise SandboxError(
-                f"write {path!r}: {stderr.decode(errors='replace').strip()}"
-            )
 
     def cleanup(self) -> None:
         if self._container is None or self._stopped:
@@ -553,12 +387,17 @@ class DockerRuntime(Runtime):
         self._stopped = (
             True  # idempotency guard; keep `_container` so the name still shows
         )
-        logger.debug("docker: removing container %s", self._container)
+        logger.debug("%s: removing container %s", self.engine, self._container)
         with contextlib.suppress(Exception):
             subprocess.run(
-                ["docker", "rm", "--force", self._container],
+                [self.engine, "rm", "--force", self._container],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 timeout=30,
                 check=False,
             )
+
+
+class PodmanRuntime(DockerRuntime):
+    engine = "podman"
+    info_cls = PodmanRuntimeInfo

--- a/verifiers/v1/runtimes/docker/__init__.py
+++ b/verifiers/v1/runtimes/docker/__init__.py
@@ -255,6 +255,8 @@ class DockerRuntime(ContainerRuntime):
                 "ALL",
                 "--cap-add",
                 "DAC_OVERRIDE",
+                "--cap-add",
+                "NET_BIND_SERVICE",
                 "--security-opt",
                 "no-new-privileges",
                 "--volume",

--- a/verifiers/v1/runtimes/docker/__init__.py
+++ b/verifiers/v1/runtimes/docker/__init__.py
@@ -4,8 +4,9 @@ CLI surface (and aliases `host.docker.internal`), so it reuses the whole impleme
 Containers get the engine's private network, so a task's ports never collide with the
 host's. Host loopback stays reachable from inside at its own port: on Linux through a
 listener planted on the container's loopback and relayed here (a "door"), off Linux
-through the engine's host alias. A service hosted in the container is published the
-other way, to a host loopback port."""
+through the engine's host alias (which a restricted runtime reaches through its egress
+proxy). A service hosted in the container is published the other way, to a host
+loopback port."""
 
 import array
 import asyncio
@@ -23,7 +24,12 @@ from verifiers.v1.configs.runtime import NetworkPolicyConfig
 from verifiers.v1.errors import SandboxError
 from verifiers.v1.runtimes.base import SERVICE_PORT, BaseRuntimeInfo, parse_gpu
 from verifiers.v1.runtimes.container import ContainerConfig, ContainerRuntime, cli
-from verifiers.v1.runtimes.docker.egress import EgressProxy, NetworkPolicy, relay
+from verifiers.v1.runtimes.docker.egress import (
+    HOST_ALIAS,
+    EgressProxy,
+    NetworkPolicy,
+    relay,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -44,8 +50,7 @@ class PodmanRuntimeInfo(PodmanConfig, BaseRuntimeInfo):
     pass
 
 
-_HOST_ALIAS = "host.docker.internal"
-_NO_PROXY = f"localhost,127.0.0.1,{_HOST_ALIAS}"
+_NO_PROXY = "localhost,127.0.0.1"
 _PLANT_LISTENERS = r"""
 import array, socket, sys
 control = socket.socket(socket.AF_UNIX)
@@ -142,7 +147,7 @@ class DockerRuntime(ContainerRuntime):
                 "net.ipv6.conf.all.disable_ipv6=1",
             ]
         if sys.platform != "linux":
-            options += ["--add-host", f"{_HOST_ALIAS}:host-gateway"]
+            options += ["--add-host", f"{HOST_ALIAS}:host-gateway"]
         env_args = [
             arg
             for key, value in self.env.items()
@@ -164,9 +169,16 @@ class DockerRuntime(ContainerRuntime):
         if run.exit_code != 0:
             raise SandboxError(f"{self.engine} run failed: {run.stderr.strip()}")
         self.info.id = run.stdout.strip()[:12]  # `run -d` prints the container id
-        # Docker creates a missing `--workdir` for `exec`; Podman refuses one.
+        # Docker creates a missing `--workdir` (as root) for `exec`; Podman refuses one.
         made = await cli(
-            self.engine, "exec", self._container, "mkdir", "-p", self.config.workdir
+            self.engine,
+            "exec",
+            "--user",
+            "0",
+            self._container,
+            "mkdir",
+            "-p",
+            self.config.workdir,
         )
         if made.exit_code != 0:
             raise SandboxError(
@@ -201,9 +213,10 @@ class DockerRuntime(ContainerRuntime):
         if parts.hostname not in ("127.0.0.1", "localhost"):
             return url
         if sys.platform != "linux":
-            return url.replace(parts.hostname, _HOST_ALIAS, 1)
+            return url.replace(parts.hostname, HOST_ALIAS, 1)
         # Same address inside: the next exec opens a door at this port.
-        self._doors.setdefault(parts.port or 80, None)
+        default_port = 443 if parts.scheme == "https" else 80
+        self._doors.setdefault(parts.port or default_port, None)
         return url
 
     async def expose(self, port: int) -> str:
@@ -266,8 +279,8 @@ class DockerRuntime(ContainerRuntime):
         return [socket.socket(fileno=fd) for fd in descriptors]
 
     async def prepare_execution(self, routes: list[str] | None) -> None:
-        """Allow the declared framework routes, then leave them and the proxy as the
-        only ways out."""
+        """Allow the declared framework routes, then leave the proxy as the only way out
+        (on Linux besides the loopback doors)."""
         if not self.network_restricted:
             return
         assert self._proxy is not None
@@ -283,8 +296,8 @@ class DockerRuntime(ContainerRuntime):
         self._proxy.policy = NetworkPolicy(self.config, framework)
         if self._cut:
             return
-        # Off Linux the host is a real address reached through the engine's gateway,
-        # so the cut keeps a route to it open on the framework and proxy ports only.
+        # Off Linux the host is a real address reached through the engine's gateway, so
+        # the cut keeps a route to it open on the proxy port only.
         host = ""
         if sys.platform != "linux":
             found = await cli(
@@ -293,16 +306,15 @@ class DockerRuntime(ContainerRuntime):
                 self._container,
                 "sh",
                 "-c",
-                f"awk '$2 == \"{_HOST_ALIAS}\" {{ print $1; exit }}' /etc/hosts",
+                f"awk '$2 == \"{HOST_ALIAS}\" {{ print $1; exit }}' /etc/hosts",
             )
             host = found.stdout.strip()
             if found.exit_code != 0 or not host:
                 raise SandboxError(
-                    f"could not resolve {_HOST_ALIAS} in {self.engine}: {found.stderr.strip()}"
+                    f"could not resolve {HOST_ALIAS} in {self.engine}: {found.stderr.strip()}"
                 )
-        ports = {urlsplit(url).port or 80 for url in routes} | {self._proxy.port}
         script = (
-            "set -eu; HOST=$1; shift; "
+            "set -eu; HOST=$1; PORT=$2; "
             'if [ -n "$HOST" ]; then apk add --no-cache iptables >/dev/null; fi; '
             "GW=$(ip route show default | awk '/^default via/{print $3; exit}'); "
             "SUBNET=$(ip route show | awk '/scope link/{print $1; exit}'); "
@@ -316,8 +328,7 @@ class DockerRuntime(ContainerRuntime):
             "ip route add blackhole 127.0.0.11/32 table local; "
             'if [ -n "$HOST" ]; then iptables -F OUTPUT; '
             "iptables -A OUTPUT -o lo -j ACCEPT; "
-            'for PORT in "$@"; do '
-            'iptables -A OUTPUT -d "$HOST" -p tcp --dport "$PORT" -j ACCEPT; done; '
+            'iptables -A OUTPUT -d "$HOST" -p tcp --dport "$PORT" -j ACCEPT; '
             "iptables -A OUTPUT -j REJECT; fi"
         )
         cut = await cli(
@@ -336,7 +347,7 @@ class DockerRuntime(ContainerRuntime):
             script,
             "cut",
             host,
-            *map(str, sorted(ports)),
+            str(self._proxy.port),
         )
         if cut.exit_code != 0:
             raise SandboxError(

--- a/verifiers/v1/runtimes/docker/egress.py
+++ b/verifiers/v1/runtimes/docker/egress.py
@@ -15,13 +15,14 @@ import h11
 
 from verifiers.v1.configs.runtime import NetworkPolicyConfig, network_rule_matches
 
-HOST_ALIAS = "vf.host.internal"
 _HEADER_TIMEOUT = 10
 _IO_TIMEOUT = 300
 
 
-async def _read(reader: asyncio.StreamReader) -> bytes:
-    return await asyncio.wait_for(reader.read(1 << 16), _IO_TIMEOUT)
+async def _read(
+    reader: asyncio.StreamReader, timeout: float | None = _IO_TIMEOUT
+) -> bytes:
+    return await asyncio.wait_for(reader.read(1 << 16), timeout)
 
 
 async def _drain(writer: asyncio.StreamWriter) -> None:
@@ -115,13 +116,8 @@ class EgressProxy:
         self.server: asyncio.Server | None = None
         self.port = 0
 
-    async def start(
-        self, bind_host: str | None = None, *, listener: socket.socket | None = None
-    ) -> None:
-        if listener is None:
-            self.server = await asyncio.start_server(self._handle, bind_host, 0)
-        else:
-            self.server = await asyncio.start_server(self._handle, sock=listener)
+    async def start(self, bind_host: str) -> None:
+        self.server = await asyncio.start_server(self._handle, bind_host, 0)
         self.port = self.server.sockets[0].getsockname()[1]
 
     async def stop(self) -> None:
@@ -191,10 +187,9 @@ class EgressProxy:
             )
             addresses = []
             if permitted:
-                dial_host = "127.0.0.1" if host.lower() == HOST_ALIAS else host
                 addresses = await asyncio.wait_for(
                     asyncio.get_running_loop().getaddrinfo(
-                        dial_host, port, type=socket.SOCK_STREAM
+                        host, port, type=socket.SOCK_STREAM
                     ),
                     _IO_TIMEOUT,
                 )
@@ -246,7 +241,7 @@ class EgressProxy:
                         return
                     upstream_writer.write(client_hello)
                     await _drain(upstream_writer)
-                await _relay(reader, writer, upstream_reader, upstream_writer)
+                await relay(reader, writer, upstream_reader, upstream_writer)
             else:
                 path = urlunsplit(("", "", parsed.path or "/", parsed.query, ""))
                 authority = f"[{host}]" if ":" in host else host
@@ -334,15 +329,19 @@ class EgressProxy:
             writer.close()
 
 
-async def _relay(
+async def relay(
     client_reader: asyncio.StreamReader,
     client_writer: asyncio.StreamWriter,
     upstream_reader: asyncio.StreamReader,
     upstream_writer: asyncio.StreamWriter,
+    *,
+    timeout: float | None = _IO_TIMEOUT,
 ) -> None:
+    """Pipe bytes both ways until either side closes; `timeout` bounds idle reads."""
+
     async def pipe(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         try:
-            while chunk := await _read(reader):
+            while chunk := await _read(reader, timeout):
                 writer.write(chunk)
                 await _drain(writer)
         finally:

--- a/verifiers/v1/runtimes/docker/egress.py
+++ b/verifiers/v1/runtimes/docker/egress.py
@@ -15,6 +15,8 @@ import h11
 
 from verifiers.v1.configs.runtime import NetworkPolicyConfig, network_rule_matches
 
+# Off Linux the engine resolves this name to the host; the proxy dials host loopback for it.
+HOST_ALIAS = "host.docker.internal"
 _HEADER_TIMEOUT = 10
 _IO_TIMEOUT = 300
 
@@ -187,9 +189,10 @@ class EgressProxy:
             )
             addresses = []
             if permitted:
+                dial_host = "127.0.0.1" if host.lower() == HOST_ALIAS else host
                 addresses = await asyncio.wait_for(
                     asyncio.get_running_loop().getaddrinfo(
-                        host, port, type=socket.SOCK_STREAM
+                        dial_host, port, type=socket.SOCK_STREAM
                     ),
                     _IO_TIMEOUT,
                 )

--- a/verifiers/v1/task.py
+++ b/verifiers/v1/task.py
@@ -59,7 +59,7 @@ class TaskResources(BaseModel):
     gpu: str | None = None
     """GPU spec, e.g. "A100" or "A100:2" (type[:count])."""
     disk: float | None = None
-    """Disk in GB (enforced by prime; advisory on docker/modal)."""
+    """Disk in GB (enforced by prime; advisory on local containers and modal)."""
 
 
 class TaskTimeout(BaseModel):


### PR DESCRIPTION
Superseded by #2528.

## What this does

Adds two new local runtimes, `type = "podman"` and `type = "apptainer"`, and moves all local containers onto a private network so a task's ports can never collide with the host's.

- Fixes #2319 (Docker used `--network host`, so a task binding port 8000 could silently talk to an unrelated host process and get graded wrong).
- Resolves #2359 by adding Apptainer for HPC clusters. Enroot is not part of this PR.
- Supersedes #2469, #2470 and #2473. Those three did the same things with a lot more code; this PR replaces them with one smaller change.

## How it is built

**One shared base for every local container.** [`runtimes/container.py`](verifiers/v1/runtimes/container.py) holds what used to be the engine-independent half of the Docker runtime: running a command, opening a live process, background processes, reading and writing files, and sending signals. All of it goes through a single method, `_exec(env)`, that returns "the host command that runs something inside this container". A runtime only has to provide `_exec`, `start` and `cleanup`.

**Podman is Docker with a different binary.** `PodmanRuntime` is a two-line subclass of `DockerRuntime`. Podman accepts the same commands and even aliases `host.docker.internal`, so there is nothing else to write. Two small differences are handled inside the Docker code: Podman refuses a `--workdir` that does not exist in the image (Docker creates it), so the workdir is now created with `mkdir -p` right after start; and Podman's `--gpus` takes `all` where Docker takes a count.

**Apptainer is a small subclass too.** It starts an unprivileged instance, binds a host directory as the workdir, and backs the contained `/tmp` and `$HOME` with disk instead of a tiny tmpfs. Images given as Docker references are pulled to a SIF once and cached under `~/.cache/verifiers`, the same way an engine keeps a pulled image. A local `.sif` path is used as is. Apptainer always shares the host network, so it has no egress fields; a task that asks for a network policy on it gets a clear error.

## How the networking works now

Every Docker/Podman container runs on the engine's bridge network. That is the fix for #2319. Two things then have to keep working:

**The container must reach the interception server on the host.** The interception server (and any host-side tool server) listens on the host's loopback. On Linux, `host_url` leaves the URL unchanged and remembers its port. Before the next command runs in the container, one small helper container that shares the network namespace binds a listener at that port on the *container's* loopback and hands the socket back to us; we relay every connection to the host's loopback. Inside the container, `http://127.0.0.1:PORT` simply works, with no proxy settings needed, so harnesses that ignore `HTTP_PROXY` (Node based ones) keep working. On macOS, `host_url` rewrites loopback to `host.docker.internal`, as before.

**Egress must be cuttable.** Restricted runtimes keep the existing HTTP(S) policy proxy and the existing route cut. The proxy is now an ordinary host-loopback service reached like any other. On Linux the cut leaves loopback alone, so the doors keep working. On macOS, restricted framework traffic goes through the proxy as before (the proxy dials the host's loopback for `host.docker.internal`), so the cut opens only the proxy port. The proxy-inside-the-container listener and the made-up `vf.host.internal` name are gone; the engine's own alias does that job.

**The host must reach a tool server placed inside a container.** The fixed service port is published to a host loopback port, and `Runtime.expose` returns it. `Runtime.expose` now defaults to host loopback, so the MCP launch code has one rule for every runtime instead of three cases.

## Behavior changes for Docker

- Private bridge network instead of the host network (the point of the PR).
- The workdir is created after start (as root, like `run --workdir` did) instead of via `run --workdir`.
- Helper images are fully qualified (`docker.io/library/...`) and the socket directory is mounted with `--volume ...:Z`, so Podman and SELinux hosts work.
- `run_background` starts the process in the background inside the container instead of `exec --detach`, which Apptainer does not have.
- In restricted mode the proxy environment is set from the start, not only after the cut. Setup traffic goes direct until the cut anyway.

## How I tested it

Automated: `uv run pytest tests/v1 -m "not e2e"` (82 tests), `uv run pre-commit run --all-files`, and `ty check verifiers` all pass. The e2e suite needs `PRIME_API_KEY`, which I do not have here.

Live, with two throwaway scripts (below) run against each engine. The first covers the process side: run, environment values containing commas, stdin closed for plain runs, binary write/read, a live process fed on stdin and then terminated with its child reaped, a background server, and installing and running a uv script inside. The second covers networking: a host HTTP server reached from inside through `host_url`, proof that the namespace is private (a port busy on the host is free inside), a server inside reached from the host through `expose`, two doors opened in one batch, and the restricted flow: host reachable before and after the cut, a blocked host gets 403, an allowed host works through the proxy, raw TCP egress is dead, and live processes see the proxy environment.

| Engine | Where | Result |
|---|---|---|
| Docker 29 | macOS, OrbStack | both scripts pass, both network modes |
| Podman 4.9 rootless | Ubuntu 24.04 arm64 VM | both scripts pass, both network modes |
| Apptainer 1.5.3 | Ubuntu 24.04 arm64 VM | both scripts pass (unrestricted only, by design) |

Not tested by hand: Podman on macOS through `podman machine` and GPU flags. Docker on Linux is covered by CI's live E2E suite, which passed on this branch. After the review fixes, both macOS Docker runs were repeated; Linux is re-verified by CI on the final commit.

Two bugs the live tests caught that unit tests would not have: rootless Podman defaults to pasta, which has no `eth0`, so `--network bridge` is now explicit for both engines; and the listener-planting helper dropped its first socket to garbage collection when two ports were requested at once.

<details>
<summary>Smoke script 1: processes and files (<code>smoke_runtime.py &lt;docker|podman|apptainer&gt; [--skip-restricted]</code>)</summary>

```python
"""Smoke-test the refactored container runtime against local Docker."""

import asyncio
import sys

from verifiers.v1.runtimes import provision_runtime
from verifiers.v1.runtimes import RuntimeConfig
from pydantic import TypeAdapter
KIND = sys.argv[1]
def Config(**kw):
    return TypeAdapter(RuntimeConfig).validate_python({"type": KIND, **kw})


async def collect(stream):
    return b"".join([chunk async for chunk in stream])


async def unrestricted():
    print("== unrestricted ==")
    async with provision_runtime(Config(), env={"BASE": "1"}) as rt:
        r = await rt.run(["sh", "-c", "echo hi $BASE $EXTRA; pwd"], {"EXTRA": "a,b=c"})
        assert r.exit_code == 0, r
        assert r.stdout.strip() == "hi 1 a,b=c\n/app".replace("\n", "\n"), repr(r.stdout)
        # stdin of `run` is EOF, not the terminal
        r = await rt.run(["sh", "-c", "cat; echo done"], {})
        assert r.stdout.strip() == "done", repr(r.stdout)
        # write / read (binary-safe), relative to workdir
        data = bytes(range(256)) * 10
        await rt.write("sub/dir/blob.bin", data)
        assert await rt.read("sub/dir/blob.bin") == data
        assert await rt.read("/app/sub/dir/blob.bin", max_bytes=len(data)) == data
        try:
            await rt.read("missing.txt")
        except Exception as e:
            print("  read missing ->", type(e).__name__, str(e)[:60])
        else:
            raise AssertionError("read of missing file did not raise")
        # live process: stdin echo, then terminate reaps the group
        p = await rt.open_process(["sh", "-c", "read x; echo got:$x; sleep 30 & wait"], {})
        await p.write(b"ping\n")
        stdout = asyncio.create_task(collect(p.stdout))
        await asyncio.sleep(0.5)
        await p.terminate()
        code = await asyncio.wait_for(p.wait(), 10)
        out = await asyncio.wait_for(stdout, 10)
        assert b"got:ping" in out, out
        print("  live process exit", code, "stdout", out)
        left = await rt.run(["sh", "-c", "cat /proc/[0-9]*/cmdline 2>/dev/null | tr '\\0' ' ' | grep -c 'sleep 3[0]' || true"], {})
        assert left.stdout.strip() == "0", ("sleep survived terminate", left.stdout)
        # background server: returns immediately, keeps running, logs to file
        t = asyncio.get_running_loop().time()
        await rt.run_background(["sh", "-c", "echo started; sleep 60"], {}, "bg.log")
        assert asyncio.get_running_loop().time() - t < 3, "run_background blocked"
        await asyncio.sleep(0.5)
        assert (await rt.read("bg.log")).strip() == b"started"
        running = await rt.run(["sh", "-c", "cat /proc/[0-9]*/cmdline 2>/dev/null | tr '\\0' ' ' | grep -c 'sleep 6[0]'"], {})
        assert running.stdout.strip() == "1", running
        print("  uv script:", (await rt.run_uv_script("# /// script\n# dependencies = []\n# ///\nprint('uv ok')")).stdout.strip())
    print("  ok")


async def restricted():
    print("== restricted ==")
    cfg = Config(image="docker.io/library/python:3.11-slim", block=["example.com"])
    async with provision_runtime(cfg) as rt:
        assert rt.network_restricted
        # setup phase: direct egress works
        r = await rt.run(["python3", "-c", "import urllib.request;print(urllib.request.urlopen('http://example.com', timeout=10).status)"], {})
        assert r.stdout.strip() == "200", r
        await rt.prepare_execution(["http://127.0.0.1:1/v1"])
        # after the cut: blocked destination fails, allowed one works through the proxy
        blocked = await rt.run(["python3", "-c", "import urllib.request;print(urllib.request.urlopen('http://example.com', timeout=10).status)"], {})
        assert blocked.exit_code != 0, blocked
        print("  blocked ->", blocked.stderr.strip().splitlines()[-1][:80])
        allowed = await rt.run(["python3", "-c", "import urllib.request;print(urllib.request.urlopen('https://pypi.org/simple/', timeout=20).status)"], {})
        assert allowed.stdout.strip() == "200", allowed
        # env plumbing after the cut includes the proxy for run + open_process
        p = await rt.open_process(["sh", "-c", "echo $HTTPS_PROXY | sed 's/:[^@]*@/:***@/'"], {})
        out = await collect(p.stdout)
        assert b"http:***@" in out, out
        print("  proxy env in live process:", out.strip())
        assert await p.wait() == 0
    print("  ok")


async def main():
    await unrestricted()
    if "--skip-restricted" not in sys.argv:
        await restricted()


asyncio.run(main())
```

</details>

<details>
<summary>Smoke script 2: networking (<code>smoke_net.py &lt;docker|podman|apptainer&gt; [--skip-restricted]</code>)</summary>

```python
"""Network smoke test: private netns, host loopback doors, published service port, cut."""

import asyncio
import sys

from aiohttp import web
from pydantic import TypeAdapter

from verifiers.v1.runtimes import RuntimeConfig, provision_runtime
from verifiers.v1.runtimes.base import SERVICE_PORT

KIND = sys.argv[1]
PY = "import sys,urllib.request;print(urllib.request.urlopen(sys.argv[1], timeout=15).read().decode())"
FETCH = ["python3", "-c", PY]


def Config(**kw):
    return TypeAdapter(RuntimeConfig).validate_python({"type": KIND, **kw})


async def host_server():
    """A host-loopback HTTP service standing in for the interception server."""
    app = web.Application()
    app.router.add_get("/ping", lambda r: web.Response(text=f"pong {r.path_qs}"))
    runner = web.AppRunner(app)
    await runner.setup()
    site = web.TCPSite(runner, "127.0.0.1", 0)
    await site.start()
    return runner, site._server.sockets[0].getsockname()[1]


async def main():
    runner, port = await host_server()
    try:
        print(f"== {KIND} unrestricted ==")
        async with provision_runtime(Config()) as rt:
            url = rt.host_url(f"http://127.0.0.1:{port}")
            print("  host_url ->", url)
            r = await rt.run([*FETCH, f"{url}/ping?a=1"], {})
            assert r.stdout.strip() == "pong /ping?a=1", r
            # private netns: a port busy on the host (and not yet door-ed) is free inside
            runner2, port2 = await host_server()
            if KIND != "apptainer":
                r = await rt.run(["python3", "-c", "import socket;s=socket.socket();s.bind(('127.0.0.1',%d));print('bound')" % port2], {})
                assert r.stdout.strip() == "bound", ("host port leaked into the container", r)
            # long idle connection through the door survives (no relay timeout)
            # published service port: a server inside on 0.0.0.0:SERVICE_PORT is reachable at expose()
            await rt.run_background(["python3", "-m", "http.server", str(SERVICE_PORT), "--bind", "0.0.0.0", "-d", "/tmp"], {}, "srv.log")
            exposed = await rt.expose(SERVICE_PORT)
            print("  expose ->", exposed)
            import urllib.request
            for _ in range(50):
                try:
                    code = urllib.request.urlopen(exposed, timeout=2).status
                    break
                except Exception:
                    await asyncio.sleep(0.2)
            assert code == 200, code
            # a second host_url'd port opens another door in the same container
            url2 = rt.host_url(f"http://127.0.0.1:{port2}")
            r = await rt.run([*FETCH, f"{url2}/ping"], {})
            assert r.stdout.strip() == "pong /ping", r
            await runner2.cleanup()
            print("  ok")

        if "--skip-restricted" in sys.argv:
            return
        print(f"== {KIND} restricted ==")
        async with provision_runtime(Config(block=["example.com"])) as rt:
            url = rt.host_url(f"http://127.0.0.1:{port}")
            # setup phase: host reachable, egress open
            r = await rt.run([*FETCH, f"{url}/ping"], {})
            assert r.stdout.strip() == "pong /ping", r
            r = await rt.run([*FETCH, "http://example.com"], {})
            assert r.exit_code == 0, r
            await rt.prepare_execution([f"{url}/v1"])
            # after the cut: host still reachable, blocked host denied, allowed host via proxy
            r = await rt.run([*FETCH, f"{url}/ping"], {})
            assert r.stdout.strip() == "pong /ping", ("interception unreachable after cut", r)
            r = await rt.run([*FETCH, "http://example.com"], {})
            assert r.exit_code != 0, r
            print("  blocked ->", r.stderr.strip().splitlines()[-1][:70])
            r = await rt.run([*FETCH, "https://pypi.org/simple/"], {})
            assert r.exit_code == 0, r
            # raw egress (proxy bypass) is cut
            r = await rt.run(["python3", "-c", "import socket;s=socket.socket();s.settimeout(3);s.connect(('1.1.1.1',80))"], {})
            assert r.exit_code != 0, ("raw egress survived the cut", r)
            # live process sees proxy env
            p = await rt.open_process(["sh", "-c", "echo $HTTPS_PROXY $NO_PROXY"], {})
            out = b"".join([c async for c in p.stdout])
            assert b"@" in out and b"localhost,127.0.0.1" in out, out
            assert await p.wait() == 0
            print("  ok")
    finally:
        await runner.cleanup()


asyncio.run(main())
```

</details>

## Known limits

- Podman GPU requests emit `--gpus all`, which needs Podman 5. Docker keeps its device count.
- Apptainer maps any GPU request to `--nv` (all NVIDIA GPUs); the count is advisory.
- Apptainer cannot restrict egress without root or CNI setup, so `allow`/`block` are rejected for it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes sandbox networking, egress restriction, and service URL exposure across Docker/Podman/MCP—mistakes could break grading, interception reachability, or leak/block traffic incorrectly.
> 
> **Overview**
> Adds **`podman`** and **`apptainer`** as v1 runtimes (wired through `RuntimeConfig`, public exports, and architecture docs) and refactors local containers around a shared **`ContainerRuntime`** in `container.py` so Docker/Podman only implement `_exec`, `start`, and `cleanup`.
> 
> **Docker/Podman** now run on the engine **bridge** (not host networking), publish the fixed service port to host loopback, and implement **`expose`** for that URL. On Linux, **`host_url`** schedules **loopback “doors”** (listeners in the container netns relayed to the host) so harnesses can reach interception on `127.0.0.1` without relying on `HTTP_PROXY`; restricted egress keeps the policy proxy on host loopback and updates the network cut / **`HOST_ALIAS`** (`host.docker.internal`) accordingly. **Podman** is a thin subclass; **Apptainer** runs unprivileged instances on the host network with cached SIF pulls.
> 
> **`Runtime.expose`** now always returns a concrete URL (default `http://127.0.0.1:{port}`), which **unifies MCP `reachable_url`** (always `expose`, Prime Tunnel only when a local runtime serves a remote consumer) and gates **`MCP_HOST`** on both `exposed` and **`published_port`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc14ff9ce64e355390d3a88ba45c958723b35960. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `PodmanRuntime` and `ApptainerRuntime` and refactor container networking
> - Extracts shared `ContainerRuntime` and `ContainerConfig` base classes so Docker and Podman share container lifecycle and execution logic. `PodmanRuntime` reuses the Docker implementation with the `podman` CLI.
> - Adds `ApptainerRuntime` for unprivileged local instances using the host network, with local image file support and a digest-keyed SIF cache.
> - Updates restricted container networking: Linux containers use lazily-created host loopback relay doors, and non-Linux containers use `host.docker.internal` for host resolution.
> - Behavioral Change: `Runtime.expose()` now returns a concrete loopback HTTP URL instead of `None`. `EgressProxy.start` no longer accepts an externally supplied listener socket. The MCP launcher omits `MCP_HOST` when `serve_in_runtime` is called with `exposed=False`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc14ff9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->