### PR TITLE
fix(v1): preserve cache usage in train responses

### DIFF
--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 from typing import Any, ClassVar, TypeVar
 
 from openai import OpenAIError
+from openai.types import CompletionUsage
 from renderers import OverlongPromptError, RenderedTokens, Renderer, RendererConfig
 from renderers.base import ToolCallParseStatus, is_multimodal
 
@@ -145,9 +146,11 @@ def response_from_generate(
             tool_calls=tool_calls,
         ),
         finish_reason=finish,
-        # /inference/v1/generate returns exact token ids but no usage details, so the
-        # completion's reasoning-token subset is unknown.
-        usage=Usage(
+        # Preserve provider cache/reasoning details through the same accounting as chat.
+        # Older endpoints/renderers may omit usage; exact token lengths remain a fallback.
+        usage=Usage.from_openai(CompletionUsage.model_validate(result["usage"]))
+        if result.get("usage") is not None
+        else Usage(
             prompt_tokens=len(prompt_ids), completion_tokens=len(completion_ids)
         ),
         # generate() returns owned, typed lists. Skip revalidation here to avoid copying


### PR DESCRIPTION
Stacked on the compact-eval-overrides branch to preserve the frozen research base.

## Change

Consume optional generate-endpoint usage through CompletionUsage and the existing
Usage.from_openai conversion. This keeps cached prompt tokens out of Usage.prompt_tokens and
preserves optional reasoning details. Responses without usage still use exact token lengths.
The existing serialize_completion already forwards those details to the harness SDK.

Requires renderers' companion `fix/forward-generate-usage` change for live metadata forwarding.
Without it the existing exact-length fallback remains. No sampling, rendering, graph, numerical
budget, or optimizer changes. The server already reports usage; no serving restart is needed.

## Validation

- 84 deterministic verifier tests passed; live-provider/sandbox e2e cases excluded.
- Six model-free cases cover unknown/zero/partial/full cache, reasoning subsets, and missing usage.
- Two tiny live synthetic requests through the actual TrainClient and SDK roundtrip passed.
  Repeated 1,045-token prompt: 1,040 cached + 5 uncached; with 3 output, charge is 8 new tokens.
- Changed-file hooks passed. All-files markdownlint/format passed; unrelated pre-existing E402
  remains in `verifiers/v1/harnesses/hermes_agent/program.py:16`.
- Type checking was attempted but `ty` is not installed in the active research environment.

Isolated commits are frozen for fresh local canaries. Existing full comparisons still use their
original dependencies; no result is silently resumed under the fix. Unsigned commit.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `response_from_generate` to preserve provider `CompletionUsage` in train responses
> - When the generate result includes usage, the parser now validates it as `CompletionUsage` and converts it via `Usage.from_openai`, preserving cache and reasoning-token fields from the provider.
> - Falls back to the existing prompt/completion token-id length calculation when usage is absent.
> - Risk: responses with malformed usage objects may now fail validation instead of silently falling back.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e4f51c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->