### PR TITLE
fix: cli inits a v1 env

### DIFF
--- a/verifiers/cli/commands/init.py
+++ b/verifiers/cli/commands/init.py
@@ -1,0 +1,6 @@
+"""Environment initialization command module for external hosts."""
+
+from verifiers.v1.cli.init import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
One line fix to default to a v1 env when initializing. Currently, running `prime env init <name>` initializes a v0 skeleton so this PR redirects the wrapper to the v1 initialziation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CLI entrypoint redirect with an intentional default change; no auth, data, or core runtime paths touched.
> 
> **Overview**
> **`prime env init`** now scaffolds a **v1 taskset package** by default. The external-host entry module `verifiers/cli/commands/init.py` delegates to `verifiers.v1.cli.init.main` instead of the legacy v0 initializer.
> 
> Users who still need the old skeleton must use **`--v0`** (as documented elsewhere in this PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d61043d84ca9695d9c43662868db887b5ef5890. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `verifiers.cli.commands.init` entrypoint delegating to `verifiers.v1.cli.init.main`
> Adds a new CLI initialization module that imports and runs the existing `main` from `verifiers.v1.cli.init` when executed as a script. This lets the CLI init a v1 environment through the new command path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d61043.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->