### PR TITLE
feat(v1): eval names each role's runtime and the client's credential source at startup

### DIFF
--- a/tests/v1/test_configs.py
+++ b/tests/v1/test_configs.py
@@ -1,10 +1,18 @@
-"""Every checked-in v1 eval config parses.
+"""Every checked-in v1 eval config parses, and the eval CLI says what a config resolved
+to before it runs anything.
 
 Mirrors prime-rl's config test: glob the configs and assert each validates into its config
 type. The root `configs/*.toml` are the `uv run eval @ <file>` v1 configs (EvalConfig).
+The CLI cases take the model-free path — the `echo-v1` fixture on the null harness in a
+subprocess, against a local stub endpoint — so they need no key and no sandbox.
 """
 
+import json
+import subprocess
+import sys
+import threading
 import tomllib
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 import pytest
@@ -18,3 +26,114 @@ CONFIGS = sorted((Path(__file__).resolve().parents[2] / "configs").glob("*.toml"
 def test_eval_config_parses(path: Path) -> None:
     config = EvalConfig.model_validate(tomllib.load(path.open("rb")))
     assert config.env.taskset.id
+
+
+class EchoModel(BaseHTTPRequestHandler):
+    """An OpenAI-compatible endpoint whose every chat completion is the last user
+    message — echo-v1 scores that 1.0."""
+
+    def log_message(self, *args) -> None:  # keep the access log off the test output
+        pass
+
+    def do_POST(self) -> None:
+        request = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+        reply = next(
+            m["content"] for m in reversed(request["messages"]) if m["role"] == "user"
+        )
+        body = json.dumps(
+            {
+                "id": "chatcmpl-stub",
+                "object": "chat.completion",
+                "created": 0,
+                "model": request["model"],
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": reply},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                },
+            }
+        ).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+@pytest.fixture
+def stub_endpoint():
+    """A local `EchoModel` for the run's client; its base URL."""
+    server = ThreadingHTTPServer(("127.0.0.1", 0), EchoModel)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    yield f"http://127.0.0.1:{server.server_port}/v1"
+    server.shutdown()
+
+
+def eval_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    """`uv run eval <args>` under the test interpreter (the fixture tasksets resolve
+    through the `PYTHONPATH` conftest sets)."""
+    return subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from verifiers.v1.cli.eval.main import main; main()",
+            *args,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+    )
+
+
+def test_eval_names_where_it_runs(stub_endpoint: str, tmp_path: Path) -> None:
+    """Before the first rollout starts, the log names each seat's harness and runtime,
+    each client's endpoint and credential variable (the name, never the value), and
+    whether the finished run is pushed — so a seat the config left on the defaults is
+    visible up front."""
+    proc = eval_cli(
+        "echo-v1",
+        "--env.agent.harness.id", "null",
+        "--env.agent.runtime.type", "subprocess",
+        "-m", "stub-model",
+        "--client.base-url", stub_endpoint,
+        "--client.api-key-var", "VF_TEST_KEY",
+        "--no-push", "--no-rich", "-n", "1", "-r", "1",
+        "-o", str(tmp_path), "--run.name", "run",
+    )  # fmt: skip
+    assert proc.returncode == 0, proc.stderr[-2000:]
+    log = proc.stderr
+    assert "rollout start" in log, log
+    started = log.index("rollout start")
+    for line in (
+        "env.agent: null harness on the subprocess runtime",
+        f"client: {stub_endpoint} ($VF_TEST_KEY)",
+        "push: off",
+    ):
+        assert line in log, log
+        assert log.index(line) < started, log
+
+
+def test_dry_run_prints_resolved_config(tmp_path: Path) -> None:
+    """`--dry-run` prints the resolved config it writes: the same JSON document, naming
+    the role's runtime and the client's endpoint and credential variable."""
+    proc = eval_cli(
+        "echo-v1",
+        "--client.base-url", "http://127.0.0.1:9/v1",
+        "--client.api-key-var", "VF_TEST_KEY",
+        "--dry-run", "-o", str(tmp_path), "--run.name", "run",
+    )  # fmt: skip
+    assert proc.returncode == 0, proc.stderr[-2000:]
+    printed = json.loads(proc.stdout)
+    written = json.loads((tmp_path / "run/configs/resolved/eval.json").read_text())
+    assert printed == written
+    assert "type" in printed["env"]["agent"]["runtime"]
+    assert printed["client"]["base_url"] == "http://127.0.0.1:9/v1"
+    assert printed["client"]["api_key_var"] == "VF_TEST_KEY"

--- a/verifiers/v1/cli/eval/main.py
+++ b/verifiers/v1/cli/eval/main.py
@@ -111,9 +111,11 @@ def main(argv: list[str] | None = None) -> None:
                 f"comparable; re-run with `uv run eval @ {saved_path} --resume`, or "
                 "start a fresh run"
             )
-    if config.dry_run:  # resolved + validated; write it to the output dir and exit
+    if config.dry_run:  # resolved + validated; write and print it, then exit
         setup_logging("DEBUG" if config.verbose else "INFO")
-        logger.info("wrote config to %s", write_config(config, run_path))
+        config_path = write_config(config, run_path)
+        print(config_path.read_text())
+        logger.info("wrote config to %s", config_path)
         return
     # Always tee this attempt's logs to `logs/attempt_<n>/eval.log` (`logs/latest`
     # points there) — in server mode (the default) the workers write there too, and

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -13,8 +13,10 @@ import asyncio
 import contextlib
 import logging
 import time
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
 from typing import cast
+
+from pydantic import BaseModel
 
 from verifiers.v1.cli.dashboard import dashboard
 from verifiers.v1.cli.eval import resume
@@ -25,16 +27,34 @@ from verifiers.v1.cli.output import (
     save_config,
 )
 from verifiers.v1.cli.resume import distribute
-from verifiers.v1.clients import ModelContext
+from verifiers.v1.clients import BaseClientConfig, ModelContext
 from verifiers.v1.configs.cli.eval import EvalConfig
 from verifiers.v1.configs.serve import ServeConfig
 from verifiers.v1.env import Env, RunSlot
 from verifiers.v1.episode import Episode, EvalRunInfo
+from verifiers.v1.runtimes import SubprocessConfig
 
 logger = logging.getLogger(__name__)
 
 RunSlotFn = Callable[[RunSlot], Awaitable[Episode]]
 OnComplete = Callable[[Episode], Awaitable[None]]
+
+
+def _endpoints(value: object, path: str = "") -> Iterator[tuple[str, BaseClientConfig]]:
+    """Every endpoint config under `value`, by its config path: the run's `client`, a
+    seat's override (`env.b.client`), a judge wherever a task config declares one
+    (`env.taskset.task.judges[0]`). Fields and list items are walked; a found
+    endpoint's own fields are not."""
+    if isinstance(value, BaseClientConfig):
+        yield path, value
+    elif isinstance(value, BaseModel):
+        for name in type(value).model_fields:
+            yield from _endpoints(
+                getattr(value, name), f"{path}.{name}" if path else name
+            )
+    elif isinstance(value, list):
+        for i, item in enumerate(value):
+            yield from _endpoints(item, f"{path}[{i}]")
 
 
 @contextlib.asynccontextmanager
@@ -196,6 +216,21 @@ async def run_eval(config: EvalConfig) -> list[Episode]:
             config.model,
             via,
         )
+    # Name where each seat runs and what each endpoint is called with before a sandbox
+    # is provisioned or a request sent: a role the config never mentions runs on the
+    # defaults, and the defaults are hosted on the author's credentials.
+    for role, harness in config.env.agent_harnesses().items():
+        runtime = getattr(config.env, role).runtime
+        where = f"{runtime.type} runtime"
+        if not isinstance(runtime, SubprocessConfig):  # a sandbox boots an image
+            where += f" ({runtime.image})"
+        logger.info("env.%s: %s harness on the %s", role, harness.name, where)
+    for path, client in _endpoints(config):
+        logger.info("%s: %s ($%s)", path, client.base_url, client.api_key_var)
+    logger.info(
+        "push: %s",
+        "on -> Prime Intellect platform ($PRIME_API_KEY)" if config.push else "off",
+    )
     start = time.time()
     logger.info("results: %s", out)
 


### PR DESCRIPTION
## Why

`AgentConfig.runtime` defaults to a Prime sandbox, the eval `client` to Prime inference on `$PRIME_API_KEY`, and `push` to on. Those defaults stay. What was missing is that a run said none of it before starting: a multi-agent config that pins one role's runtime and forgets another runs the forgotten role in a hosted Prime sandbox on the author's credentials, calls Prime inference on the same key, and uploads the finished run, while the startup line names only the model and the pool. `--dry-run` wrote the resolved config but printed only its path.

## What changes

Before a sandbox is provisioned or a request is sent, the eval log names:

- each seat's harness and runtime, with the image a sandbox boots;
- each endpoint in the resolved config with the name of its credential variable, never the value: the run's `client`, a seat's `client` override, a judge wherever a task config declares one (`env.taskset.task.judges[0]`);
- whether the run pushes.

`--dry-run` prints the resolved config it writes (the same JSON document) to stdout; the log line with its path stays. Nothing printed is a credential: the config carries them by name (`api_key_var` is an environment variable name, `HarnessConfig.forward_env` forwards host variables without writing them into config), and the document is the one every run already saves to `configs/resolved/eval.json`.

No flag or config was added. `verifiers/v1/cli/eval/runner.py` and `verifiers/v1/cli/eval/main.py` are the only source changes. `tests/v1/test_configs.py` gains two model-free CLI cases: `echo-v1` on the null harness in a subprocess against a local stub endpoint, so they need no key and no sandbox.

## Example

`uv run eval echo-v1 --env.agent.harness.id null --env.agent.runtime.type subprocess -m stub-model --client.base-url http://127.0.0.1:49254/v1 --client.api-key-var VF_TEST_KEY --no-push --no-rich -n 1 -r 1`:

```
10:42:42    INFO running 1x1 rollouts on stub-model via the env-server elastic pool
10:42:42    INFO env.agent: null harness on the subprocess runtime
10:42:42    INFO client: http://127.0.0.1:49254/v1 ($VF_TEST_KEY)
10:42:42    INFO push: off
10:42:42    INFO results: /tmp/vf-eval-example/run
10:42:43    INFO EnvServerPool up: address=tcp://127.0.0.1:49285 workers=1/inf multiplex=128 elastic=True
```

The same taskset from a TOML that also plugs a `reference` judge and gives the seat its own client:

```
10:39:13    INFO env.agent: null harness on the subprocess runtime
10:39:13    INFO env.taskset.task.judges[0]: http://127.0.0.1:62944/v1 ($VF_JUDGE_KEY)
10:39:13    INFO env.agent.client: http://127.0.0.1:62944/v1 ($VF_SEAT_KEY)
10:39:13    INFO client: http://127.0.0.1:62944/v1 ($VF_TEST_KEY)
10:39:13    INFO push: off
```

Two roles, one of them on a sandbox (`uv run eval duet-v1 --env.a.runtime.type subprocess --env.b.runtime.type docker ... --no-push --no-rich --no-serve`):

```
10:44:02    INFO running 1x1 rollouts on stub-model
10:44:02    INFO env.a: null harness on the subprocess runtime
10:44:02    INFO env.b: null harness on the docker runtime (python:3.11-slim)
10:44:02    INFO client: http://127.0.0.1:50082/v1 ($VF_TEST_KEY)
10:44:02    INFO push: off
```

`uv run eval duet-v1 --env.a.runtime.type subprocess --dry-run`, with role `b` left unsaid and the default client, prints the resolved config it writes: `env.a.runtime.type` is `subprocess`, `env.b.runtime.type` is `prime` with image `python:3.11-slim`, `client.base_url` is `https://api.pinference.ai/api/v1`, `client.api_key_var` is `PRIME_API_KEY`, and `push` is `true`.

## Checks

`uv run ruff check --fix .`, `uv run ruff format .`, `uv run pytest tests/v1 -n auto -m "not e2e"` (85 passed), `uv run pre-commit run --all-files`, `uv run ty check verifiers`. The two new tests fail against the unchanged source and pass here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
