### PR TITLE
fix(v1): enable Prime Agent cpython kernel prebootstrap for network-isolated tasks

### DIFF
--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -39,7 +39,7 @@ export PATH="/var/tmp/vf-node/bin:$PATH"
 prefix="$VF_PRIME_AGENT_DIR/$PRIME_AGENT_COMMIT"
 [ -x "$prefix/bin/prime-agent" ] && exit 0
 export NPM_CONFIG_PREFIX="$prefix"
-export PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL=0
+export PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL=1
 release_url="$VF_PRIME_AGENT_GITHUB_RELEASE_URL/v$PRIME_AGENT_RELEASE_VERSION"
 agent_tarball="prime-agent-$PRIME_AGENT_RELEASE_VERSION.tgz"
 ai_tarball="prime-agent-ai-$PRIME_AGENT_RELEASE_VERSION.tgz"

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -37,7 +37,7 @@ INSTALL = r"""
 set -e
 export PATH="/var/tmp/vf-node/bin:$PATH"
 prefix="$VF_PRIME_AGENT_DIR/$PRIME_AGENT_COMMIT"
-[ -x "$prefix/bin/prime-agent" ] && exit 0
+[ -x "$prefix/bin/prime-agent" ] && [ -f "$HOME/.prime/agent/kernel-venv/.bootstrap-version" ] && exit 0
 export NPM_CONFIG_PREFIX="$prefix"
 export PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL=1
 release_url="$VF_PRIME_AGENT_GITHUB_RELEASE_URL/v$PRIME_AGENT_RELEASE_VERSION"
@@ -84,6 +84,7 @@ repacked="$(npm pack "$download_dir/package-root/package" \
 PRIME_AGENT_BOOTSTRAP_TOOLS_ON_INSTALL=1 npm install -g \
     --no-fund --no-audit --loglevel=error --progress=false \
     "$download_dir/repacked/$repacked"
+[ -f "$HOME/.prime/agent/kernel-venv/.bootstrap-version" ]
 """
 
 


### PR DESCRIPTION
## Problem

Prime Agent harness tasks with an empty network allowlist (`network_allow=[]`, such as ScaleSWE) fail every episode because the cpython kernel bootstrap happens during first agent use, after Verifiers applies the task network policy. The managed Python/runtime bootstrap then cannot download its requirements, so the agent cannot execute tools and produces no patch.

## Change

Flip `PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL` from `0` to `1`. Harness installation runs before Verifiers applies the task network policy, so Prime Agent can prepare its managed cpython environment while setup network access is still available. First agent use then reuses that environment without external access.

## Safety

- The existing install path already runs under the Verifiers install lock.
- The bootstrap prepares the sandbox-local cpython runtime. It does not execute the task prompt or model.
- No task, runtime, scoring, or agent behavior changes after setup.

## Validation

A controlled ScaleSWE smoke with the flag enabled confirmed that cpython starts after network restriction, reads and edits files, runs the project tests, and produces a non-empty patch.

The code change is one line. There are no dependency or generated-file changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Install now always runs kernel bootstrap and fails if the marker cannot be created; previously cached installs without a kernel may reinstall or fail setup rather than failing mid-episode.
> 
> **Overview**
> Fixes Prime Agent episodes that run with **no task network** (e.g. ScaleSWE) by bootstrapping the managed cpython kernel during harness **install**, while setup still has network access, instead of on first agent use after the policy is applied.
> 
> The `prime_agent` install script now sets **`PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL=1`**, tightens the cached-install skip so it only succeeds when both the **`prime-agent` binary** and **`$HOME/.prime/agent/kernel-venv/.bootstrap-version`** exist, and **asserts the marker file** at the end of install so a failed bootstrap does not leave a silently broken cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9df6a3c01bb640c34380f4f6dff63a1b168dee22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable Prime Agent cpython kernel prebootstrap and tighten cached-install guard
> - Enables the kernel bootstrap flag in the `prime_agent` harness install script, which was previously disabled, so the cpython kernel is prebuilt for network-isolated tasks
> - Changes the cached-install guard to exit early only when both the Prime Agent executable and the kernel bootstrap marker exist; if the executable is present but the marker is missing, installation now reruns
> - Adds a post-install assertion that fails when the bootstrap marker is absent after installation completes
> - Risk: installations that previously skipped kernel bootstrap will now run it and fail if the marker cannot be created; check the bootstrap marker logic in [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2515/files#diff-20ba08f960d62f6e395d3eb05c3a6b051e309727747f31f1a381d7aa7396323b)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9df6a3c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->