### PR TITLE
Avoid redundant directory RPCs in Prime uploads

### DIFF
--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -384,21 +384,14 @@ class PrimeRuntime(Runtime):
             raise SandboxError(f"read {path!r}: {e}") from e
 
     async def write(self, path: str, data: bytes) -> None:
-        # Upload via the gateway (multipart) — never inline the bytes on the command line
-        # (a large file, e.g. a task tarball, overflows the exec command-length limit and
-        # fails with ENAMETOOLONG). The upload does NOT run in the workdir, so resolve a
-        # relative path against it (and mkdir its parent) — otherwise the sidecar writes
-        # it somewhere unwritable ("Operation not permitted").
+        # The gateway creates missing parents and uploads binary data without command-line
+        # limits. Resolve relative paths here because uploads do not use this runtime's workdir.
         target = (
             path
             if path.startswith("/")
             else f"{self.config.workdir.rstrip('/')}/{path}"
         )
         try:
-            await self._client.execute_command(
-                self.info.id,
-                f"mkdir -p {shlex.quote(str(PurePosixPath(target).parent))}",
-            )
             await self._client.upload_bytes(
                 self.info.id, target, data, filename=PurePosixPath(target).name
             )


### PR DESCRIPTION
`PrimeRuntime.write` runs a remote `mkdir -p` before a multipart upload that already creates missing parent directories. Let the upload handle directory creation, saving one remote command per write while retaining workdir-relative paths and the existing upload/error handling.

Measured against `b6f5e344d7b9ff6ed2b585024d7fbcf0748d2ac0` with the locked `prime-sandboxes==0.2.40` SDK on actual Prime VMs (`vm=True`, cached `python:3.11-slim`, 1 CPU, 2 GB memory). Each row uses two warmup pairs followed by ten interleaved baseline/candidate pairs. Times are median seconds [Q1, Q3], covering the runtime or harness call and excluding provisioning.

| Workload | Baseline | This change | Reduction |
| --- | --- | --- | --- |
| Four 4 KiB writes, existing parents, VM 1 | 1.273 [1.270, 1.282] | 0.634 [0.631, 0.636] | 50.2% |
| Four 4 KiB writes, fresh nested parents, VM 1 | 1.267 [1.257, 1.275] | 0.630 [0.624, 0.635] | 50.3% |
| Four 4 KiB writes, existing parents, VM 2 | 1.286 [1.284, 1.297] | 0.645 [0.639, 0.653] | 49.9% |
| Four 4 KiB writes, fresh nested parents, VM 2 | 1.282 [1.279, 1.294] | 0.645 [0.636, 0.653] | 49.7% |
| Unchanged `Harness.install_skills`, eight config/script/reference files (8,375 bytes), VM 3 | 2.582 [2.550, 2.608] | 1.284 [1.272, 1.291] | 50.3% |

The complete unchanged `PrimeAgentHarness.prepare_acp` path was noisy and showed no repeatable gain: medians were 2.810 → 2.481 seconds in one VM window and 2.886 → 3.085 seconds in the other. The repeatable gain applies to writes and skill uploads. Image builds, agent installation, and model calls are outside these measurements. Caller changes that reduce upload counts have overlapping savings and should be measured separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to Prime upload sequencing; relies on gateway parent-dir creation already used for multipart uploads.
> 
> **Overview**
> **`PrimeRuntime.write` no longer runs a remote `mkdir -p` before each upload.** The Prime gateway’s `upload_bytes` already creates missing parent directories and avoids putting file bytes on the exec command line, so the extra `execute_command` round trip was redundant.
> 
> Relative paths are still resolved against `workdir` before upload (uploads don’t use the runtime workdir automatically), and failures still surface as `SandboxError`. Comment text was updated to match this behavior.
> 
> Benchmarks in the PR description report ~50% lower latency for small multi-file writes and skill installs, from eliminating one remote command per write.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ded159f8aa50e60aae479bea065801a68a90df6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove redundant `mkdir` RPC in `PrimeRuntime.write`
> Drops the preliminary shell command that created the target's parent directory before uploading file contents. The upload now relies on the gateway to create missing parent directories, as documented in the updated comment in [prime.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2539/files#diff-d22d61279ff7587a2b14c72ab1a0fc9d3f805a735338a70f8efc7fe19aaa8502). Relative path resolution against the configured workdir and `upload_bytes` delivery are unchanged.
> - Behavioral Change: `PrimeRuntime.write` no longer sends a separate directory-creation RPC; the gateway must create parent dirs during upload.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ded159.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->