### PR TITLE
Batch artifact existence checks

### DIFF
--- a/verifiers/v1/utils/artifacts.py
+++ b/verifiers/v1/utils/artifacts.py
@@ -91,18 +91,31 @@ async def collect(
             raise RuntimeError(f"artifact {artifact.source!r} declared more than once")
         seen.add(artifact.source)
 
-    # Check all roots in one job: remote runtimes pay a round trip per command.
-    sources = shlex.join([artifact.source for artifact in entries])
-    existence = await _run(
-        runtime,
-        f"for source in {sources}; do "
-        'if test -e "$source" || test -L "$source"; then echo 1; else echo 0; fi; '
-        "done",
-        "check artifact roots",
-    )
+    # Batch roots to save remote round trips. Leave room below the shell argument
+    # limit for the command itself and further quoting by runtime transports.
+    batches: list[list[str]] = [[]]
+    batch_bytes = 0
+    for artifact in entries:
+        source_bytes = len(shlex.quote(artifact.source).encode()) + 1
+        if batches[-1] and batch_bytes + source_bytes > 8 * 1024:
+            batches.append([])
+            batch_bytes = 0
+        batches[-1].append(artifact.source)
+        batch_bytes += source_bytes
+
+    existence: list[str] = []
+    for sources in batches:
+        output = await _run(
+            runtime,
+            f"for source in {shlex.join(sources)}; do "
+            'if test -e "$source" || test -L "$source"; then echo 1; else echo 0; fi; '
+            "done",
+            "check artifact roots",
+        )
+        existence.extend(output.splitlines())
     collected: dict[str, bytes | None] = {}
     budget = MAX_ARTIFACT_BYTES
-    for artifact, exists in zip(entries, existence.splitlines(), strict=True):
+    for artifact, exists in zip(entries, existence, strict=True):
         source = artifact.source
         if exists != "1":
             if not artifact.required:

--- a/verifiers/v1/utils/artifacts.py
+++ b/verifiers/v1/utils/artifacts.py
@@ -91,12 +91,20 @@ async def collect(
             raise RuntimeError(f"artifact {artifact.source!r} declared more than once")
         seen.add(artifact.source)
 
+    # Check all roots in one job: remote runtimes pay a round trip per command.
+    sources = shlex.join([artifact.source for artifact in entries])
+    existence = await _run(
+        runtime,
+        f"for source in {sources}; do "
+        'if test -e "$source" || test -L "$source"; then echo 1; else echo 0; fi; '
+        "done",
+        "check artifact roots",
+    )
     collected: dict[str, bytes | None] = {}
     budget = MAX_ARTIFACT_BYTES
-    for artifact in entries:
+    for artifact, exists in zip(entries, existence.splitlines(), strict=True):
         source = artifact.source
-        exists = f"test -e {shlex.quote(source)} || test -L {shlex.quote(source)}"
-        if (await runtime.run(["sh", "-c", exists], {})).exit_code != 0:
+        if exists != "1":
             if not artifact.required:
                 collected[source] = None
                 continue
@@ -205,8 +213,9 @@ def _validate_restore(root: str, archive: bytes | None) -> None:
         raise RuntimeError(f"unreadable artifact archive for {root!r}: {exc}") from exc
 
 
-async def _run(runtime: Runtime, command: str, action: str) -> None:
+async def _run(runtime: Runtime, command: str, action: str) -> str:
     result = await runtime.run(["sh", "-c", command], {})
     if result.exit_code:
         detail = (result.stderr or result.stdout).strip()[-500:]
         raise RuntimeError(f"failed to {action}: {detail}")
+    return result.stdout


### PR DESCRIPTION
Artifact collection checks the implicit `/logs/artifacts` directory and declared roots in batches, using one remote command for ordinary artifact lists. Batches are bounded by 8 KiB of UTF-8 shell-quoted paths, leaving room for runtime transport wrappers and avoiding a command that grows with the entire declaration list. On Prime VMs, this reduces collection time by removing repeated existence-check jobs. Each root keeps its own archive, exclusions, and cleanup; reads continue to share the aggregate source-enforced byte budget. Declaration order and host validation before grader mutation remain unchanged.

The comparison uses actual Prime VMs (`vm=True`), the logged-in SDK (`prime-sandboxes==0.2.40`), and cached `python:3.11-slim` images with 1 CPU and 2 GB memory. Each declared root contains a 16 KiB public binary file, producing a 20 KiB tar archive; the implicit convention directory is missing. Provisioning is separate from these warm collection measurements. After a warmup for each case and version, six pairs alternate baseline/candidate order under the shared campaign benchmark lock.

| Declared roots, plus the implicit root check | Collection commands | Baseline median | Candidate median | Reduction, ratio of medians | Median paired saving [min, max] |
| --- | --- | --- | --- | --- | --- |
| 0 | 1 → 1 | 0.829 s | 0.749 s | Within observed variation | 0.040 s [-0.138, 1.786] |
| 1 | 5 → 4 | 3.999 s | 2.936 s | 26.6% | 1.153 s [0.567, 3.354] |
| 3 | 13 → 10 | 10.905 s | 7.652 s | 29.8% | 3.019 s [2.145, 4.842] |

Every one-root and three-root collection pair was faster. The percentage column compares the two medians; the final column summarizes differences within each matched pair. Restore has the same implementation and operation counts, and its observed variation is not attributed to this change. These small-artifact results do not establish a restore or total evaluation speedup.

A separate native `Agent.run()` → `IsolatedVerifierEnv.grade()` window used a deterministic solver and a newly provisioned Prime VM for each solver and grader. After one one-root warmup per version, two interleaved pairs per case measured collection medians of 3.713 → 3.057 seconds for one declared root, and 12.471 → 8.661 seconds for three declared roots. The paired collection savings were 0.417–0.894 seconds and 2.635–4.985 seconds, respectively. Full handoff durations varied with provisioning and do not support a total evaluation speedup claim.

<details>
<summary>Benchmark source provenance</summary>

Baseline commit: `b6f5e344d7b9ff6ed2b585024d7fbcf0748d2ac0`.

SHA-256 of `verifiers/v1/utils/artifacts.py`:

- Baseline: `1a8c19b9b5c693a36156068050a0955d8a0187fdcbd40c342c01deead37097c8`
- Measured candidate (`e537814eead5ceafc7cc47f0a3cd7319dad6c4e1`): `0d6b39bc87548675d45a1fd584a963cdb48fbe1d9878e5d0150e5760520062f4`

The timings above belong to that measured commit. The batch-size bound preserves its single existence-check command for these zero-, one-, and three-root fixtures; the bounded revision was not re-timed.

Unchanged `verifiers/v1/runtimes/prime.py`: `93f9dd2352a60168b13be8e9fd16e5d893abf6206c5240c6e01b934064454f53`.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Batching ties correctness to one stdout line per artifact in order; strict zip will fail loudly on mismatch, but a partial or malformed remote response could change which roots are treated as missing before archive.
> 
> **Overview**
> **Artifact collection** now verifies declared roots with **batched remote shell loops** instead of one `test -e`/`test -L` job per path, cutting round trips on Prime VMs when many roots are declared.
> 
> Sources are grouped into batches capped at **8 KiB** of UTF-8 shell-quoted path length so the combined command stays under transport/shell limits. Each batch runs a single `for source in …` loop that prints `1` or `0` per root; results are **strictly zipped** with the entry list and only `"1"` counts as present, so optional vs required missing-root behavior is unchanged. Per-root tar, exclusions, byte budget, and duplicate-source checks are untouched.
> 
> **`_run`** now returns command **stdout** on success (failures still raise); existence checking is the caller that consumes it—other `_run` sites ignore the return value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e26dba9742d87cac99ed98593ba410b00cd6c185. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Batch artifact existence checks in `collect` to reduce runtime commands
> - `collect` now groups declared artifact roots into shell argument batches capped at ~8 KiB and issues one remote existence check per batch, aligning returned status lines with the declared entries instead of checking each artifact individually.
> - `_run` now returns the command's standard output on success; nonzero exits still raise `RuntimeError` with the existing diagnostics.
> - Optional-artifact handling, required-artifact failures, tar creation, and the byte budget are unchanged.
> - Risk: callers of `_run` in [artifacts.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2538/files#diff-0d082bad54931be61d7ef55ddce0757034be3013f69ae71cb803cd8416df9138) that previously ignored the return value are unaffected, but any caller relying on the old void return now receives stdout.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e26dba9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->