### PR TITLE
fix(v1): include tools in branch identity

### DIFF
--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -16,7 +16,7 @@ from renderers.base import ToolCallParseStatus, is_multimodal
 from verifiers.v1.clients.base import build_async_openai
 from verifiers.v1.clients.client import SESSION_ID_HEADER, Client
 from verifiers.v1.configs.client import TrainClientConfig
-from verifiers.v1.dialects import FINISH_REASONS, ChatDialect, Dialect, parse_tools
+from verifiers.v1.dialects import FINISH_REASONS, ChatDialect, Dialect
 from verifiers.v1.dialects.chat import message_to_wire
 from verifiers.v1.errors import ProviderError, model_error
 from verifiers.v1.graph import PendingTurn
@@ -343,10 +343,9 @@ class TrainClient(Client):
                 f"{type(dialect).__name__}. Use the proxy client for this dialect, or add "
                 f"renderer support for it."
             )
-        # Intercepted turns already own the typed prompt, so only their tools need parsing here.
         if turn is not None:
             prompt = turn.prompt
-            tools = parse_tools(body.get("tools"))
+            tools = turn.tools
         else:
             request = dialect.parse_request(body)
             prompt = request.messages

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -87,6 +87,8 @@ class MessageNode(BaseModel):
 
     parent: int | None = None
     """Index into `Trace.nodes` of the predecessor message; None for a root."""
+    tools: list[Tool] = Field(default_factory=list, exclude_if=lambda tools: not tools)
+    """Tools rendered into this branch's prompt. Populated only on root nodes."""
     semantic_parents: list[ParentLink] = Field(default_factory=list)
     """Additional harness-declared parents in the semantic execution graph.
 
@@ -277,9 +279,8 @@ def message_hash(message: Message) -> str:
     """Stable content hash on the fields that round-trip through a prompt — role, content
     (None and "" equal), assistant reasoning content when present, assistant tool calls,
     opaque continuation state, tool call id. Two messages hash equal iff they're the same
-    conversational message, so a re-stated prefix message dedups to one node. The dedup key
-    for sharing a prefix across turns/branches; salt-free so it is identical across processes
-    and after deserialization."""
+    conversational message, so a re-stated prefix message dedups to one node. The message part
+    of the prefix key; salt-free so it is identical across processes and after deserialization."""
     digest = hashlib.blake2b(digest_size=16)
 
     def add(value: str) -> None:
@@ -350,14 +351,52 @@ def message_hash(message: Message) -> str:
     return digest.hexdigest()
 
 
-def _head_index(trace: Trace) -> dict[tuple[int | None, str], int]:
-    """`(parent, msg_hash) -> node_id`, rebuilt lazily from `nodes` after deserialization."""
+def _tools_hash(tools: list[Tool] | None) -> str:
+    payload = [tool.model_dump(mode="json", exclude_none=True) for tool in tools or []]
+    data = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.blake2b(data, digest_size=16).hexdigest()
+
+
+def _node_key(
+    parent: int | None, message: Message, tools: list[Tool] | None = None
+) -> tuple[int | None, str | None, str]:
+    return (
+        parent,
+        _tools_hash(tools) if parent is None else None,
+        message_hash(message),
+    )
+
+
+def _head_index(trace: Trace) -> dict[tuple[int | None, str | None, str], int]:
+    """Physical node key -> id, rebuilt lazily after deserialization."""
     if not trace._head_index and trace.nodes:
         trace._head_index = {
-            (node.parent, message_hash(node.message)): nid
+            _node_key(node.parent, node.message, node.tools): nid
             for nid, node in enumerate(trace.nodes)
         }
     return trace._head_index
+
+
+def message_prefix_len(trace: Trace, prompt: list[Message]) -> int:
+    """Length of the longest message-only graph prefix matching `prompt`."""
+    children: dict[int | None, list[int]] = {}
+    for node_id, node in enumerate(trace.nodes):
+        children.setdefault(node.parent, []).append(node_id)
+
+    parents: list[int | None] = [None]
+    matched = 0
+    for message in prompt:
+        key = message_hash(message)
+        parents = [
+            node_id
+            for parent in parents
+            for node_id in children.get(parent, [])
+            if message_hash(trace.nodes[node_id].message) == key
+        ]
+        if not parents:
+            break
+        matched += 1
+    return matched
 
 
 def _matching_node(
@@ -365,6 +404,7 @@ def _matching_node(
     parent: int | None,
     message: Message,
     token_ids: list[int] | None = None,
+    tools: list[Tool] | None = None,
 ) -> int | None:
     """Find an existing child, optionally requiring its exact physical token span.
 
@@ -372,7 +412,7 @@ def _matching_node(
     prefix breaks can leave older physical variants under the same key, so a token mismatch falls
     back to a reverse scan rather than materializing a duplicate of an already-existing variant.
     """
-    key = (parent, message_hash(message))
+    key = _node_key(parent, message, tools)
     indexed = _head_index(trace).get(key)
     if indexed is not None and (
         token_ids is None or trace.nodes[indexed].token_ids == token_ids
@@ -387,7 +427,7 @@ def _matching_node(
         if (
             node.parent == parent
             and node.token_ids == token_ids
-            and message_hash(node.message) == key[1]
+            and _node_key(node.parent, node.message, node.tools) == key
         ):
             return node_id
     return None
@@ -400,6 +440,7 @@ def _matching_prefix_node(
     prompt_ids: list[int],
     start: int,
     stop: int,
+    tools: list[Tool] | None = None,
 ) -> int | None:
     """Find the longest content-equivalent child matching inside `[start, stop]`.
 
@@ -408,7 +449,7 @@ def _matching_prefix_node(
     otherwise-missing message boundary. The next attributed message's start bounds the match:
     a sampled variant must never consume tokens that the renderer assigned to that message.
     """
-    key = (parent, message_hash(message))
+    key = _node_key(parent, message, tools)
     indexed = _head_index(trace).get(key)
     candidates: list[int] = []
     if indexed is not None:
@@ -417,8 +458,12 @@ def _matching_prefix_node(
         node_id
         for node_id in range(len(trace.nodes) - 1, -1, -1)
         if node_id != indexed
-        and trace.nodes[node_id].parent == parent
-        and message_hash(trace.nodes[node_id].message) == key[1]
+        and _node_key(
+            trace.nodes[node_id].parent,
+            trace.nodes[node_id].message,
+            trace.nodes[node_id].tools,
+        )
+        == key
     )
     matches = [
         node_id
@@ -443,6 +488,7 @@ class PendingTurn:
 
     trace: Trace
     prompt: list[Message]
+    tools: list[Tool]
     prefix_node_ids: list[int]
     path_len: int
 
@@ -498,33 +544,43 @@ class PendingTurn:
             for span in tail_spans
         ]
 
-    def commit(self, response: Response, tools: list[Tool] | None = None) -> int:
+    def commit(self, response: Response) -> int:
         """Add this turn to the graph; returns the committed assistant node's id."""
         assistant_id = _commit_turn(self, response)
-        if tools:
-            self.trace.tools = tools
+        self.trace.tools = self.tools
         return assistant_id
 
-    def commit_prompt(self, tools: list[Tool] | None = None) -> None:
+    def commit_prompt(self) -> None:
         """Record an input that terminated before model inference."""
         parent = self.prefix_node_ids[-1] if self.prefix_node_ids else None
         index = _head_index(self.trace)
         for message in self.tail:
-            existing = _matching_node(self.trace, parent, message)
+            existing = _matching_node(self.trace, parent, message, tools=self.tools)
             if existing is not None:
                 parent = existing
                 continue
             previous = parent
-            self.trace.nodes.append(MessageNode(parent=parent, message=message))
+            self.trace.nodes.append(
+                MessageNode(
+                    parent=parent,
+                    message=message,
+                    tools=self.tools if parent is None else [],
+                )
+            )
             parent = len(self.trace.nodes) - 1
-            index[(previous, message_hash(message))] = parent
-        if tools:
-            self.trace.tools = tools
+            index[_node_key(previous, message, self.tools)] = parent
+        self.trace.tools = self.tools
 
 
-def prepare_turn(trace: Trace, prompt: list[Message]) -> PendingTurn:
-    """Resolve `prompt` against the trace graph without mutating it."""
+def prepare_turn(
+    trace: Trace,
+    prompt: list[Message],
+    tools: list[Tool] | None = None,
+) -> PendingTurn:
+    """Resolve a physical message-and-tools prefix without mutating the trace."""
     idx = _head_index(trace)
+    tools = list(tools or [])
+    tools_hash = _tools_hash(tools)
     parent: int | None = None
     path_len = 0
     prefix_node_ids: list[int] = []
@@ -537,15 +593,19 @@ def prepare_turn(trace: Trace, prompt: list[Message]) -> PendingTurn:
         ):
             children = [
                 node_id
-                for (node_parent, _), node_id in idx.items()
+                for (node_parent, node_tools_hash, _), node_id in idx.items()
                 if node_parent == parent
+                and (parent is not None or node_tools_hash == tools_hash)
             ]
             # Repeated image URLs are cheaper to compare than to encode and hash again.
             # Only scan short, unambiguous parents; all other cases use the stable index.
             if len(children) == 1 and trace.nodes[children[0]].message == msg:
                 existing = children[0]
         if existing is None:
-            existing = idx.get((parent, message_hash(msg)))
+            message_key = message_hash(msg)
+            existing = idx.get(
+                (parent, tools_hash if parent is None else None, message_key)
+            )
         if existing is None:
             break
         prefix_node_ids.append(existing)
@@ -554,6 +614,7 @@ def prepare_turn(trace: Trace, prompt: list[Message]) -> PendingTurn:
     return PendingTurn(
         trace=trace,
         prompt=prompt,
+        tools=tools,
         prefix_node_ids=prefix_node_ids,
         path_len=path_len,
     )
@@ -718,7 +779,13 @@ def _commit_turn(turn: PendingTurn, response: Response) -> int:
                 len(prompt_ids),
             )
             existing = _matching_prefix_node(
-                trace, parent, prompt[i], prompt_ids, path_len, next_start
+                trace,
+                parent,
+                prompt[i],
+                prompt_ids,
+                path_len,
+                next_start,
+                turn.tools,
             )
             if existing is not None:
                 end += len(trace.nodes[existing].token_ids)
@@ -729,6 +796,7 @@ def _commit_turn(turn: PendingTurn, response: Response) -> int:
                 parent,
                 prompt[i],
                 node_tokens if tokens is not None else None,
+                turn.tools,
             )
         if existing is None:
             break
@@ -746,7 +814,7 @@ def _commit_turn(turn: PendingTurn, response: Response) -> int:
     if multi_modal_data is not None:
         mm_path = [(nid, prompt[i]) for i, nid in enumerate(prefix)]
     for i, msg in enumerate(prompt[num_reused:], start=num_reused):
-        key = (parent, message_hash(msg))
+        key = _node_key(parent, msg, turn.tools)
         start = path_len if cursor is None else cursor
         span = spans[i] if spans and i < len(spans) else None
         end = span[1] if span else start
@@ -756,6 +824,7 @@ def _commit_turn(turn: PendingTurn, response: Response) -> int:
             # potentially huge token slices a second time.
             MessageNode.model_construct(
                 parent=parent,
+                tools=turn.tools if parent is None else [],
                 message=msg,
                 token_ids=node_tokens,
                 mask=[False] * len(node_tokens),
@@ -776,6 +845,7 @@ def _commit_turn(turn: PendingTurn, response: Response) -> int:
     trace.nodes.append(
         MessageNode.model_construct(
             parent=parent,
+            tools=turn.tools if parent is None else [],
             message=response.message,
             sampled=True,
             token_ids=[*gen_prompt, *comp_ids],
@@ -789,7 +859,7 @@ def _commit_turn(turn: PendingTurn, response: Response) -> int:
     )
     # Register the assistant so the next turn's prompt (which restates it) reuses this node.
     assistant_id = len(trace.nodes) - 1
-    idx[(parent, message_hash(response.message))] = assistant_id
+    idx[_node_key(parent, response.message, turn.tools)] = assistant_id
     new_node_ids.append(assistant_id)
 
     # Attribute this turn's images onto the input nodes that introduced them (by content part).

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -628,8 +628,10 @@ class InterceptionServer(Interception):
         except BaseException:
             raise
         if stopped is not None:
-            turn = graph.prepare_turn(session.trace, model_request.messages)
-            turn.commit_prompt(model_request.tools)
+            turn = graph.prepare_turn(
+                session.trace, model_request.messages, model_request.tools
+            )
+            turn.commit_prompt()
             session.trace.stop(stopped)
             return web.json_response(
                 dialect.error_body(f"rollout stopped: {stopped}"),
@@ -639,7 +641,9 @@ class InterceptionServer(Interception):
         try:
             body, policy_paths = self.mediate_capabilities(session, dialect, body)
             model_request = dialect.parse_request(body)
-            turn = graph.prepare_turn(session.trace, model_request.messages)
+            turn = graph.prepare_turn(
+                session.trace, model_request.messages, model_request.tools
+            )
         except ValueError as error:
             return web.json_response(dialect.error_body(str(error)), status=400)
         except RolloutError as error:
@@ -719,7 +723,7 @@ class InterceptionServer(Interception):
                             ),
                             status=400,
                         )
-                    node = turn.commit(call_response, model_request.tools)
+                    node = turn.commit(call_response)
                     session.consume_prepared(turn.tail)
                     session.trace.response_rewrites.extend(response_rewrites)
                     if stopped is not None:
@@ -885,7 +889,7 @@ class InterceptionServer(Interception):
                         ),
                         status=409 if session.released else 400,
                     )
-                node = turn.commit(response, model_request.tools)
+                node = turn.commit(response)
                 session.consume_prepared(turn.tail)
                 session.trace.response_rewrites.extend(response_rewrites)
                 if stopped is not None:
@@ -993,7 +997,7 @@ class InterceptionServer(Interception):
                     raise parser_error
                 response = parser.finish()
                 if not session.released and not session.stopped:
-                    node = turn.commit(response, model_request.tools)
+                    node = turn.commit(response)
                     session.consume_prepared(turn.tail)
                     logger.debug("intercept stream turn: id=%s", session.trace.id)
                 elif session.stopped:

--- a/verifiers/v1/session.py
+++ b/verifiers/v1/session.py
@@ -158,11 +158,11 @@ class RolloutSession:
         """Run typed request interceptors and stops over one canonical request."""
         if not self.request_interceptors and (not run_stops or not self.request_stops):
             return request, [], None
-        turn = graph.prepare_turn(self.trace, request.messages)
+        tail_start = graph.message_prefix_len(self.trace, request.messages)
         prepared_users = self.prepared_users.copy()
         prepared: set[int] = set()
         candidates: set[int] = set()
-        for position in range(turn.tail_start, len(request.messages)):
+        for position in range(tail_start, len(request.messages)):
             message = request.messages[position]
             if isinstance(message, UserMessage):
                 candidates.add(position)
@@ -347,7 +347,7 @@ class RolloutSession:
         request, records, stopped = await self.rewrite_request(
             Request(
                 messages=[*branch.messages, *previous, message],
-                tools=self.trace.tools or None,
+                tools=branch.tools or None,
             )
         )
         candidate = request.messages[-1]
@@ -355,7 +355,7 @@ class RolloutSession:
         self.trace.request_rewrites.extend(records)
         if stopped is not None:
             committed = request.messages if phase == "after" else request.messages[:-1]
-            turn = graph.prepare_turn(self.trace, committed)
+            turn = graph.prepare_turn(self.trace, committed, request.tools)
             turn.commit_prompt()
             self.consume_prepared(turn.tail)
             self.trace.stop(stopped)

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -209,6 +209,10 @@ class Branch(BaseModel):
         return [n.message for n in self.nodes]
 
     @property
+    def tools(self) -> list[Tool]:
+        return self.nodes[0].tools if self.nodes else []
+
+    @property
     def token_ids(self) -> list[int]:
         """Training input IDs formed by concatenating node token spans."""
         tokens: list[int] = []
@@ -444,7 +448,7 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
     timing: Timing = Field(default_factory=Timing)
 
     _head_index: dict = PrivateAttr(default_factory=dict)
-    """`(parent, msg_hash) -> node_id` for the graph builder."""
+    """Physical node key -> node id for the graph builder."""
 
     @field_serializer("mm_token_type_id_map")
     def serialize_mm_token_type_id_map(self, mapping: dict[int, int]) -> dict[str, int]:


### PR DESCRIPTION
## Summary

- carry the final typed request tools on each pending turn
- store tools on physical branch roots and include them in root prefix identity
- prevent prefix reuse and renderer bridging when tools change
- use a separate message-only prefix helper for request interception

## Validation

- `uv run pytest tests/` (86 passed, 75 live tests skipped without credentials)
- `uv run pytest -q tests/v1/test_graph.py tests/v1/test_trace.py`
- `uv run pre-commit run --all-files`
- manual physical/semantic prefix and serialization round-trip checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core graph deduplication and renderer prefix reuse; a new serialized field may not align with older traces that omitted root tools.
> 
> **Overview**
> Graph **physical prefix identity** now treats tool declarations as part of the root branch, not just message content. Root `MessageNode`s store a `tools` list, `PendingTurn` carries the typed tools for the turn, and dedup keys use `_node_key` (parent + message hash + root tools hash) instead of `(parent, message_hash)` alone.
> 
> **Prepare/commit flow** threads `request.tools` through `prepare_turn` and keeps them on the turn for renderer bridging and commits (`commit` / `commit_prompt` no longer take a separate tools argument). The train client reads `turn.tools` for intercepted turns; interception and tool-hook paths pass tools into `prepare_turn` and use **`branch.tools`** (from the root node) when building tool-result requests.
> 
> **Request interception** uses new **`message_prefix_len`** so only the message tail is considered for hooks, without requiring a tools-aware physical prefix match.
> 
> **Risk note for persisted traces:** older serialized graphs without `MessageNode.tools` deserialize to an empty list at roots, which can diverge from newly created branches that carry non-empty tools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50ec1037a7f4bc04dcc91801d305cd27f0014f44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Include tool definitions in graph branch identity and `PendingTurn`
> - Graph physical node keys and prefix/lookup helpers now incorporate a stable hash of tool definitions, so root nodes with identical messages but different tool sets are treated as distinct branches.
> - `PendingTurn` carries the request tools through turn preparation, interception, renderer processing, and commit; `commit` and `commit_prompt` no longer take a separate tools argument.
> - `MessageNode` gains an optional `tools` field populated on root nodes; `Branch.tools` exposes it to consumers.
> - The interception server passes parsed request tools into `prepare_turn` across stopped, buffered, and streaming paths. Session tool-result handling now uses the selected branch's tools instead of trace-wide tools.
> - Renderer-backed intercepted turns render tools from `PendingTurn.tools` rather than re-parsing the raw request body.
> - Risk: callers that previously supplied tools to `PendingTurn.commit` or `PendingTurn.commit_prompt` must now pass them via `prepare_turn`; existing graph indices keyed only on message/parent identity will not match the new tool-aware physical keys in [graph.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2514/files#diff-64c9d635eb215902a512c9e8ab316fd9b9967c36db03d4049aacc812cdfbd740).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 50ec103.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

## Latest main sync (2026-09-14)

- Merged Verifiers `main` through `27f80a147`.
- Preserved restricted-network request re-parsing before tools-aware physical turn preparation.
- Preserved the interceptor-only fast path while keeping its prefix comparison message-only.
- Validation: 86 tests passed, 75 credential-dependent tests skipped; Ruff, formatting, Markdown, and ty checks passed.
