### PR TITLE
test: remove tests duplicated by surviving ones

### DIFF
--- a/tests/v1/test_judges.py
+++ b/tests/v1/test_judges.py
@@ -406,12 +406,6 @@ async def test_view_modes(fake_judge_model):
     assert "SECRET REASONING" not in fake_judge_model[1]
 
 
-def test_view_defaults():
-    # reference grades the final answer; rubric grades the process by default.
-    assert vf.ReferenceJudgeConfig().view == "last_reply"
-    assert vf.RubricJudgeConfig(path="x.toml").view == "full_trace"
-
-
 async def test_rubric_view_full_trace(tmp_path, fake_judge_model):
     # The rubric judge's default view: criteria are judged against the whole transcript.
     judge = rubric_judge(tmp_path)
@@ -438,14 +432,6 @@ async def test_config_prompt_overrides_class_template(tmp_path, fake_judge_model
 
 
 # --- reference input/verdict knobs ------------------------------------------------------------
-
-
-async def test_reference_empty_response_short_circuits(fake_judge_model):
-    # An empty reply scores 0 without paying for the (foregone) judge call.
-    trace = make_trace(reply="")
-    assert await vf.ReferenceJudge().score(trace.task.data, trace) == 0.0
-    assert fake_judge_model == []
-    assert "judge" not in trace.info
 
 
 async def test_reference_list_answer(fake_judge_model):
@@ -512,6 +498,7 @@ async def test_error_attribution(monkeypatch, tmp_path):
     trace = make_trace(reply="")
     await JudgedTask(trace.task.data, taskset.config.task).score(trace, runtime=None)
     assert trace.rewards["reference"].score == 0.0
+    assert "judge_calls" not in trace.info  # the (foregone) judge call was never made
     # judge failure: unparseable verdict -> the rollout errors, no reward recorded
     trace = make_trace()
     with pytest.raises(vf.TaskError, match="no yes/no verdict"):
@@ -582,13 +569,13 @@ def test_rubric_rejects_bad_files(tmp_path):
         ).criteria
 
 
-@pytest.mark.parametrize("weight", [float("nan"), float("inf"), float("-inf")])
-def test_judge_composition_weights_are_finite(weight):
-    with pytest.raises(ValueError, match="finite number"):
-        vf.JudgeConfig(weight=weight)
-    for field in ("task_weight", "judge_weight"):
+def test_judge_composition_weights_are_finite():
+    for weight in (float("nan"), float("inf"), float("-inf")):
         with pytest.raises(ValueError, match="finite number"):
-            ScoreConfig.model_validate({field: weight})
+            vf.JudgeConfig(weight=weight)
+        for field in ("task_weight", "judge_weight"):
+            with pytest.raises(ValueError, match="finite number"):
+                ScoreConfig.model_validate({field: weight})
 
 
 async def test_rubric_score(tmp_path, fake_judge_model):
@@ -700,7 +687,7 @@ async def test_task_score_runs_plugged_judges(tmp_path, fake_judge_model):
     taskset = JudgedTaskset(cfg)
     trace = make_trace()
     await JudgedTask(trace.task.data, taskset.config.task).score(trace, runtime=None)
-    assert trace.rewards["own"].score == 0.25  # decorated rewards still run
+    assert trace.rewards["own"] == vf.Reward(score=0.25)  # decorated rewards still run
     assert trace.rewards["reference"] == vf.Reward(
         score=1.0, weight=0.5
     )  # raw score + weight, under the id-derived name
@@ -710,9 +697,3 @@ async def test_task_score_runs_plugged_judges(tmp_path, fake_judge_model):
     assert (
         len(trace.info["judge_calls"]) == 2
     )  # every judge call recorded (rubric = one call)
-
-
-async def test_task_without_judges_scores_as_before():
-    trace = make_trace()
-    await JudgedTask(trace.task.data).score(trace, runtime=None)
-    assert trace.rewards == {"own": vf.Reward(score=0.25)}

--- a/tests/v1/test_taskset.py
+++ b/tests/v1/test_taskset.py
@@ -30,11 +30,6 @@ def idxs(tasks) -> list[int]:
     return [task.data.idx for task in tasks]
 
 
-def test_head_bounds_an_infinite_taskset() -> None:
-    tasks = list(InfiniteTaskset(vf.TasksetConfig()).head(5))
-    assert idxs(tasks) == [0, 1, 2, 3, 4]
-
-
 def test_iteration_materializes_a_finite_taskset() -> None:
     taskset = FiniteTaskset(vf.TasksetConfig())
     tasks = list(taskset)
@@ -84,7 +79,8 @@ def test_head_only_builds_what_the_run_takes() -> None:
                 built.append(i)
                 yield CountTask(vf.TaskData(idx=i, prompt=f"task {i}"))
 
-    list(RecordingTaskset(vf.TasksetConfig()).head(3))
+    tasks = list(RecordingTaskset(vf.TasksetConfig()).head(3))
+    assert idxs(tasks) == [0, 1, 2]
     assert built == [0, 1, 2]
 
 


### PR DESCRIPTION
Audit of `tests/` for redundant tests and CI time. Removes four deterministic tests whose contracts a surviving test already locks (each named below), collapses one parametrize whose three cases hit a single branch, and strengthens three survivors so no assertion is lost. No production code changes, no e2e changes.

## Numbers

Deterministic suite (`uv run pytest tests/ -n auto -m "not e2e"`), warm cache, 16-core laptop:

| | before | after |
|---|---|---|
| collected / passed | 84 / 84 | 78 / 78 |
| wall, serial (`-p no:xdist`) | 3.2 s | 3.0 s |
| wall, `-n 4` | 3.7 s | 3.2 s |
| wall, `-n auto` | 7.3 s | 6.0 s |
| slowest test | `test_eval_config_parses[alphabet_sort.toml]` 1.1 s (5.5 s cold) | same |

Differences are run-to-run noise: every removed test ran in under 50 ms. The suite's cost is imports, not tests (collection alone is 2.2 s; the three slowest tests are config parses whose taskset modules import `datasets`).

## Removed or merged

| removed | contract | surviving coverage |
|---|---|---|
| `test_judges::test_view_defaults` | reference judge defaults to `last_reply`, rubric to `full_trace` | `test_view_modes` and `test_rubric_view_full_trace` assert the same defaults through what reaches the judge prompt |
| `test_judges::test_reference_empty_response_short_circuits` | an empty reply scores 0.0 without a judge call | `test_error_attribution`'s model-failure half, at the `Task.score` boundary; it now also asserts `"judge_calls" not in trace.info`. The removed test's `"judge" not in trace.info` named a key nothing writes. |
| `test_judges::test_task_without_judges_scores_as_before` | a judge-less `Task.score` records only the decorated rewards | `test_scoring::test_defer_scoring_defers_only_task_scoring` asserts the exact reward keys; `test_task_score_runs_plugged_judges` now compares the decorated reward as a whole `Reward`, keeping the default-weight check |
| `test_taskset::test_head_bounds_an_infinite_taskset` | `head(n)` on an infinite taskset yields exactly the first n | `test_head_only_builds_what_the_run_takes` now asserts the yielded idxs as well as what `load()` built (also `test_views_do_not_mutate_the_base_taskset`, `test_head_then_shuffle_bounds_an_infinite_taskset`) |
| `test_judges::test_judge_composition_weights_are_finite[nan\|inf\|-inf]` (3 items to 1) | non-finite weights are rejected | the same test with the cases as a loop: all three hit the one `FiniteFloat` branch, the style `test_rubric_rejects_bad_files` already uses |

Kept after checking against the code: the graph reconciliation tests (each pins a distinct token layout), the three trace round-trips (bare / typed / `WireTrace` assert different fields), `test_transcript` (the only lock on the transcript format), `test_reference_parse` (the only lock on case-insensitive verdict parsing), and both shuffle tests (one per arm of the seed default).

Method: read each module against the code it tests, then one `--cov-context=test` run to list tests whose covered lines are a subset of another single test's, and judged those by their assertions. `ruff`, `pre-commit run --all-files`, and `uv run pytest tests/ -n auto -m "not e2e"` are green before and after.

## Not in this PR: CI observations

From the three most recent green `Test` runs on main (job and step timings via the Actions API) and the `-vv` log of one live E2E job:

- The workflow's critical path is the live E2E job: 12.9, 20.4, 23.7 min. The three deterministic matrix jobs each finish in about 1 min (checkout + uv about 20 s, `pytest` 25 to 32 s); the matrix is not where time goes.
- Inside the live E2E job (4 xdist workers, 62 tests, about 72 worker-minutes): `test_envs.py::test_eval[*]`, 17 `uv run eval` subprocess smoke runs, accounts for about 37 worker-min and `test_e2e.py` for about 35. Longest single tests: `test_eval[code_golf]` 340 s, `test_kuhn_poker_self_play` 308 s, `test_eval[color_codeword]` 233 s (it hit the 600 s cap in run 33794754929, the only red main run of the last 12), `test_eval[grayscale_interception]` 204 s. Durations are estimated from consecutive outcome timestamps per worker; `--durations=20` on that job would make them exact.
- `test_eval[kuhn_poker]`, `[reverse_text]`, and `[scratchpad]` run tasksets that `test_e2e.py` also runs in-process (`test_kuhn_poker_self_play`, `test_replay_round_trip`, `test_shared_tool_isolation`). They are the only per-taskset coverage at the CLI boundary, so they stay; narrowing the CLI smoke to tasksets without an in-process e2e would save about 3.5 worker-min.
- The deterministic job's `pytest` step takes 25 to 32 s in CI against 3 s serial warm here. The gap is cold caches (the first import of `datasets` through `test_eval_config_parses[alphabet_sort.toml]`: 5.5 s cold, 1.1 s warm) plus `--cov` (about 0.8 s) and xdist startup. `-n auto` buys nothing on this suite: serial 3.2 s, `-n 4` 3.7 s, `-n auto` on 16 cores 7.3 s.
- `.github/workflows/README.md` describes a 3.12/3.13 matrix, Codecov upload, HTML coverage artifacts, and PR comments; `test.yml` runs 3.11 to 3.13 and does none of the rest.
- `tests/v1/test_trace.py::test_failed_segment_does_not_reuse_prior_root_reply` builds its `Rollout` from nine private attributes (`_opened`, `_closed`, `_failure`, ...). The contract is real and not duplicated, so it stays, but a rename inside `Rollout` breaks it without any behavior change.

No fixture or wait speedups to make: `tests/` has no sleeps or polling loops, and the only non-trivial fixtures are the live e2e runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with assertions preserved on surviving tests; no runtime behavior changes.
> 
> **Overview**
> This PR trims the deterministic test suite from **84 to 78** tests by deleting cases whose behavior is already asserted elsewhere, with **no production or e2e changes**.
> 
> In **`test_judges.py`**, it drops `test_view_defaults`, `test_reference_empty_response_short_circuits`, and `test_task_without_judges_scores_as_before`, and folds the three-way parametrize on `test_judge_composition_weights_are_finite` into a single test with a loop. Survivors pick up the lost checks: `test_error_attribution` now asserts `"judge_calls" not in trace.info` when an empty reply skips the judge, and `test_task_score_runs_plugged_judges` compares the decorated reward to a full `vf.Reward(score=0.25)` instead of only `.score`.
> 
> In **`test_taskset.py`**, it removes `test_head_bounds_an_infinite_taskset` and adds `assert idxs(tasks) == [0, 1, 2]` to `test_head_only_builds_what_the_run_takes` so `head(3)` on an infinite taskset still locks the yielded indices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2edd6b5551321f71704b4ce4ec5c918b40e87cef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove duplicated tests in `test_judges.py` and `test_taskset.py`
> - Drops tests in [test_judges.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2523/files#diff-2a3a25145d7c98b86bd9b776a86e133bfb38d08864cdef197a667593015aef48) that duplicated coverage already provided by surviving tests, including `test_view_defaults`, `test_reference_empty_response_short_circuits`, and `test_task_without_judges_scores_as_before`
> - Folds the removed checks into existing tests where useful: `test_error_attribution` now asserts no `judge_calls` for empty replies, `test_judge_composition_weights_are_finite` loops over NaN and infinities instead of using parametrization, and `test_task_score_runs_plugged_judges` compares the full reward object
> - In [test_taskset.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2523/files#diff-e8114d4d442cb26c4c976ec6c0eabc5e3537bdc22ac2cdd74c6d380d9bc28fad), removes `test_head_bounds_an_infinite_taskset` and adds an index assertion to `test_head_only_builds_what_the_run_takes`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2edd6b5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->