### PR TITLE
fix(v1): apply task weights when isolated judge is skipped

### DIFF
--- a/tests/v1/test_judges.py
+++ b/tests/v1/test_judges.py
@@ -4,12 +4,18 @@ rewards. Judge model calls are faked at `Judge.complete` — no network."""
 
 import json
 import re
+from typing import cast
 
 import pytest
 from pydantic import Field
 
 import verifiers.v1 as vf
-from verifiers.v1.envs.agentic_judge import JudgeTaskConfig, ScoreConfig
+from verifiers.v1.envs.agentic_judge import (
+    AgenticJudgeEnvConfig,
+    IsolatedAgenticJudgeEnv,
+    JudgeTaskConfig,
+    ScoreConfig,
+)
 from verifiers.v1.envs.agentic_judge.env import TRACE_FILE, JudgeTask
 from verifiers.v1.graph import MessageNode
 from verifiers.v1.judge import Judge, JudgeResponse
@@ -597,6 +603,34 @@ def test_judge_composition_weights_are_finite():
         for field in ("task_weight", "judge_weight"):
             with pytest.raises(ValueError, match="finite number"):
                 ScoreConfig.model_validate({field: weight})
+
+
+@pytest.mark.parametrize("task_weight", [0.0, 0.25, 1.0])
+async def test_failed_isolated_agentic_judge_scales_task_rewards(
+    task_weight: float,
+) -> None:
+    solution = make_trace()
+    solution.record_reward("partial", 0.5, weight=0.5)
+    solution.rewards["unscored"] = None
+
+    class FailedSolver:
+        async def run(self, task: vf.Task, *, collect_artifacts: bool) -> vf.Trace:
+            assert collect_artifacts
+            return solution
+
+    class FailedAgents:
+        solver = FailedSolver()
+
+    env = object.__new__(IsolatedAgenticJudgeEnv)
+    env.config = AgenticJudgeEnvConfig(score=ScoreConfig(task_weight=task_weight))
+
+    with pytest.raises(RuntimeError, match="the judge never ran"):
+        await env.run(vf.Task(solution.task.data), cast(vf.Agents, FailedAgents()))
+
+    assert solution.rewards["partial"] is not None
+    assert solution.rewards["partial"].weight == 0.5 * task_weight
+    assert solution.rewards["unscored"] is None
+    assert "judge" not in solution.rewards
 
 
 async def test_rubric_score(tmp_path, fake_judge_model):

--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -319,6 +319,13 @@ class AgenticJudgeEnv(vf.Env[AgenticJudgeEnvConfig]):
         # The judge grades the policy; its tokens are never training data.
         agents.judge.trainable = False
 
+    def _scale_task_rewards(self, solution: vf.Trace) -> None:
+        if self.config.score.task_weight == 1.0:
+            return
+        for reward in solution.rewards.values():
+            if reward is not None:
+                reward.weight *= self.config.score.task_weight
+
     async def finalize(self, task: vf.Task, episode: vf.Episode) -> None:
         by_agent = {t.agent.name: t for t in episode.traces}
         solution, verdict = by_agent["solver"], by_agent["judge"]
@@ -327,10 +334,7 @@ class AgenticJudgeEnv(vf.Env[AgenticJudgeEnvConfig]):
         scores = score_verdicts(verdicts, criteria, "the rubric's")
         for criterion in criteria:
             solution.record_metric(f"judge/{criterion.name}", scores[criterion.name])
-        if self.config.score.task_weight != 1.0:
-            for reward in solution.rewards.values():
-                if reward is not None:
-                    reward.weight *= self.config.score.task_weight
+        self._scale_task_rewards(solution)
         total = sum(criterion.weight for criterion in criteria)
         reward = sum(c.weight * scores[c.name] for c in criteria) / total
         solution.record_reward("judge", reward, weight=self.config.score.judge_weight)
@@ -356,6 +360,7 @@ class IsolatedAgenticJudgeEnv(AgenticJudgeEnv):
     async def run(self, task: vf.Task, agents: vf.Agents) -> None:
         solution = await agents.solver.run(task, collect_artifacts=True)
         if not solution.ok:
+            self._scale_task_rewards(solution)
             raise RuntimeError("the solver's rollout failed, so the judge never ran")
         await agents.judge.run(
             JudgeTask.from_trace(solution, self.config.task, share_runtime=False)


### PR DESCRIPTION
## Summary

- scale existing task rewards when an isolated solver fails before the judge runs
- share the scaling path with successful agentic-judge finalization so reward composition stays consistent
- preserve `None` rewards and leave the absent judge reward as the signal that no verdict was produced

Fixes #2197

## Testing

- `uv run pytest tests/` — 86 passed, 76 skipped (live E2E tests require `PRIME_API_KEY`, which is not available in this shell)
- `uv run ruff check --fix .`
- `uv run pre-commit run --all-files`
- focused regression verified failing before the implementation and passing afterward

## AI assistance

Implemented and reviewed with OpenAI Codex. I inspected the current control flow, reproduced the bug with a focused regression, and verified the final diff and repository checks.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix task weight scaling in `IsolatedAgenticJudgeEnv.run` when judge is skipped
> - Failed isolated solver rollouts previously skipped the judge but left existing task reward weights unscaled; now `IsolatedAgenticJudgeEnv.run` scales non-null reward weights by the configured task weight before raising the rollout failure error.
> - Extracts the shared `AgenticJudgeEnv._scale_task_rewards` helper (no-op when task weight is 1.0) and refactors `finalize` to call it, replacing the inline loop.
> - Adds a parametrized test covering task weights 0.0, 0.25, and 1.0 to verify scaling on failed rollouts and confirm no judge reward is created.
> - Risk: any caller relying on the old behavior of leaving reward weights untouched on failed isolated rollouts will see scaled weights in [env.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2513/files#diff-6c0b86ec43e4d94e2bde0d8ed0ac8ff6c3a422e074161c486bb7aa45c9ae1c81).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 293c631.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->