### PR TITLE
perf(v1): skip unused interception parsing and hashing

### DIFF
--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -490,13 +490,13 @@ class InterceptionServer(Interception):
             body = from_json(raw)
         except ValueError:
             body = json.loads(raw)
-        req_hash = await _request_digest(raw)
+        body = dialect.apply_overrides(body, session.ctx.model, session.ctx.sampling)
+        streaming = dialect.streaming(body)
+        req_hash = await _request_digest(raw) if not streaming else b""
         # Keep `read()` for aiohttp's size guard, then release its cache and our local
         # alias after parsing so the wire body does not survive model inference.
         request._read_bytes = None
         del raw
-        body = dialect.apply_overrides(body, session.ctx.model, session.ctx.sampling)
-        streaming = dialect.streaming(body)
         try:
             acp, upstream_headers = extract_acp_info(request.headers)
         except ValueError as error:
@@ -638,7 +638,9 @@ class InterceptionServer(Interception):
 
         try:
             body, policy_paths = self.mediate_capabilities(session, dialect, body)
-            model_request = dialect.parse_request(body)
+            # Restricted mediation can mutate the body without reporting policy paths.
+            if request_rewrites or session.network_policy.network_restricted:
+                model_request = dialect.parse_request(body)
             turn = graph.prepare_turn(session.trace, model_request.messages)
         except ValueError as error:
             return web.json_response(dialect.error_body(str(error)), status=400)

--- a/verifiers/v1/session.py
+++ b/verifiers/v1/session.py
@@ -158,22 +158,24 @@ class RolloutSession:
         """Run typed request interceptors and stops over one canonical request."""
         if not self.request_interceptors and (not run_stops or not self.request_stops):
             return request, [], None
-        turn = graph.prepare_turn(self.trace, request.messages)
-        prepared_users = self.prepared_users.copy()
         prepared: set[int] = set()
         candidates: set[int] = set()
-        for position in range(turn.tail_start, len(request.messages)):
-            message = request.messages[position]
-            if isinstance(message, UserMessage):
-                candidates.add(position)
-                key = graph.message_hash(message)
-                if prepared_users[key]:
-                    prepared_users[key] -= 1
-                    prepared.add(position)
-            elif isinstance(message, ToolMessage):
-                candidates.add(position)
-                if self.prepared_tool_results.get(message.tool_call_id) == message:
-                    prepared.add(position)
+        if self.request_interceptors:
+            turn = graph.prepare_turn(self.trace, request.messages)
+            prepared_users = self.prepared_users.copy()
+            for position in range(turn.tail_start, len(request.messages)):
+                message = request.messages[position]
+                if isinstance(message, UserMessage):
+                    candidates.add(position)
+                    if prepared_users:
+                        key = graph.message_hash(message)
+                        if prepared_users[key]:
+                            prepared_users[key] -= 1
+                            prepared.add(position)
+                elif isinstance(message, ToolMessage):
+                    candidates.add(position)
+                    if self.prepared_tool_results.get(message.tool_call_id) == message:
+                        prepared.add(position)
         already_intercepted = candidates and candidates == prepared
 
         current = request
@@ -240,7 +242,7 @@ class RolloutSession:
     def consume_prepared(self, messages: Messages) -> None:
         """Forget pre-harness rewrites only after their model request commits."""
         for message in messages:
-            if isinstance(message, UserMessage):
+            if isinstance(message, UserMessage) and self.prepared_users:
                 key = graph.message_hash(message)
                 if self.prepared_users[key]:
                     self.prepared_users[key] -= 1


### PR DESCRIPTION
Large model requests spend time reparsing unchanged input and hashing data that the current path does not consume. Reuse the parsed request when no request rewrite or restricted network mediation ran, prepare rewrite positions only for request interceptors, and skip prepared-user hashes for empty counters and replay digests for streaming requests.

Restricted mediation still reparses because it can change the native body in place without reporting policy paths. Hook copies, tool-result consumption, streaming delivery, and non-streaming replay retain their existing behavior.

Measured through the real local HTTP interception server and EvalClient against a synthetic local provider, comparing main `1e3e72923` with this change:

| Workload | Dialect | Before (ms) | After (ms) | Latency reduction |
| --- | --- | ---: | ---: | ---: |
| 2,000-message history, no hooks | Chat Completions | 14.26 | 12.49 | 12.4% |
| 2,000-message history, request stop hook | Chat Completions | 21.32 | 15.95 | 25.22% |
| New 8 MiB inline image, streaming | Chat Completions | 42.73 | 31.94 | 25.27% |
| 2,000-message history, no hooks | Responses | 14.61 | 12.47 | 14.69% |
| 2,000-message history, request stop hook | Responses | 23.24 | 17.67 | 23.96% |
| New 8 MiB inline image, streaming | Responses | 43.08 | 32.38 | 24.83% |
| 2,000-message history, no hooks | Anthropic | 14.15 | 11.99 | 15.22% |
| 2,000-message history, request stop hook | Anthropic | 21.57 | 16.19 | 24.94% |
| New 8 MiB inline image, streaming | Anthropic | 43.71 | 32.33 | 26.04% |

Medians of 21 alternating before/after samples after five warmups, serialized against other campaign workloads on macOS ARM64 / CPython 3.13.14. The long history has 1 KiB per message plus a new user turn, about 2.12 MB on the wire. Image samples start with a fresh trace outside the timed region. Median absolute deviations for these workloads were 0.11–1.01 ms. This measures request processing and two loopback HTTP hops; it excludes real model inference and remote network latency. Small 50-message requests saved only 0.05–0.08 ms, within observed noise.

Separate probes isolate roughly 2 ms for the second parse in a successful stub-backed handler, 3.22 ms for stop-only bookkeeping, 5.62 ms for consuming an image against an empty prepared-user counter, and 5.41 ms for the unused streaming digest. The image request-interceptor path also saves 5.59 ms when that counter is empty.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request parsing, idempotency binding, and hook bookkeeping on every model call; mistakes could affect replay semantics or interceptor eligibility, though changes are guarded by existing flags.
> 
> **Overview**
> This PR trims work on the interception hot path when the extra parsing, graph bookkeeping, and body hashing are not needed for correctness.
> 
> **Interception server:** Overrides and streaming mode are applied before deciding whether to hash the wire body, and **streaming requests skip the Blake2 replay digest** (empty hash) since retry/idempotency replay does not apply the same way there. After capability mediation, **`dialect.parse_request` runs only when request hooks rewrote the request or restricted network policy may have mutated the native body**; otherwise the first parse is reused.
> 
> **Rollout session:** **`rewrite_request` only walks the message tail and prepared-user counters when request interceptors are registered**, so request-stop-only paths avoid `prepare_turn` and hash work. **`consume_prepared` and the interceptor path skip `message_hash` when the prepared-user counter map is empty.**
> 
> Behavior for hook copies, tool-result consumption, non-streaming replay, and restricted mediation reparse is unchanged where those features actually run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de362427c490bfbdba8320da363b2b69b74fe17b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip unused interception digest computation and re-parsing for streaming requests
> - In [server.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2533/files#diff-84e2f8d027d609e8760ef6d533535ec9d99dfc6384d5ddb6111b4001b2010f35), request-body overrides now run before streaming classification, so streaming detection reflects the final body. Streaming requests bypass request-digest calculation and use an empty digest; re-parsing the mediated model request happens only when request rewrites or network restrictions are active.
> - In [session.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2533/files#diff-0eeafa9506eb0d53c459cf476e308ce72a99d147d2f84979affa04baaee79a66), `RolloutSession.rewrite_request` skips graph preparation, prepared-user copying, and message scanning when no request interceptors are configured. `consume_prepared` guards hashing and decrementing against an empty prepared-user collection.
> - Behavioral Change: streaming interception requests now receive an empty digest instead of a computed one; mediated bodies are no longer re-parsed unconditionally after capability mediation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized de36242.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->