### PR TITLE
feat(v1): propagate structural completion metadata through responses and traces

### DIFF
--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -22,7 +22,7 @@ from verifiers.v1.semantic import (
     ACP_SEMANTIC_EDGES_METADATA_KEY,
     extract_acp_info,
 )
-from verifiers.v1.types import AssistantMessage, UserMessage
+from verifiers.v1.types import AssistantMessage, CompletionStatus, UserMessage
 
 
 class MyTask(vf.TaskData):
@@ -122,6 +122,15 @@ def test_custom_task_state_round_trip():
         ],
     )
     tr.record_reward("r", 0.5)
+    tr.calls.append(
+        vf.ModelCall(
+            node=1,
+            finish_reason="stop",
+            completion_status=CompletionStatus(
+                status="incomplete", reason="unfinished_reasoning"
+            ),
+        )
+    )
     wire = tr.model_dump()
     assert "state" not in wire  # transient state is excluded from the dump
 
@@ -132,6 +141,8 @@ def test_custom_task_state_round_trip():
     assert rt.task.type == "MyTask"  # the producing class's name survives the wire
     assert rt.num_turns == 1 and rt.num_branches == 1
     assert rt.reward == 0.5  # property recomputed from `rewards`
+    assert rt.calls[0].completion_status == tr.calls[0].completion_status
+    assert rt.calls[0].finish_reason == "stop"
 
 
 def test_wire_trace_round_trip():

--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -31,6 +31,7 @@ from verifiers.v1.types import (
     ToolCall,
     TurnTokens,
     Usage,
+    completion_status_from_wire,
 )
 
 logger = logging.getLogger(__name__)
@@ -93,6 +94,15 @@ def serialize_completion(response: Response, model: str) -> dict:
                 "index": 0,
                 "message": message,
                 "finish_reason": response.finish_reason or "stop",
+                **(
+                    {
+                        "vf_completion": response.model_dump(
+                            include={"completion_status"}
+                        )["completion_status"]
+                    }
+                    if response.completion_status is not None
+                    else {}
+                ),
             }
         ],
         "usage": usage,
@@ -146,6 +156,7 @@ def response_from_generate(
             tool_calls=tool_calls,
         ),
         finish_reason=finish,
+        completion_status=completion_status_from_wire(result.get("completion_status")),
         # Preserve provider cache/reasoning details through the same accounting as chat.
         # Older endpoints/renderers may omit usage; exact token lengths remain a fallback.
         usage=Usage.from_openai(CompletionUsage.model_validate(result["usage"]))

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -40,6 +40,7 @@ from verifiers.v1.types import (
     ToolMessage,
     Usage,
     UserMessage,
+    completion_status_from_wire,
     content_to_parts,
 )
 
@@ -213,6 +214,9 @@ def response_from_wire(completion: ChatCompletion) -> Response:
         model=completion.model,
         message=message,
         finish_reason=finish,
+        completion_status=completion_status_from_wire(
+            getattr(choice, "vf_completion", None)
+        ),
         usage=usage,
     )
 
@@ -232,6 +236,7 @@ class ChatStreamParser(StreamParser):
         default_factory=dict
     )
     finish_reason: str | None = None
+    vf_completion: dict | None = None
     usage: dict | None = None
     head: dict | None = None
 
@@ -246,6 +251,8 @@ class ChatStreamParser(StreamParser):
             if choice.get("index", 0) != 0:
                 continue
             self.finish_reason = choice.get("finish_reason") or self.finish_reason
+            if "vf_completion" in choice:
+                self.vf_completion = choice["vf_completion"]
             delta = choice.get("delta") or {}
             for key in ("content", "reasoning_content", "reasoning"):
                 if delta.get(key) is not None:
@@ -332,6 +339,11 @@ class ChatStreamParser(StreamParser):
                     "index": 0,
                     "message": self.message,
                     "finish_reason": self.finish_reason or "stop",
+                    **(
+                        {"vf_completion": self.vf_completion}
+                        if self.vf_completion is not None
+                        else {}
+                    ),
                 }
             ],
             "usage": self.usage,
@@ -538,6 +550,11 @@ class ChatDialect(Dialect[ChatCompletion]):
             if isinstance(choice.get("message"), dict):
                 choice["message"] = {"role": "assistant", "content": text}
                 choice["finish_reason"] = "stop"
+                choice["vf_completion"] = {
+                    "version": 1,
+                    "status": "unknown",
+                    "reason": "response_rewritten",
+                }
                 choice.pop("logprobs", None)
 
     def stream_events(self, raw: dict) -> list[bytes]:
@@ -551,6 +568,11 @@ class ChatDialect(Dialect[ChatCompletion]):
                     "delta": choice.get("message")
                     or {"role": "assistant", "content": ""},
                     "finish_reason": choice.get("finish_reason"),
+                    **(
+                        {"vf_completion": choice["vf_completion"]}
+                        if "vf_completion" in choice
+                        else {}
+                    ),
                 }
             ],
         }

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -54,6 +54,8 @@ class CompactionConfig(BaseConfig):
     max_attempts: PositiveInt | None = None
     """Summary-generation attempts within one compaction cycle; `None` =
     nano-rlm's default (5)."""
+    require_completion_status: bool | None = None
+    """Require explicit structural completion evidence when accepting a checkpoint."""
 
 
 class RLMHarnessConfig(HarnessConfig):
@@ -180,6 +182,9 @@ class RLMHarness(ACPHarness[RLMHarnessConfig]):
             policy_knobs["summarize_at_tokens"] = compaction.summarize_at_tokens
             policy_knobs["max_compactions"] = compaction.max_compactions
             policy_knobs["max_compaction_attempts"] = compaction.max_attempts
+            policy_knobs["require_compaction_completion_status"] = (
+                compaction.require_completion_status
+            )
         appends = [
             text
             for text in (system_prompt, self.config.append_to_system_prompt)

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -63,7 +63,7 @@ from verifiers.v1.interception.tunnel import (
 from verifiers.v1.semantic import ACPInfo, extract_acp_info
 from verifiers.v1.session import IdempotentRequest, ReplayResponse, RolloutSession
 from verifiers.v1.trace import Error, ModelCall, PolicyEvent, TimeSpan
-from verifiers.v1.types import FinishReason, Request, Response, Usage
+from verifiers.v1.types import CompletionStatus, FinishReason, Request, Response, Usage
 
 logger = logging.getLogger(__name__)
 
@@ -422,6 +422,7 @@ class InterceptionServer(Interception):
         *,
         node: int | None = None,
         finish_reason: "FinishReason" = None,
+        completion_status: CompletionStatus | None = None,
         usage: "Usage | None" = None,
         error: BaseException | None = None,
         policy_paths: list[str] | None = None,
@@ -452,6 +453,7 @@ class InterceptionServer(Interception):
                 sampling=sampling,
                 endpoint=dialect.upstream_path,
                 finish_reason=finish_reason,
+                completion_status=completion_status,
                 usage=usage,
                 time=TimeSpan(start=started, end=time.time()),
                 error=None
@@ -770,6 +772,9 @@ class InterceptionServer(Interception):
                     if call_response
                     else None,
                     usage=call_response.usage if call_response else None,
+                    completion_status=call_response.completion_status
+                    if call_response
+                    else None,
                     error=error,
                     policy_paths=policy_paths,
                     acp=acp,
@@ -1033,6 +1038,9 @@ class InterceptionServer(Interception):
                 node=node,
                 finish_reason=response.finish_reason if response is not None else None,
                 usage=response.usage if response is not None else None,
+                completion_status=response.completion_status
+                if response is not None
+                else None,
                 error=error,
                 policy_paths=policy_paths,
                 acp=acp,

--- a/verifiers/v1/session.py
+++ b/verifiers/v1/session.py
@@ -25,6 +25,7 @@ from verifiers.v1.errors import RolloutError, TaskError
 from verifiers.v1.trace import InterceptRecord, Trace
 from verifiers.v1.types import (
     AssistantMessage,
+    CompletionStatus,
     Messages,
     Request,
     Response,
@@ -298,7 +299,14 @@ class RolloutSession:
                     raise ValueError(
                         "response interceptors must return an inert text-only message"
                     )
-                response = result.model_copy(update={"finish_reason": "stop"})
+                response = result.model_copy(
+                    update={
+                        "finish_reason": "stop",
+                        "completion_status": CompletionStatus(
+                            status="unknown", reason="response_rewritten"
+                        ),
+                    }
+                )
                 records.append(InterceptRecord(handler=handler.__name__))
 
             for stop in self.response_stops:

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -25,6 +25,7 @@ from verifiers.v1.state import State, StateT
 from verifiers.v1.task import DataT, WireTaskData
 from verifiers.v1.types import (
     AssistantMessage,
+    CompletionStatus,
     FinishReason,
     Message,
     Messages,
@@ -165,6 +166,8 @@ class ModelCall(BaseModel):
     """The provider endpoint path the request went to (e.g. `/chat/completions`)."""
     finish_reason: FinishReason = None
     """Why the model stopped, normalized (`stop` / `length` / `tool_calls`)."""
+    completion_status: CompletionStatus | None = None
+    """Structural completion evidence, separate from termination and task success."""
     usage: Usage | None = None
     """Provider-reported token usage for this exchange, cache reads included."""
     time: TimeSpan = Field(default_factory=TimeSpan)

--- a/verifiers/v1/types.py
+++ b/verifiers/v1/types.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import Annotated, Any, Literal
 
 import numpy as np
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, ValidationError
 from renderers.base import MultiModalData
 from typing_extensions import TypedDict
 
@@ -241,12 +241,34 @@ class TurnTokens(BaseModel):
     sampling_mask: SamplingMask | None = Field(default=None, exclude=True)
 
 
+class CompletionStatus(BaseModel):
+    """Versioned structural-output evidence carried on a response choice."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+    version: Literal[1] = 1
+    status: Literal["complete", "incomplete", "invalid", "unknown"]
+    reason: str | None = None
+
+
+def completion_status_from_wire(value: Any) -> CompletionStatus | None:
+    """Invalid extension data rejects output, not the successfully executed model call."""
+    if value is None:
+        return None
+    if not isinstance(value, dict) or type(value.get("version")) is not int:
+        return CompletionStatus(status="invalid", reason="invalid_completion_metadata")
+    try:
+        return CompletionStatus.model_validate(value)
+    except ValidationError:
+        return CompletionStatus(status="invalid", reason="invalid_completion_metadata")
+
+
 class Response(BaseModel):
     id: str
     created: int
     model: str
     message: AssistantMessage
     finish_reason: FinishReason
+    completion_status: CompletionStatus | None = None
     usage: Usage | None = None
     tokens: TurnTokens | None = None
     raw: dict | None = Field(default=None, exclude=True, repr=False)


### PR DESCRIPTION
## Summary
Stacked on #2542. Carry versioned structural completion evidence from renderer generate results through Response, choice-level vf_completion, chat SDK/SSE roundtrips and stored ModelCalls. Malformed metadata fails closed without retrying an otherwise successful model request. Rewritten responses invalidate previous completion evidence.

Expose optional RLM compaction.require_completion_status forwarding. Defaults remain compatible; strict use requires both companions:
- https://github.com/PrimeIntellect-ai/renderers/pull/153
- https://github.com/PrimeIntellect-ai/nano-rlm/pull/175

No new dependencies or production pins changed. Renderer-specific parsing remains outside nano-rlm.

## Validation
12 existing trace tests passed; offline renderer/VF/SDK/stream/trace/nano checks and two synthetic local-model requests passed. Changed-file Ruff and commit hooks passed. Required Python3.13 ty check passed in an isolated lockfile environment. Whole-repo lint has pre-existing E402 in untouched hermes_agent/program.py:16. Full sandbox end-to-end propagation validation follows under fresh run identities.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add structural `CompletionStatus` to responses and traces
> - Adds a strict `CompletionStatus` model in [types.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2543/files#diff-88a4e4ee0c58ac5dc7344161a011374082a3767eda2ad32af97c942dca982112) and converts wire metadata into valid, invalid, or absent statuses via `completion_status_from_wire`
> - Stores the status on `Response.completion_status` and `ModelCall.completion_status` in [types.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2543/files#diff-88a4e4ee0c58ac5dc7344161a011374082a3767eda2ad32af97c942dca982112) and [trace.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2543/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e)
> - Propagates `vf_completion` extension data through chat parsing, streaming, and response rewriting in [chat.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2543/files#diff-5d2fcbf59a03489b63b0626038a853eee89543b591074597161ee29aab901280) and [train.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2543/files#diff-c9bcd6c691890b1de6942fe012d2e74678460b22bf335721a8bba5e939d139c3)
> - Records the status for non-streaming and streaming model calls in traces via [server.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2543/files#diff-84e2f8d027d609e8760ef6d533535ec9d99dfc6384d5ddb6111b4001b2010f35)
> - Adds `require_completion_status` to `CompactionConfig` in [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2543/files#diff-3955da24b5fd88f62482297bbda7ba0936f633927f15576db27fed6e58f668ec)
> - Risk: `completion_status_from_wire` converts malformed `vf_completion` extension data into an `invalid` status rather than raising a validation error
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1df5901.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->