### PR TITLE
Avoid redundant Codex home directory command

### DIFF
--- a/verifiers/v1/harnesses/codex/harness.py
+++ b/verifiers/v1/harnesses/codex/harness.py
@@ -120,12 +120,6 @@ class CodexHarness(ACPHarness[CodexHarnessConfig]):
         mcp_urls: dict[str, str],
     ) -> dict[str, str]:
         home = self.trace_home(trace)
-        created = await runtime.run(["mkdir", "-p", home], {})
-        if created.exit_code != 0:
-            raise RuntimeError(
-                f"failed to create Codex home: {created.stderr.strip()[-500:]}"
-            )
-
         mcp_config = "features={mcp_2026_07_28=true}\n" + (
             "mcp_servers={"
             + ",".join(


### PR DESCRIPTION
Codex creates its per-launch home directory with a separate runtime command immediately before writing `config.toml`. Every runtime's `write()` already creates the parent directory. Let that write own directory creation and propagate failures, removing the redundant command and its error branch.

Median `CodexHarness.build_env()` latency with a fresh home for each call:

| Runtime | No MCP servers, before → after | Three MCP servers, before → after | Reduction |
| --- | --- | --- | --- |
| Prime VM | 1,065 → 336 ms | 1,079 → 335 ms | 68–69% |
| Docker | 66.9 → 34.7 ms | 71.7 → 37.0 ms | 48% |
| macOS subprocess | 3.91 → 0.187 ms | 3.98 → 0.200 ms | 95% |

The comparison alternated before/after calls, with two discarded warmups per variant and workload, then 15 paired samples per Prime workload, 30 per Docker workload, and 50 per subprocess workload. The host was an Apple M4 Max running macOS 27.0 and CPython 3.14.6; Docker was 29.4.0. Docker and the US-region Prime VM used `python:3.11-slim`, one CPU, and 1 GB RAM; Prime used SDK 0.2.40. Local workloads ran under a shared process lock.

On Prime, the removed command uses the background-job path, including launch, status and stdout/stderr reads. The SDK polls immediately, and each measured job completed on its first poll; this does not imply a fixed one-second saving. These timings cover environment/config preparation only, excluding sandbox provisioning, package installation, model startup, readback and cleanup. Subprocess is a diagnostic of this method; the Codex harness itself requires a container runtime.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small harness change that relies on existing `runtime.write()` parent-directory behavior; no auth or data-path changes.
> 
> **Overview**
> **`CodexHarness.build_env()`** no longer runs a separate `mkdir -p` for the per-trace Codex home before writing `config.toml`. Directory creation is left to **`runtime.write()`**, which already ensures the parent path exists and surfaces write failures.
> 
> This removes an extra runtime round-trip (notably the background-job path on Prime) and the dedicated error handling for a failed mkdir.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 022ab96b6e870c4df65065dcec11bcba2f306de9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove redundant Codex home directory creation in `CodexHarness.build_env`
> Drops the explicit `mkdir` command for the trace-specific Codex home and its nonzero-exit error handling from [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2530/files#diff-904c37fe437bb3b42e0238258ed85a8c6cede02461216bcf9c7417c5f3b72b7b). The MCP configuration and returned environment entries are unchanged.
> - Behavioral Change: `CodexHarness.build_env` no longer raises `RuntimeError` when the home directory cannot be created; the directory is expected to exist or be created elsewhere.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 022ab96.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->