### PR TITLE
fix(v1): drain EnvClient cancel tasks by removal so close() cannot spin

### DIFF
--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -5,6 +5,9 @@ combinations a test runs — every axis value at least once plus the cross-bound
 with distinct networking — instead of fanning the full cross product. prime/modal rows
 are local-only (their marks are excluded in CI)."""
 
+import subprocess
+import sys
+
 import pytest
 
 mark = pytest.mark
@@ -673,6 +676,37 @@ async def test_multi_agent_env_server(run_v1_server, tmp_path):
     for trace in traces:
         assert trace.ok
         assert trace.metrics["duet"] == 1.0
+
+
+# `_request` parks a cancelled run's fire-and-forget cancel in `_cancel_tasks` with a
+# `discard` done-callback. One loop turn later the sends have finished but the callbacks
+# are still queued behind us, so `close()` meets a set of finished tasks.
+CLOSE_WITH_FINISHED_CANCELS = """
+import asyncio, uuid
+from verifiers.v1.serve.client import EnvClient
+
+async def main():
+    client = EnvClient("tcp://127.0.0.1:1")
+    for _ in range(3):
+        task = asyncio.get_running_loop().create_task(client._send_cancel(uuid.uuid4().hex))
+        client._cancel_tasks.add(task)
+        task.add_done_callback(client._cancel_tasks.discard)
+    await asyncio.sleep(0)
+    assert all(task.done() for task in client._cancel_tasks) and client._cancel_tasks
+    await client.close()
+
+asyncio.run(main())
+"""
+
+
+def test_env_client_close_drains_finished_cancels():
+    """`close()` returns once every fire-and-forget cancel has run, also when all of them
+    finished before it looked: the state Ctrl-C leaves behind in served mode. A child
+    process bounds the check, since a `close()` that never yields to the loop never lets
+    an in-loop timeout fire either."""
+    subprocess.run(
+        [sys.executable, "-c", CLOSE_WITH_FINISHED_CANCELS], check=True, timeout=30
+    )
 
 
 @pytest.mark.e2e

--- a/verifiers/v1/serve/client.py
+++ b/verifiers/v1/serve/client.py
@@ -187,8 +187,12 @@ class EnvClient:
             self._receiver = None
         # Let scheduled fire-and-forget cancels reach the socket first, or a
         # run cancelled right before close() leaves its server-side rollout
-        # running. Loop: awaiting one wave can schedule another
+        # running. Pop before awaiting: awaiting finished tasks never yields
+        # (since CPython 3.12 a gather of them completes eagerly), so their
+        # queued `discard` callbacks cannot be what empties the set
         while self._cancel_tasks:
-            await asyncio.gather(*list(self._cancel_tasks), return_exceptions=True)
+            task = self._cancel_tasks.pop()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
         self.socket.close()
         self.ctx.term()


### PR DESCRIPTION
## Symptom

In served mode (the default), Ctrl-C with rollouts in flight leaves the eval leader alive at 100% CPU after it prints `interrupted — cleaning up, please wait...`; only `kill -9` ends it. A supervisor's SIGTERM to the whole process group does the same. Faulthandler shows the leader inside `EnvClient.close()`, called from `_server`'s teardown under `asyncio.run`'s `_cancel_all_tasks`.

## Cause

`_cancel_all_tasks` cancels the in-flight `client.run()` calls; each one schedules a fire-and-forget `_send_cancel` task and parks it in `_cancel_tasks` with `set.discard` as its done callback. By the time `close()` runs, those sends have finished, and their `discard` callbacks are queued on the loop but have not run.

`close()` drained the set with `while self._cancel_tasks: await asyncio.gather(*self._cancel_tasks, return_exceptions=True)`. Since CPython 3.12, `gather()` over futures that are all already done completes eagerly inside `gather()` itself, so the `await` returns without yielding to the loop. The queued `discard` callbacks never run, the set never empties, and the loop spins.

A stdlib-only version of the loop (three finished tasks, `discard` done-callbacks, the same `while` / `gather` drain) drains on 3.11.10 and spins on 3.12.13, 3.13.14 and 3.14.7.

## Fix

`close()` pops each task from the set before awaiting it, so the set shrinks by removal rather than by callback. Cancels scheduled while a pending one is awaited are still picked up by the `while`. The `discard` callback stays for the normal path, where it releases a finished cancel's reference during the run.

## Measurement

A served-mode eval of the `echo-v1` fixture (null harness, subprocess runtime) against a local OpenAI-compatible stub that never answers, so both rollouts sit in `EnvClient._request`, then one signal. Python 3.13.14, macOS.

| signal | before | after |
| --- | --- | --- |
| SIGINT to the leader | alive 60 s later at 98-100% CPU, until the driver aborted it | exit 130 in 0.8 s, nothing left in the process group |
| SIGTERM to the process group | alive 60 s later at 100% CPU, until the driver aborted it | exit 130 in 0.8 s, nothing left in the process group |

## Test

`test_env_client_close_drains_finished_cancels` seeds an `EnvClient` with finished `_send_cancel` tasks in the state above and calls `close()`. It runs the scenario in a child interpreter with a `subprocess` timeout: the old `close()` never yields to the loop, so no in-loop timeout (`asyncio.wait_for`) can bound it. Fails on `main` under 3.12+ (killed at 30 s), passes with this change in about a second.

## Related issues

#1991, #1992 and #1994 describe the pool's own shutdown of its workers: a hard-killed worker orphaning its subprocess, the broker keeping a dead worker's request pending, remote resources a killed worker cannot release. This is a different mechanism. The pool and its workers already exit when the leader dies (the death pipe in `_arm_teardown`); here it is the leader itself that cannot exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches eval teardown and ZMQ client shutdown on interrupt; behavior change is narrow but on a critical exit path used by served-mode eval.
> 
> **Overview**
> Fixes **served-mode shutdown** where the eval leader could sit at 100% CPU inside `EnvClient.close()` after SIGINT/SIGTERM (Python 3.12+), because draining fire-and-forget `_send_cancel` tasks with `asyncio.gather()` on already-finished tasks completes without yielding, so `discard` done-callbacks never run and `_cancel_tasks` never empties.
> 
> **`EnvClient.close()`** now **pops** each task from `_cancel_tasks` and awaits it individually, shrinking the set by removal instead of relying on callbacks. The existing `discard` callback remains for the normal in-run path.
> 
> Adds **`test_env_client_close_drains_finished_cancels`**, which reproduces finished cancel tasks with queued callbacks in a **child process** with a 30s subprocess timeout (in-loop timeouts cannot bound a non-yielding spin).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14abddd8e4a39bc6dfdbac5285630982767cac7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `EnvClient.close` spinning when cancel tasks are already finished
> - Replaces the `gather`-based drain in `EnvClient.close` with a loop that removes each tracked task from the set before awaiting it, so finished cancel tasks don't keep the set non-empty
> - Adds a subprocess-based regression test in [test_e2e.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2518/files#diff-ebbbd919487889487f891b359a756e6c4630e106b16ddaef8ccddc6b900a96e1) that registers finished cancel tasks and asserts `close()` completes within 30 seconds
> - Risk: non-`CancelledError` exceptions from an individual cancel task now propagate from `close`, whereas the previous `gather` call suppressed them
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 14abddd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->