### PR TITLE
Reuse MCP sandbox installations across colocated servers

### DIFF
--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -32,6 +32,7 @@ from verifiers.v1.runtimes import (
 )
 from verifiers.v1.runtimes.base import _ENSURE_UV
 from verifiers.v1.state import State
+from verifiers.v1.utils.aio import run_shielded
 
 if TYPE_CHECKING:
     from verifiers.v1.mcp.toolset import Toolset
@@ -188,35 +189,36 @@ async def _install_in_sandbox(server: ServerBase, runtime: Runtime) -> str:
     root = str(PurePosixPath(workdir) / ".vf-src")
     temp = str(PurePosixPath(workdir) / ".vf-tmp")
     cache = str(PurePosixPath(workdir) / ".vf-uv-cache")
-    vf, env = _verifiers_root(), Path(source_dir)
-    vf_name, vf_data = await _cached_sdist(vf)
-    if env == vf:
-        env_name, env_data = vf_name, vf_data
-    else:
-        env_name, env_data = await _cached_sdist(env)
-    vf_remote = f"{root}/{vf_name}"
-    env_remote = f"{root}/{env_name}"
-    await runtime.write(vf_remote, vf_data)
-    if env_remote != vf_remote:
-        await runtime.write(env_remote, env_data)
     venv = str(PurePosixPath(workdir) / ".vf-venv")
     root_q, temp_q, cache_q, venv_q = map(shlex.quote, (root, temp, cache, venv))
-    vf_source = shlex.quote(vf_remote)
-    env_source = shlex.quote(env_remote)
-    setup = (
-        f"set -e; mkdir -p {root_q} {temp_q} {cache_q}; "
-        f"export TMPDIR={temp_q} UV_CACHE_DIR={cache_q}; "
-        f"{_ENSURE_UV}; "
-        f"uv venv {venv_q} && "
-        f"uv pip install --python {venv_q} {vf_source} && "
-        f"uv pip install --python {venv_q} {env_source}"
-    )
-    result = await runtime.run(["sh", "-c", setup], {})
-    if result.exit_code != 0:
-        raise ToolsetError(
-            f"server {server.server_name!r} install failed in runtime: "
-            f"{(result.stderr or result.stdout).strip()[-2000:]}"
+    # Colocated servers and borrowed views install into one physical environment.
+    # Serialize its mutations and only remember sources after a successful install.
+    async with runtime._mcp_install_lock:
+        sources = dict.fromkeys((str(_verifiers_root()), source_dir))
+        pending = [source for source in sources if source not in runtime._mcp_sources]
+        if not pending:
+            return f"{venv}/bin/python"
+        setup = (
+            f"set -e; mkdir -p {root_q} {temp_q} {cache_q}; "
+            f"export TMPDIR={temp_q} UV_CACHE_DIR={cache_q}; "
+            'export PATH="$HOME/.local/bin:$PATH"; '
         )
+        if not runtime._mcp_sources:
+            # Failed installs can leave the venv behind; retain it when retrying.
+            setup += f"{_ENSURE_UV}; uv venv --allow-existing {venv_q}; "
+        for source in pending:
+            name, data = await _cached_sdist(Path(source))
+            remote = f"{root}/{name}"
+            await runtime.write(remote, data)
+            setup += f"uv pip install --python {venv_q} {shlex.quote(remote)}; "
+        # A cancelled caller must not let another installer overlap its remote command.
+        result = await run_shielded(runtime.run(["sh", "-c", setup], {}))
+        if result.exit_code != 0:
+            raise ToolsetError(
+                f"server {server.server_name!r} install failed in runtime: "
+                f"{(result.stderr or result.stdout).strip()[-2000:]}"
+            )
+        runtime._mcp_sources.update(pending)
     return f"{venv}/bin/python"
 
 

--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -206,12 +206,12 @@ async def _install_in_sandbox(server: ServerBase, runtime: Runtime) -> str:
         if not runtime._mcp_sources:
             # Failed installs can leave the venv behind; retain it when retrying.
             setup += f"{_ENSURE_UV}; uv venv --allow-existing {venv_q}; "
+        # Drain remote writes and installs before cancellation releases the lock.
         for source in pending:
             name, data = await _cached_sdist(Path(source))
             remote = f"{root}/{name}"
-            await runtime.write(remote, data)
+            await run_shielded(runtime.write(remote, data))
             setup += f"uv pip install --python {venv_q} {shlex.quote(remote)}; "
-        # A cancelled caller must not let another installer overlap its remote command.
         result = await run_shielded(runtime.run(["sh", "-c", setup], {}))
         if result.exit_code != 0:
             raise ToolsetError(

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -155,6 +155,8 @@ class Runtime(ABC):
         self.env: dict[str, str] = {}
         self._uv_interpreters: dict[str, str] = {}
         self._uv_script_locks: dict[str, asyncio.Lock] = {}
+        self._mcp_sources: set[str] = set()
+        self._mcp_install_lock = asyncio.Lock()
         self._setup_claimed = False
         self.stopped = False
         """Whether teardown has begun (set by `stop`). A stopped runtime is dead: a rollout


### PR DESCRIPTION
Colocated MCP servers install into the same `.vf-venv`, but every launch uploads the source archives, bootstraps uv, recreates the venv, and reinstalls Verifiers. Current uv rejects the second venv creation, so multiple servers and warm provisioning fail.

Prepare the environment and each source package once per physical runtime. A runtime-owned lock coordinates colocated servers and borrowed views, while server processes and task environments remain independent. Installs retain their existing source order and dependency resolution; successful sources are cached, failed attempts can reuse their partial venv, and cancellation waits for remote uploads and install commands before releasing the lock. Existing host sdist caching is retained.

### Provisioning measurements

Five interleaved samples per case on an isolated Prime VM (1 CPU, 2 GB RAM, Debian 13, Python 3.11.15, uv 0.12.9), using identical prebuilt sdists. Cold means a fresh venv and per-workdir uv cache; VM creation, host sdist builds, server startup, and model calls are excluded.

The unmodified baseline fails when its venv already exists. The successful comparisons below repair **only** that baseline command with `uv venv --allow-existing`; they do not time the failure path.

| Two colocated servers | Before median (range) | After median (range) | Latency reduction |
| --- | --- | --- | --- |
| Both from Verifiers | 6.64 s (6.55–7.07) | 4.28 s (4.21–4.58) | 36% |
| Both from glossary | 7.91 s (7.70–8.07) | 4.83 s (4.71–5.16) | 39% |
| glossary + scratchpad | 7.97 s (7.84–10.57) | 6.02 s (5.96–6.07) | 25% |

Warm provisioning drops from 2.25–4.94 s to zero remote operations (0.16–0.50 ms median locally). An unchanged single-server cold baseline measures 3.71 s versus 3.79 s: there is no meaningful first-server speedup. The benefit comes from avoiding repeated provisioning in the same sandbox.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared sandbox provisioning and locking for all MCP launches on a runtime; incorrect cache or lock behavior could break multi-server or warm-start scenarios, but scope is isolated to remote install paths.
> 
> **Overview**
> **Colocated MCP servers on the same runtime now share one `.vf-venv` install** instead of re-uploading sdists, bootstrapping `uv`, and recreating the venv on every launch.
> 
> `_install_in_sandbox` runs under a runtime-wide `_mcp_install_lock`, tracks successfully installed source paths in `_mcp_sources`, and skips remote work when everything is already provisioned. New sources are uploaded and `uv pip install`’d in order; the first install uses `uv venv --allow-existing` (fixing failures when the venv already exists) and prepends `~/.local/bin` to `PATH`. The remote shell command runs through `run_shielded` so a cancelled caller does not release the lock while install is still in flight; failed installs do not update the source cache so retries can reuse a partial venv.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e375e15c1bf5808a1f1207244b5a26a2147a59ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deduplicate and serialize MCP sandbox installs across colocated servers
> - `mcp._install_in_sandbox` now tracks per-runtime installed source paths and skips re-installing sources already recorded for that runtime
> - Concurrent installs for the same runtime are serialized via an asyncio lock added to `Runtime.__init__`; the lock is not released until shielded writes and installation execution drain, including on cancellation
> - Failed installs do not add their sources to the installed set, preserving an existing virtual environment on retry via `uv venv --allow-existing`
> - `Runtime.__init__` in [base.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2531/files#diff-0811c040a163eb5a3212208f1e3a6c6388d7690fcc4780c081cc7754036232b9) gains the installed-source set and lock fields that the installer reads
> - Risk: the installed-source set is per-`Runtime` instance; any code that creates fresh `Runtime` instances for the same sandbox will bypass deduplication and reinstall from scratch
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b1e877.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
