### PR TITLE
Launch Prime Agent without uploading a wrapper

### DIFF
--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -3,7 +3,6 @@
 import hashlib
 import json
 import logging
-import shlex
 from typing import Literal
 
 from verifiers.v1.acp import ACPConfig, ACPHarness, ACPTurn
@@ -256,25 +255,17 @@ class PrimeAgentHarness(ACPHarness[PrimeAgentHarnessConfig]):
         if system_prompt:
             args += ["--append-system-prompt", system_prompt]
 
-        wrapper = f"{root}/prime-agent"
-        await runtime.write(
-            wrapper,
-            (
-                "#!/bin/sh\n"
-                "set -eu\n"
-                f'export PATH="{NODE_BIN_DIR}:$HOME/.local/bin:$PATH"\n'
-                f'exec {shlex.join(args)} "$@"\n'
-            ).encode(),
-        )
-        executable = await runtime.run(["chmod", "700", wrapper], {})
-        if executable.exit_code != 0:
-            raise RuntimeError(
-                f"prime-agent wrapper chmod failed: {executable.stderr.strip()[-500:]}"
-            )
-
         return ACPConfig(
             env=self._env(trace, secret),
-            command=[wrapper],
+            # Expand the sandbox's PATH while keeping every agent argument literal.
+            command=[
+                "/bin/sh",
+                "-eu",
+                "-c",
+                f'export PATH="{NODE_BIN_DIR}:$HOME/.local/bin:$PATH"; exec "$@"',
+                "prime-agent",
+                *args,
+            ],
             prompt=prompt,
         )
 


### PR DESCRIPTION
Prime Agent rollouts now launch through ACP's command argv, avoiding the upload and chmod of a generated shell wrapper. A short `/bin/sh -eu -c` command expands the sandbox's Node and user-bin PATH, then executes the agent with literal positional arguments. Private per-trace directories and `models.json`, environment variables, agent flags, and ACP session ownership remain unchanged.

Measured against `b6f5e344d7b9ff6ed2b585024d7fbcf0748d2ac0` on two actual Prime sandboxes with **`vm=True`**, SDK 0.2.40, cached `python:3.11-slim`, 2 CPUs, `memory_gb=4`, and the pinned Prime Agent 0.9.1 dependencies installed. Samples alternate baseline/candidate order under the shared benchmark lock, after two preparation warmups and one native-session warmup per variant per VM.

| Measured warm scope | Paired samples | Baseline median | Candidate median | Reduction |
| --- | ---: | ---: | ---: | ---: |
| `prepare_acp`, VM 1 | 10 | 2.895 s | 1.750 s | 39.5% |
| `prepare_acp`, VM 2 | 6 | 2.963 s | 1.717 s | 42.0% |
| Preparation + native ACP startup + two IPython turns + close | 8 across both VMs | 5.272 s | 4.001 s | 24.1% |

Preparation improved in all 16 pairs, with a median paired saving of **1.135 seconds**. Its pooled interquartile range was 2.811–3.032 s for baseline and 1.694–2.027 s for the candidate. The session figures use deterministic streaming model responses inside the VM; they exclude host interception and paid model inference. Cold dependency setup was measured separately at 23.675 s and 24.118 s and is unchanged by this patch; provisioning and cleanup are also outside the warm intervals.

The guest process count increased and available memory decreased across repeated sessions in both variants. One later session lost its VM process stream, and the second repeated-session run was interrupted; aborted samples are excluded and the incomplete MCP timing stage is omitted from the table. These figures describe warm harness work in a reused benchmark VM. Ordinary `Agent.run()` owns and destroys a VM per rollout, while explicitly borrowed runtimes have a separate lifetime. This change does not diagnose or alter that lifecycle behavior.

The savings overlap with a separate optimization to Prime upload parent-directory preparation and should not be added to its percentage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized harness launch refactor with equivalent env and CLI args; no auth or data-handling changes.
> 
> **Overview**
> Prime Agent ACP sessions no longer **write and chmod** a per-trace `prime-agent` shell wrapper in the sandbox. **`prepare_acp`** now passes the launch through ACP’s **`command` argv**: `/bin/sh -eu -c` exports the Node and user-bin **`PATH`**, then **`exec "$@"`** runs the real **`prime-agent`** binary with the same flags as before (mode, provider, model, daemon socket, skills, system prompt, etc.).
> 
> The unused **`shlex`** import is removed. Per-trace state dirs, **`models.json`**, env vars, and cleanup behavior are unchanged; the intent is faster **`prepare_acp`** by skipping wrapper upload while keeping agent arguments literal in the process argv.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34c998706caf48536d95b41a1ad7c5b147fb9aed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Launch Prime Agent via inline `/bin/sh` instead of a wrapper script
> Removes the temporary `prime-agent` wrapper script creation, write, and chmod from `PrimeAgentHarness`. The ACP config now returns an inline `/bin/sh -eu -c` command that prepends Node and local-bin dirs to `PATH` and `exec`s the agent argv. Arguments pass as literal argv values. Risk: `ACP` command shape changes; callers that inspect or depend on the wrapper file path in `PrimeAgentHarness` will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 34c9987.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->