### PR TITLE
perf(v1): skip unused response conversion work

### DIFF
--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -15,6 +15,7 @@ from typing import Any
 from urllib.parse import urlsplit
 
 from openai.types.chat import ChatCompletion
+from openai.types.chat.chat_completion import Choice
 
 from verifiers.v1.configs.runtime import NetworkPolicyConfig
 from verifiers.v1.dialects.base import (
@@ -44,12 +45,18 @@ from verifiers.v1.types import (
 )
 
 
+class ModdedChoice(Choice):
+    # Logprobs are relayed in Response.raw; trace conversion never reads them.
+    logprobs: Any = None
+
+
 class ModdedChatCompletion(ChatCompletion):
     """The OpenAI SDK closes `service_tier` to a fixed `Literal`, but providers return tiers
     outside it (e.g. Prime's `provisioned`), which makes `model_validate` reject an otherwise
     valid completion. Widen the field to a plain string — we don't consume it — so parsing stays
     lenient about the label instead of dropping it."""
 
+    choices: list[ModdedChoice]
     service_tier: str | None = None
 
 

--- a/verifiers/v1/dialects/responses.py
+++ b/verifiers/v1/dialects/responses.py
@@ -315,7 +315,10 @@ def fold_assistant(items: list[dict] | None) -> AssistantMessage:
 def response_from_wire(response: OpenAIResponse) -> Response:
     """An OpenAI Responses object -> a vf `Response` (its `output` items folded into one
     assistant message)."""
-    data = response.model_dump()
+    # Copy the output snapshot without traversing echoed tools or request settings.
+    data = response.model_dump(
+        include={"id", "created_at", "model", "status", "error", "output"}
+    )
     status = data.get("status")
     if status not in (None, "completed", "incomplete"):
         error = data.get("error") or {}


### PR DESCRIPTION
Trace conversion spends time and memory constructing Chat logprob models it never reads and copying Responses tool schemas it immediately discards. Keep Chat logprobs opaque in the parse-only choice model and restrict the Responses dump to the fields conversion consumes.

Message, tool-call, completion metadata, and usage validation stay in place. The full provider JSON is still relayed in `Response.raw`, and Responses output remains an independent snapshot for `provider_state`. Malformed **unconsumed Chat logprobs** now pass through unchanged instead of causing a schema-validation 502. Training-token handling is unchanged.

Measured median latency for the real `EvalClient.get_response` path, including request serialization and a keepalive HTTP connection to a local synthetic provider:

| Response workload | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| Chat, 256 output tokens, top-5 logprobs (96 KB) | 1.999 ms | 1.009 ms | 1.98× |
| Chat, 2,048 output tokens, sampled logprobs only (160 KB) | 2.708 ms | 1.290 ms | 2.10× |
| Chat, 2,048 output tokens, top-5 logprobs (766 KB) | 12.306 ms | 4.449 ms | 2.77× |
| Chat, 2,048 output tokens, top-20 logprobs (2.54 MB) | 42.307 ms | 13.789 ms | 3.07× |
| Responses, 20 echoed tools with 5 properties each (15 KB) | 0.508 ms | 0.482 ms | 1.05× |
| Responses, 100 echoed tools with 20 properties each (239 KB) | 1.681 ms | 1.289 ms | 1.30× |

For the top-20 Chat case, peak Python allocations per client call fell from **44.58 to 16.19 MB** (64% lower). For the 100-tool Responses case they fell from **1.649 to 1.196 MB**. These are `tracemalloc` peaks with the response retained, not process RSS. Ordinary Chat without logprobs was effectively unchanged (0.453 to 0.450 ms).

Measurements compare `1e3e72923c560960cd68cc13976fc56f18e9b2da` with this change on an Apple M4 Max, macOS 27, Python 3.14.6, OpenAI 2.54.0 and Pydantic 2.13.4. Each case uses warmups and 12 interleaved before/after batches, with all campaign installs, tests and benchmarks serialized under one process lock. Median absolute deviations were 0.429/0.111 ms for top-20 Chat and 0.010/0.012 ms for 100-tool Responses. JSON decode plus conversion alone improved from 41.83 to 11.94 ms and 0.724 to 0.341 ms, respectively. Synthetic response bodies and local HTTP isolate client overhead; these figures do not include provider inference, WAN latency, or concurrent rollout throughput.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Parse-path optimizations that preserve consumed fields and raw relay; the main behavior shift is more lenient acceptance of malformed Chat logprobs.
> 
> **Overview**
> Speeds up v1 dialect parsing by not building Pydantic models for provider fields the trace layer never uses.
> 
> **Chat completions:** choices now go through **`ModdedChoice`**, which keeps **`logprobs`** as an opaque **`Any`** instead of validating large top-k logprob trees during **`ModdedChatCompletion.model_validate`**. Message, finish reason, and usage handling are unchanged; full provider JSON still lands in **`Response.raw`**. Malformed logprob payloads that conversion does not read should no longer fail validation with a 502.
> 
> **Responses API:** **`response_from_wire`** dumps only **`id`**, **`created_at`**, **`model`**, **`status`**, **`error`**, and **`output`**, avoiding work on echoed tool schemas and other request metadata that conversion discards anyway.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db68d6ca470d60840ecee9a97ef90f742e83c04b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip unused response conversion work in v1 dialects
> - Adds `ModdedChoice` in [chat.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2534/files#diff-5d2fcbf59a03489b63b0626038a853eee89543b591074597161ee29aab901280) with a broadened `logprobs: Any` field so provider-supplied logprob data passes validation without conforming to the SDK's narrower type. `ModdedChatCompletion` now uses a list of `ModdedChoice` for its `choices` annotation.
> - Narrows the intermediate dump in `response_from_wire` in [responses.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2534/files#diff-73f89a1b25536fd7a806555e765120f5189cb934eff813f4c7900838efa56b5a) to only `id`, `created_at`, `model`, `status`, `error`, and `output`, avoiding serialization of unused response fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db68d6c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->