### PR TITLE
feat: exclude rejected compaction attempts from training

### DIFF
--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -20,6 +20,7 @@ from verifiers.v1.rollout import Rollout, RolloutTimeouts
 from verifiers.v1.semantic import (
     ACP_EXTENSION_HEADERS,
     ACP_SEMANTIC_EDGES_METADATA_KEY,
+    ACP_TRAINING_EXCLUSIONS_METADATA_KEY,
     extract_acp_info,
 )
 from verifiers.v1.types import AssistantMessage, UserMessage
@@ -432,6 +433,100 @@ def test_acp_semantic_edge_metadata_is_optional():
     )
 
     assert all(not node.semantic_parents for node in trace.nodes)
+
+
+def test_acp_excludes_rejected_compaction_attempt_but_trains_accepted_summary():
+    trace = vf.Trace(
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
+        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="q")),
+        nodes=[
+            MessageNode(parent=None, message=UserMessage(content="work")),
+            MessageNode(
+                parent=0,
+                message=AssistantMessage(content="working"),
+                sampled=True,
+                token_ids=[1],
+                mask=[True],
+                logprobs=[-0.1],
+            ),
+            MessageNode(parent=1, message=UserMessage(content="summarize")),
+            MessageNode(
+                parent=2,
+                message=AssistantMessage(content="bad tool call"),
+                sampled=True,
+                token_ids=[2, 3],
+                mask=[True, True],
+                logprobs=[-0.2, -0.3],
+            ),
+            MessageNode(
+                parent=2,
+                message=AssistantMessage(content="accepted summary"),
+                sampled=True,
+                token_ids=[4, 5],
+                mask=[True, True],
+                logprobs=[-0.4, -0.5],
+            ),
+            MessageNode(parent=0, message=UserMessage(content="compacted context")),
+            MessageNode(
+                parent=5,
+                message=AssistantMessage(content="answer"),
+                sampled=True,
+                token_ids=[6],
+                mask=[True],
+                logprobs=[-0.6],
+            ),
+        ],
+        calls=[
+            vf.ModelCall(node=1, acp=vf.ACPInfo(request_id="work")),
+            vf.ModelCall(node=3, acp=vf.ACPInfo(request_id="rejected")),
+            vf.ModelCall(node=4, acp=vf.ACPInfo(request_id="accepted")),
+            vf.ModelCall(node=6, acp=vf.ACPInfo(request_id="resumed")),
+        ],
+    )
+    harness = RLMHarness(RLMHarnessConfig(id="rlm"))
+    harness._consume_protocol_metadata(
+        trace,
+        {
+            ACP_SEMANTIC_EDGES_METADATA_KEY: {
+                "edges": [
+                    {
+                        "source_request_id": "work",
+                        "target_request_id": "rejected",
+                        "type": "compaction_attempt",
+                    },
+                    {
+                        "source_request_id": "work",
+                        "target_request_id": "accepted",
+                        "type": "compaction_attempt",
+                    },
+                    {
+                        "source_request_id": "accepted",
+                        "target_request_id": "resumed",
+                        "type": "compaction",
+                    },
+                ]
+            },
+            ACP_TRAINING_EXCLUSIONS_METADATA_KEY: {"request_ids": ["rejected"]},
+        },
+    )
+
+    assert trace.nodes[3].sampled is True
+    assert trace.nodes[3].mask == [False, False]
+    assert trace.nodes[4].mask == [True, True]
+    assert trace.nodes[6].mask == [True]
+    assert trace.nodes[3].semantic_parents == [
+        vf.ParentLink(node=1, type="compaction_attempt")
+    ]
+    assert trace.nodes[4].semantic_parents == [
+        vf.ParentLink(node=1, type="compaction_attempt")
+    ]
+    assert trace.nodes[6].semantic_parents == [vf.ParentLink(node=4, type="compaction")]
+    assert trace.num_branches == 3
+
+    restored = vf.WireTrace.model_validate_json(trace.model_dump_json())
+    assert restored.nodes[3].sampled is True
+    assert restored.nodes[3].mask == [False, False]
+    assert restored.nodes[4].mask == [True, True]
 
 
 def test_semantic_edge_set_rejects_duplicate_self_and_cyclic_edges():

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -20,7 +20,6 @@ from verifiers.v1.rollout import Rollout, RolloutTimeouts
 from verifiers.v1.semantic import (
     ACP_EXTENSION_HEADERS,
     ACP_SEMANTIC_EDGES_METADATA_KEY,
-    ACP_TRAINING_EXCLUSIONS_METADATA_KEY,
     extract_acp_info,
 )
 from verifiers.v1.types import AssistantMessage, UserMessage
@@ -435,7 +434,7 @@ def test_acp_semantic_edge_metadata_is_optional():
     assert all(not node.semantic_parents for node in trace.nodes)
 
 
-def test_acp_excludes_rejected_compaction_attempt_but_trains_accepted_summary():
+def test_acp_derives_compaction_attempt_branch_trainability():
     trace = vf.Trace(
         agent=vf.AgentInfo(config=vf.AgentConfig()),
         task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="q")),
@@ -499,6 +498,30 @@ def test_acp_excludes_rejected_compaction_attempt_but_trains_accepted_summary():
                         "target_request_id": "accepted",
                         "type": "compaction_attempt",
                     },
+                ]
+            },
+        },
+    )
+
+    attempts = {branch.nodes[-1].message.content: branch for branch in trace.branches}
+    assert attempts["bad tool call"].trainable is False
+    assert attempts["accepted summary"].trainable is False
+
+    harness._consume_protocol_metadata(
+        trace,
+        {
+            ACP_SEMANTIC_EDGES_METADATA_KEY: {
+                "edges": [
+                    {
+                        "source_request_id": "work",
+                        "target_request_id": "rejected",
+                        "type": "compaction_attempt",
+                    },
+                    {
+                        "source_request_id": "work",
+                        "target_request_id": "accepted",
+                        "type": "compaction_attempt",
+                    },
                     {
                         "source_request_id": "accepted",
                         "target_request_id": "resumed",
@@ -506,12 +529,11 @@ def test_acp_excludes_rejected_compaction_attempt_but_trains_accepted_summary():
                     },
                 ]
             },
-            ACP_TRAINING_EXCLUSIONS_METADATA_KEY: {"request_ids": ["rejected"]},
         },
     )
 
     assert trace.nodes[3].sampled is True
-    assert trace.nodes[3].mask == [False, False]
+    assert trace.nodes[3].mask == [True, True]
     assert trace.nodes[4].mask == [True, True]
     assert trace.nodes[6].mask == [True]
     assert trace.nodes[3].semantic_parents == [
@@ -522,11 +544,22 @@ def test_acp_excludes_rejected_compaction_attempt_but_trains_accepted_summary():
     ]
     assert trace.nodes[6].semantic_parents == [vf.ParentLink(node=4, type="compaction")]
     assert trace.num_branches == 3
+    branches = {branch.nodes[-1].message.content: branch for branch in trace.branches}
+    assert branches["bad tool call"].trainable is False
+    assert branches["accepted summary"].trainable is True
+    assert branches["answer"].trainable is True
+    assert branches["bad tool call"].nodes[-2] is trace.nodes[2]
+    assert branches["accepted summary"].nodes[-2] is trace.nodes[2]
 
     restored = vf.WireTrace.model_validate_json(trace.model_dump_json())
     assert restored.nodes[3].sampled is True
-    assert restored.nodes[3].mask == [False, False]
+    assert restored.nodes[3].mask == [True, True]
     assert restored.nodes[4].mask == [True, True]
+    restored_branches = {
+        branch.nodes[-1].message.content: branch for branch in restored.branches
+    }
+    assert restored_branches["bad tool call"].trainable is False
+    assert restored_branches["accepted summary"].trainable is True
 
 
 def test_semantic_edge_set_rejects_duplicate_self_and_cyclic_edges():

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -84,10 +84,12 @@ from verifiers.v1.runtimes import (
 )
 from verifiers.v1.semantic import (
     ACP_SEMANTIC_EDGES_METADATA_KEY,
+    ACP_TRAINING_EXCLUSIONS_METADATA_KEY,
     ACPInfo,
     ParentLink,
     SemanticEdge,
     SemanticEdgeSet,
+    TrainingExclusionSet,
 )
 from verifiers.v1.state import State, StateT
 from verifiers.v1.task import Task, TaskData, TaskResources, TaskTimeout, WireTaskData
@@ -234,7 +236,9 @@ __all__ = [  # noqa: RUF022 - grouped by public API area
     "EvalWorkInfo",
     "ModelCall",
     "ACPInfo",
+    "ACP_TRAINING_EXCLUSIONS_METADATA_KEY",
     "ACP_SEMANTIC_EDGES_METADATA_KEY",
+    "TrainingExclusionSet",
     "ParentLink",
     "SemanticEdge",
     "SemanticEdgeSet",

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -84,12 +84,10 @@ from verifiers.v1.runtimes import (
 )
 from verifiers.v1.semantic import (
     ACP_SEMANTIC_EDGES_METADATA_KEY,
-    ACP_TRAINING_EXCLUSIONS_METADATA_KEY,
     ACPInfo,
     ParentLink,
     SemanticEdge,
     SemanticEdgeSet,
-    TrainingExclusionSet,
 )
 from verifiers.v1.state import State, StateT
 from verifiers.v1.task import Task, TaskData, TaskResources, TaskTimeout, WireTaskData
@@ -236,9 +234,7 @@ __all__ = [  # noqa: RUF022 - grouped by public API area
     "EvalWorkInfo",
     "ModelCall",
     "ACPInfo",
-    "ACP_TRAINING_EXCLUSIONS_METADATA_KEY",
     "ACP_SEMANTIC_EDGES_METADATA_KEY",
-    "TrainingExclusionSet",
     "ParentLink",
     "SemanticEdge",
     "SemanticEdgeSet",

--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -18,9 +18,7 @@ from verifiers.v1.harness import Harness, HarnessSession
 from verifiers.v1.runtimes import ProgramResult, Runtime, RuntimeProcess
 from verifiers.v1.semantic import (
     ACP_SEMANTIC_EDGES_METADATA_KEY,
-    ACP_TRAINING_EXCLUSIONS_METADATA_KEY,
     SemanticEdgeSet,
-    TrainingExclusionSet,
 )
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
@@ -85,11 +83,6 @@ class ACPHarness(Harness[ConfigT]):
                 response_metadata[ACP_SEMANTIC_EDGES_METADATA_KEY]
             )
             trace.add_semantic_edges(edge_set)
-        if ACP_TRAINING_EXCLUSIONS_METADATA_KEY in response_metadata:
-            exclusions = TrainingExclusionSet.model_validate(
-                response_metadata[ACP_TRAINING_EXCLUSIONS_METADATA_KEY]
-            )
-            trace.apply_training_exclusions(exclusions)
 
     @abstractmethod
     async def prepare_acp(

--- a/verifiers/v1/acp/__init__.py
+++ b/verifiers/v1/acp/__init__.py
@@ -18,7 +18,9 @@ from verifiers.v1.harness import Harness, HarnessSession
 from verifiers.v1.runtimes import ProgramResult, Runtime, RuntimeProcess
 from verifiers.v1.semantic import (
     ACP_SEMANTIC_EDGES_METADATA_KEY,
+    ACP_TRAINING_EXCLUSIONS_METADATA_KEY,
     SemanticEdgeSet,
+    TrainingExclusionSet,
 )
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
@@ -78,12 +80,16 @@ class ACPHarness(Harness[ConfigT]):
         self, trace: Trace, response_metadata: dict[str, Any]
     ) -> None:
         """Attach optional protocol extensions understood by every ACP harness."""
-        if ACP_SEMANTIC_EDGES_METADATA_KEY not in response_metadata:
-            return
-        edge_set = SemanticEdgeSet.model_validate(
-            response_metadata[ACP_SEMANTIC_EDGES_METADATA_KEY]
-        )
-        trace.add_semantic_edges(edge_set)
+        if ACP_SEMANTIC_EDGES_METADATA_KEY in response_metadata:
+            edge_set = SemanticEdgeSet.model_validate(
+                response_metadata[ACP_SEMANTIC_EDGES_METADATA_KEY]
+            )
+            trace.add_semantic_edges(edge_set)
+        if ACP_TRAINING_EXCLUSIONS_METADATA_KEY in response_metadata:
+            exclusions = TrainingExclusionSet.model_validate(
+                response_metadata[ACP_TRAINING_EXCLUSIONS_METADATA_KEY]
+            )
+            trace.apply_training_exclusions(exclusions)
 
     @abstractmethod
     async def prepare_acp(

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -57,7 +57,7 @@ class CompactionConfig(BaseConfig):
 
 
 class RLMHarnessConfig(HarnessConfig):
-    version: str = Field(default="728caa9", min_length=1)
+    version: str = Field(default="e384006", min_length=1)
     """Git ref (branch, tag, or commit) of nano-rlm to install. Must know every
     field this harness puts on the wire, i.e. be at least the default ref."""
     max_depth: NonNegativeInt | None = None

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -54,7 +54,7 @@ class CompactionConfig(BaseConfig):
 
 
 class RLMHarnessConfig(HarnessConfig):
-    version: str = Field(default="dd2c04f", min_length=1)
+    version: str = Field(default="f405cd1", min_length=1)
     """Git ref (branch, tag, or commit) of nano-rlm to install. Must know every
     field this harness puts on the wire, i.e. be at least the default ref."""
     max_depth: NonNegativeInt | None = None

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -57,7 +57,7 @@ class CompactionConfig(BaseConfig):
 
 
 class RLMHarnessConfig(HarnessConfig):
-    version: str = Field(default="c3eba7f", min_length=1)
+    version: str = Field(default="728caa9", min_length=1)
     """Git ref (branch, tag, or commit) of nano-rlm to install. Must know every
     field this harness puts on the wire, i.e. be at least the default ref."""
     max_depth: NonNegativeInt | None = None

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -57,7 +57,7 @@ class CompactionConfig(BaseConfig):
 
 
 class RLMHarnessConfig(HarnessConfig):
-    version: str = Field(default="c40cd97", min_length=1)
+    version: str = Field(default="c3eba7f", min_length=1)
     """Git ref (branch, tag, or commit) of nano-rlm to install. Must know every
     field this harness puts on the wire, i.e. be at least the default ref."""
     max_depth: NonNegativeInt | None = None

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -51,10 +51,13 @@ class CompactionConfig(BaseConfig):
     max_compactions: PositiveInt | None = None
     """Compactions per session before the engine stops compacting; `None` =
     nano-rlm's default."""
+    max_attempts: PositiveInt | None = None
+    """Summary-generation attempts within one compaction cycle; `None` =
+    nano-rlm's default (5)."""
 
 
 class RLMHarnessConfig(HarnessConfig):
-    version: str = Field(default="f405cd1", min_length=1)
+    version: str = Field(default="c40cd97", min_length=1)
     """Git ref (branch, tag, or commit) of nano-rlm to install. Must know every
     field this harness puts on the wire, i.e. be at least the default ref."""
     max_depth: NonNegativeInt | None = None
@@ -170,6 +173,7 @@ class RLMHarness(ACPHarness[RLMHarnessConfig]):
             policy_knobs["compaction"] = True
             policy_knobs["summarize_at_tokens"] = compaction.summarize_at_tokens
             policy_knobs["max_compactions"] = compaction.max_compactions
+            policy_knobs["max_compaction_attempts"] = compaction.max_attempts
         appends = [
             text
             for text in (system_prompt, self.config.append_to_system_prompt)

--- a/verifiers/v1/semantic.py
+++ b/verifiers/v1/semantic.py
@@ -12,7 +12,6 @@ EDGE_TYPE_PATTERN = r"^[A-Za-z][A-Za-z0-9._:-]{0,127}$"
 """Semantic label syntax, for example ``subagent_return`` or ``vendor:review``."""
 
 ACP_SEMANTIC_EDGES_METADATA_KEY = "ai.prime.acp/semantic-edges-v1"
-ACP_TRAINING_EXCLUSIONS_METADATA_KEY = "ai.prime.acp/training-exclusions-v1"
 ACP_MODEL_REQUEST_ID_HEADER = "X-ACP-Model-Request-ID"
 
 ACP_EXTENSION_HEADERS = frozenset({ACP_MODEL_REQUEST_ID_HEADER.lower()})
@@ -107,23 +106,6 @@ class SemanticEdgeSet(BaseModel):
                     stack.append(child)
         if visited != len(nodes):
             raise ValueError("semantic edge cycle detected")
-        return self
-
-
-class TrainingExclusionSet(BaseModel):
-    """Logical model requests whose sampled tokens must remain out of training."""
-
-    model_config = ConfigDict(extra="forbid", strict=True)
-
-    request_ids: list[str]
-
-    @model_validator(mode="after")
-    def reject_duplicates(self) -> TrainingExclusionSet:
-        if len(set(self.request_ids)) != len(self.request_ids):
-            raise ValueError("duplicate excluded model request ID")
-        for request_id in self.request_ids:
-            if re.fullmatch(ACP_REQUEST_ID_PATTERN, request_id) is None:
-                raise ValueError(f"invalid excluded model request ID: {request_id!r}")
         return self
 
 

--- a/verifiers/v1/semantic.py
+++ b/verifiers/v1/semantic.py
@@ -12,6 +12,7 @@ EDGE_TYPE_PATTERN = r"^[A-Za-z][A-Za-z0-9._:-]{0,127}$"
 """Semantic label syntax, for example ``subagent_return`` or ``vendor:review``."""
 
 ACP_SEMANTIC_EDGES_METADATA_KEY = "ai.prime.acp/semantic-edges-v1"
+ACP_TRAINING_EXCLUSIONS_METADATA_KEY = "ai.prime.acp/training-exclusions-v1"
 ACP_MODEL_REQUEST_ID_HEADER = "X-ACP-Model-Request-ID"
 
 ACP_EXTENSION_HEADERS = frozenset({ACP_MODEL_REQUEST_ID_HEADER.lower()})
@@ -63,8 +64,8 @@ class SemanticEdgeSet(BaseModel):
     """A harness-published set of semantic edges over logical request IDs.
 
     Edge labels are intentionally extensible. Initial harnesses use ``continuation``,
-    ``compaction``, ``subagent_call``, and ``subagent_return``; consumers must preserve
-    unknown labels.
+    ``compaction_attempt``, ``compaction``, ``subagent_call``, and ``subagent_return``;
+    consumers must preserve unknown labels.
     """
 
     model_config = ConfigDict(extra="forbid", strict=True)
@@ -106,6 +107,23 @@ class SemanticEdgeSet(BaseModel):
                     stack.append(child)
         if visited != len(nodes):
             raise ValueError("semantic edge cycle detected")
+        return self
+
+
+class TrainingExclusionSet(BaseModel):
+    """Logical model requests whose sampled tokens must remain out of training."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    request_ids: list[str]
+
+    @model_validator(mode="after")
+    def reject_duplicates(self) -> TrainingExclusionSet:
+        if len(set(self.request_ids)) != len(self.request_ids):
+            raise ValueError("duplicate excluded model request ID")
+        for request_id in self.request_ids:
+            if re.fullmatch(ACP_REQUEST_ID_PATTERN, request_id) is None:
+                raise ValueError(f"invalid excluded model request ID: {request_id!r}")
         return self
 
 

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -20,12 +20,7 @@ from verifiers.v1.configs.agent import AgentConfig, WireAgentConfig
 from verifiers.v1.errors import ProviderError
 from verifiers.v1.graph import RECORD_FLOAT_DECIMALS, MessageNode
 from verifiers.v1.runtimes import RuntimeInfo
-from verifiers.v1.semantic import (
-    ACPInfo,
-    ParentLink,
-    SemanticEdgeSet,
-    TrainingExclusionSet,
-)
+from verifiers.v1.semantic import ACPInfo, ParentLink, SemanticEdgeSet
 from verifiers.v1.state import State, StateT
 from verifiers.v1.task import DataT, WireTaskData
 from verifiers.v1.types import (
@@ -202,6 +197,8 @@ class Branch(BaseModel):
     index: int
     nodes: list[MessageNode]
     calls: list[ModelCall] = Field(default_factory=list)
+    trainable: bool = True
+    """Whether this physical path contributes a training sample."""
     mm_token_type_id_map: dict[int, int] = Field(default_factory=dict)
     """The trace's `mm_token_type_id_map`, carried so `mm_token_type_ids` is self-contained."""
 
@@ -493,8 +490,18 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
 
     @property
     def branches(self) -> list[Branch]:
-        """One root-to-leaf path per graph leaf, its calls attached in path order."""
+        """One root-to-leaf view per graph leaf, with no duplicated node storage.
+
+        A compaction attempt is a dangling physical leaf. It is trainable only when
+        the final semantic graph shows that the harness resumed from it.
+        """
         by_node = {c.node: c for c in self.calls if c.node is not None}
+        accepted_compaction_attempts = {
+            link.node
+            for node in self.nodes
+            for link in node.semantic_parents
+            if link.type == "compaction"
+        }
         branches: list[Branch] = []
         for i, leaf in enumerate(graph.leaves(self)):
             path: list[int] = []
@@ -503,11 +510,19 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
                 path.append(nid)
                 nid = self.nodes[nid].parent
             path.reverse()
+            is_compaction_attempt = any(
+                link.type == "compaction_attempt"
+                for link in self.nodes[leaf].semantic_parents
+            )
             branches.append(
                 Branch(
                     index=i,
                     nodes=[self.nodes[n] for n in path],
                     calls=[by_node[n] for n in path if n in by_node],
+                    trainable=(
+                        not is_compaction_attempt
+                        or leaf in accepted_compaction_attempts
+                    ),
                     mm_token_type_id_map=self.mm_token_type_id_map,
                 )
             )
@@ -578,32 +593,6 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
 
         for target, link in additions:
             self.nodes[target].semantic_parents.append(link)
-
-    def apply_training_exclusions(self, exclusions: TrainingExclusionSet) -> None:
-        """Mask committed responses identified by a cumulative ACP exclusion set."""
-        requested = set(exclusions.request_ids)
-        nodes: set[int] = set()
-        resolved: set[str] = set()
-        for call in self.calls:
-            if call.acp is None or call.acp.request_id not in requested:
-                continue
-            if call.node is None:
-                continue
-            if not 0 <= call.node < len(self.nodes):
-                raise ValueError(f"model call has invalid message node {call.node}")
-            if not self.nodes[call.node].sampled:
-                raise ValueError(f"model call node {call.node} is not sampled")
-            nodes.add(call.node)
-            resolved.add(call.acp.request_id)
-
-        if missing := requested - resolved:
-            raise ValueError(
-                f"excluded model requests have no committed message nodes: {sorted(missing)!r}"
-            )
-        for node_id in nodes:
-            node = self.nodes[node_id]
-            node.mask = [False] * len(node.mask)
-            node.sampling_mask = None
 
     @property
     def messages(self) -> Messages:

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -24,6 +24,7 @@ from verifiers.v1.semantic import (
     ACPInfo,
     ParentLink,
     SemanticEdgeSet,
+    TrainingExclusionSet,
 )
 from verifiers.v1.state import State, StateT
 from verifiers.v1.task import DataT, WireTaskData
@@ -577,6 +578,32 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
 
         for target, link in additions:
             self.nodes[target].semantic_parents.append(link)
+
+    def apply_training_exclusions(self, exclusions: TrainingExclusionSet) -> None:
+        """Mask committed responses identified by a cumulative ACP exclusion set."""
+        requested = set(exclusions.request_ids)
+        nodes: set[int] = set()
+        resolved: set[str] = set()
+        for call in self.calls:
+            if call.acp is None or call.acp.request_id not in requested:
+                continue
+            if call.node is None:
+                continue
+            if not 0 <= call.node < len(self.nodes):
+                raise ValueError(f"model call has invalid message node {call.node}")
+            if not self.nodes[call.node].sampled:
+                raise ValueError(f"model call node {call.node} is not sampled")
+            nodes.add(call.node)
+            resolved.add(call.acp.request_id)
+
+        if missing := requested - resolved:
+            raise ValueError(
+                f"excluded model requests have no committed message nodes: {sorted(missing)!r}"
+            )
+        for node_id in nodes:
+            node = self.nodes[node_id]
+            node.mask = [False] * len(node.mask)
+            node.sampling_mask = None
 
     @property
     def messages(self) -> Messages:


### PR DESCRIPTION
## Summary

- recognize `compaction_attempt` and `compaction` relationships in ACP semantic metadata
- mark branches ending at rejected compaction attempts untrainable
- keep accepted compaction attempts and their resumed continuations trainable
- preserve every attempt response as an ordinary sampled message node for tracing and visualization
- update the default nano-RLM pin to main commit `e384006`

## Design

`Trace` derives branch trainability from the cumulative semantic graph. A leaf reached by `compaction_attempt` is untrainable unless that attempt is the source of a later `compaction` edge. Recomputing this classification when new ACP metadata arrives allows a pending attempt to become trainable once the harness confirms that it was accepted.

Attempt nodes share their existing physical prefix, so rejected leaves do not duplicate message history. ACP metadata remains training-agnostic: it describes relationships, while Verifiers decides how those relationships affect training. Traces without these relationships continue to produce trainable branches.

## Testing

- `uv run --no-sync pytest tests/` (84 passed, 76 credential-gated tests skipped)
- `uv run --no-sync pre-commit run --all-files`
- PR CI: Python 3.11–3.13, Ruff, ty, CodeQL, and live v1 E2E passed
- regression coverage verifies rejected → untrainable, accepted → trainable, resumed → trainable, shared prefix identity, unchanged sampled flags, and unchanged token masks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how training samples are selected from multi-branch compaction traces; misclassified edges could drop or include wrong trajectories, but logic is localized to semantic metadata and branch derivation.
> 
> **Overview**
> Training branches now carry a **`trainable`** flag derived from ACP semantic edges. Leaves tagged **`compaction_attempt`** stay **untrainable** until a later **`compaction`** edge shows the harness resumed from that attempt; rejected summary branches stay out of training while accepted attempts and post-compaction continuations remain trainable. Message nodes, sampling flags, and token masks are unchanged—only which root-to-leaf paths count as samples changes when metadata arrives incrementally.
> 
> Docs and wire semantics add **`compaction_attempt`** alongside **`compaction`**. RLM harness compaction config gains **`max_attempts`**, forwarded as **`max_compaction_attempts`**, and the default nano-RLM pin moves to **`e384006`**. ACP **`_consume_protocol_metadata`** no longer early-returns when semantic edges are absent (behavior unchanged when the key is missing).
> 
> Regression test **`test_acp_derives_compaction_attempt_branch_trainability`** covers pending vs accepted compaction, shared prefixes, and JSON round-trip of **`trainable`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5d97a327fe471e329982c3b354c9373326142a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Exclude rejected compaction-attempt branches from training in `Trace.branches`
> - Adds a `trainable` boolean field (default `true`) to `trace.Branch` so physical paths can be flagged as excluded from training samples
> - `Trace.branches` now collects source node IDs of semantic `compaction` links as accepted attempts, and marks any leaf branch whose leaf has a `compaction_attempt` semantic parent as `trainable=false` unless that attempt is the accepted source
> - Adds `CompactionConfig.max_attempts` (optional positive int) so RLM compaction config can cap summary-generation attempts; the value flows into the ACP policy payload as `max_compaction_attempts` when compaction is configured in object form
> - Bumps the default `RLMHarnessConfig` nano-rlm installation ref from `dd2c04f` to `e384006`
> - Risk: branches that previously had no `trainable` attribute now serialize with `trainable`; consumers deserializing older traces must handle the new field. The default ref bump means new installs without an explicit version will use `e384006`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d5d97a3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->