### PR TITLE
fix(v1): compact long eval dashboard overrides

### DIFF
--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -183,6 +183,15 @@ def _warning(config: EvalConfig) -> Text | None:
     return None
 
 
+def _display_override(value: object) -> str:
+    """Bound overview values without changing the config or its serialized form."""
+    formatted = format_override(value)
+    compact = " ".join(formatted.split())
+    if len(compact) > 60:
+        return f"{compact[:40]}… ({len(formatted)} chars)"
+    return compact
+
+
 def overrides(
     config: BaseModel,
     default: BaseModel | None = None,
@@ -217,7 +226,7 @@ def overrides(
                 and "type" not in child_skip
                 and (discriminator := getattr(value, "type", None)) is not None
             ):
-                segments.append(f"{field}.type={format_override(discriminator)}")
+                segments.append(f"{field}.type={_display_override(discriminator)}")
             # A switched class is a new shape, so diff against its own defaults, not the instance.
             segments.extend(
                 f"{field}.{seg}"
@@ -226,7 +235,7 @@ def overrides(
                 )
             )
         elif value != field_def:
-            segments.append(f"{field}={format_override(value)}")
+            segments.append(f"{field}={_display_override(value)}")
     return segments
 
 


### PR DESCRIPTION
Stacked on #2525 (`codex/pin-subagent-timeout-semantics`) to preserve the research evaluation base.

## Change

Fold whitespace and abbreviate long override values in the native Rich evaluation overview only.
Long research prompts otherwise consume the viewport and hide the per-rollout rows. Full prompt
values remain unchanged in the evaluator and resolved configuration.

## Validation

- Model-free diagnostic checked exact prompt preservation, serialization, defaults, nested skips,
  and 400-slot layouts at 80x24, 100x30, 120x40, and 160x48.
- Native live dashboard inspected at 120x40 and 160x48 with full 100x4 evaluations.
- 84 deterministic verifier tests passed; changed-file hooks passed.
- All-files hooks: markdownlint/format passed; lint reports an existing unrelated E402 in
  `verifiers/v1/harnesses/hermes_agent/program.py:16`.

Presentation-only change. No rollout budget, retry, prompt, or sampling change. Unsigned commit.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Truncate and normalize whitespace in eval dashboard override display values
> Adds `_display_override` in [eval.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2541/files#diff-0a27b905958929f3ae9e01937dd7e3cf97a60dec137caddcbf87792784fc9035), which collapses whitespace runs to single spaces and truncates compact text longer than 60 characters to the first 40 characters plus an ellipsis and character count. Both override-segment construction paths (nested discriminator and ordinary field) now use `_display_override` instead of `format_override`. The underlying configuration and serialized representation are unchanged.
>
> Behavioral Change: override strings shown by `overrides` now collapse whitespace and may be truncated; values previously displayed in full will appear shortened.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 773467e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->