### PR TITLE
feat(v1): expose RLM execution timeout

### DIFF
--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -58,7 +58,7 @@ class CompactionConfig(BaseConfig):
 
 class RLMHarnessConfig(HarnessConfig):
     version: str = Field(
-        default="342f119fe84ef6c35e139cf7cb762bc94f439135", min_length=1
+        default="bc3ab4d033d1978ad942f032700577eda8950163", min_length=1
     )
     """Git ref (branch, tag, or commit) of nano-rlm to install. Must know every
     field this harness puts on the wire, i.e. be at least the default ref."""

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -57,7 +57,9 @@ class CompactionConfig(BaseConfig):
 
 
 class RLMHarnessConfig(HarnessConfig):
-    version: str = Field(default="e384006", min_length=1)
+    version: str = Field(
+        default="1f439d5317dfcf99695dc78546d37d20b43ac147", min_length=1
+    )
     """Git ref (branch, tag, or commit) of nano-rlm to install. Must know every
     field this harness puts on the wire, i.e. be at least the default ref."""
     max_depth: NonNegativeInt | None = None
@@ -83,6 +85,9 @@ class RLMHarnessConfig(HarnessConfig):
     max_tool_output_bytes: PositiveInt | None = None
     """Byte budget for a single tool result entering the conversation (middle truncation);
     overrides rlm's built-in 20KB default in either direction."""
+    exec_timeout: PositiveInt | None = None
+    """Active execution budget for one IPython cell; `None` = nano-rlm's default.
+    Responsive waits on supervisor-owned sub-agents and skills do not consume it."""
     append_to_system_prompt: str | None = None
     """Appended to the root engine's system prompt, after the taskset's system prompt."""
     subagent_append_to_system_prompt: str | None = None
@@ -166,6 +171,7 @@ class RLMHarness(ACPHarness[RLMHarnessConfig]):
             "max_total_turns": self.config.max_total_turns,
             "max_total_tokens": self.config.max_total_tokens,
             "max_tool_output_bytes": self.config.max_tool_output_bytes,
+            "exec_timeout": self.config.exec_timeout,
         }
         if isinstance(compaction, bool):
             policy_knobs["compaction"] = compaction

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -58,7 +58,7 @@ class CompactionConfig(BaseConfig):
 
 class RLMHarnessConfig(HarnessConfig):
     version: str = Field(
-        default="1f439d5317dfcf99695dc78546d37d20b43ac147", min_length=1
+        default="082963af9c532caa0dc7afe44e7afe92959d4af9", min_length=1
     )
     """Git ref (branch, tag, or commit) of nano-rlm to install. Must know every
     field this harness puts on the wire, i.e. be at least the default ref."""

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -58,7 +58,7 @@ class CompactionConfig(BaseConfig):
 
 class RLMHarnessConfig(HarnessConfig):
     version: str = Field(
-        default="082963af9c532caa0dc7afe44e7afe92959d4af9", min_length=1
+        default="b436832d5a1eafbcbcff8c96f0f248f9336ebec9", min_length=1
     )
     """Git ref (branch, tag, or commit) of nano-rlm to install. Must know every
     field this harness puts on the wire, i.e. be at least the default ref."""
@@ -87,7 +87,7 @@ class RLMHarnessConfig(HarnessConfig):
     overrides rlm's built-in 20KB default in either direction."""
     exec_timeout: PositiveInt | None = None
     """Active execution budget for one IPython cell; `None` = nano-rlm's default.
-    Responsive waits on supervisor-owned sub-agents and skills do not consume it."""
+    Direct broker waits and gathers made only of broker calls do not consume it."""
     append_to_system_prompt: str | None = None
     """Appended to the root engine's system prompt, after the taskset's system prompt."""
     subagent_append_to_system_prompt: str | None = None

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -58,7 +58,7 @@ class CompactionConfig(BaseConfig):
 
 class RLMHarnessConfig(HarnessConfig):
     version: str = Field(
-        default="b436832d5a1eafbcbcff8c96f0f248f9336ebec9", min_length=1
+        default="342f119fe84ef6c35e139cf7cb762bc94f439135", min_length=1
     )
     """Git ref (branch, tag, or commit) of nano-rlm to install. Must know every
     field this harness puts on the wire, i.e. be at least the default ref."""
@@ -87,7 +87,7 @@ class RLMHarnessConfig(HarnessConfig):
     overrides rlm's built-in 20KB default in either direction."""
     exec_timeout: PositiveInt | None = None
     """Active execution budget for one IPython cell; `None` = nano-rlm's default.
-    Direct broker waits and gathers made only of broker calls do not consume it."""
+    Direct sub-agent waits and gathers made only of sub-agent calls do not consume it."""
     append_to_system_prompt: str | None = None
     """Appended to the root engine's system prompt, after the taskset's system prompt."""
     subagent_append_to_system_prompt: str | None = None


### PR DESCRIPTION
## Summary

- expose `exec_timeout` on the v1 RLM harness and pass it through the ACP runtime policy
- pin nano-RLM commit `bc3ab4d033d1978ad942f032700577eda8950163`
- define the setting as active IPython execution time: direct sub-agent waits and gathers made only of sub-agent calls are excluded; skills and other work remain charged

The timeout mechanism lives in nano-RLM’s trusted supervisor broker. Verifiers only owns the public harness setting, ACP transport, and exact compatible pin.

Companion: PrimeIntellect-ai/nano-rlm#171

## Validation

- `uv run pytest tests/` — 84 passed; 76 credentialed integration cases skipped locally
- `uv run pre-commit run --all-files`
- pre-push `ty` CI-parity check
- signed commits verified as SSH signatures
- old nano-RLM regression: `exec_timeout=1` interrupted a plain two-child gather after one second, despite both child inference calls completing
- exact pinned commit on Prime: 3/3 DeepSeek V4 Flash rollouts completed the same plain gather; each waited 4.31–5.50 seconds, both children overlapped, no timeout was emitted, and all semantic call/return/continuation edges were present
