### PR TITLE
fix(v1/harnesses): survive slow inference in bash mode (no turn read timeout, retry compaction on transport errors)

### DIFF
--- a/verifiers/v1/harnesses/utils/compaction.py
+++ b/verifiers/v1/harnesses/utils/compaction.py
@@ -2,7 +2,13 @@
 
 from typing import TYPE_CHECKING
 
-from openai import APIError, APIStatusError, AsyncOpenAI
+from openai import (
+    APIConnectionError,
+    APIError,
+    APIStatusError,
+    APITimeoutError,
+    AsyncOpenAI,
+)
 
 if TYPE_CHECKING:
     # The harness bundles this module into the generated script before execution.
@@ -10,6 +16,11 @@ if TYPE_CHECKING:
 
 RESERVE_TOKENS = 16_384
 """Compact when this many tokens remain below the model context window."""
+
+COMPACTION_TIMEOUT_SECONDS = 1800.0
+"""Read timeout for one checkpoint-summary request. Summarizing a near-window context is
+a single huge, uncached prefill that can wait behind thousands of other turns on a loaded
+fleet, so it gets its own budget instead of the client's per-turn default."""
 
 COMPACTION_ATTEMPTS = 3
 """Checkpoint attempts before compaction fails: a rejected request falls back to the
@@ -229,7 +240,7 @@ class Compactor:
             ]
             try:
                 completion = await chat(
-                    self.client,
+                    self.client.with_options(timeout=COMPACTION_TIMEOUT_SECONDS),
                     self.model,
                     checkpoint,
                     self.tools,
@@ -238,6 +249,12 @@ class Compactor:
             except APIStatusError as error:
                 if not is_context_overflow(error):
                     raise
+                base = messages[: self.last_good]
+                continue
+            except (APITimeoutError, APIConnectionError):
+                # A transport failure on the summary request is a retryable attempt,
+                # not a reason to kill an episode that has the most work invested:
+                # fall back to the last good snapshot like a rejected checkpoint.
                 base = messages[: self.last_good]
                 continue
             message = completion.choices[0].message

--- a/verifiers/v1/harnesses/utils/core.py
+++ b/verifiers/v1/harnesses/utils/core.py
@@ -345,7 +345,7 @@ async def main() -> None:
     client = AsyncOpenAI(
         base_url=args.base_url,
         api_key=args.api_key,
-        timeout=httpx.Timeout(600.0 if args.bash else None, connect=5.0),
+        timeout=httpx.Timeout(None, connect=5.0),
     )
     tool_client = (
         httpx.AsyncClient(timeout=httpx.Timeout(None, connect=5.0))


### PR DESCRIPTION
## What

Two client-timeout fixes for the bundled chat program (`verifiers/v1/harnesses/utils/`), carried as local patches during the GLM-5.3 SWE synthetic-data runs and now ported onto `main` (the code moved from `minimal/program.py` into `utils/core.py` / `utils/compaction.py` in #2506).

1. **Per-turn client read timeout: `None` in every mode** (was 600s in bash mode, `None` otherwise; `utils/core.py`).
   At 2–4k concurrent episodes a single turn's prefill queueing plus a long decode routinely exceeds 600s. The client's `APITimeoutError` is uncaught, so the whole episode dies. Observed 2026-09-02 at 4k in-flight: 116 of 143 completed episodes in a 15-minute window died this way while inference was healthy (decode 63% KV). No client-side cap at all now: other layers already bound the request (we hit a 30-minute cap in the sandbox tunnel), so any client cap below that only kills healthy turns.

2. **Compaction summary request: own 1800s timeout + retry on transport errors** (`COMPACTION_TIMEOUT_SECONDS` in `utils/compaction.py`).
   The checkpoint summary is one huge, uncached prefill of a near-window context (~245k tokens with GLM-5.3), and it waits behind every other turn. An `httpx.ReadTimeout` there killed exactly the episodes with the most work invested. The request now gets its own budget, and `APITimeoutError` / `APIConnectionError` fall back to `self.last_good` and consume one of the `COMPACTION_ATTEMPTS`, the same path a rejected (context-overflow) checkpoint already takes.

## Why not configurable / why 1800 for compaction

Kept as module constants to stay minimal; happy to thread them through the harness config if preferred. The compaction summary keeps a bounded 1800s budget (it has its own retry + fallback-to-snapshot path, so a bound there is safe and a dead upstream cannot wedge an episode). Per-turn requests have no client read timeout at all, since the outer layers already cap them.

## Behaviour

No change to what the model sees or to the compaction threshold (`RESERVE_TOKENS`). Only how the harness survives slow inference.

## Testing

Ran as a local patch on the previous layout (`6da786ec`) for ~2 days of production rollouts (30k+ clean episodes); the timeout-death class disappeared. On this branch: `py_compile` + `ruff check` / `ruff format --check` on both files pass. No test changes; existing compaction tests should be unaffected since the retry path reuses the rejected-checkpoint fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Unbounded read timeouts on normal turns can leave episodes hanging if upstream stalls, while compaction transport failures are swallowed into retries instead of failing fast.
> 
> **Overview**
> **Inference client timeouts** are relaxed so long-running bash rollouts are less likely to die on slow upstream queues. The bundled `AsyncOpenAI` client in `core.py` no longer applies a **600s read timeout in bash mode**; read timeout is **unset** (`None`) while **connect stays at 5s**.
> 
> **Context checkpoint compaction** in `compaction.py` gives the summary `chat` call its own **`COMPACTION_TIMEOUT_SECONDS` (1800s)** via `client.with_options(...)`, separate from the default client. **`APITimeoutError` and `APIConnectionError`** on that request are treated like a rejected overflow checkpoint: rewind to **`last_good`** and retry within **`COMPACTION_ATTEMPTS`**, instead of aborting the episode.
> 
> Model-facing compaction logic and thresholds are unchanged; only HTTP timeout and retry behavior around slow inference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97264238bd2c368f2537c8ac0c515c1ec2f00c32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix compaction transport-error retries and remove bash-mode client timeout in `core.py`
> - Removes the 600-second overall read timeout previously applied to the AsyncOpenAI client in bash mode; the client now keeps only its 5-second connection timeout in all modes
> - Adds a dedicated 1,800-second timeout for checkpoint-summary requests inside `Compactor.complete`, applied via a copied client instance
> - On timeout or connection errors during checkpoint-summary calls, compaction now resets the checkpoint base to the last good snapshot and retries instead of propagating the failure
> - Behavioral Change: normal chat requests in bash mode no longer have a client-level 600-second timeout; any per-request timeout must be supplied explicitly by the caller
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 9726423. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
