### PR TITLE
feat(bash): add nano-rlm's git history guard to the bash tool

### DIFF
--- a/verifiers/v1/harnesses/bash/harness.py
+++ b/verifiers/v1/harnesses/bash/harness.py
@@ -28,6 +28,15 @@ SEARCH_PROMPT = (
     "You also have a search tool that returns Google results (title, URL, snippet) for a query; "
     "use it to research, and use bash (e.g. curl) to read result pages in full when needed."
 )
+# nano-rlm's GIT_HISTORY_GUARD_PROMPT verbatim, appended when the git history guard is active.
+GIT_HISTORY_GUARD_PROMPT = (
+    "Do not cheat by using online solutions or hints specific to this task, or "
+    "by copying or inferring solutions from other branches, tags, remotes, "
+    "reflogs, or broad git history in the project. Broad-history `git log` "
+    "options such as `--all`, `-all`, `--branches`, `--remotes`, `--tags`, "
+    "`--glob`, `--alternate-refs`, `--reflog`, `--walk-reflogs`, or `-g` will "
+    "be refused."
+)
 
 
 class CompactionConfig(BaseConfig):
@@ -48,10 +57,10 @@ class BashHarnessConfig(HarnessConfig):
     eval environment; the key is handed to the program over argv (like the interception secret) so
     the agent's `bash` subprocesses don't inherit it."""
 
-    block_git: bool = True
-    """Refuse `git` invocations in the `bash` tool (matching nano-rlm and mini_swe_agent_plus),
-    so e.g. SWE tasks can't recover fixes from repo history. Set
-    `--env.agent.harness.block-git false` to allow git."""
+    allow_git: bool = False
+    """Allow unrestricted git history access in the `bash` tool. Off by default: broad-history
+    `git log` options (`--all`, `--branches`, ...) are refused and the system prompt warns the
+    model, matching nano-rlm's git history guard. Ordinary git commands are always allowed."""
 
     compaction: CompactionConfig | None = None
     """Context compaction policy. Set an empty config to use automatic thresholds."""
@@ -84,13 +93,15 @@ class BashHarness(Harness[BashHarnessConfig]):
             fragments.append(EDIT_SYSTEM_PROMPT)
         if self.config.search:
             fragments.append(SEARCH_PROMPT)
+        if not self.config.allow_git:
+            fragments.append(GIT_HISTORY_GUARD_PROMPT)
         system_prompt = "\n\n".join(
             p for p in (" ".join(fragments), system_prompt) if p
         )
         env = {**self.config.resolved_env}
         args = ["--bash"]
-        if self.config.block_git:
-            args.append("--block-git")
+        if self.config.allow_git:
+            args.append("--allow-git")
         if tool_interception_url:
             args.append(f"--tool-interception-url={tool_interception_url}")
         if self.config.compaction is not None:

--- a/verifiers/v1/harnesses/bash/harness.py
+++ b/verifiers/v1/harnesses/bash/harness.py
@@ -48,6 +48,11 @@ class BashHarnessConfig(HarnessConfig):
     eval environment; the key is handed to the program over argv (like the interception secret) so
     the agent's `bash` subprocesses don't inherit it."""
 
+    block_git: bool = True
+    """Refuse `git` invocations in the `bash` tool (matching nano-rlm and mini_swe_agent_plus),
+    so e.g. SWE tasks can't recover fixes from repo history. Set
+    `--env.agent.harness.block-git false` to allow git."""
+
     compaction: CompactionConfig | None = None
     """Context compaction policy. Set an empty config to use automatic thresholds."""
 
@@ -84,6 +89,8 @@ class BashHarness(Harness[BashHarnessConfig]):
         )
         env = {**self.config.resolved_env}
         args = ["--bash"]
+        if self.config.block_git:
+            args.append("--block-git")
         if tool_interception_url:
             args.append(f"--tool-interception-url={tool_interception_url}")
         if self.config.compaction is not None:

--- a/verifiers/v1/harnesses/utils/core.py
+++ b/verifiers/v1/harnesses/utils/core.py
@@ -4,6 +4,7 @@ import argparse
 import asyncio
 import json
 import re
+import shlex
 import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -137,25 +138,96 @@ def run_search(query: str, api_key: str, num_results: int = 5) -> str:
         return f"search failed ({e}). Try again or rephrase the query."
 
 
-# Mirrors nano-rlm's git block (itself mirroring mini_swe_agent_plus's execute_bash.py):
-# split on `&&`, `||`, `;`, `|` and refuse if any segment invokes git. The refusal string
-# is reused verbatim so agent-visible logs stay consistent across the harnesses.
+# Ports nano-rlm's git history guard: ordinary git commands stay available, but `git log`
+# invocations that read beyond current-branch history (`--all`, `--branches`, ...) are
+# refused. The refusal string is reused verbatim so agent-visible logs stay consistent
+# across the harnesses.
 GIT_REFUSAL = (
-    "Bash command '{cmd}' is not allowed. Please use a different command or tool."
+    "Git history option '{cmd}' is not allowed. Use current-branch history only."
 )
 _BASH_SEPARATORS = re.compile(r"&&|\|\||;|\|")
+_RESTRICTED_LOG_OPTIONS = {
+    "--all",
+    "-all",
+    "--alternate-refs",
+    "--reflog",
+    "--walk-reflogs",
+    "-g",
+}
+_RESTRICTED_LOG_OPTION_PREFIXES = ("--branches", "--glob", "--remotes", "--tags")
+_GIT_GLOBAL_OPTIONS_WITH_VALUE = {
+    "-C",
+    "-c",
+    "--config-env",
+    "--exec-path",
+    "--git-dir",
+    "--namespace",
+    "--work-tree",
+}
 
 
-def invokes_git(command: str) -> bool:
+def _split_segment(segment: str) -> list:
+    try:
+        return shlex.split(segment)
+    except ValueError:
+        return segment.strip().split()
+
+
+def _is_git_binary(token: str) -> bool:
+    return token == "git" or token.rsplit("/", 1)[-1] == "git"
+
+
+def _skip_git_global_options(argv: list, index: int) -> int:
+    while index < len(argv):
+        token = argv[index]
+        if token == "--":
+            return index + 1
+        if not token.startswith("-"):
+            return index
+        option = token.split("=", 1)[0]
+        if option in _GIT_GLOBAL_OPTIONS_WITH_VALUE and "=" not in token:
+            index += 2
+        else:
+            index += 1
+    return index
+
+
+def _is_restricted_log_option(token: str) -> bool:
+    if token in _RESTRICTED_LOG_OPTIONS:
+        return True
     return any(
-        segment.strip().split()[:1] == ["git"]
-        for segment in _BASH_SEPARATORS.split(command)
+        token == option or token.startswith(f"{option}=")
+        for option in _RESTRICTED_LOG_OPTION_PREFIXES
     )
 
 
-def run_bash(command: str, block_git: bool = False) -> str:
-    if block_git and invokes_git(command):
-        return GIT_REFUSAL.format(cmd=command)
+def find_blocked_git_log_option(argv: list) -> "str | None":
+    if not argv or not _is_git_binary(argv[0]):
+        return None
+    subcommand_index = _skip_git_global_options(argv, 1)
+    if subcommand_index >= len(argv) or argv[subcommand_index] != "log":
+        return None
+    for token in argv[subcommand_index + 1 :]:
+        if token == "--":
+            return None
+        if _is_restricted_log_option(token):
+            return token
+    return None
+
+
+def find_blocked_command(command: str) -> "str | None":
+    for segment in _BASH_SEPARATORS.split(command):
+        blocked = find_blocked_git_log_option(_split_segment(segment))
+        if blocked is not None:
+            return blocked
+    return None
+
+
+def run_bash(command: str, allow_git: bool = True) -> str:
+    if not allow_git:
+        blocked = find_blocked_command(command)
+        if blocked is not None:
+            return GIT_REFUSAL.format(cmd=blocked)
     try:
         result = subprocess.run(
             ["bash", "-c", command],
@@ -294,7 +366,7 @@ async def run_chat_loop(
                     content = await call_mcp(servers, dispatch, name, tool_args)
                 elif name == "bash" and args.bash:
                     content = await asyncio.to_thread(
-                        run_bash, tool_args.get("command", ""), args.block_git
+                        run_bash, tool_args.get("command", ""), args.allow_git
                     )
                 elif name == "edit" and args.edit:
                     content = await asyncio.to_thread(
@@ -345,7 +417,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--mcp-config", default="")
     parser.add_argument("--tool-interception-url", default="")
     parser.add_argument("--bash", action="store_true")
-    parser.add_argument("--block-git", action="store_true")
+    parser.add_argument("--allow-git", action="store_true")
     parser.add_argument("--compaction", action="store_true")
     parser.add_argument("--summarize-at-tokens", type=int)
     parser.add_argument("--edit", action="store_true")

--- a/verifiers/v1/harnesses/utils/core.py
+++ b/verifiers/v1/harnesses/utils/core.py
@@ -3,6 +3,7 @@
 import argparse
 import asyncio
 import json
+import re
 import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -136,7 +137,25 @@ def run_search(query: str, api_key: str, num_results: int = 5) -> str:
         return f"search failed ({e}). Try again or rephrase the query."
 
 
-def run_bash(command: str) -> str:
+# Mirrors nano-rlm's git block (itself mirroring mini_swe_agent_plus's execute_bash.py):
+# split on `&&`, `||`, `;`, `|` and refuse if any segment invokes git. The refusal string
+# is reused verbatim so agent-visible logs stay consistent across the harnesses.
+GIT_REFUSAL = (
+    "Bash command '{cmd}' is not allowed. Please use a different command or tool."
+)
+_BASH_SEPARATORS = re.compile(r"&&|\|\||;|\|")
+
+
+def invokes_git(command: str) -> bool:
+    return any(
+        segment.strip().split()[:1] == ["git"]
+        for segment in _BASH_SEPARATORS.split(command)
+    )
+
+
+def run_bash(command: str, block_git: bool = False) -> str:
+    if block_git and invokes_git(command):
+        return GIT_REFUSAL.format(cmd=command)
     try:
         result = subprocess.run(
             ["bash", "-c", command],
@@ -275,7 +294,7 @@ async def run_chat_loop(
                     content = await call_mcp(servers, dispatch, name, tool_args)
                 elif name == "bash" and args.bash:
                     content = await asyncio.to_thread(
-                        run_bash, tool_args.get("command", "")
+                        run_bash, tool_args.get("command", ""), args.block_git
                     )
                 elif name == "edit" and args.edit:
                     content = await asyncio.to_thread(
@@ -326,6 +345,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--mcp-config", default="")
     parser.add_argument("--tool-interception-url", default="")
     parser.add_argument("--bash", action="store_true")
+    parser.add_argument("--block-git", action="store_true")
     parser.add_argument("--compaction", action="store_true")
     parser.add_argument("--summarize-at-tokens", type=int)
     parser.add_argument("--edit", action="store_true")


### PR DESCRIPTION
## Overview

The bash+edit harness had no git guard at all: `run_bash` executed commands raw, so agents could read gold patches straight out of repo history with `git log --all`. This ports nano-rlm's current git history guard, with full behavioral parity.

## Details

- **Guard, not a blanket block**: ordinary git (`status`, `diff`, `commit`, current-branch `git log`) stays available; only broad-history `git log` options are refused: `--all`, `-all`, `--branches[=..]`, `--remotes[=..]`, `--tags[=..]`, `--glob[=..]`, `--alternate-refs`, `--reflog`, `--walk-reflogs`, `-g`. Handles chained commands (split on `&&`/`||`/`;`/`|`), git global options (`-C`, `-c`, ...), path-prefixed binaries (`/usr/bin/git`), and the `--` pathspec terminator — same as nano-rlm's `git_block.py`.
- **Prompt**: nano-rlm's `GIT_HISTORY_GUARD_PROMPT` is appended verbatim to the system prompt while the guard is active, so the model is told up front (see PrimeIntellect-ai/nano-rlm#172 which closes the same prompt gap for nano-rlm's own bash tool).
- **Refusal string** reused byte-for-byte: `Git history option '--all' is not allowed. Use current-branch history only.`
- **Config**: `BashHarnessConfig.allow_git` (default `false` = guard on, mirroring nano-rlm's policy naming); `--env.agent.harness.allow-git true` lifts the guard and drops the prompt line.

Verified with a throwaway script: a 26-command corpus asserted identical outputs between this predicate and nano-rlm's `find_blocked_command`, plus byte-equality of the refusal template and guard prompt against the nano-rlm source, argv wiring, and both bundled program variants carrying the guard. `ruff check`/`format` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default bash tool behavior for all bash harness rollouts (commands may be refused that previously ran); opt-in `allow_git` restores prior unrestricted history access.
> 
> **Overview**
> The bash harness **enables a git history guard by default** so eval agents cannot mine solutions from broad `git log` history (e.g. `git log --all`), matching nano-rlm behavior.
> 
> **Runtime enforcement** in the bundled chat program inspects bash commands (including chained segments) and **refuses** `git log` with broad-history flags (`--all`, `--branches`, `--remotes`, `--tags`, `--glob`, reflog options, etc.) while leaving normal git and current-branch `git log` alone. Blocked calls return a fixed refusal message instead of running the shell.
> 
> **Harness wiring**: new `BashHarnessConfig.allow_git` (default `false`) appends nano-rlm’s `GIT_HISTORY_GUARD_PROMPT` to the system prompt when the guard is on and passes `--allow-git` only when operators opt in via `--env.agent.harness.allow-git true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c700f1b4d0618370c6f6dbdbcdbf762e4c1b04e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add git history guard to `BashHarness` to block broad `git log` access
> - Adds a guard that inspects bash commands before execution and refuses `git log` invocations using broad-history options (e.g. `--all`, branch globs, remotes, tags) when `allow_git` is false
> - Shell-tokenizes command segments separated by `&&`, `||`, `;`, and pipes so each is checked independently; falls back to whitespace splitting when shell parsing fails
> - `BashHarnessConfig` defaults `allow_git` to false, appending a system-prompt warning about restricted git history; enabling it omits the warning and passes `--allow-git` to the child chat program
> - Behavioral Change: `run_bash` in [core.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2526/files#diff-4641f7de541bf21c7f3e30a2d8d49f14c1179c70cf21f3dff5fa19deb9a1e206) defaults `allow_git` to true for direct callers, but the bash harness sets it to false by default — broad `git log` commands now return a refusal message instead of executing
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized c700f1b. 2 files reviewed, 3 issues evaluated, 0 issues filtered, 3 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->