### PR TITLE
perf(v1): reuse completed dashboard statistics

### DIFF
--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -295,9 +295,22 @@ def _push_footer(push: "PushState | None") -> Group | None:
     return Group(Rule(style="dim"), line)
 
 
+class TraceStats:
+    """Resource totals for a dashboard frame, retained once the episode is final."""
+
+    def __init__(self, trace: Trace) -> None:
+        self.num_input_tokens = trace.num_input_tokens
+        self.num_output_tokens = trace.num_output_tokens
+        self.num_turns = trace.num_turns
+        self.num_branches = trace.num_branches
+        self.usage = trace.usage
+        self.judge_usage = Usage.aggregate(trace.extra_usage)
+
+
 def Progress(
     slots: list[RunSlot],
     start: float,
+    completed: dict[str, TraceStats],
     page: tuple[int, int] | None = None,
 ) -> Group:
     # On resume, `slots` includes the previous session's kept rollouts (as finished slots), so
@@ -332,7 +345,7 @@ def Progress(
         ProgressBar(total=total or 1, completed=len(done)),
         Text(stats),
     )
-    breakdown = _breakdown(scored, done_traces)
+    breakdown = _breakdown(scored, done_traces, completed)
     return Group(row, breakdown) if breakdown is not None else Group(row)
 
 
@@ -362,7 +375,9 @@ def _score(trace: Trace, source: str, name: str) -> float:
     return value if value is not None else 0.0
 
 
-def _breakdown(scored: list[Trace], done: list[Trace]) -> Table | None:
+def _breakdown(
+    scored: list[Trace], done: list[Trace], completed: dict[str, TraceStats]
+) -> Table | None:
     """Score rows read the policy view (`scored` — trainable traces); with several
     roles in play they split per role, each role averaging over its OWN traces (no
     dilution, so the split covers every role — an untrainable seat's received
@@ -401,9 +416,10 @@ def _breakdown(scored: list[Trace], done: list[Trace]) -> Table | None:
     phase_count: dict[str, int] = {}
     model_secs = harness_secs = 0.0
     for trace in done:
-        total_in += trace.num_input_tokens
-        total_out += trace.num_output_tokens
-        usage = trace.usage
+        stats = completed[trace.id]
+        total_in += stats.num_input_tokens
+        total_out += stats.num_output_tokens
+        usage = stats.usage
         if usage is not None:
             if usage.cached_input_tokens is not None:
                 total_cached += usage.cached_input_tokens
@@ -415,7 +431,7 @@ def _breakdown(scored: list[Trace], done: list[Trace]) -> Table | None:
                 total_cost += usage.cost
                 have_cost = True
         # Judge / auxiliary scoring calls (off the message graph) shown separately from the agent's.
-        judge = Usage.aggregate(trace.extra_usage)
+        judge = stats.judge_usage
         if judge is not None:
             total_judge_in += judge.input_tokens
             total_judge_out += judge.completion_tokens
@@ -530,7 +546,12 @@ def _brace(i: int, size: int) -> str:
     return "╭" if i == 0 else "╰" if i == size - 1 else "│"
 
 
-def Rows(groups: list[list[RunSlot]], now: float, runtime_type: str) -> Table:
+def Rows(
+    groups: list[list[RunSlot]],
+    now: float,
+    runtime_type: str,
+    completed: dict[str, TraceStats],
+) -> Table:
     # (brace, state, left sections, result, time); a slot contributes one row per live
     # trace (a multi-agent episode shows each role's trace), braced per task.
     rows: list[tuple[str, str, list[str], str, str]] = []
@@ -596,7 +617,8 @@ def Rows(groups: list[list[RunSlot]], now: float, runtime_type: str) -> Table:
                     runtime = f"{rt.type}({rt.id})" if rt.id else rt.type
                 else:
                     runtime = runtime_type
-                turns = t.num_turns
+                stats = completed[t.id] if slot.done else TraceStats(t)
+                turns = stats.num_turns
                 start = t.timing.boot.start or t.timing.setup.start
                 end = (
                     t.timing.scoring.end
@@ -611,9 +633,9 @@ def Rows(groups: list[list[RunSlot]], now: float, runtime_type: str) -> Table:
                     )
                     or now
                 )
-                prompt, completion = t.num_input_tokens, t.num_output_tokens
-                nbranches = t.num_branches
-                usage = t.usage
+                prompt, completion = stats.num_input_tokens, stats.num_output_tokens
+                nbranches = stats.num_branches
+                usage = stats.usage
                 cached = usage.cached_input_tokens if usage else None
                 reasoning = usage.reasoning_tokens if usage else None
                 cost = usage.cost if usage else None
@@ -786,16 +808,24 @@ def _render(
     pager: Pager,
     header: Group | Table,
     runtime_type: str,
+    completed: dict[str, TraceStats],
     push: "PushState | None" = None,
     tail: LogTail | None = None,
 ) -> Group:
     now = time.time()
+    # A trace can finish before other agents and env scoring update the episode.
+    # Only done slots are final; resumed episodes enter the view already done.
+    for slot in slots:
+        if slot.done:
+            for trace in slot.traces:
+                if trace.id not in completed:
+                    completed[trace.id] = TraceStats(trace)
     # The --push status line (and, on Ctrl-C, the cleanup notice) appear under the rollouts. Measure
     # the fixed top (header + progress + rule) and the footer so the rollout rows fill what's left;
     # page through them (timer / arrows) when they'd overflow (else rich truncates).
     footers = [f for f in (_push_footer(push), _interrupt_footer()) if f is not None]
     footer = Group(*footers) if footers else None
-    progress = Progress(slots, start)
+    progress = Progress(slots, start, completed)
     top = Group(header, progress, Rule(style="dim"))
     reserved = len(_CONSOLE.render_lines(top))
     if footer is not None:
@@ -813,12 +843,12 @@ def _render(
         return Group(*parts)
     page_groups, index, count = _paginate(_groups(slots), rows_per_page, pager, now)
     if count > 1:
-        progress = Progress(slots, start, page=(index + 1, count))
+        progress = Progress(slots, start, completed, page=(index + 1, count))
     parts = [
         header,
         progress,
         Rule(style="dim"),
-        Rows(page_groups, now, runtime_type),
+        Rows(page_groups, now, runtime_type, completed),
     ]
     if footer is not None:
         parts.append(footer)
@@ -833,6 +863,7 @@ async def dashboard(
     push: "PushState | None" = None,
 ):
     pager = Pager()
+    completed: dict[str, TraceStats] = {}
     warning = _warning(config)
     header = Group(warning, Text(""), Overview(config)) if warning else Overview(config)
     runtime_type = (
@@ -850,7 +881,9 @@ async def dashboard(
         else None
     )
     async with live_view(
-        lambda: _render(slots, start, pager, header, runtime_type, push, tail),
+        lambda: _render(
+            slots, start, pager, header, runtime_type, completed, push, tail
+        ),
         on_key=None if tail is not None else pager.on_key,
     ):
         yield

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -815,11 +815,13 @@ def _render(
     now = time.time()
     # A trace can finish before other agents and env scoring update the episode.
     # Only done slots are final; resumed episodes enter the view already done.
-    for slot in slots:
-        if slot.done:
-            for trace in slot.traces:
-                if trace.id not in completed:
-                    completed[trace.id] = TraceStats(trace)
+    completed.update(
+        (trace.id, TraceStats(trace))
+        for slot in slots
+        if slot.done
+        for trace in slot.traces
+        if trace.id not in completed
+    )
     # The --push status line (and, on Ctrl-C, the cleanup notice) appear under the rollouts. Measure
     # the fixed top (header + progress + rule) and the footer so the rollout rows fill what's left;
     # page through them (timer / arrows) when they'd overflow (else rich truncates).


### PR DESCRIPTION
The evaluation dashboard rebuilds branches and sums model usage for every completed trace on every refresh, blocking the evaluation event loop as a run grows. Retain each trace's resource statistics when its episode becomes final and reuse them in the progress breakdown and rollout rows.

The snapshot belongs to the dashboard and is populated only for `RunSlot.done`, after every agent and environment finalization. Resumed episodes use the same path. Token counts still come from the existing Trace properties, preserving branch accounting, provider usage, and judge usage. Live traces continue to update normally.

Measured complete paginated dashboard refreshes (`_render` plus Rich `Live.update(..., refresh=True)`):

| Completed workload | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| 100 traces × 100 turns | 50.2 ms | 5.0 ms | 10.1× |
| 1,000 traces × 100 turns | 414.8 ms | 15.5 ms | 26.8× |
| 1,000 traces × 300 turns | 1,245.7 ms | 14.2 ms | 87.4× |
| 1,000 traces × 100 turns, five branches | 802.4 ms | 15.0 ms | 53.4× |
| 500 two-agent episodes: 100-turn/five-branch policy + 10-turn judge | 443.5 ms | 13.6 ms | 32.6× |
| 10,000 traces × 10 turns | 691.2 ms | 189.1 ms | 3.7× |

Apple M4 Max, 64 GB, CPython 3.14.6, repository-locked dependencies. Seven interleaved samples after two warmups, a 160×40 interactive Rich console writing to an in-memory stream, and 32 additional running slots. At 1,000 × 100 turns, sample ranges were 413.6–417.7 ms before and 13.9–16.8 ms after. Under the actual `live_view` refresh loop, maximum lateness of a 5 ms timer fell from 435 to 30 ms; at 300 turns it fell from 1,277 to 41 ms.

These are synthetic native Trace/Episode workloads exercising the real dashboard, not end-to-end model evaluation speedups or terminal-emulator I/O measurements. Newly completed traces still require a one-time calculation: loading 1,000 completed 300-turn traces took 677 ms for the first candidate frame. Work proportional to episode count, including score aggregation and pagination, remains.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only display optimization with no eval scoring or persistence changes; stale stats would only matter if trace usage mutates after the slot is marked done.
> 
> **Overview**
> The v1 eval dashboard was recomputing expensive `Trace` resource properties (branch-aware token totals, turn/branch counts, judge usage) on **every** Rich refresh for all finished rollouts, which slowed the live view as completed workload grew.
> 
> This PR introduces **`TraceStats`** to snapshot those fields once when a trace belongs to a **`RunSlot.done`** episode. A **`completed`** map is owned by the dashboard session, filled incrementally in **`_render`**, and passed into **`Progress`**, **`_breakdown`**, and **`Rows`** so aggregate usage and per-row token/turn/branch display reuse cached values. **In-flight** traces still build **`TraceStats(trace)`** each frame; rewards, timing spans, and stage logic keep reading live **`Trace`** objects.
> 
> **Risk note:** completed rows show usage frozen at done-slot time—correct if counters are final by then.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed9bb0c678aa849fc851958f79b22bda0bab2196. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Snapshot completed dashboard traces into `TraceStats` to keep resource rows stable
> - Adds a `TraceStats` class that captures a completed trace's token counts, turns, branches, usage details, and aggregated `trace.extra_usage` into judge usage
> - Threads a per-dashboard `completed` snapshot map through `_render`, `Progress`, `Rows`, and `_breakdown` so done rows and progress breakdowns read retained values instead of the live trace
> - Unfinished rows continue to build a fresh `TraceStats` from the current trace each frame
> - Risk: completed-row totals now freeze on first render where the slot is done; if a trace's counts change after completion, the dashboard will not reflect those updates
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ed9bb0c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->