### PR TITLE
ci: split the live e2e job and trim the CLI smokes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
           uv run pytest tests/v1 -vv -n auto -m "not e2e" --cov=verifiers --cov-report=xml --cov-report=term
 
   v1-e2e:
-    name: V1 live E2E (Python 3.12)
+    name: V1 live ${{ matrix.suite.name }} (Python 3.12)
     if: >-
       github.event_name != 'pull_request' ||
       (github.event.pull_request.head.repo.full_name == github.repository &&
@@ -77,6 +77,19 @@ jobs:
       PRIME_API_KEY: ${{ secrets.PRIME_API_KEY }}
       PRIME_TEAM_ID: ${{ secrets.PRIME_TEAM_ID }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
+    strategy:
+      fail-fast: false
+      # One runner per live suite: the in-process E2Es split by their `docker`
+      # mark (the container rows are the long ones), and the CLI smoke of every
+      # example taskset. prime/modal rows stay local-only (tests/v1/conftest.py).
+      matrix:
+        suite:
+          - name: E2E docker
+            tests: tests/v1/test_e2e.py -m "docker and not prime and not modal"
+          - name: E2E host
+            tests: tests/v1/test_e2e.py -m "not docker and not prime and not modal"
+          - name: env smokes
+            tests: tests/v1/test_envs.py
 
     steps:
       - uses: actions/checkout@v7
@@ -102,6 +115,6 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
-      - name: Run live v1 E2Es
+      - name: Run live v1 ${{ matrix.suite.name }}
         run: |
-          uv run pytest tests/v1 -vv -n auto -m "e2e and not prime and not modal" --cov=verifiers --cov-report=xml --cov-report=term
+          uv run pytest ${{ matrix.suite.tests }} -vv -n auto --cov=verifiers --cov-report=xml --cov-report=term

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -17,7 +17,7 @@ Every combination carries its axes' pytest marks, so subsets select with `-m`:
 
     uv run pytest tests/v1 -n auto                                # everything (needs modal setup)
     uv run pytest tests/v1 -n auto -m "not e2e"                   # deterministic CI matrix
-    uv run pytest tests/v1 -n auto -m "e2e and not prime and not modal"  # live CI job
+    uv run pytest tests/v1 -n auto -m "e2e and not prime and not modal"  # every live CI suite at once
     uv run pytest tests/v1 -n auto -m docker                      # any case touching the docker runtime
     uv run pytest tests/v1 -n auto -m bash                        # only the bash harness
     uv run pytest tests/v1 -n auto -m prime                       # only prime (real sandboxes; local)
@@ -29,7 +29,8 @@ harnesses `null` / `bash` / `rlm` / `kimi_code` / `pi` / `pool` / `openclaw` / `
 A mark is applied per axis, so it selects every case touching that value on ANY axis; for one exact
 combination use `-k` on the test id (e.g. `-k "harness-in-docker-with-tool-in-subprocess"`).
 prime/modal provision real remote sandboxes (slow, infra-flaky, need setup), so they're local-only.
-CI runs deterministic tests across the Python matrix and the remaining live E2Es once.
+CI runs deterministic tests across the Python matrix and the remaining live E2Es once,
+on three runners: the `docker` rows, the host rows, and the CLI smokes (test_envs.py).
 """
 
 import os

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -474,6 +474,7 @@ async def test_env_id_best_of_n(run_v1, tmp_path):
 
 
 @pytest.mark.e2e
+@pytest.mark.docker
 async def test_env_id_shared_agentic_judge(run_v1, tmp_path):
     """The shared agentic judge provisions one restricted solver-owned box and
     safely reuses it for the judge's empirical verification."""
@@ -517,6 +518,7 @@ async def test_env_id_shared_agentic_judge(run_v1, tmp_path):
 
 
 @pytest.mark.e2e
+@pytest.mark.docker
 async def test_env_id_agentic_judge(run_v1, tmp_path):
     """The isolated agentic judge destroys the restricted solver box, transfers
     its declared artifact, and restores it in a fresh box with the same policy."""

--- a/tests/v1/test_envs.py
+++ b/tests/v1/test_envs.py
@@ -27,6 +27,12 @@ SKIP_EVAL = {"nemo_gym_weather"}
 # don't already cover.
 E2E_COVERED = {"kuhn_poker", "reverse_text", "scratchpad"}
 
+# Smoke-sized env knobs: the fewest turns/attempts that still score an episode.
+SMOKE_FLAGS: dict[str, tuple[str, ...]] = {
+    "alphabet_sort": ("--env.taskset.max-turns", "1"),
+    "code_golf": ("--env.attempts", "1"),
+}
+
 # Per-run caps are seat fields; recipe envs name their own seats.
 SEATS: dict[str, tuple[str, ...]] = {
     "code_golf": ("golfer",),
@@ -78,7 +84,7 @@ def test_eval(taskset: str):
     cmd = [
         "uv", "run", "--no-sync", "eval", taskset,
         *model,
-        "-n", "1", "-r", "1", *caps,
+        "-n", "1", "-r", "1", *caps, *SMOKE_FLAGS.get(taskset, ()),
         "--sampling.max-tokens", "512", "--no-rich", "--no-push",
     ]  # fmt: skip
     try:

--- a/tests/v1/test_envs.py
+++ b/tests/v1/test_envs.py
@@ -1,8 +1,8 @@
-"""Smoke-eval every example taskset in `environments/` through the `eval` CLI.
+"""Smoke-eval the example tasksets in `environments/` through the `eval` CLI.
 
 Each taskset runs with its required harness for one short, capped rollout, so a broken
-example taskset fails CI. `compact` is excluded (it's a harness, not a taskset);
-SWE/container tasksets need a docker/prime runtime and are covered by dedicated V1 e2e tests.
+example taskset fails CI. `compact` is excluded (it's a harness, not a taskset), and so
+are the tasksets tests/v1/test_e2e.py already runs end to end (`E2E_COVERED`).
 """
 
 import os
@@ -20,6 +20,13 @@ ENVIRONMENTS = Path(__file__).parent.parent.parent / "environments"
 # V1 tasksets that aren't part of the default CI install.
 SKIP_EVAL = {"nemo_gym_weather"}
 
+# Tasksets tests/v1/test_e2e.py already runs end to end and asserts on: kuhn_poker
+# (test_kuhn_poker_self_play), reverse_text (test_replay_round_trip), scratchpad
+# (test_shared_tool_isolation, through the env-server pool). Their rewards read the
+# trace alone, so the CLI's default harness path adds nothing the remaining smokes
+# don't already cover.
+E2E_COVERED = {"kuhn_poker", "reverse_text", "scratchpad"}
+
 # Per-run caps are seat fields; recipe envs name their own seats.
 SEATS: dict[str, tuple[str, ...]] = {
     "code_golf": ("golfer",),
@@ -36,7 +43,10 @@ def v1_tasksets() -> list[str]:
     return sorted(
         d.name
         for d in ENVIRONMENTS.iterdir()
-        if d.is_dir() and d.name != "compact" and (d / "pyproject.toml").exists()
+        if d.is_dir()
+        and d.name != "compact"
+        and d.name not in E2E_COVERED
+        and (d / "pyproject.toml").exists()
     )
 
 

--- a/tests/v1/test_envs.py
+++ b/tests/v1/test_envs.py
@@ -69,7 +69,7 @@ def test_eval(taskset: str):
         "uv", "run", "--no-sync", "eval", taskset,
         *model,
         "-n", "1", "-r", "1", *caps,
-        "--sampling.max-tokens", "512", "--no-rich",
+        "--sampling.max-tokens", "512", "--no-rich", "--no-push",
     ]  # fmt: skip
     try:
         proc = subprocess.run(


### PR DESCRIPTION
## Summary

The live E2E job ran the in-process E2Es and the 17 CLI smokes in one pytest session on one 4-vCPU runner. Recent `main` runs took 12.9 min on a normal day and 20.4 / 23.7 min on Sept 3, when the same tests saw 2-4x slower model calls. This PR trims the smokes and runs the live suites on three runners.

## Baseline (main, per-test wall time reconstructed from the job logs)

| | Sept 2, 12.9 min job | Sept 3, 20.4 min job |
|---|---|---|
| `test_e2e.py`, 44 tests | 27.9 worker-min | 38.5 worker-min |
| `test_envs.py`, 17 smokes | 16.4 worker-min | 36.8 worker-min |
| slowest tests | wordle 184 s, wiki_search 167 s, openclaw ACP 96 s | code_golf 340 s, kuhn_poker (e2e) 308 s, color_codeword 233 s |

The smokes already run one task and one rollout (`-n 1 -r 1`, four turns, 512 tokens). Their cost is per-process overhead (`uv run`, the env-server worker, one Prime VM sandbox per agent run) plus whatever the env fans out to.

## Changes

1. `--no-push` on the smoke evals. They uploaded every CI rollout to the team's Evaluations tab; nothing asserts on the upload (push errors are swallowed by design), and it was a network round trip after every eval.
2. Drop the three smokes `test_e2e.py` already runs end to end and asserts on: kuhn_poker (`test_kuhn_poker_self_play`), reverse_text (`test_replay_round_trip`), scratchpad (`test_shared_tool_isolation`, through the env-server pool). Their rewards read the trace alone; the remaining 14 smokes keep exercising the CLI's default bash-on-Prime path.
3. Smoke-size the two envs that fan out: code_golf `--env.attempts 1` (was two sandboxes and two model calls) and alphabet_sort `--env.taskset.max-turns 1` (was one to three turns). The sibling comparison and the per-turn reward still score the single trace.
4. Three runners: `E2E docker` (the rows marked `docker`, the long ones), `E2E host`, `env smokes`. Same tests, same marks; prime/modal rows stay local-only.

## Smokes before and after

Local, same model and Prime VM runtime as CI, 4 workers. Every remaining smoke's trace is `ok` with a reward recorded.

| smoke | before | after | |
|---|---|---|---|
| alphabet_sort | 30 s | 32 s | 2 model calls -> 1 |
| bash_interception | 19 | 19 | |
| code_golf | 32 | 27 | 2 attempts -> 1 (21 s run alone) |
| color_codeword | 34 | 27 | |
| deepwiki | 29 | 38 | remote MCP server |
| glossary | 30 | 28 | |
| grayscale_interception | 21 | 22 | |
| gsm8k | 32 | 23 | |
| interception | 22 | 20 | |
| openenv_wordle | 52 | 46 | |
| proposer_solver | 29 | 30 | see below |
| web_search_interception | 46 | 40 | |
| wiki_search | 106 | 38 | warm local chroma index on the second run; CI rebuilds it every run (~170 s) |
| wordle | 43 | 26 | |
| kuhn_poker | 41 | dropped | |
| reverse_text | 24 | dropped | |
| scratchpad | 31 | dropped | |
| total | 10.4 worker-min | 6.9 worker-min | |

proposer_solver never reaches its solvers in CI: the proposer spends the 512-token cap on reasoning and returns an empty reply, `SolveTask.from_trace` raises, and the episode ends before any solver runs. The CLI exits 0 on an errored episode, so the smoke passes as before without touching the taskset's scoring. A 2048 cap did not change that. Left as is, flagged here.

## CI time on this PR

Two runs on this PR, both green: [33812011782](https://github.com/PrimeIntellect-ai/verifiers/actions/runs/33812011782) at 5.9 min and [33812686711](https://github.com/PrimeIntellect-ai/verifiers/actions/runs/33812686711) at 6.1 min of live wall time, against 12.9 / 20.4 / 23.7 min on the last `main` runs, for about the same total work (42.7 worker-min against 44.3 on Sept 2). The second run:

| job | pytest | job | worker-min | slowest |
|---|---|---|---|---|
| E2E docker (28 tests) | 5:31 | 6:05 | 22.2 | openclaw ACP 117 s, claude-code ACP 81 s, kimi single-turn 70 s |
| env smokes (14) | 4:43 | 5:15 | 13.4 | wiki_search 169 s, wordle 158 s, deepwiki 54 s |
| E2E host (16) | 1:50 | 2:24 | 7.1 | multi_agent_env_server 50 s, tool_state colocated 47 s |

wordle and web_search_interception swing between ~45 s and ~180 s from run to run (wordle 184 / 176 / 45 / 158 s, web_search 62 / 94 / 181 / 45 s across the last four runs) while their traces look the same, so the slow path is in provisioning or the endpoint rather than the taskset. The smokes runner has the headroom for it.

## Left alone

- Triggers: per-job path filters aren't native to Actions, and the workflow-level `paths` already scope the run to Python and packaging changes (`environments/**` are `.py` files).
- The smokes stay on the default runtime, a Prime VM sandbox per agent run (#2356). Sandbox setup measured 3-14 s per rollout locally.
- wordle takes ~180 s in CI against 26-43 s locally; a cold nltk data dir did not reproduce it. wiki_search rebuilds its chroma index each CI run (~170 s). Both sit on the smokes runner, which is not the critical path.
- The in-process E2E tests and their parameters.

## Verification

- `uv run pytest tests/v1 -n auto -m "not e2e"`: 84 passed. `uv run pre-commit run --all-files`: green.
- `uv run pytest tests/v1/test_envs.py -n 4`: 14 passed, 1 skipped, 2:16.
- The in-process E2Es locally: 39/44 passed; the five tool-in-docker placements fail on macOS Docker Desktop (the host cannot reach container addresses) and pass in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
