### PR TITLE
Prepare one chat program for Null and Bash

### DIFF
--- a/verifiers/v1/harnesses/bash/harness.py
+++ b/verifiers/v1/harnesses/bash/harness.py
@@ -8,7 +8,6 @@ from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.harness import Harness
 from verifiers.v1.harnesses.utils.launch import (
     CHAT_PROGRAM_SOURCE,
-    MCP_CHAT_PROGRAM_SOURCE,
     launch_chat_program,
 )
 from verifiers.v1.runtimes import ProgramResult, Runtime
@@ -122,7 +121,6 @@ class BashHarness(Harness[BashHarnessConfig]):
             mcp_urls,
             system_prompt,
             prompt,
-            source_with_mcp=MCP_CHAT_PROGRAM_SOURCE,
             extra_args=args,
             env=env,
             activate=False,

--- a/verifiers/v1/harnesses/null/harness.py
+++ b/verifiers/v1/harnesses/null/harness.py
@@ -3,7 +3,6 @@ from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.harness import Harness
 from verifiers.v1.harnesses.utils.launch import (
     CHAT_PROGRAM_SOURCE,
-    MCP_CHAT_PROGRAM_SOURCE,
     launch_chat_program,
 )
 from verifiers.v1.runtimes import ProgramResult, Runtime
@@ -47,5 +46,4 @@ class NullHarness(Harness[NullHarnessConfig]):
             mcp_urls,
             system_prompt,
             prompt,
-            source_with_mcp=MCP_CHAT_PROGRAM_SOURCE,
         )

--- a/verifiers/v1/harnesses/utils/launch.py
+++ b/verifiers/v1/harnesses/utils/launch.py
@@ -29,8 +29,7 @@ CHAT_PROGRAM = (
     '# dependencies = ["openai", "mcp==2.0.0", "httpx", "httpx2", "tenacity"]\n'
     "# ///\n"
 )
-CHAT_PROGRAM_SOURCE = bundle_program(CHAT_PROGRAM, compaction, core)
-MCP_CHAT_PROGRAM_SOURCE = bundle_program(CHAT_PROGRAM, mcp, compaction, core)
+CHAT_PROGRAM_SOURCE = bundle_program(CHAT_PROGRAM, mcp, compaction, core)
 
 
 async def launch_chat_program(
@@ -45,7 +44,6 @@ async def launch_chat_program(
     system_prompt: str | None,
     prompt: str | Messages | None,
     *,
-    source_with_mcp: str | None = None,
     extra_args: Sequence[str] = (),
     env: dict[str, str] | None = None,
     activate: bool = True,
@@ -60,7 +58,6 @@ async def launch_chat_program(
     if system_prompt:
         args.append(f"--system-prompt={system_prompt}")
     if mcp_urls:
-        source = source_with_mcp or source
         args.append(
             "--mcp-config="
             + json.dumps(

--- a/verifiers/v1/harnesses/utils/mcp.py
+++ b/verifiers/v1/harnesses/utils/mcp.py
@@ -1,11 +1,9 @@
 from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 from contextlib import AsyncExitStack, asynccontextmanager, suppress
-from typing import Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
-import httpx2
-from mcp import Client
-from mcp.client.streamable_http import create_mcp_http_client, streamable_http_client
-from tenacity import AsyncRetrying, stop_after_attempt, wait_exponential_jitter
+if TYPE_CHECKING:
+    from mcp import Client
 
 MCP_CALL_ATTEMPTS = 6
 MCP_TIMEOUT = 600.0
@@ -14,13 +12,21 @@ T = TypeVar("T")
 
 
 @asynccontextmanager
-async def mcp_client(spec: dict[str, Any]) -> AsyncIterator[Client]:
+async def mcp_client(spec: dict[str, Any]) -> AsyncIterator["Client"]:
     """Open one fresh MCP client in the caller's task.
 
     The client negotiates the newest protocol and falls back for older servers.
     Teardown failures after the body completes are suppressed so closing noise cannot
     fail or replay a call whose result is already available.
     """
+    # Bundled chat programs also run without tools; load MCP only when it is used.
+    import httpx2
+    from mcp import Client
+    from mcp.client.streamable_http import (
+        create_mcp_http_client,
+        streamable_http_client,
+    )
+
     stack = AsyncExitStack()
     try:
         http_client = await stack.enter_async_context(
@@ -41,6 +47,8 @@ async def mcp_client(spec: dict[str, Any]) -> AsyncIterator[Client]:
 
 async def with_retry(call: Callable[[], Awaitable[T]]) -> T:
     """Run one client operation with the existing at-least-once retries."""
+    from tenacity import AsyncRetrying, stop_after_attempt, wait_exponential_jitter
+
     async for attempt in AsyncRetrying(
         stop=stop_after_attempt(MCP_CALL_ATTEMPTS),
         wait=wait_exponential_jitter(initial=0.5, max=30),


### PR DESCRIPTION
Null and Bash now prepare one standalone chat program during harness setup and reuse it at launch. MCP imports are deferred until tools are used, keeping no-tool startup light.

MCP rollouts selected a second source hash at launch even though both programs declared identical dependencies. Sharing one source removes the redundant upload and uv script environment preparation. Preparation stays within the setup timeout, and Bash keeps its direct interpreter launch so child processes do not inherit the script environment.

Five interleaved before/after pairs using the native Docker runtime, a local MCP 2.0.0 echo server, and deterministic model HTTP responses produced these median times for setup plus a complete Null run (two model requests and one tool call):

| MCP cache state | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Fresh container, empty uv caches | 6.975 s | 6.371 s | 8.7% |
| Dependencies cached, interpreter map cleared | 1.787 s | 1.319 s | 26.2% |
| Already prepared runtime | 0.828 s | 0.822 s | Within noise |

For cached dependencies, preparation itself fell from 0.962 s to 0.519 s. Complete runs ranged from 1.699–1.908 s before and 1.301–1.334 s after; every pair saved 0.381–0.574 s. Uploads and script environments fall from two to one. No-tool medians remained similar: 5.933 → 5.971 s cold and 0.519 → 0.512 s on an already prepared runtime.

Measurements used `python:3.11-slim` (Python 3.11.16), one CPU, 2 GiB, uv 0.12.9 and OpenAI 3.8.0 on OrbStack/macOS arm64, comparing `1e3e72923` with this change. Local workloads were serialized across the performance tasks. Container startup/image pulling are excluded; cold dependency downloads are included and can vary with the network. The cached-dependency case retains the container filesystem while clearing the runtime's interpreter cache. These are deterministic HTTP model responses, so the numbers do not include provider inference latency or establish Prime/Modal savings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of harness program bundling and import timing; behavior should match prior MCP vs no-MCP paths with lower prep overhead.
> 
> **Overview**
> **Null and Bash now share a single bundled chat program** for setup and launch, instead of maintaining a second MCP-specific source that was selected at launch when `mcp_urls` were set.
> 
> `CHAT_PROGRAM_SOURCE` always embeds the `mcp` utils module; **`MCP_CHAT_PROGRAM_SOURCE` and `launch_chat_program`'s `source_with_mcp` switch are removed**. MCP runs still pass `--mcp-config` on the same prepared script.
> 
> In **`mcp.py`**, heavy dependencies (`mcp`, `httpx2`, `tenacity`) are **imported inside `mcp_client` and `with_retry`**, so no-tool chat loops avoid paying import cost at startup while the bundled program stays one artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69480edaffcbbc1cf3f3bea937653fd10c425b66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate `BashHarness` and `NullHarness` chat programs to include MCP source in `CHAT_PROGRAM_SOURCE`
> - Merges the MCP source fragment into the bundled `CHAT_PROGRAM_SOURCE` constant in [launch.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2536/files#diff-f00f52fdf451c06e9bd80d3a7b1c0fe095bd3797ca76f6fec3a4cea166504016), removing the separate MCP-specific bundled source.
> - `launch_chat_program` no longer accepts an alternate-source parameter or swaps in a separate MCP source when MCP URLs are present; it always prepares and executes the caller-supplied source while still serializing MCP configuration into launch arguments.
> - `BashHarness.launch` and `NullHarness.launch` drop their separate MCP chat source imports and now rely on the common `CHAT_PROGRAM_SOURCE`.
> - Moves `httpx2`, MCP client/transport, and `tenacity` imports from module scope into function bodies in [mcp.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2536/files#diff-6205a980689d451f55c0faaa493c44b765687fe75c9ef015d1c0f874dacac502), so importing the MCP utility module no longer pulls in those dependencies at load time.
> - Risk: any out-of-tree caller passing a custom alternate source to `launch_chat_program` will break, since that parameter was removed; MCP dependencies are now loaded lazily inside `mcp_client` and `with_retry` rather than at module import.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 69480ed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->