### PR TITLE
Preserve GPU types in Harbor verifier environments

### DIFF
--- a/verifiers/v1/tasksets/harbor/taskset.py
+++ b/verifiers/v1/tasksets/harbor/taskset.py
@@ -379,7 +379,13 @@ def task_resources(environment, multiplier: float) -> TaskResources:
         memory=environment.memory_mb / 1024 * multiplier
         if environment.memory_mb
         else None,
-        gpu=str(environment.gpus) if environment.gpus else None,
+        gpu=(
+            f"{environment.gpu_types[0]}:{environment.gpus}"
+            if environment.gpu_types
+            else str(environment.gpus)
+        )
+        if environment.gpus
+        else None,
         disk=environment.storage_mb / 1024 * multiplier
         if environment.storage_mb
         else None,
@@ -694,7 +700,7 @@ def parse_verifier_environment(
         )
     unsupported = [
         field
-        for field in ("mcp_servers", "skills_dir", "gpu_types", "tpu")
+        for field in ("mcp_servers", "skills_dir", "tpu")
         if getattr(environment, field, None)
     ]
     if environment.os != TaskOS.LINUX or unsupported:


### PR DESCRIPTION
Harbor tasks that declare `gpu_types` in a separate verifier environment can now load with their requested GPU type and count. A declaration such as `gpus = 1` with `gpu_types = ["H100"]` becomes `H100:1` in the existing runtime configuration.

Remove `gpu_types` from the verifier's unsupported-field guard and preserve it in the shared solver/verifier resource mapper. Select the first acceptable type, matching Harbor's Modal backend, while keeping count-only requests and resource scaling unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how GPU requests are serialized for Harbor tasks and verifier environments, which affects runtime provisioning but follows the existing `type:count` contract.
> 
> **Overview**
> Harbor task loading now maps declared **`gpu_types`** into **`TaskResources.gpu`** as **`{type}:{count}`** (using the first type when multiple are listed), instead of passing only the GPU count. Count-only requests stay unchanged.
> 
> Separate **`[verifier.environment]`** blocks may declare **`gpu_types`** without tripping the unsupported-field check, so verifier boxes get the same typed GPU spec as the agent environment when tasks request it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79f144ac05b049c353eed04f78ae834a45129b5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve GPU types in Harbor verifier `TaskResources` and environment parsing
> - `task_resources` in [taskset.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2548/files#diff-2bff5dabcb9a41f4d830e8bbb890e8cc6f5b8331ef2ac4c3b19ffad0e046fe00) now serializes GPU requests as `type:count` when a GPU type is present, using the first declared type; bare count strings are still used when no type is set.
> - `parse_verifier_environment` removes `gpu_types` from the unsupported-field set, so verifier environments declaring GPU types are no longer rejected and their GPU type config passes through to the returned verifier configuration.
> - Risk: consumers that parse the GPU resource string and expect a plain integer count will break for environments that declare a GPU type.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 79f144a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->