### PR TITLE
fix(v1): hide reasoning from agentic judges

### DIFF
--- a/tests/v1/test_judges.py
+++ b/tests/v1/test_judges.py
@@ -9,7 +9,8 @@ import pytest
 from pydantic import Field
 
 import verifiers.v1 as vf
-from verifiers.v1.envs.agentic_judge import ScoreConfig
+from verifiers.v1.envs.agentic_judge import JudgeTaskConfig, ScoreConfig
+from verifiers.v1.envs.agentic_judge.env import TRACE_FILE, JudgeTask
 from verifiers.v1.graph import MessageNode
 from verifiers.v1.judge import Judge, JudgeResponse
 from verifiers.v1.types import AssistantMessage, UserMessage
@@ -361,6 +362,7 @@ def full_trace_fixture() -> vf.Trace:
                 message=AssistantMessage(
                     content="Let me look it up.",
                     reasoning_content="SECRET REASONING",
+                    provider_state=[{"type": "reasoning", "data": "SECRET STATE"}],
                     tool_calls=[
                         ToolCall(id="1", name="search", arguments='{"q": "france"}')
                     ],
@@ -390,6 +392,25 @@ def test_transcript():
     assert "[tool search]\nTOOL RESULT: Paris is the capital." in transcript
     assert "It is Paris." in transcript
     assert "SECRET REASONING" not in transcript  # reasoning is excluded
+
+
+def test_agentic_judge_trace_hidden_reasoning_toggle():
+    task = JudgeTask.from_trace(full_trace_fixture(), JudgeTaskConfig())
+    record = json.loads(task.files[TRACE_FILE])
+    assistant = record["nodes"][1]["message"]
+    assert assistant["content"] == "Let me look it up."
+    assert assistant["tool_calls"][0]["name"] == "search"
+    assert "reasoning_content" not in assistant
+    assert "provider_state" not in assistant
+
+    task = JudgeTask.from_trace(
+        full_trace_fixture(), JudgeTaskConfig(include_hidden_reasoning=True)
+    )
+    assistant = json.loads(task.files[TRACE_FILE])["nodes"][1]["message"]
+    assert assistant["reasoning_content"] == "SECRET REASONING"
+    assert assistant["provider_state"] == [
+        {"type": "reasoning", "data": "SECRET STATE"}
+    ]
 
 
 async def test_view_modes(fake_judge_model):

--- a/verifiers/v1/envs/agentic_judge/env.py
+++ b/verifiers/v1/envs/agentic_judge/env.py
@@ -5,7 +5,9 @@ a fresh box from the solver's runtime policy and restores only the task's collec
 artifacts; `--env.id shared-agentic-judge` explicitly runs the judge in the
 solver's box. The judge grades rubric criteria (`[env.task]`: policy prompt,
 criteria file) and writes its verdicts to `/tmp/verdict.json`, with the solver's
-full trace record uploaded at `/tmp/trace.json`. `finalize()` validates them
+observable trace record uploaded at `/tmp/trace.json`. Hidden reasoning and opaque
+provider state are omitted by default and may be explicitly included through the
+judge task config. `finalize()` validates the verdicts
 strictly onto the solver's trace — `judge/<name>` metrics plus a weighted-mean
 `judge` reward, composed with the taskset's own rewards via `[env.score]`
 (judge-only by default).
@@ -82,15 +84,16 @@ def _render(template: str, **fields: str) -> str:
 
 
 _RECORD_NOTE = f"""\
-The agent's raw trace record (JSON: messages, tool calls, and its `info`
+The agent's observable trace record (JSON: messages, tool calls, and its `info`
 artifacts) is written by the harness — not the agent — at `{TRACE_FILE}`. The
 record can be very large — never dump it whole; peek selectively (list its
 keys, then slice out specific fields with python or jq) and pull only what you
-need. It is complete — it may also carry the task's own scores/metrics and
-reference material (a gold answer, a reference solution, held-out tests). Those
-are context, not your standard: recorded scores can be wrong and references can
-be narrower than the task; do not over-index on how a reference solves it. Your
-verdict is what YOU verified by execution."""
+need. Hidden reasoning and opaque provider state are not included unless the run
+explicitly opts in. The record may also carry the task's own scores/metrics and
+reference material (a gold answer, a reference solution, held-out tests). Those are
+context, not your standard: recorded scores can be wrong and references can be
+narrower than the task; do not over-index on how a reference solves it. Your verdict
+is what YOU verified by execution."""
 
 SHARED_WORKSPACE_NOTE = f"""\
 ## Your workspace
@@ -146,7 +149,13 @@ class JudgeTask(vf.Task):
         paths they had.
         """
         solved = solution.task.data
-        files = {TRACE_FILE: json.dumps(solution.to_record()).encode()}
+        record = solution.to_record()
+        if not config.include_hidden_reasoning:
+            for node in record["nodes"]:
+                message = node["message"]
+                message.pop("reasoning_content", None)
+                message.pop("provider_state", None)
+        files = {TRACE_FILE: json.dumps(record).encode()}
         template = config.build_prompt()
         body = _render(template, prompt=solved.prompt_text)
         if "{prompt}" not in template:
@@ -224,6 +233,9 @@ class JudgeTaskConfig(vf.BaseConfig):
     """Criteria the judge grades against: a `.toml`/`.json` file with a
     `criteria` list — the plugged rubric judge's format, so the same rubric
     files work for both. None grades the single built-in `solved` criterion."""
+    include_hidden_reasoning: bool = False
+    """Include assistant reasoning and opaque provider state in `/tmp/trace.json`.
+    Disabled by default so the judge grades only observable agent behavior."""
 
     @staticmethod
     def _resolve(value: TextSource) -> str:


### PR DESCRIPTION
## Summary

- add `env.task.include_hidden_reasoning` as an explicit agentic-judge toggle
- default the toggle to `false`, so `/tmp/trace.json` excludes assistant `reasoning_content`
- also exclude opaque `provider_state`, which may contain signed or encrypted reasoning state
- preserve observable assistant content, tool calls, tool outputs, metrics, and trace metadata
- allow experiments to restore the old raw-trace behavior with `--env.task.include-hidden-reasoning true`

The solver's persisted trace is unchanged; filtering happens only on the copy provided to the judge.

## Verification

- `uv run pytest tests/v1/test_judges.py -q`
- `uv run pytest tests/ -q`
- `uv run pre-commit run --all-files`
- pre-push hooks: markdownlint, Ruff, formatting, and ty

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default behavior changes what agentic judges can read from traces (privacy/security win), but workflows that implicitly relied on hidden reasoning must opt in explicitly.
> 
> **Overview**
> Agentic judge runs now receive an **observable** copy of the solver trace at `/tmp/trace.json`: by default, assistant **`reasoning_content`** and **`provider_state`** are stripped when `JudgeTask.from_trace` builds the judge task, while visible content, tool calls, and metadata stay intact. The solver’s stored trace is unchanged—filtering applies only to what the judge agent sees.
> 
> A new **`JudgeTaskConfig.include_hidden_reasoning`** flag (default **`false`**, opt in via env task config) restores the previous full raw trace for experiments. Judge-facing docs and workspace notes were updated to describe the default omission and the toggle.
> 
> Tests cover the toggle and extend the multi-turn fixture with **`provider_state`** so both fields are asserted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99c4349ee7e1e92700909fb348ea37a4a8469017. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide reasoning and provider state from agentic judge traces by default
> - Adds `include_hidden_reasoning` flag to `JudgeTaskConfig`, defaulting to false
> - `JudgeTask.from_trace` now strips `reasoning_content` and `provider_state` from all recorded nodes before writing `TRACE_FILE` unless the flag is enabled
> - Updates judge workspace instructions to describe the trace as observable by default and hidden reasoning as opt-in
> - Behavioral Change: existing `JudgeTask.from_trace` callers will see `reasoning_content` and `provider_state` dropped from `TRACE_FILE`; set `JudgeTaskConfig.include_hidden_reasoning=True` to restore them
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 99c4349.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->