### PR TITLE
Reuse chat programs and rollout MCP clients

### DIFF
--- a/verifiers/v1/harnesses/bash/harness.py
+++ b/verifiers/v1/harnesses/bash/harness.py
@@ -8,7 +8,6 @@ from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.harness import Harness
 from verifiers.v1.harnesses.utils.launch import (
     CHAT_PROGRAM_SOURCE,
-    MCP_CHAT_PROGRAM_SOURCE,
     launch_chat_program,
 )
 from verifiers.v1.runtimes import ProgramResult, Runtime
@@ -122,7 +121,6 @@ class BashHarness(Harness[BashHarnessConfig]):
             mcp_urls,
             system_prompt,
             prompt,
-            source_with_mcp=MCP_CHAT_PROGRAM_SOURCE,
             extra_args=args,
             env=env,
             activate=False,

--- a/verifiers/v1/harnesses/browser_use/program.py
+++ b/verifiers/v1/harnesses/browser_use/program.py
@@ -27,6 +27,7 @@ import subprocess
 import sys
 import time
 import urllib.request
+from contextlib import AsyncExitStack
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urlsplit
@@ -226,63 +227,60 @@ async def main() -> None:
     config = json.loads(args.mcp_config or "{}")
     tools = [BROWSER_TOOL]
     reserved = {"browser"}
-    mcp_tools, dispatch, servers = (
-        await connect_mcp(config, reserved)
-        if config.get("mcpServers")
-        else ([], {}, {})
-    )
-    tools += mcp_tools
-    messages = (
-        [{"role": "system", "content": args.system_prompt}]
-        if args.system_prompt
-        else []
-    )
-    if initial:
-        messages.extend(initial)
-    elif args.prompt:
-        messages.append({"role": "user", "content": args.prompt})
-    while True:
-        message = await chat(client, args.model, messages, tools)
-        messages.append(message.model_dump(exclude_none=True))
-        if not message.tool_calls:
-            break
-        for call in message.tool_calls:
-            name = call.function.name
-            try:
-                tool_args = json.loads(call.function.arguments or "{}")
-            except json.JSONDecodeError as e:
+    async with AsyncExitStack() as mcp_stack:
+        mcp_tools, dispatch, servers = await connect_mcp(config, mcp_stack, reserved)
+        tools += mcp_tools
+        messages = (
+            [{"role": "system", "content": args.system_prompt}]
+            if args.system_prompt
+            else []
+        )
+        if initial:
+            messages.extend(initial)
+        elif args.prompt:
+            messages.append({"role": "user", "content": args.prompt})
+        while True:
+            message = await chat(client, args.model, messages, tools)
+            messages.append(message.model_dump(exclude_none=True))
+            if not message.tool_calls:
+                break
+            for call in message.tool_calls:
+                name = call.function.name
+                try:
+                    tool_args = json.loads(call.function.arguments or "{}")
+                except json.JSONDecodeError as e:
+                    messages.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": call.id,
+                            "content": f"error: invalid JSON in tool arguments ({e}); resend the call with valid JSON",
+                        }
+                    )
+                    continue
+                # Valid JSON can still be a non-object (`[]`, `42`, `null`); the `.get(...)` calls
+                # below assume a dict, so reject anything else as a tool error rather than crashing.
+                if not isinstance(tool_args, dict):
+                    messages.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": call.id,
+                            "content": f"error: tool arguments must be a JSON object, got {type(tool_args).__name__}; resend as an object",
+                        }
+                    )
+                    continue
+                if name in dispatch:
+                    content = await call_mcp(servers, dispatch, name, tool_args)
+                elif name == "browser":
+                    content = await asyncio.to_thread(
+                        run_browser,
+                        tool_args.get("code", ""),
+                        browser_env,
+                    )
+                else:
+                    content = f"error: unknown tool {name!r}"
                 messages.append(
-                    {
-                        "role": "tool",
-                        "tool_call_id": call.id,
-                        "content": f"error: invalid JSON in tool arguments ({e}); resend the call with valid JSON",
-                    }
+                    {"role": "tool", "tool_call_id": call.id, "content": content}
                 )
-                continue
-            # Valid JSON can still be a non-object (`[]`, `42`, `null`); the `.get(...)` calls
-            # below assume a dict, so reject anything else as a tool error rather than crashing.
-            if not isinstance(tool_args, dict):
-                messages.append(
-                    {
-                        "role": "tool",
-                        "tool_call_id": call.id,
-                        "content": f"error: tool arguments must be a JSON object, got {type(tool_args).__name__}; resend as an object",
-                    }
-                )
-                continue
-            if name in dispatch:
-                content = await call_mcp(servers, dispatch, name, tool_args)
-            elif name == "browser":
-                content = await asyncio.to_thread(
-                    run_browser,
-                    tool_args.get("code", ""),
-                    browser_env,
-                )
-            else:
-                content = f"error: unknown tool {name!r}"
-            messages.append(
-                {"role": "tool", "tool_call_id": call.id, "content": content}
-            )
 
 
 if __name__ == "__main__":

--- a/verifiers/v1/harnesses/null/harness.py
+++ b/verifiers/v1/harnesses/null/harness.py
@@ -3,7 +3,6 @@ from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.harness import Harness
 from verifiers.v1.harnesses.utils.launch import (
     CHAT_PROGRAM_SOURCE,
-    MCP_CHAT_PROGRAM_SOURCE,
     launch_chat_program,
 )
 from verifiers.v1.runtimes import ProgramResult, Runtime
@@ -47,5 +46,4 @@ class NullHarness(Harness[NullHarnessConfig]):
             mcp_urls,
             system_prompt,
             prompt,
-            source_with_mcp=MCP_CHAT_PROGRAM_SOURCE,
         )

--- a/verifiers/v1/harnesses/utils/core.py
+++ b/verifiers/v1/harnesses/utils/core.py
@@ -4,6 +4,7 @@ import argparse
 import asyncio
 import json
 import subprocess
+from contextlib import AsyncExitStack
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -361,35 +362,37 @@ async def main() -> None:
     if args.search:
         tools.append(SEARCH_TOOL)
         reserved.add("search")
-    if config.get("mcpServers"):
-        mcp_tools, dispatch, servers = await asyncio.wait_for(
-            connect_mcp(config, reserved), timeout=None if args.bash else 60
+    async with AsyncExitStack() as mcp_stack:
+        if config.get("mcpServers"):
+            mcp_tools, dispatch, servers = await asyncio.wait_for(
+                connect_mcp(config, mcp_stack, reserved),
+                timeout=None if args.bash else 60,
+            )
+        else:
+            mcp_tools, dispatch, servers = [], {}, {}
+        tools += mcp_tools
+        messages = (
+            [{"role": "system", "content": args.system_prompt}]
+            if args.system_prompt
+            else []
         )
-    else:
-        mcp_tools, dispatch, servers = [], {}, {}
-    tools += mcp_tools
-    messages = (
-        [{"role": "system", "content": args.system_prompt}]
-        if args.system_prompt
-        else []
-    )
-    if initial:
-        messages.extend(initial)
-    elif args.prompt:
-        messages.append({"role": "user", "content": args.prompt})
-    compactor = Compactor(
-        client,
-        args.model,
-        tools,
-        args.compaction,
-        args.summarize_at_tokens,
-    )
-    if compactor.enabled and compactor.threshold is None:
-        compactor.threshold = await discover_threshold(client, args.model)
-    # The initial conversation is the floor for checkpoint fallbacks: a first-turn
-    # checkpoint must never retry from an empty base.
-    compactor.note_good(messages)
-    await run_chat_loop(args, compactor, messages, dispatch, servers, tool_client)
+        if initial:
+            messages.extend(initial)
+        elif args.prompt:
+            messages.append({"role": "user", "content": args.prompt})
+        compactor = Compactor(
+            client,
+            args.model,
+            tools,
+            args.compaction,
+            args.summarize_at_tokens,
+        )
+        if compactor.enabled and compactor.threshold is None:
+            compactor.threshold = await discover_threshold(client, args.model)
+        # The initial conversation is the floor for checkpoint fallbacks: a first-turn
+        # checkpoint must never retry from an empty base.
+        compactor.note_good(messages)
+        await run_chat_loop(args, compactor, messages, dispatch, servers, tool_client)
     if tool_client is not None:
         await tool_client.aclose()
 

--- a/verifiers/v1/harnesses/utils/launch.py
+++ b/verifiers/v1/harnesses/utils/launch.py
@@ -29,8 +29,7 @@ CHAT_PROGRAM = (
     '# dependencies = ["openai", "mcp==2.0.0", "httpx", "httpx2", "tenacity"]\n'
     "# ///\n"
 )
-CHAT_PROGRAM_SOURCE = bundle_program(CHAT_PROGRAM, compaction, core)
-MCP_CHAT_PROGRAM_SOURCE = bundle_program(CHAT_PROGRAM, mcp, compaction, core)
+CHAT_PROGRAM_SOURCE = bundle_program(CHAT_PROGRAM, mcp, compaction, core)
 
 
 async def launch_chat_program(
@@ -45,7 +44,6 @@ async def launch_chat_program(
     system_prompt: str | None,
     prompt: str | Messages | None,
     *,
-    source_with_mcp: str | None = None,
     extra_args: Sequence[str] = (),
     env: dict[str, str] | None = None,
     activate: bool = True,
@@ -60,7 +58,6 @@ async def launch_chat_program(
     if system_prompt:
         args.append(f"--system-prompt={system_prompt}")
     if mcp_urls:
-        source = source_with_mcp or source
         args.append(
             "--mcp-config="
             + json.dumps(

--- a/verifiers/v1/harnesses/utils/mcp.py
+++ b/verifiers/v1/harnesses/utils/mcp.py
@@ -4,9 +4,9 @@ from contextlib import AsyncExitStack, asynccontextmanager, suppress
 from typing import Any, TypeVar, cast
 
 import httpx2
+from anyio import CancelScope
 from mcp import Client
 from mcp.client.streamable_http import create_mcp_http_client, streamable_http_client
-from tenacity import AsyncRetrying, stop_after_attempt, wait_exponential_jitter
 
 MCP_CALL_ATTEMPTS = 6
 MCP_TIMEOUT = 600.0
@@ -40,18 +40,6 @@ async def mcp_client(spec: dict[str, Any]) -> AsyncIterator[Client]:
             await stack.aclose()
 
 
-async def with_retry(call: Callable[[], Awaitable[T]]) -> T:
-    """Run one client operation with the existing at-least-once retries."""
-    async for attempt in AsyncRetrying(
-        stop=stop_after_attempt(MCP_CALL_ATTEMPTS),
-        wait=wait_exponential_jitter(initial=0.5, max=30),
-        reraise=True,
-    ):
-        with attempt:
-            return await call()
-    raise RuntimeError("retrying stopped without returning or raising")
-
-
 class MCPConnection:
     """One rollout-owned client, with operations serialized across reconnects.
 
@@ -60,17 +48,29 @@ class MCPConnection:
     """
 
     def __init__(self, spec: dict[str, Any]):
+        # Bundled programs without MCP should not import the retry machinery.
+        from tenacity import AsyncRetrying, stop_after_attempt, wait_exponential_jitter
+
         self.spec = spec
         self.task: asyncio.Task[None] | None = None
         self.ready: asyncio.Future[Client] | None = None
+        self.cancel_scope: CancelScope | None = None
         self.lock = asyncio.Lock()
+        self.run = AsyncRetrying(
+            stop=stop_after_attempt(MCP_CALL_ATTEMPTS),
+            wait=wait_exponential_jitter(initial=0.5, max=30),
+            reraise=True,
+        ).wraps(self._run)
 
-    async def serve(self, ready: asyncio.Future["Client"]) -> None:
+    async def serve(
+        self, ready: asyncio.Future["Client"], cancel_scope: CancelScope
+    ) -> None:
+        stack = AsyncExitStack()
         try:
-            async with mcp_client(self.spec) as client:
-                ready.set_result(client)
-                with suppress(asyncio.CancelledError):
-                    await asyncio.Future()
+            stack.enter_context(cancel_scope)
+            client = await stack.enter_async_context(mcp_client(self.spec))
+            ready.set_result(client)
+            await asyncio.Future()
         except asyncio.CancelledError:
             pass
         except Exception as error:  # noqa: BLE001 - deliver owner failures to the caller
@@ -79,27 +79,43 @@ class MCPConnection:
         finally:
             if not ready.done():
                 ready.cancel()
+            await stack.aclose()
 
-    async def run(self, operation: Callable[["Client"], Awaitable[T]]) -> T:
-        async def attempt():
-            async with self.lock:
-                if self.task is None or self.task.done():
-                    self.ready = asyncio.get_running_loop().create_future()
-                    self.task = asyncio.create_task(self.serve(self.ready))
-                assert self.ready is not None
-                try:
-                    return await operation(await self.ready)
-                except BaseException:
-                    await self.aclose()
-                    raise
+    async def _run(self, operation: Callable[["Client"], Awaitable[T]]) -> T:
+        await self.lock.acquire()
+        try:
+            if self.task is None or self.task.done():
+                self.ready = asyncio.get_running_loop().create_future()
+                self.cancel_scope = CancelScope()
+                self.task = asyncio.create_task(
+                    self.serve(self.ready, self.cancel_scope)
+                )
+            assert self.ready is not None
+            client = await self.ready
+            return await operation(client)
+        except BaseException as error:
+            await self.aclose(abort=isinstance(error, asyncio.CancelledError))
+            raise
+        finally:
+            self.lock.release()
 
-        return await with_retry(attempt)
-
-    async def aclose(self) -> None:
-        if self.task is not None:
-            task, self.task = self.task, None
+    async def aclose(self, *, abort: bool = False) -> None:
+        if self.task is None:
+            return
+        task, self.task = self.task, None
+        cancel_scope = self.cancel_scope
+        assert cancel_scope is not None
+        # Caller cancellation must also interrupt session termination requests.
+        if abort:
+            cancel_scope.cancel()
+        else:
             task.cancel()
+        try:
             await asyncio.shield(task)
+        except asyncio.CancelledError:
+            cancel_scope.cancel()
+            await asyncio.shield(task)
+            raise
 
 
 async def connect_mcp(

--- a/verifiers/v1/harnesses/utils/mcp.py
+++ b/verifiers/v1/harnesses/utils/mcp.py
@@ -65,7 +65,7 @@ class MCPConnection:
         self.ready: asyncio.Future[Client] | None = None
         self.lock = asyncio.Lock()
 
-    async def serve(self, ready: asyncio.Future[Client]) -> None:
+    async def serve(self, ready: asyncio.Future["Client"]) -> None:
         try:
             async with mcp_client(self.spec) as client:
                 ready.set_result(client)
@@ -80,7 +80,7 @@ class MCPConnection:
             if not ready.done():
                 ready.cancel()
 
-    async def run(self, operation: Callable[[Client], Awaitable[T]]) -> T:
+    async def run(self, operation: Callable[["Client"], Awaitable[T]]) -> T:
         async def attempt():
             async with self.lock:
                 if self.task is None or self.task.done():

--- a/verifiers/v1/harnesses/utils/mcp.py
+++ b/verifiers/v1/harnesses/utils/mcp.py
@@ -1,12 +1,12 @@
 import asyncio
 from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 from contextlib import AsyncExitStack, asynccontextmanager, suppress
-from typing import Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
-import httpx2
 from anyio import CancelScope
-from mcp import Client
-from mcp.client.streamable_http import create_mcp_http_client, streamable_http_client
+
+if TYPE_CHECKING:
+    from mcp import Client
 
 MCP_CALL_ATTEMPTS = 6
 MCP_TIMEOUT = 600.0
@@ -15,13 +15,21 @@ T = TypeVar("T")
 
 
 @asynccontextmanager
-async def mcp_client(spec: dict[str, Any]) -> AsyncIterator[Client]:
+async def mcp_client(spec: dict[str, Any]) -> AsyncIterator["Client"]:
     """Open one fresh MCP client in the caller's task.
 
     The client negotiates the newest protocol and falls back for older servers.
     Teardown failures after the body completes are suppressed so closing noise cannot
     fail or replay a call whose result is already available.
     """
+    # Bundled chat programs also run without tools; load MCP only when it is used.
+    import httpx2
+    from mcp import Client
+    from mcp.client.streamable_http import (
+        create_mcp_http_client,
+        streamable_http_client,
+    )
+
     stack = AsyncExitStack()
     try:
         http_client = await stack.enter_async_context(

--- a/verifiers/v1/harnesses/utils/mcp.py
+++ b/verifiers/v1/harnesses/utils/mcp.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 from contextlib import AsyncExitStack, asynccontextmanager, suppress
 from typing import Any, TypeVar, cast
@@ -51,26 +52,73 @@ async def with_retry(call: Callable[[], Awaitable[T]]) -> T:
     raise RuntimeError("retrying stopped without returning or raising")
 
 
+class MCPConnection:
+    """One rollout-owned client, with operations serialized across reconnects.
+
+    The SDK's AnyIO contexts enter and exit in the owner task, even when discovery
+    runs under wait_for or a tool call is cancelled by another task.
+    """
+
+    def __init__(self, spec: dict[str, Any]):
+        self.spec = spec
+        self.task: asyncio.Task[None] | None = None
+        self.ready: asyncio.Future[Client] | None = None
+        self.lock = asyncio.Lock()
+
+    async def serve(self, ready: asyncio.Future[Client]) -> None:
+        try:
+            async with mcp_client(self.spec) as client:
+                ready.set_result(client)
+                with suppress(asyncio.CancelledError):
+                    await asyncio.Future()
+        except asyncio.CancelledError:
+            pass
+        except Exception as error:  # noqa: BLE001 - deliver owner failures to the caller
+            if not ready.done():
+                ready.set_exception(error)
+        finally:
+            if not ready.done():
+                ready.cancel()
+
+    async def run(self, operation: Callable[[Client], Awaitable[T]]) -> T:
+        async def attempt():
+            async with self.lock:
+                if self.task is None or self.task.done():
+                    self.ready = asyncio.get_running_loop().create_future()
+                    self.task = asyncio.create_task(self.serve(self.ready))
+                assert self.ready is not None
+                try:
+                    return await operation(await self.ready)
+                except BaseException:
+                    await self.aclose()
+                    raise
+
+        return await with_retry(attempt)
+
+    async def aclose(self) -> None:
+        if self.task is not None:
+            task, self.task = self.task, None
+            task.cancel()
+            await asyncio.shield(task)
+
+
 async def connect_mcp(
-    config: dict[str, Any], reserved: set[str] | None = None
+    config: dict[str, Any], stack: AsyncExitStack, reserved: set[str] | None = None
 ) -> tuple[
     list[dict[str, Any]],
     dict[str, tuple[str, str]],
-    dict[str, dict[str, Any]],
+    dict[str, MCPConnection],
 ]:
     """Enumerate MCP tools and return their schemas, dispatch map, and servers."""
     tool_schemas: list[dict[str, Any]] = []
     dispatch: dict[str, tuple[str, str]] = {}
-    servers: dict[str, dict[str, Any]] = {}
+    servers: dict[str, MCPConnection] = {}
     reserved = reserved or set()
     for name, spec in config.get("mcpServers", {}).items():
-        servers[name] = spec
-
-        async def list_tools(spec: dict[str, Any] = spec):
-            async with mcp_client(spec) as client:
-                return (await client.list_tools()).tools
-
-        for tool in await with_retry(list_tools):
+        server = servers[name] = MCPConnection(spec)
+        stack.push_async_callback(server.aclose)
+        result = await server.run(lambda client: client.list_tools())
+        for tool in result.tools:
             full = f"{name}_{tool.name}" if name else tool.name
             if full in reserved or full in dispatch:
                 raise ValueError(
@@ -111,17 +159,15 @@ def mcp_content_to_chat_content(
 
 
 async def call_mcp(
-    servers: dict[str, dict[str, Any]],
+    servers: dict[str, MCPConnection],
     dispatch: dict[str, tuple[str, str]],
     name: str,
     arguments: dict[str, Any],
 ) -> str | list[dict[str, Any]]:
-    """Call one MCP tool with a fresh client per retry attempt."""
+    """Reuse the rollout's client, reconnecting before retrying a failed call."""
     server_name, raw = dispatch[name]
 
-    async def call():
-        async with mcp_client(servers[server_name]) as client:
-            return await client.call_tool(raw, arguments)
-
-    result = await with_retry(call)
+    result = await servers[server_name].run(
+        lambda client: client.call_tool(raw, arguments)
+    )
     return mcp_content_to_chat_content(result.content)

--- a/verifiers/v1/harnesses/utils/mcp.py
+++ b/verifiers/v1/harnesses/utils/mcp.py
@@ -79,7 +79,9 @@ class MCPConnection:
         finally:
             if not ready.done():
                 ready.cancel()
-            await stack.aclose()
+            # Owner teardown must not replace the caller's error with cancellation.
+            with suppress(asyncio.CancelledError):
+                await stack.aclose()
 
     async def _run(self, operation: Callable[["Client"], Awaitable[T]]) -> T:
         await self.lock.acquire()
@@ -105,8 +107,10 @@ class MCPConnection:
         task, self.task = self.task, None
         cancel_scope = self.cancel_scope
         assert cancel_scope is not None
-        # Caller cancellation must also interrupt session termination requests.
-        if abort:
+        caller = asyncio.current_task()
+        assert caller is not None
+        # Stack cleanup can follow cancellation while awaiting a model or local tool.
+        if abort or caller.cancelling():
             cancel_scope.cancel()
         else:
             task.cancel()


### PR DESCRIPTION
Null and Bash prepare one chat program during setup and reuse it at launch. Null, Bash, and Browser Use also keep one MCP client per server from tool discovery through the end of each rollout. Together, these remove duplicate program preparation at startup and repeated connection setup between successful tool calls.

The shared chat program defers MCP imports until tools are used, keeping no-tool startup light. It removes a second source hash, upload, and uv script environment for Null and Bash MCP runs. Preparation stays within the setup timeout, and Bash keeps its direct interpreter launch so child processes do not inherit the script environment.

Each MCP client enters and exits the SDK contexts in a dedicated owner task. Operations are serialized per server; different servers and rollouts own independent clients. Failed operations close the client before retrying. Cancellation aborts teardown and drains the owner task, including when the rollout is cancelled while awaiting a model response or a local tool. The existing six-attempt retry policy, backoff, configured HTTP timeouts, and Null discovery timeout are retained.

The two optimizations were measured separately against `1e3e72923`; the measurements below do not establish a combined end-to-end speedup.

For program preparation, five interleaved before/after pairs used the native Docker runtime, a local MCP 2.0.0 echo server, and deterministic model HTTP responses. Median setup plus a complete Null run (two model requests and one tool call):

| MCP cache state | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Fresh container, empty uv caches | 6.975 s | 6.371 s | 8.7% |
| Dependencies cached, interpreter map cleared | 1.787 s | 1.319 s | 26.2% |
| Already prepared runtime | 0.828 s | 0.822 s | Within noise |

For cached dependencies, preparation itself fell from 0.962 s to 0.519 s. Complete runs ranged from 1.699–1.908 s before and 1.301–1.334 s after; every pair saved 0.381–0.574 s. Uploads and script environments fall from two to one. No-tool medians remained similar: 5.933 → 5.971 s cold and 0.519 → 0.512 s on an already prepared runtime.

These measurements used `python:3.11-slim` (Python 3.11.16), one CPU, 2 GiB, uv 0.12.9 and OpenAI 3.8.0 on OrbStack/macOS arm64. Container startup and image pulling are excluded; cold dependency downloads are included and can vary with the network. The cached-dependency case retains the container filesystem while clearing the runtime's interpreter cache. The model responses exclude provider inference latency, and these results do not establish Prime or Modal savings.

For MCP client reuse, discovery plus 20 successful echo calls used the actual MCP client utilities and an MCP 2.0.0 HTTP server on an Apple M4 Max (64 GiB RAM), macOS arm64, CPython 3.14.6, httpx2 2.12.0, and AnyIO 4.14.2. Each variant received a two-call warmup followed by five interleaved samples. With 20 ms added server-side to every HTTP request:

| Transport | Before median (range) | After median (range) | Speedup |
| --- | --- | --- | --- |
| Modern | 1.517 s (1.465–1.550) | 0.514 s (0.501–0.538) | 2.95× |
| Legacy stateless | 2.532 s (2.465–2.601) | 0.588 s (0.569–0.615) | 4.30× |
| Legacy stateful | 3.056 s (3.023–3.097) | 0.593 s (0.578–0.615) | 5.15× |

Every transport reduced `server/discover` and `tools/list` from 21 requests each to one each. Observed TCP connections fell from 21 to 1 for modern HTTP, 42 to 2 for legacy stateless, and 63 to 3 for legacy stateful. Legacy stateful teardown sent one DELETE per rollout instead of 21. With no added latency, modern HTTP improved from 75.4 to 21.1 ms.

These are real loopback HTTP measurements with controlled request delay. They exclude model inference, TLS, and remote network variability. Legacy fallback was exercised by rejecting `server/discover` before forwarding the remaining requests to the SDK server. Local workloads were serialized across the performance investigations for both experiments.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate chat program source and add persistent `MCPConnection` manager
> - Removes the separate `MCP_CHAT_PROGRAM_SOURCE` and bundles MCP support directly into the shared `CHAT_PROGRAM_SOURCE`; harnesses no longer pass a `source_with_mcp` argument to `launch_chat_program` in [launch.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2535/files#diff-f00f52fdf451c06e9bd80d3a7b1c0fe095bd3797ca76f6fec3a4cea166504016), [bash/harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2535/files#diff-1544e2ee3426241d8c97940a3e8daf25b2eeeeb95f8abb27e88bed4af420e609), and [null/harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2535/files#diff-3a22fc74c4c14bfe87584d18fe476635e861b1b33232a5ed977f72ef3d5f5204)
> - Adds the `MCPConnection` class in [mcp.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2535/files#diff-6205a980689d451f55c0faaa493c44b765687fe75c9ef015d1c0f874dacac502) that keeps a server connection alive across the chat loop via a background owner task, applies a six-attempt retry policy, executes operations serially per server, and closes the connection on failure
> - Wraps MCP setup and the chat loop in `AsyncExitStack` in [core.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2535/files#diff-4641f7de541bf21c7f3e30a2d8d49f14c1179c70cf21f3dff5fa19deb9a1e206) and [browser_use/program.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2535/files#diff-ef4ab9f701283b63b308953085dfac1bba4f972b5b476b2c7849d2252e3a957a) so connections are released when the loop exits
> - `connect_mcp` now takes an `AsyncExitStack`, creates `MCPConnection` instances, and registers `aclose` with the stack; `call_mcp` reuses the active connection instead of creating a fresh client per call
> - Behavioral Change: MCP transport and retry packages (`httpx2`, MCP client classes, `tenacity`) are now lazily imported inside connection code rather than at module load; `with_retry` helper is removed and replaced by per-`MCPConnection` retry wrapping. Any out-of-tree code importing `with_retry` or `MCP_CHAT_PROGRAM_SOURCE` from `mcp.py` or `launch.py` will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3e44eee. 4 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->