### PR TITLE
fix(v1): eval writes summary.json beside traces.jsonl

### DIFF
--- a/docs/v1/evaluation.md
+++ b/docs/v1/evaluation.md
@@ -29,7 +29,7 @@ Validate the config by using `uv run eval @ config.toml --dry-run`. To run the e
 
 Use dotted arguments to set values using the CLI, e.g. `--sampling.temperature 0.5`. CLI arguments overwrite toml arguments when both are present.
 
-The output from evaluations are written into `outputs/<env>--<model>--<harness>/<uuid>/` by default, where `<env>` is the taskset, prefixed by the paired env id when `--env.id` sets one (use `output_dir` to overwrite the folder). The folder contains the used `config.toml`, all the episodes in `traces.jsonl`, as well as logs of the run and workers in `logs/attempt_<n>/eval.log` — one directory per launch attempt (a resume starts a new one), with `logs/latest` pointing at the current attempt.
+The output from evaluations are written into `outputs/<env>--<model>--<harness>/<uuid>/` by default, where `<env>` is the taskset, prefixed by the paired env id when `--env.id` sets one (use `output_dir` to overwrite the folder). The folder contains the used `config.toml`, all the episodes in `traces.jsonl`, as well as logs of the run and workers in `logs/attempt_<n>/eval.log` — one directory per launch attempt (a resume starts a new one), with `logs/latest` pointing at the current attempt. When the run completes, `summary.json` beside `traces.jsonl` records how it went: episodes, failures by error type, the mean reward over scored rollouts, and the same per task.
 
 ## Common config values
 

--- a/skills/evaluate-environments/SKILL.md
+++ b/skills/evaluate-environments/SKILL.md
@@ -163,10 +163,11 @@ A run writes to `output_dir / run.dir` (`-o` sets `output_dir`, default `outputs
 outputs/<env>--<model>--<harness>--<short-id>/
 ├── configs/eval.json
 ├── logs/eval.log
+├── summary.json
 └── traces.jsonl
 ```
 
-`configs/eval.json` is the run's resolved config, re-runnable via `@`. `traces.jsonl` is one **episode** per line — the episode's traces plus their shared standing — appended after each episode finishes, so an episode is durable whole or not at all (a torn last line is the whole episode redone on resume).
+`configs/eval.json` is the run's resolved config, re-runnable via `@`. `traces.jsonl` is one **episode** per line — the episode's traces plus their shared standing — appended after each episode finishes, so an episode is durable whole or not at all (a torn last line is the whole episode redone on resume). `summary.json` is written when the run completes: episodes, failures by error type, the mean reward over scored rollouts, and the same per task — read it rather than re-deriving those from `traces.jsonl`.
 
 Resume in place by re-running the run's own saved config with `--resume` (it re-runs only the missing/errored rollouts; any config drift from the saved run is refused):
 

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -40,6 +40,7 @@ import pytest
 import verifiers.v1 as vf
 from verifiers.v1.cli.eval.runner import run_eval
 from verifiers.v1.configs.cli.eval import EvalConfig
+from verifiers.v1.configs.client import EvalClientConfig
 from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.trace import Trace
 from verifiers.v1.utils.loaders import harness_config_type
@@ -133,11 +134,12 @@ def _eval_config(
     pool: dict | None = None,
     reasoning_effort: str | None = None,
     server: bool = False,
+    client: EvalClientConfig | None = None,
 ) -> EvalConfig:
     """Build the smallest `EvalConfig` that still exercises the path, shared by the in-process
     (`run_v1`) and env-server (`run_v1_server`) fixtures. `taskset_overrides` merges onto the
     `{id: ...}` config; `runtime` places the `agent` seat's harness (an agent field, not a
-    harness one).
+    harness one); `client` swaps the default endpoint (the local `stub_model`).
 
     `harness=None` leaves every seat on its own story — the multi-agent case: there
     is no run-level harness, so a single-agent test's `harness` lands on the `agent`
@@ -188,6 +190,7 @@ def _eval_config(
         output_dir=output_dir.parent,
         run={"dir": output_dir.name},
         model=CI_MODEL,
+        client=client or EvalClientConfig(),
     )
 
 
@@ -235,3 +238,67 @@ async def live_ctx():
         client=EvalClientConfig(),
         sampling=SamplingConfig(max_tokens=2048),
     )
+
+
+@pytest.fixture
+def stub_model():
+    """A local OpenAI-compatible endpoint standing in for the model, so an eval runs
+    with no key and no network — the model-free counterpart of `live_ctx`. Every chat
+    completion answers "hello world" (echo-v1 scores that 1.0 on the matching phrase,
+    0.0 on any other), and a request whose prompt mentions "fail" errors upstream (a
+    500), so one run lands scored, unscored and failed rollouts. Yields the endpoint's
+    client config."""
+    import json
+    import threading
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *args) -> None:
+            pass  # no access log in the test output
+
+        def do_POST(self) -> None:
+            request = json.loads(self.rfile.read(int(self.headers["content-length"])))
+            prompt = " ".join(
+                str(m["content"]) for m in request["messages"] if m["role"] == "user"
+            )
+            if "fail" in prompt:
+                status = 500
+                reply = {"error": {"message": "stub failure", "type": "server_error"}}
+            else:
+                status = 200
+                reply = {
+                    "id": "chatcmpl-stub",
+                    "object": "chat.completion",
+                    "created": 0,
+                    "model": request["model"],
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {"role": "assistant", "content": "hello world"},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {
+                        "prompt_tokens": 1,
+                        "completion_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                }
+            body = json.dumps(reply).encode()
+            self.send_response(status)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    server.daemon_threads = True
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        yield EvalClientConfig(
+            base_url=f"http://127.0.0.1:{server.server_port}/v1",
+            api_key_var="VF_STUB_KEY",  # unset: the client sends "EMPTY", the stub ignores it
+        )
+    finally:
+        server.shutdown()
+        server.server_close()

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -742,3 +742,76 @@ async def test_replay_round_trip(run_v1, tmp_path):
     # The wire task keeps its taskset-specific fields in the replay's own output.
     raw = (tmp_path / "replay2" / "traces.jsonl").read_text()
     assert '"answer"' in raw
+
+
+@mark.null
+@mark.subprocess
+async def test_summary(run_v1, stub_model, tmp_path):
+    """`summary.json` lands beside `traces.jsonl` when the run completes, with the run's
+    reading of itself. Model-free: the stub answers every request with "hello world" and
+    fails the "fail" phrase upstream, so the three echo tasks land scored 1.0, scored 0.0
+    and failed (a `ProviderError` on the trace) — no key, no network."""
+    import json
+
+    # The stub's failure is deterministic; a retry would only replay it.
+    no_retry = {"max_retries": 0}
+    traces = await run_v1(
+        "echo-v1",
+        output_dir=tmp_path,
+        runtime={"type": "subprocess"},
+        client=stub_model,
+        taskset_overrides={"phrases": ["hello world", "wrong", "fail"]},
+        num_tasks=3,
+        env={"retries": no_retry, "agent": {"retries": no_retry}},
+    )
+    assert len(traces) == 3
+    assert json.loads((tmp_path / "summary.json").read_text()) == {
+        "episodes": 3,
+        "failed": 1,
+        "errors": {"ProviderError": 1},
+        "reward": 0.5,
+        "tasks": {
+            "echo:hello world": {
+                "name": None,
+                "rollouts": 1,
+                "failed": 0,
+                "reward": 1.0,
+            },
+            "echo:wrong": {"name": None, "rollouts": 1, "failed": 0, "reward": 0.0},
+            "echo:fail": {"name": None, "rollouts": 1, "failed": 1, "reward": None},
+        },
+    }
+
+
+def test_summary_reads_policy_traces():
+    """A rollout's reward is its policy traces' (`trainable`): a frozen seat's own reward
+    (a judge's, a modeled user's) never dilutes the mean, every trace counts when no seat
+    is trainable, and a trace that scored nothing leaves its rollout unscored, outside
+    the mean."""
+    import verifiers.v1 as vf
+    from verifiers.v1.cli.output import summarize
+
+    task = vf.TraceTask(type="Task", data=vf.TaskData(idx=0), key="t")
+
+    def trace(reward: float | None, trainable: bool = True) -> vf.Trace:
+        return vf.Trace(
+            task=task,
+            agent=vf.AgentInfo(config=vf.AgentConfig(), trainable=trainable),
+            rewards={} if reward is None else {"r": vf.Reward(score=reward)},
+            ok=True,
+        )
+
+    def episode(*traces: vf.Trace) -> vf.Episode:
+        return vf.Episode(task=task, traces=list(traces), ok=True)
+
+    summary = summarize(
+        [
+            episode(trace(1.0), trace(0.0, trainable=False)),  # the policy's 1.0
+            episode(trace(0.0, trainable=False), trace(0.5, trainable=False)),  # 0.25
+            episode(trace(None)),  # unscored
+        ]
+    )
+    assert summary.episodes == 3
+    assert summary.reward == pytest.approx((1.0 + 0.25) / 2)
+    assert summary.tasks["t"].rollouts == 3
+    assert summary.tasks["t"].reward == pytest.approx((1.0 + 0.25) / 2)

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -783,35 +783,50 @@ async def test_summary(run_v1, stub_model, tmp_path):
     }
 
 
-def test_summary_reads_policy_traces():
-    """A rollout's reward is its policy traces' (`trainable`): a frozen seat's own reward
-    (a judge's, a modeled user's) never dilutes the mean, every trace counts when no seat
-    is trainable, and a trace that scored nothing leaves its rollout unscored, outside
-    the mean."""
+def test_summary_rules():
+    """The rules the echo run can't reach. A rollout's reward is its policy traces'
+    (`trainable`): a frozen seat's own reward (a judge's, a modeled user's) never dilutes
+    the mean, every trace counts when no seat is trainable, and a trace that scored
+    nothing leaves its rollout unscored, outside the mean. A failure is attributed to the
+    failed trace's error, never to the history an ok trace kept from its own retries."""
     import verifiers.v1 as vf
     from verifiers.v1.cli.output import summarize
 
     task = vf.TraceTask(type="Task", data=vf.TaskData(idx=0), key="t")
 
-    def trace(reward: float | None, trainable: bool = True) -> vf.Trace:
+    def trace(
+        reward: float | None,
+        trainable: bool = True,
+        ok: bool = True,
+        errors: tuple[str, ...] = (),
+    ) -> vf.Trace:
         return vf.Trace(
             task=task,
             agent=vf.AgentInfo(config=vf.AgentConfig(), trainable=trainable),
             rewards={} if reward is None else {"r": vf.Reward(score=reward)},
-            ok=True,
+            ok=ok,
+            errors=[vf.Error(type=type_, message="") for type_ in errors],
         )
 
-    def episode(*traces: vf.Trace) -> vf.Episode:
-        return vf.Episode(task=task, traces=list(traces), ok=True)
+    def episode(*traces: vf.Trace, ok: bool = True) -> vf.Episode:
+        return vf.Episode(task=task, traces=list(traces), ok=ok)
 
     summary = summarize(
         [
             episode(trace(1.0), trace(0.0, trainable=False)),  # the policy's 1.0
             episode(trace(0.0, trainable=False), trace(0.5, trainable=False)),  # 0.25
             episode(trace(None)),  # unscored
+            episode(  # failed by the policy seat; the frozen seat recovered from its own
+                trace(0.0, trainable=False, errors=("ProviderError",)),
+                trace(None, ok=False, errors=("TaskError",)),
+                ok=False,
+            ),
         ]
     )
-    assert summary.episodes == 3
+    assert summary.episodes == 4
+    assert summary.failed == 1
+    assert summary.errors == {"TaskError": 1}
     assert summary.reward == pytest.approx((1.0 + 0.25) / 2)
-    assert summary.tasks["t"].rollouts == 3
+    assert summary.tasks["t"].rollouts == 4
+    assert summary.tasks["t"].failed == 1
     assert summary.tasks["t"].reward == pytest.approx((1.0 + 0.25) / 2)

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -16,7 +16,7 @@ from rich.table import Table
 from rich.text import Text
 
 from verifiers.v1.cli.dashboard.base import live_view
-from verifiers.v1.cli.output import attempt_log_file, output_path
+from verifiers.v1.cli.output import attempt_log_file, output_path, summarize
 from verifiers.v1.configs.cli.eval import EvalConfig
 from verifiers.v1.env import RunSlot
 from verifiers.v1.trace import Trace
@@ -304,21 +304,17 @@ def Progress(
     # progress, reward, err, and the breakdown cover the whole run, not just this session's.
     done = [s for s in slots if s.done]  # fully scored episodes
     done_traces = [t for s in done for t in s.traces]
-    # Score aggregates read the policy's traces: auxiliary roles (a judge's verdict
-    # run, a modeled user) are `trainable=False` and carry no rewards, so counting
+    # The breakdown's score rows read the policy's traces: auxiliary roles (a judge's
+    # verdict run, a modeled user) are `trainable=False` and carry no rewards, so counting
     # them dilutes every mean with structural zeros. An all-untrainable run (every
     # role frozen) falls back to all traces rather than showing nothing.
     scored = [t for t in done_traces if t.agent.trainable] or done_traces
     total = len(slots)
-    # Headline reward = mean over non-errored traces; when any errored, `format_mean` appends
-    # the global avg (errored count as 0) in parens. `err` is the share of episodes that
-    # ended not-ok (a trace errored, or the env's rollout()/score() hook itself failed).
-    reward = format_mean(scored, lambda t: t.reward)
-    err = (
-        f"{sum(s.episode is None or not s.episode.ok for s in done) / len(done):.2f}"
-        if done
-        else "—"
-    )
+    # The headline is the run summary's own reading (`summary.json`): mean reward over
+    # scored rollouts, and `err` the share of episodes that ended not-ok.
+    summary = summarize([s.episode for s in done if s.episode is not None])
+    reward = "—" if summary.reward is None else f"{summary.reward:.2f}"
+    err = f"{summary.failed / summary.episodes:.2f}" if summary.episodes else "—"
     stats = (
         f"{len(done)}/{total} · {format_time(time.time() - start)} · "
         f"reward {reward} · err {err}"

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -19,10 +19,13 @@ from typing import cast
 from verifiers.v1.cli.dashboard import dashboard
 from verifiers.v1.cli.eval import resume
 from verifiers.v1.cli.output import (
+    SUMMARY_FILE,
     append_episode,
     attempt_log_file,
     output_path,
     save_config,
+    summarize,
+    write_summary,
 )
 from verifiers.v1.cli.resume import distribute
 from verifiers.v1.clients import ModelContext
@@ -176,6 +179,9 @@ async def run_eval(config: EvalConfig) -> list[Episode]:
             raise SystemExit(0)
         counts = distribute(keys, owed, config.num_rollouts)
         plan = [(task, n) for task, n in zip(tasks, counts) if n]
+        # The kept rows are a new run state: the summary described the old one, and
+        # the run rewrites it on completion.
+        (out / SUMMARY_FILE).unlink(missing_ok=True)
         logger.info(
             "resuming %s: %d task(s), %d rollout(s) owed",
             out,
@@ -246,4 +252,12 @@ async def run_eval(config: EvalConfig) -> list[Episode]:
 
                 push_state.started = True
                 await asyncio.to_thread(push_traces, episodes, config, push_state)
+    summary = summarize(episodes)
+    write_summary(out, summary)
+    logger.info(
+        "summary: episodes=%d failed=%d reward=%s",
+        summary.episodes,
+        summary.failed,
+        "—" if summary.reward is None else f"{summary.reward:.3f}",
+    )
     return episodes

--- a/verifiers/v1/cli/output.py
+++ b/verifiers/v1/cli/output.py
@@ -1,4 +1,4 @@
-"""On-disk output: traces.jsonl (one rollout episode per line) + configs/<cli>.json.
+"""On-disk output: traces.jsonl (one rollout episode per line) + configs/<cli>.json + summary.json.
 
 Each line is an `Episode` — the episode's standing (`id`/`env`/`errors`) inlined
 next to its flat, self-contained traces — so an episode persists whole or not at all: a torn line is the
@@ -6,12 +6,15 @@ whole episode owed on resume, and a failure before any trace minted still leaves
 its errors on disk. The JSON file is the run's resolved config in the format the
 CLI reads (`@ configs/<cli>.json`), so a run is re-runnable from its own output. Lines
 append as episodes complete, so results are durable mid-run. Files written
-by this surface contain episodes only.
+by this surface contain episodes only. `summary.json` is how the completed run went,
+read off those episodes once (`summarize`) so no consumer re-derives it.
 """
 
 import asyncio
 import json
 import os
+from collections import Counter
+from collections.abc import Sequence
 from functools import cache
 from pathlib import Path
 
@@ -20,12 +23,15 @@ from pydantic import BaseModel, TypeAdapter
 from verifiers.v1.configs.cli.eval import EvalConfig
 from verifiers.v1.episode import EnvInfo, Episode, WireEpisode
 from verifiers.v1.state import StateT
-from verifiers.v1.task import DataT
-from verifiers.v1.trace import AgentConfigT, Trace
+from verifiers.v1.task import DataT, Task
+from verifiers.v1.trace import AgentConfigT, Error, Trace
 from verifiers.v1.utils.aio import run_shielded
 
 TRACES_FILE = "traces.jsonl"
 """Filename a run's rollout episodes are written to (one JSON episode per line)."""
+
+SUMMARY_FILE = "summary.json"
+"""Filename a completed run's `Summary` is written to, beside `traces.jsonl`."""
 
 CONFIG_DIR = "configs"
 """Directory inside a run dir holding its configs: the launch TOML copied verbatim to
@@ -203,3 +209,90 @@ async def append_trace(
         ok=trace.ok,
     )
     await append_episode(results_dir, episode, lock)
+
+
+class TaskSummary(BaseModel):
+    """One task's rollouts, counted as `Summary` counts the run's."""
+
+    name: str | None
+    """The task's `TaskData.name`, when it has one."""
+    rollouts: int
+    failed: int
+    reward: float | None
+    """Mean reward over the task's scored rollouts; None when none was scored."""
+
+
+class Summary(BaseModel):
+    """How a run went, read off its finished episodes. An episode failed iff it ended
+    not ok. A rollout's reward is the mean `Trace.reward` over its scored policy
+    traces — the `trainable` ones, or every trace when no seat is — where a trace is
+    scored once any of its rewards landed (all None: scoring never ran); a rollout
+    with no scored trace is unscored and sits outside every mean."""
+
+    episodes: int
+    failed: int
+    errors: dict[str, int]
+    """Failed episodes by the type of the error that failed them: an errored trace's
+    last error (the traces are the final attempt's), else the episode's own last
+    error (a hook's). A failed episode that recorded no error is counted nowhere here."""
+    reward: float | None
+    """Mean reward over the run's scored rollouts; None when none was scored."""
+    tasks: dict[str, TaskSummary]
+    """Per task, keyed by `task.key` (its `hash` when unset), in first-seen order."""
+
+
+def _task_key(episode: Episode) -> str:
+    # Rows written before the key and hash were recorded hash their data, as resume does.
+    return episode.task.key or episode.task.hash or Task(episode.task.data).hash
+
+
+def _cause(episode: Episode) -> Error | None:
+    """The error that failed `episode` (see `Summary.errors`)."""
+    return next(
+        (t.last_error for t in episode.traces if t.last_error), episode.last_error
+    )
+
+
+def _rollout_reward(episode: Episode) -> float | None:
+    """The episode's reward as one rollout (see `Summary`); None when unscored."""
+    policy = [t for t in episode.traces if t.agent.trainable] or episode.traces
+    rewards = [
+        t.reward for t in policy if any(r is not None for r in t.rewards.values())
+    ]
+    return sum(rewards) / len(rewards) if rewards else None
+
+
+def _mean_reward(episodes: Sequence[Episode]) -> float | None:
+    rewards = [r for e in episodes if (r := _rollout_reward(e)) is not None]
+    return sum(rewards) / len(rewards) if rewards else None
+
+
+def summarize(episodes: Sequence[Episode]) -> Summary:
+    """The run's `Summary` over its finished episodes."""
+    by_task: dict[str, list[Episode]] = {}
+    for episode in episodes:
+        by_task.setdefault(_task_key(episode), []).append(episode)
+    causes = [c for e in episodes if not e.ok and (c := _cause(e)) is not None]
+    return Summary(
+        episodes=len(episodes),
+        failed=sum(not e.ok for e in episodes),
+        errors=dict(Counter(c.type for c in causes)),
+        reward=_mean_reward(episodes),
+        tasks={
+            key: TaskSummary(
+                name=group[0].task.data.name,
+                rollouts=len(group),
+                failed=sum(not e.ok for e in group),
+                reward=_mean_reward(group),
+            )
+            for key, group in by_task.items()
+        },
+    )
+
+
+def write_summary(results_dir: Path, summary: Summary) -> Path:
+    """Write the completed run's `summary.json` beside its traces; return its path. Nulls
+    included: an unscored reward reads as `null`, never as a missing key."""
+    path = results_dir / SUMMARY_FILE
+    path.write_text(summary.model_dump_json(indent=2))
+    return path

--- a/verifiers/v1/cli/output.py
+++ b/verifiers/v1/cli/output.py
@@ -232,9 +232,10 @@ class Summary(BaseModel):
     episodes: int
     failed: int
     errors: dict[str, int]
-    """Failed episodes by the type of the error that failed them: an errored trace's
-    last error (the traces are the final attempt's), else the episode's own last
-    error (a hook's). A failed episode that recorded no error is counted nowhere here."""
+    """Failed episodes by the type of the error that failed them: a failed trace's
+    last error, else the episode's own last error (a hook's) — the live errors
+    `episode_should_retry` reads, since an ok trace's errors are history its per-agent
+    retry recovered from. A failed episode that recorded no error is counted nowhere here."""
     reward: float | None
     """Mean reward over the run's scored rollouts; None when none was scored."""
     tasks: dict[str, TaskSummary]
@@ -249,7 +250,8 @@ def _task_key(episode: Episode) -> str:
 def _cause(episode: Episode) -> Error | None:
     """The error that failed `episode` (see `Summary.errors`)."""
     return next(
-        (t.last_error for t in episode.traces if t.last_error), episode.last_error
+        (t.last_error for t in episode.traces if not t.ok and t.last_error),
+        episode.last_error,
     )
 
 


### PR DESCRIPTION
## What the run dir lacked

A finished `eval` run dir held `traces.jsonl`, `configs/resolved/eval.json` and `logs/`, and nothing that said how the run went. The dashboard computed a mean reward and an error share for display only, so anyone reading a run afterwards (a script, a pipeline, a person with `jq`) re-derived pass rate, mean reward and failures from `traces.jsonl` with their own reading of `Episode.ok`, `Trace.reward` and `agent.trainable`. Those readings drift. The constraint here is one reading of the record, owned by verifiers.

## What changes

- `cli/output.py` gains `summarize(episodes) -> Summary` and `write_summary`. `run_eval` writes `summary.json` beside `traces.jsonl` when the run completes and logs one `summary: episodes=… failed=… reward=…` line (on the console under `--no-rich`, in `logs/latest/eval.log` always). A `--resume` drops the previous summary before re-running the owed rollouts, since `resume.load` rewrites `traces.jsonl` underneath it, and writes a fresh one on completion. The file's presence therefore means the run completed.
- The dashboard footer's `reward … · err …` reads `summarize` instead of its own formula; the per-signal breakdown rows keep `format_mean`.
- `docs/v1/evaluation.md` and the `evaluate-environments` skill name the file.
- No new config, flag or dependency.

## What `summary.json` holds

```json
{
  "episodes": 6,
  "failed": 2,
  "errors": {"ProviderError": 2},
  "reward": 0.5,
  "tasks": {
    "echo:hello world": {"name": null, "rollouts": 2, "failed": 0, "reward": 1.0},
    "echo:ping":        {"name": null, "rollouts": 2, "failed": 2, "reward": null},
    "echo:verifiers":   {"name": null, "rollouts": 2, "failed": 0, "reward": 0.0}
  }
}
```

- `episodes`: finished episodes, one per rollout (on a resume, the kept ones plus the re-run ones).
- `failed`: episodes that ended not ok (`Episode.ok` is false).
- `errors`: failed episodes by the type of the error that failed them: a failed trace's last error, else the episode's own last error (a hook's). These are the live errors `episode_should_retry` reads; an ok trace's errors are history its per-agent retry recovered from, and are never the cause. A failed episode that recorded no error is counted nowhere here, so the counts sum to at most `failed`.
- `reward`: mean over scored rollouts. A rollout's reward is the mean `Trace.reward` over its policy traces (`agent.trainable`, or every trace when no seat is trainable) that were scored; a trace whose rewards are all `None` (or empty) was never scored, and a rollout with no scored trace is unscored and outside every mean. `null` when nothing was scored.
- `tasks`: the same per task, keyed by `task.key` (`task.hash` when unset; rows written before either was recorded hash their data, as resume does), with `TaskData.name` when the task has one.

`utils/platform.run_metrics` (the `--push` metadata) keeps its v0-shaped `avg_reward` / `avg_error`, where an errored trace counts as 0. That is a platform contract and is untouched here.

## How it was checked

- `tests/v1/test_e2e.py::test_summary` runs `echo-v1` on the null harness (subprocess runtime, in-process) against a local stub endpoint that answers every request with "hello world" and fails the `fail` phrase upstream, so it needs no key and no network. It asserts `summary.json` verbatim: 3 episodes, 1 failed, `{"ProviderError": 1}`, reward 0.5, per task 1.0 / 0.0 / null. `test_summary_rules` pins the rules that run can't reach over hand-built episodes: a frozen seat's reward is not counted, every trace counts when no seat is trainable, an unscored trace leaves its rollout out of the mean, and a failure is attributed to the failed trace's error rather than to history a recovered sibling kept.
- The default served path through the CLI (`uv run eval echo-v1 --env.agent.harness.id null --env.agent.runtime.type subprocess --no-rich -n 3 -r 2`, same stub): the run dir gains the `summary.json` above, the log ends with `summary: episodes=6 failed=2 reward=0.500`, and a `--resume` of that dir re-runs the two failed rollouts and rewrites the summary.
- `uv run ruff check --fix .`, `uv run ruff format .`, `uv run pytest tests/v1 -n auto -m "not e2e"` (85 passed), `uv run pre-commit run --all-files` and `ty check verifiers` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive run output and aligned dashboard display; resume behavior only removes a stale summary file before recomputation.
> 
> **Overview**
> Finished **eval** runs now emit **`summary.json`** next to **`traces.jsonl`**, giving pipelines and humans a single canonical rollup instead of re-parsing episodes with ad hoc reward/error rules.
> 
> **`summarize(episodes)`** in `cli/output.py` defines that rollup: episode and failure counts, failures grouped by error type, mean reward over **scored** rollouts (policy/`trainable` traces only, with documented fallbacks for multi-agent and unscored cases), plus the same stats per task key. **`run_eval`** writes the file on completion, logs a one-line summary, and **deletes the old `summary.json` on `--resume`** before rewriting it when the resumed run finishes. The live dashboard **reward · err** footer now uses **`summarize`** so on-screen numbers match the file.
> 
> Docs/skills mention **`summary.json`**. Tests add a local **`stub_model`** HTTP stub (no API key/network), an e2e check of the echo run’s summary shape, and unit tests for aggregation edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2331dcd70248e2cca06b87145639fd45e423892d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Write `summary.json` beside `traces.jsonl` on eval completion
> - Adds `Summary` and `TaskSummary` Pydantic models plus `summarize` and `write_summary` helpers in [output.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2520/files#diff-07fce45dd0fa633f34d25e19962ab801b705a509774833de0d81bfe872787e8b) to aggregate episode counts, failure counts by error type, scored reward means, and per-task results
> - Integrates summary generation into [runner.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2520/files#diff-65be4a576330571f2729a3bbcdbe92ac81bbcba450c313597c1bdca3a1c3f2e4): `run_eval` writes `summary.json` after all episodes finish and deletes any stale summary before a resumed run's owed rollouts
> - Updates the live dashboard in [eval.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2520/files#diff-0a27b905958929f3ae9e01937dd7e3cf97a60dec137caddcbf87792784fc9035) so headline reward and error values follow the `Summary` aggregation rules (reward mean excludes unscored rollouts; error ratio uses failed/total episodes)\n- Adds a local HTTP stub-model fixture and end-to-end/aggregation tests in [test_e2e.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2520/files#diff-ebbbd919487889487f891b359a756e6c4630e106b16ddaef8ccddc6b900a96e1) and [conftest.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2520/files#diff-bc28790d38dc6e7e4f2c44639d40bc33dea724d6c73149abf7ba82b37d14f40b), plus docs in [evaluation.md](https://github.com/PrimeIntellect-ai/verifiers/pull/2520/files#diff-dcded4c488b9e44f4750d10743f8f2319c8ff959fae7ca1a23d3d81c88a64848) and [SKILL.md](https://github.com/PrimeIntellect-ai/verifiers/pull/2520/files#diff-36d08ee11d380ecaa5beacd5b98cd8bfa0791dfa784b93956b128cafc58dbe0d)
> - Behavioral Change: resumed evaluations now remove and rewrite `summary.json`; reward means prefer trainable-agent traces and exclude unscored rollouts, which may change displayed dashboard values versus prior direct calculation
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2331dcd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->