### PR TITLE
fix(v1): backfill unforwarded routing at turn boundaries

### DIFF
--- a/tests/v1/test_graph.py
+++ b/tests/v1/test_graph.py
@@ -1,6 +1,7 @@
 import base64
 
 import numpy as np
+import pytest
 
 import verifiers.v1 as vf
 from verifiers.v1 import graph
@@ -34,9 +35,13 @@ def _routed_payload(
     }
 
 
-def test_routed_experts_attributed_and_aligned_across_turns():
-    """Each turn's full routing (start=0) is attributed to the nodes it created; the new turn's
-    nodes get this turn's slice and reused nodes keep theirs, so `Branch.routed_experts`
+@pytest.mark.parametrize("omitted_final", [False, True])
+@pytest.mark.parametrize("second_start", [0, 4, 5])
+def test_routed_experts_attributed_and_aligned_across_turns(
+    omitted_final, second_start
+):
+    """Full and delta routing preserve observed prefix rows and fill an unforwarded boundary.
+    New nodes get this turn's slice, so `Branch.routed_experts`
     concatenates back to a `[tokens, layers, top_k]` array aligned 1:1 with `branch.token_ids` —
     and survives the base64 wire round-trip."""
     trace = vf.Trace(
@@ -55,9 +60,16 @@ def test_routed_experts_attributed_and_aligned_across_turns():
                 prompt_ids=[10, 11, 12],
                 completion_ids=[20, 21],
                 message_spans=[(0, 2)],
-                routed_experts=_routed_payload(5, 0, 0),
+                routed_experts=_routed_payload(5 - omitted_final, 0, 0),
             ),
         )
+    )
+    assert trace.branches[-1].routed_experts.shape[0] == 5
+    trace = type(trace).model_validate(trace.model_dump())
+    num_reused_nodes = len(trace.nodes)
+    assert (
+        trace.nodes[-1].routed_experts.shape[0]
+        == len(trace.nodes[-1].token_ids) - omitted_final
     )
     graph.prepare_turn(
         trace,
@@ -73,21 +85,30 @@ def test_routed_experts_attributed_and_aligned_across_turns():
                 prompt_ids=[10, 11, 12, 20, 21, 30, 31],
                 completion_ids=[40, 41],
                 message_spans=[(0, 2), None, (5, 7)],
-                routed_experts=_routed_payload(9, 0, 100),
+                routed_experts=_routed_payload(
+                    9 - second_start - omitted_final,
+                    second_start,
+                    100 + 2 * second_start,
+                ),
             ),
         )
     )
     branch = trace.branches[-1]
     re = branch.routed_experts
+    if omitted_final and second_start == 5:
+        assert re is None  # The now-interior boundary row was never captured.
+        return
     assert re is not None
     assert re.shape[0] == len(branch.token_ids)
+    np.testing.assert_array_equal(re[:4, :, 0], np.arange(8).reshape(4, 2))
+    np.testing.assert_array_equal(re[4, :, 0], [108, 109] if omitted_final else [8, 9])
 
     restored = type(trace).model_validate(trace.model_dump())
     re2 = restored.branches[-1].routed_experts
     assert re2 is not None and re2.shape == re.shape and bool((re2 == re).all())
     assert all(
         node.routed_experts is None or node.routed_experts.flags.owndata
-        for node in trace.nodes
+        for node in trace.nodes[num_reused_nodes:]
     )
 
 

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -151,9 +151,9 @@ class MessageNode(BaseModel):
     `mm_kwargs`. Rides the wire as raw bytes (msgpack `bin`) since pydantic can't JSON the numpy;
     kept off disk by the dump-site `exclude` in prime-rl (the tensors bloat the rollout jsonl)."""
     routed_experts: SkipJsonSchema[np.ndarray | None] = None
-    """This node's slice of the MoE expert-routing array — uint8 `[len(token_ids), layers,
-    top_k]`, the expert ids inference selected for exactly this node's tokens. Attributed from
-    the turn's `generate` payload by `_attribute_routed_experts`; `Branch.routed_experts`
+    """This node's observed MoE routing — `[tokens, layers, top_k]`. The final token's row
+    may be absent until a subsequent turn forwards it; branch views pad only a terminal gap.
+    Attributed from the turn's `generate` payload by `_attribute_routed_experts`; `Branch.routed_experts`
     concatenates these along the path into the trainer's router-replay input. Rides the wire as
     a raw-bytes `__nd__` dict; kept off disk by the dump-site `exclude` in prime-rl."""
     sampling_mask: SkipJsonSchema[SamplingMask | None] = None
@@ -608,6 +608,7 @@ def _attribute_mm(
 
 def _attribute_routed_experts(
     trace: Trace,
+    prefix_node_ids: list[int],
     new_node_ids: list[int],
     path_len: int,
     payload: Any,
@@ -616,8 +617,8 @@ def _attribute_routed_experts(
     payload's array covers the turn's prompt+completion from `payload["start"]` (0 = from token
     0); the nodes created this turn tile sequence positions `[path_len:]` in creation order, so
     we hand each node `arr[off : off+len(node.token_ids)]` and advance. Reused-prefix nodes keep
-    the routing attributed when they were first created. A node whose slice falls outside the
-    array (a `start` past `path_len`, e.g. an unexpected prefix-cache delta) is left unset — the
+    observed routing; an unforwarded suffix is filled when the payload covers it. A node whose
+    slice falls outside the array (a `start` past `path_len`, e.g. an unexpected prefix-cache delta) is left unset — the
     branch then reports no routing rather than misaligning."""
     if payload is None:
         return
@@ -625,7 +626,17 @@ def _attribute_routed_experts(
     arr = np.frombuffer(raw, dtype=np.dtype(payload.get("dtype", "uint8"))).reshape(
         payload["shape"]
     )
-    off = path_len - int(payload.get("start", 0) or 0)
+    start = int(payload.get("start", 0) or 0)
+    position = 0
+    for nid in prefix_node_ids:
+        node = trace.nodes[nid]
+        position += len(node.token_ids)
+        observed = node.routed_experts
+        if observed is not None and observed.shape[0] == len(node.token_ids) - 1:
+            row = position - 1 - start
+            if 0 <= row < arr.shape[0]:
+                node.routed_experts = np.concatenate([observed, arr[row : row + 1]])
+    off = path_len - start
     needed = off + sum(len(trace.nodes[nid].token_ids) for nid in new_node_ids)
     for nid in new_node_ids:
         n = len(trace.nodes[nid].token_ids)
@@ -634,11 +645,8 @@ def _attribute_routed_experts(
             # Own only this node's rows; a view would retain the turn's full-context array.
             trace.nodes[nid].routed_experts = arr[off:end].copy()
         elif n and arr.shape[0] and 0 <= off and end == needed == arr.shape[0] + 1:
-            # The engine omits the turn's final position because no forward pass follows it.
-            # Pad only the final node's suffix instead of copying the full-context array.
-            trace.nodes[nid].routed_experts = np.concatenate(
-                [arr[off:], arr[-1:]], axis=0
-            )
+            # Keep the unforwarded suffix distinguishable from observed routing.
+            trace.nodes[nid].routed_experts = arr[off:].copy()
         off = end
 
 
@@ -799,7 +807,7 @@ def _commit_turn(turn: PendingTurn, response: Response) -> int:
     # Attribute this turn's expert-routing array onto the nodes created this turn (new input
     # nodes in creation order, then the assistant node), each getting the routing for its tokens.
     _attribute_routed_experts(
-        trace, new_node_ids, path_len, tokens.routed_experts if tokens else None
+        trace, prefix, new_node_ids, path_len, tokens.routed_experts if tokens else None
     )
 
     # Sampling masks are completion-aligned, so only the sampled node carries them.

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -336,11 +336,25 @@ class Branch(BaseModel):
 
     @property
     def routed_experts(self) -> np.ndarray | None:
-        """uint8 `[tokens, layers, top_k]` routing; partial data returns None."""
+        """Token-aligned routing. Only the terminal unforwarded row may be padded."""
         nodes = [n for n in self.nodes if n.token_ids]
         if not nodes or any(n.routed_experts is None for n in nodes):
             return None
-        merged = np.concatenate([n.routed_experts for n in nodes], axis=0)
+        arrays = []
+        for i, node in enumerate(nodes):
+            arr = node.routed_experts
+            assert arr is not None
+            if i == len(nodes) - 1 and arr.shape[0] == len(node.token_ids) - 1:
+                padding = (
+                    arr[-1:]
+                    if len(arr)
+                    else np.zeros((1, *arr.shape[1:]), dtype=arr.dtype)
+                )
+                arr = np.concatenate([arr, padding])
+            if arr.shape[0] != len(node.token_ids):
+                return None
+            arrays.append(arr)
+        merged = np.concatenate(arrays, axis=0)
         total = sum(len(n.token_ids) for n in nodes)
         return merged if merged.shape[0] == total else None
 


### PR DESCRIPTION
## Summary

Stacked on #2543; this PR contains only the routed-expert boundary fix.

Routing capture can omit the final sampled token because it has not been forwarded yet. A subsequent bridged request supplies its actual routing row. Graph attribution previously stored a duplicated placeholder and ignored that newly observed row in the reused prefix.

- Store only observed routing rows on nodes and backfill an unobserved prefix suffix when a later response covers it.
- Apply alignment padding only to a branch's terminal, unforwarded token; return no routing array for an unresolved interior gap.
- Preserve observed rows and missingness across trace serialization, without adding a public field or changing tokens, sampling, or optimization.

Consumers must use the compatible verifier version to interpret the short terminal node arrays. Previously serialized, already-padded graphs cannot be retrospectively repaired by this change.

## Validation

- 89 non-e2e tests pass, including 15 graph tests.
- Expanded the existing attribution test across full/delta payloads, omitted final rows, missing boundary coverage, and serialization roundtrip.
- A synthetic graph-to-wire-to-training-sample-to-trainer-preparation check preserves the corrected boundary through the compatible consumer stack; no optimizer was run.
- Full `ty check verifiers`, touched-file lint/format, and pre-push checks pass.
- Whole-repository pre-commit encounters the existing unrelated E402 in `verifiers/v1/harnesses/hermes_agent/program.py`.
- Live routing capture remains to be validated; these checks establish graph attribution and alignment behavior, not end-to-end replay readiness.
