### PR TITLE
Validate requested GPU types in Docker runtime

### DIFF
--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -366,8 +366,8 @@ async def _serve(
             runtime = harness_runtime
         else:
             runtime = make_runtime(cfg.runtime)
-            await runtime.start()
             stack.push_async_callback(runtime.stop)
+            await runtime.start()
         # Only consumers outside the server runtime need its fixed published port. Colocated tools
         # use independent OS-assigned ports, avoiding clashes on the runtime's service port.
         exposed = runtime is not harness_runtime

--- a/verifiers/v1/runtimes/docker/__init__.py
+++ b/verifiers/v1/runtimes/docker/__init__.py
@@ -4,6 +4,7 @@ import array
 import asyncio
 import contextlib
 import logging
+import re
 import shlex
 import socket
 import subprocess
@@ -40,8 +41,9 @@ class DockerConfig(NetworkPolicyConfig):
     memory: float | None = None
     """Hard memory limit in GB (docker `--memory`). None = unlimited."""
     gpu: str | None = None
-    """GPU spec, e.g. "A100" or "2" (docker `--gpus` uses the count; needs the nvidia
-    container toolkit). None = none."""
+    """GPU type[:count] or count only; Docker selects by count. A requested type is
+    checked with nvidia-smi inside the container (case-insensitive, whitespace/hyphen
+    boundaries). Requires the NVIDIA Container Toolkit. None = none."""
     disk: float | None = None
     """Advisory disk request in GB. Docker has no portable per-container size limit, so
     this is accepted (so a task can declare it without a warning) but not enforced."""
@@ -211,7 +213,7 @@ class DockerRuntime(Runtime):
             limits += ["--cpus", str(self.config.cpu)]
         if self.config.memory is not None:
             limits += ["--memory", f"{self.config.memory}g"]
-        _, gpu_count = parse_gpu(self.config.gpu)
+        gpu_type, gpu_count = parse_gpu(self.config.gpu)
         if gpu_count:
             limits += ["--gpus", str(gpu_count)]
         restricted = self.network_restricted
@@ -257,6 +259,29 @@ class DockerRuntime(Runtime):
         self.info.id = run.stdout.strip()[
             :12
         ]  # `docker run -d` prints the container id
+        if gpu_type and gpu_count:
+            # Check the devices Docker actually exposed, including on remote daemons.
+            gpus = await docker(
+                "exec",
+                self._container,
+                "nvidia-smi",
+                "--query-gpu=name",
+                "--format=csv,noheader",
+            )
+            if gpus.exit_code != 0:
+                raise SandboxError(
+                    f"Cannot verify Docker GPU type: {(gpus.stderr or gpus.stdout).strip()}"
+                )
+            names = gpus.stdout.strip().splitlines()
+            if len(names) != gpu_count or any(
+                not re.search(
+                    rf"(?:^|[\s-]){re.escape(gpu_type)}(?:$|[\s-])", name, re.IGNORECASE
+                )
+                for name in names
+            ):
+                raise SandboxError(
+                    f"Requested {self.config.gpu!r}, but Docker exposed: {', '.join(names) or 'no GPUs'}"
+                )
         if restricted:
             # Setup is trusted; colocated servers fetch their task from host interception
             # before the final framework routes are known.


### PR DESCRIPTION
Typed GPU requests such as `H100:2` keep Docker's `--gpus 2` allocation and check the exposed devices before task setup. Startup fails with a clear error when the GPU type or count does not match, or when the device query cannot run.

The check uses one `nvidia-smi` invocation inside the started container, so it inspects devices exposed by the selected Docker daemon. Product names match case-insensitively at whitespace and hyphen boundaries. Count-only and no-GPU requests retain their existing behavior.

Separately provisioned MCP server runtimes register teardown before startup, so partially started containers are removed when startup fails or is cancelled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> GPU-backed sandboxes can fail at startup when the image lacks `nvidia-smi` or NVIDIA product names do not match the configured type string, though mis-provisioned GPUs are caught earlier with clearer errors.
> 
> **Overview**
> **Docker runtime** now verifies typed GPU configs (e.g. `H100:2`) after `docker run` succeeds, instead of only passing `--gpus` with the parsed count.
> 
> When both a GPU **type** and **count** come from `parse_gpu`, the runtime runs `nvidia-smi` inside the new container and fails startup with `SandboxError` if the query fails, the number of exposed devices differs from the count, or any device name does not match the requested type (case-insensitive match at whitespace/hyphen boundaries via `re`). Count-only specs (`2`) and no-GPU configs are unchanged—no type check runs without a type.
> 
> The `DockerConfig.gpu` field docstring is updated to describe the `type[:count]` format and this validation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2843527193b3d1271fb7e580e4119661acf0e89a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate requested GPU types in `DockerRuntime.start` and fix cleanup ordering in `mcp._serve`
> - `DockerRuntime.start` now runs `nvidia-smi` after container startup for typed GPU requests and rejects startup if the query fails, the exposed GPU count differs, or device names do not match the requested type (case-insensitive, whitespace/hyphen boundaries). Count-only GPU requests skip this check.
> - Updates `DockerConfig` GPU field docs to describe type-with-count and count-only forms plus the `nvidia-smi` verification requirement.
> - `mcp._serve` registers the runtime stop callback before awaiting startup for separately provisioned runtimes, so `runtime.stop()` runs during cleanup if `runtime.start()` raises.
> - Behavioral Change: typed GPU requests that previously started with mismatched or unqueryable GPUs now raise `SandboxError`; existing configs with correct types are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a091797.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->