### PR TITLE
fix(v1): restore request-interceptor rewrites when the harness replays its originals

### DIFF
--- a/tests/v1/test_session.py
+++ b/tests/v1/test_session.py
@@ -1,0 +1,102 @@
+"""Request-interceptor rewrites survive the harness replaying its own originals."""
+
+import verifiers.v1 as vf
+from verifiers.v1 import graph
+from verifiers.v1.clients import EvalClientConfig, ModelContext
+from verifiers.v1.session import RolloutSession
+
+
+def _session(*interceptors) -> RolloutSession:
+    trace = vf.Trace(
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
+        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="x")),
+    )
+    return RolloutSession(
+        ctx=ModelContext(model="m", client=EvalClientConfig()),
+        trace=trace,
+        request_interceptors=list(interceptors),
+    )
+
+
+def _commit(session: RolloutSession, request: vf.Request, text: str) -> None:
+    response = vf.Response(
+        id="a",
+        created=0,
+        model="m",
+        message=vf.AssistantMessage(content=text),
+        finish_reason="stop",
+    )
+    graph.prepare_turn(session.trace, request.messages).commit(response)
+
+
+async def test_tool_result_rewrite_is_restored_when_the_harness_replays_its_original():
+    seen: list[vf.Message] = []
+
+    def redact_last(request: vf.Request) -> vf.Request | None:
+        last = request.messages[-1]
+        seen.append(last)
+        if isinstance(last, vf.ToolMessage) and last.content == "secret":
+            redacted = last.model_copy(update={"content": "[redacted]"})
+            return request.model_copy(
+                update={"messages": [*request.messages[:-1], redacted]}
+            )
+        return None
+
+    session = _session(redact_last)
+    call = vf.ToolCall(id="c1", type="function", name="bash", arguments="{}")
+    turn1 = vf.Request(
+        messages=[
+            vf.UserMessage(content="run it"),
+            vf.AssistantMessage(content=None, tool_calls=[call]),
+            vf.ToolMessage(tool_call_id="c1", content="secret"),
+        ]
+    )
+    model1, records1, _ = await session.rewrite_request(turn1)
+    assert model1.messages[-1].content == "[redacted]"
+    assert [r.handler for r in records1] == ["redact_last"]
+    _commit(session, model1, "done")
+
+    # The harness stored `secret`, not `[redacted]`, and replays it with its next turn.
+    turn2 = vf.Request(
+        messages=[
+            *turn1.messages,
+            vf.AssistantMessage(content="done"),
+            vf.UserMessage(content="next"),
+        ]
+    )
+    model2, records2, _ = await session.rewrite_request(turn2)
+    assert model2.messages[2].content == "[redacted]"
+    assert records2 == []
+    # Only the new message reached the interceptor, and the committed history was reused whole.
+    assert seen[-1] == turn2.messages[-1]
+    assert graph.prepare_turn(session.trace, model2.messages).tail_start == 4
+
+
+async def test_repeated_user_originals_map_to_their_rewrites_in_order():
+    def shout_last(request: vf.Request) -> vf.Request | None:
+        last = request.messages[-1]
+        if isinstance(last, vf.UserMessage) and isinstance(last.content, str):
+            shouted = last.model_copy(update={"content": last.content.upper()})
+            return request.model_copy(
+                update={"messages": [*request.messages[:-1], shouted]}
+            )
+        return None
+
+    session = _session(shout_last)
+    turn1 = vf.Request(messages=[vf.UserMessage(content="go")])
+    model1, _, _ = await session.rewrite_request(turn1)
+    assert model1.messages[0].content == "GO"
+    _commit(session, model1, "ok")
+
+    # The replayed original is restored; the identical new message is intercepted afresh.
+    turn2 = vf.Request(
+        messages=[
+            vf.UserMessage(content="go"),
+            vf.AssistantMessage(content="ok"),
+            vf.UserMessage(content="go"),
+        ]
+    )
+    model2, records2, _ = await session.rewrite_request(turn2)
+    assert [m.content for m in model2.messages] == ["GO", "ok", "GO"]
+    assert [r.handler for r in records2] == ["shout_last"]
+    assert graph.prepare_turn(session.trace, model2.messages).tail_start == 2

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -613,8 +613,10 @@ class InterceptionServer(Interception):
             )
             if request_rewrites:
                 session.trace.request_rewrites.extend(request_rewrites)
-                if stopped is None:
-                    dialect.rewrite_request(body, original_request, model_request)
+            # Patch the native body whenever the model-facing request differs from what the
+            # harness sent: a fresh rewrite, or an earlier one restored over a replayed original.
+            if stopped is None and model_request != original_request:
+                dialect.rewrite_request(body, original_request, model_request)
         except RolloutError as error:
             return self._fail(session, dialect, error)
         except Exception as error:  # noqa: BLE001 - surface task hook failures

--- a/verifiers/v1/session.py
+++ b/verifiers/v1/session.py
@@ -147,15 +147,58 @@ class RolloutSession:
     the exchange (upstream call, simulator turn) — unregistering cancels these instead."""
     prepared_tool_results: dict[str, ToolMessage] = field(default_factory=dict)
     prepared_users: Counter[str] = field(default_factory=Counter)
+    rewritten_tool_results: dict[str, ToolMessage] = field(default_factory=dict)
+    """Tool results request interceptors rewrote on their way to the model, by tool-call id.
+    The harness keeps its original, so later turns replay that; the rewrite is restored."""
+    rewritten_users: dict[str, list[UserMessage]] = field(default_factory=dict)
+    """User messages request interceptors rewrote, keyed by the original's hash, in order of
+    application (a repeated original maps to its rewrites in sequence)."""
 
     @property
     def stopped(self) -> bool:
         return self.trace.stop_condition is not None
 
+    def restore_rewrites(self, request: Request) -> Request:
+        """`request` with earlier interceptor rewrites put back where the harness replays the
+        originals it stored, so the model sees the same history it saw before. Providers that
+        bind reasoning to the preceding context (Anthropic's preserved thinking) reject a
+        replay whose earlier messages changed."""
+        if not self.rewritten_tool_results and not self.rewritten_users:
+            return request
+        seen: Counter[str] = Counter()
+        messages = list(request.messages)
+        changed = False
+        for position, message in enumerate(messages):
+            if isinstance(message, ToolMessage):
+                rewritten = self.rewritten_tool_results.get(message.tool_call_id)
+                if rewritten is not None and rewritten != message:
+                    messages[position] = rewritten
+                    changed = True
+            elif isinstance(message, UserMessage):
+                key = graph.message_hash(message)
+                rewrites = self.rewritten_users.get(key)
+                if rewrites and seen[key] < len(rewrites):
+                    messages[position] = rewrites[seen[key]]
+                    changed = True
+                seen[key] += 1
+        return request.model_copy(update={"messages": messages}) if changed else request
+
+    def _record_rewrites(self, before: Request, after: Request) -> None:
+        for original, rewritten in zip(before.messages, after.messages, strict=True):
+            if original == rewritten:
+                continue
+            if isinstance(rewritten, ToolMessage):
+                self.rewritten_tool_results[rewritten.tool_call_id] = rewritten
+            elif isinstance(rewritten, UserMessage):
+                key = graph.message_hash(original)
+                self.rewritten_users.setdefault(key, []).append(rewritten)
+
     async def rewrite_request(
         self, request: Request, *, run_stops: bool = True
     ) -> tuple[Request, list[InterceptRecord], str | None]:
-        """Run typed request interceptors and stops over one canonical request."""
+        """Run typed request interceptors and stops over one canonical request, with earlier
+        rewrites restored first (see `restore_rewrites`)."""
+        request = self.restore_rewrites(request)
         if not self.request_interceptors and (not run_stops or not self.request_stops):
             return request, [], None
         turn = graph.prepare_turn(self.trace, request.messages)
@@ -218,6 +261,7 @@ class RolloutSession:
                 if result != current:
                     current = result
                     records.append(InterceptRecord(handler=handler.__name__))
+            self._record_rewrites(request, current)
 
             stops = self.request_stops if run_stops else []
             for stop in stops:


### PR DESCRIPTION
**The bug.** A `@vf.intercept` request handler rewrites a new user or tool message on its way to the model (the two shipped examples, `grayscale` and `rewrite_git`, both rewrite `messages[-1]`). The harness never sees that rewrite; it keeps the message it produced. On the next turn it replays that original. `prepare_turn` then fails to match the committed (rewritten) node at that position, so:

- the model sees the **original** at that position while it saw the rewrite one turn earlier;
- the graph **forks**, and the leaf that gets scored and trained on carries the harness's original, not what the model saw;
- a provider that binds reasoning to its preceding context rejects the replay. Anthropic's preserved thinking (release notes, 2026-09-01) returns a 400 on Fable 5.1 for API accounts created after 2026-08-31 when "the `system` prompt, `tools`, or an earlier message changed" before a replayed thinking block, and will apply to everyone on later models.

Blast radius today: no prime-envs taskset uses request interceptors, and the three verifiers examples run on the bash harness. It is the first thing that breaks once a Claude Code, Kimi Code or Pi rollout on an Anthropic transport uses one.

**The fix.** `RolloutSession` records every rewrite it applies — tool results by tool-call id, user messages by the original's hash in order of application, so a repeated original maps to its rewrites in sequence — and `rewrite_request` restores them before the graph lookup and before interceptors run. Consequences:
- committed history is reused whole (no fork), and interceptors only see the truly new messages instead of re-running over a mismatched tail every turn;
- the interception server patches the native body whenever the model-facing request differs from what the harness sent, not only when a new rewrite happened this turn.

The existing pre-harness `prepared_*` bookkeeping (env-authored user turns the harness stores already rewritten) is untouched.

**Tests.** `tests/v1/test_session.py`, two cases: a redacting tool-result interceptor whose rewrite survives the harness replaying `secret`, with the committed nodes reused whole; and a user-message interceptor where the replayed original is restored while an identical new message is intercepted afresh. Both fail on main (`'secret' == '[redacted]'`, `['go','ok','GO'] == ['GO','ok','GO']`) and pass here. `ruff`, `ty`, and the full unit suite (85) pass.

**Not in this PR.** `tool_choice: any|tool` now 400s on Fable 5.1 / Mythos 5.1; verifiers passes the harness's choice through and only sends `none` itself, so nothing to change unless we want the network-policy mediation to stop treating `any`/`tool` as valid on Anthropic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore request-interceptor rewrites when harness replays originals in `RolloutSession`
> - `RolloutSession` now stores interceptor rewrites (tool results by tool-call ID, user messages by original hash) and restores them before request preparation when the harness replays a prior original message
> - `_record_rewrites` captures the original-to-final interceptor differences after each interceptor chain so later replays can reconstruct the model-facing request
> - The `InterceptionServer` model-boundary handler rewrites the native request body whenever the model-facing request differs from the harness request and the turn was not stopped, including restoration-only rewrites with no new interceptor records
> - Added regression tests in [test_session.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2511/files#diff-19919269c42661f2b3b7eeba3319faeedbb8f17d8db03ac5b9467abf957d8160) for tool-result restoration and ordered mapping of repeated user originals
> - Risk: `restore_rewrites` substitutes stored rewrites by tool-call ID and user-message hash; mismatched keys (e.g. harness changing a tool-call ID or user-message content between replays) would silently skip restoration
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e01906c. 2 files reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the model-boundary request path and message graph matching; incorrect restoration keys could leave originals visible to the model, but scope is limited to sessions using request interceptors.
> 
> **Overview**
> Fixes a mismatch where **request interceptors** rewrite user or tool messages for the model, but the harness keeps and replays the **original** text on later turns. That broke graph alignment (forked traces, wrong training leaf) and could trigger provider errors when earlier context must stay byte-identical (e.g. Anthropic preserved thinking).
> 
> **`RolloutSession`** now **records** interceptor rewrites (tool results by `tool_call_id`, user messages by original hash with ordered slots for duplicates) and **`restore_rewrites`** swaps harness replays back to what the model saw **before** `prepare_turn` and interceptors run. **`_record_rewrites`** updates that store after each interceptor pass. On later turns, committed history matches and interceptors only touch the new tail.
> 
> The **interception server** patches the native request body whenever the model-facing request differs from the harness payload—not only when this turn produced new `request_rewrites`—so restoration-only turns still reach upstream correctly.
> 
> Adds **`tests/v1/test_session.py`** for tool-result redaction across replay and repeated identical user messages mapping to rewrites in order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e01906ca5d4154142927dfc5f6642fe1549cade6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->