### PR TITLE
Read bounded files as binary in Subprocess and Docker

### DIFF
--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -316,13 +316,28 @@ class Runtime(ABC):
         """Read `path` into host memory. `max_bytes` caps the transfer, raising past
         the cap — for a file written by something we don't control, whose size we
         can't assume. The cap is enforced inside the box rather than after the
-        transfer, and base64 because `run` returns decoded text. Framework method —
-        override `_read`, not this."""
+        transfer. Framework method — override `_read`, not this."""
         if max_bytes is None:
             return await self._read(path)
+        if max_bytes < 0:
+            raise ValueError("max_bytes must be non-negative")
+        # One extra byte distinguishes an exact fit from a truncated file.
+        data = await self._read(path, max_bytes=max_bytes + 1)
+        if len(data) > max_bytes:
+            raise SandboxError(f"read {path!r}: over the {max_bytes} byte limit")
+        return data
+
+    @abstractmethod
+    async def _read(self, path: str, max_bytes: int | None = None) -> bytes:
+        """Read at most `max_bytes` bytes at the source, or the whole file if None.
+
+        Runtimes without bounded binary reads delegate capped reads here, using
+        base64 because `run` returns decoded text.
+        """
+        assert max_bytes is not None
         # Through a temp file, not a pipe: `head | base64` exits with base64's 0
         # even when the path is missing, and a missing file must raise here just
-        # as it does from `_read`.
+        # as it does from a native binary read.
         result = await self.run(
             [
                 "sh",
@@ -333,21 +348,14 @@ class Runtime(ABC):
                     'base64 < "$t"; rc=$?; rm -f "$t"; exit $rc'
                 ),
                 "sh",
-                str(max_bytes + 1),
+                str(max_bytes),
                 path,
             ],
             {},
         )
         if result.exit_code:
             raise SandboxError(f"read {path!r}: {result.stderr.strip()[-500:]}")
-        data = base64.b64decode(result.stdout)
-        if len(data) > max_bytes:
-            raise SandboxError(f"read {path!r}: over the {max_bytes} byte limit")
-        return data
-
-    @abstractmethod
-    async def _read(self, path: str) -> bytes:
-        """Read the whole file at `path`; `read` adds the optional transfer cap."""
+        return base64.b64decode(result.stdout)
 
     @abstractmethod
     async def write(self, path: str, data: bytes) -> None:

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -331,6 +331,8 @@ class Runtime(ABC):
     async def _read(self, path: str, max_bytes: int | None = None) -> bytes:
         """Read at most `max_bytes` bytes at the source, or the whole file if None.
 
+        Overrides must accept `max_bytes` and enforce it before transferring data.
+        The public `read` method checks for overflow using one extra byte.
         Runtimes without bounded binary reads delegate capped reads here, using
         base64 because `run` returns decoded text.
         """

--- a/verifiers/v1/runtimes/docker/__init__.py
+++ b/verifiers/v1/runtimes/docker/__init__.py
@@ -506,14 +506,16 @@ class DockerRuntime(Runtime):
         if run.exit_code != 0:
             raise SandboxError(f"docker exec -d failed: {run.stderr.strip()}")
 
-    async def _read(self, path: str) -> bytes:
+    async def _read(self, path: str, max_bytes: int | None = None) -> bytes:
+        argv = ["cat"] if max_bytes is None else ["head", "-c", str(max_bytes)]
         proc = await asyncio.create_subprocess_exec(
             "docker",
             "exec",
             "--workdir",
             self.config.workdir,
             self._container,
-            "cat",
+            *argv,
+            "--",
             path,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,

--- a/verifiers/v1/runtimes/docker/__init__.py
+++ b/verifiers/v1/runtimes/docker/__init__.py
@@ -520,7 +520,14 @@ class DockerRuntime(Runtime):
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-        stdout, stderr = await proc.communicate()
+        try:
+            stdout, stderr = await proc.communicate()
+        except BaseException:
+            if proc.returncode is None:
+                with contextlib.suppress(ProcessLookupError):
+                    proc.kill()
+            await run_shielded(proc.communicate())
+            raise
         if proc.returncode != 0:
             raise SandboxError(
                 f"read {path!r}: {stderr.decode(errors='replace').strip()}"

--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -279,7 +279,9 @@ class ModalRuntime(Runtime):
             return path
         return f"{self.config.workdir.rstrip('/')}/{path}"
 
-    async def _read(self, path: str) -> bytes:
+    async def _read(self, path: str, max_bytes: int | None = None) -> bytes:
+        if max_bytes is not None:
+            return await super()._read(path, max_bytes)
         try:
             return await self._sandbox.filesystem.read_bytes.aio(self._abs(path))
         except Exception as e:

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -365,7 +365,9 @@ class PrimeRuntime(Runtime):
         except Exception as e:
             raise SandboxError(f"prime background launch failed: {e}") from e
 
-    async def _read(self, path: str) -> bytes:
+    async def _read(self, path: str, max_bytes: int | None = None) -> bytes:
+        if max_bytes is not None:
+            return await super()._read(path, max_bytes)
         # Avoid background-job log limits and base64 overhead by downloading binary data directly.
         # The temporary file is removed on every exit, and its byte read stays off the event loop.
         target = (

--- a/verifiers/v1/runtimes/subprocess.py
+++ b/verifiers/v1/runtimes/subprocess.py
@@ -11,6 +11,7 @@ from typing import ClassVar, Literal
 
 from pydantic_config import BaseConfig
 
+from verifiers.v1.errors import SandboxError
 from verifiers.v1.runtimes.base import (
     BaseRuntimeInfo,
     ProgramResult,
@@ -161,8 +162,20 @@ class SubprocessRuntime(Runtime):
             proc
         )  # killed in stop() — a host process won't die on its own
 
-    async def _read(self, path: str) -> bytes:
-        return await asyncio.to_thread((self.workdir / path).read_bytes)
+    async def _read(self, path: str, max_bytes: int | None = None) -> bytes:
+        if max_bytes is None:
+            return await asyncio.to_thread((self.workdir / path).read_bytes)
+
+        # Keep the handle in the worker: cancellation must not close a file on
+        # the event loop while that worker still holds its buffered-read lock.
+        def read() -> bytes:
+            with (self.workdir / path).open("rb") as file:
+                return file.read(max_bytes)
+
+        try:
+            return await asyncio.to_thread(read)
+        except OSError as exc:
+            raise SandboxError(f"read {path!r}: {exc}") from exc
 
     async def write(self, path: str, data: bytes) -> None:
         target = self.workdir / path

--- a/verifiers/v1/runtimes/subprocess.py
+++ b/verifiers/v1/runtimes/subprocess.py
@@ -5,6 +5,7 @@ import contextlib
 import os
 import shutil
 import signal
+import stat
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import ClassVar, Literal
@@ -166,16 +167,24 @@ class SubprocessRuntime(Runtime):
         if max_bytes is None:
             return await asyncio.to_thread((self.workdir / path).read_bytes)
 
-        # Keep the handle in the worker: cancellation must not close a file on
-        # the event loop while that worker still holds its buffered-read lock.
-        def read() -> bytes:
-            with (self.workdir / path).open("rb") as file:
+        # Leave special files to the cancellable shell path without opening a
+        # FIFO and waking its writer. A nonblocking open and descriptor check
+        # also cover a regular path being replaced by a FIFO after the stat.
+        def read() -> bytes | None:
+            target = self.workdir / path
+            if not stat.S_ISREG(target.stat().st_mode):
+                return None
+            fd = os.open(target, os.O_RDONLY | os.O_NONBLOCK)
+            with os.fdopen(fd, "rb") as file:
+                if not stat.S_ISREG(os.fstat(file.fileno()).st_mode):
+                    return None
                 return file.read(max_bytes)
 
         try:
-            return await asyncio.to_thread(read)
+            data = await asyncio.to_thread(read)
         except OSError as exc:
             raise SandboxError(f"read {path!r}: {exc}") from exc
+        return data if data is not None else await super()._read(path, max_bytes)
 
     async def write(self, path: str, data: bytes) -> None:
         target = self.workdir / path


### PR DESCRIPTION
Bounded `Runtime.read()` calls use binary transfers in Subprocess and Docker, removing the temporary-file and base64 roundtrip during artifact collection. The transfer remains capped at the source, with one extra byte used to detect overflow.

Runtime subclasses implement `_read(path, max_bytes=None)` and enforce a supplied limit before transferring data. All four built-in runtimes implement this contract. Prime and Modal delegate capped reads to the shared shell/base64 fallback; their unbounded native downloads are unchanged.

Subprocess keeps native reads for regular files and uses the cancellable shell path for special files. It checks the target before opening, then uses a nonblocking open and checks the descriptor to cover a regular path being replaced by a FIFO. Docker kills and reaps its local CLI client if communication is interrupted, using the same shielded cleanup as its existing command helper. As with `DockerRuntime.run`, this does not signal a container-side process: a blocked FIFO reader can survive until container teardown.

Measurements on an Apple M4 Max, macOS arm64, CPython 3.13.14, and Docker 29.4.0 under OrbStack, with the Docker container limited to 1 CPU and 1 GiB:

| Runtime operation | Payload | Before | After | Speedup |
| --- | ---: | ---: | ---: | ---: |
| Subprocess bounded read | 32 MiB | 108.90 ms | 1.90 ms | 57.36× |
| Docker bounded read | 32 MiB | 146.96 ms | 72.45 ms | 2.03× |
| Subprocess artifact collection and validation | 31 MiB | 146.36 ms | 44.11 ms | 3.32× |
| Docker artifact collection and validation | 31 MiB | 301.15 ms | 221.19 ms | 1.36× |

Each case uses two warmup pairs and 15 measured pairs with alternating before/after order against the same runtime and inputs. The baseline is `1e3e72923c560960cd68cc13976fc56f18e9b2da`. Collection includes tar creation, transfer, cleanup, host archive validation, and extraction. The middle half of Docker 32 MiB read samples was 141.10–150.72 ms before and 70.53–73.78 ms after. The measurements cover warm-cache runtime operations, excluding container provisioning and model inference. Small Docker collections showed little improvement in the broader initial sweep. No Prime/Modal speedup is claimed.

At 32 MiB, Docker stdout falls from 43.23 MiB of wrapped base64 to 32 MiB of binary, and peak host Python allocations fall from 162.11 MiB to 64.11 MiB. Subprocess's bounded `file.read` reserves capacity up to the cap even for small files. Separate allocation tracing and kernel RSS measurements distinguish that capacity from resident memory.

At 128 overlapping Subprocess reads, the default executor uses 20 workers. Distinct binary files are read under the normal 32 MiB cap, retaining all outputs until each burst completes:

| File size | Old burst median | New burst median | Old RSS increase | New RSS increase |
| --- | ---: | ---: | ---: | ---: |
| 1 KiB | 354.47 ms | 7.86 ms | 3.84–3.95 MiB | 2.20–2.27 MiB |
| 16 KiB | 377.41 ms | 7.84 ms | 12.45–12.70 MiB | 4.86–4.94 MiB |
| 64 KiB | 445.56 ms | 7.92 ms | 36.03–40.88 MiB | 9.28–9.58 MiB |

Each condition uses two fresh processes, two warmup bursts, and nine measured bursts per process. RSS ranges cover the two processes; old shell child memory is excluded. Compared with a fixture-sized-cap control, the normal cap adds under 1.5 MiB RSS and changes burst medians by at most 0.11 ms. A separate tracing pass reports 96.73–128.55 MiB of requested Python allocation capacity for 128 × 1 KiB reads, versus the 2.20–2.27 MiB untraced RSS increase. These results cover this macOS host and its default executor, not Linux allocators, custom executors, or whole-evaluation memory usage. All benchmark workloads were serialized.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sandbox file I/O used by artifact collection across all runtimes; behavior is intended to stay the same but Subprocess/Docker paths changed materially and negative `max_bytes` is a new failure mode.
> 
> **Overview**
> **Bounded `Runtime.read()`** now enforces limits in shared `read()` (non-negative `max_bytes`, one extra byte at the source to detect overflow) and pushes the byte cap into `_read()` instead of always using a shell `head` + base64 roundtrip.
> 
> **Subprocess** reads capped regular files directly on a worker thread (`read` up to `max_bytes`); non-regular paths still use the base fallback. **Docker** streams binary data via `docker exec` with `head -c` or `cat`, including kill/reap on cancelled reads. **Modal** and **Prime** keep fast unbounded provider downloads; capped reads still go through the base fallback.
> 
> Callers that pass negative `max_bytes` now get **`ValueError`** instead of undefined behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb4b1533ed6a55b7ac0536e1223c441c5c2978c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add bounded binary reads to `Runtime._read` in Subprocess and Docker
> - `Runtime.read` now validates the byte limit, requests one extra byte for overflow detection, and raises `SandboxError` when the result exceeds the requested limit; negative limits raise `ValueError`
> - `DockerRuntime._read` uses bounded `head` for capped reads with an argument terminator before the path, and interrupted reads now kill and reap the Docker subprocess
> - `SubprocessRuntime._read` reads regular files via a nonblocking descriptor in a worker thread for capped reads; special files and paths that change type fall back to the base shell/base64 path
> - `ModalRuntime._read` and `PrimeRuntime._read` delegate capped reads to the base bounded-read fallback; uncapped reads are unchanged
> - Risk: `Runtime.read` is now documented as framework code that callers should not override; all `_read` implementations must enforce the limit before transferring data, so out-of-tree runtime subclasses need to add the optional limit parameter to remain compatible
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb4b153.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
