### PR TITLE
Remove legacy Harbor author metadata fallback

### DIFF
--- a/verifiers/v1/tasksets/harbor/taskset.py
+++ b/verifiers/v1/tasksets/harbor/taskset.py
@@ -534,9 +534,6 @@ def parse_task(task_dir: Path, idx: int, harbor_config: HarborConfig) -> HarborD
         if task
         else []
     )
-    # Older registry entries stored one author in [metadata].
-    if not authors and meta.get("author_name"):
-        authors = [Author(name=meta["author_name"], email=meta.get("author_email"))]
     if harbor_config.ignore_timeouts:
         agent_timeout = scoring_timeout = None
     else:


### PR DESCRIPTION
Remove the legacy `author_name`/`author_email` fallback from Harbor task loading. List-valued attribution metadata could otherwise make a valid task fail VF's scalar `Author` validation.

Author attribution continues to come from Harbor's structured `[task].authors`. Legacy attribution metadata is ignored; task execution and grading do not use it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavior change for old registry entries that relied on metadata-only authors; execution and grading are unchanged.
> 
> **Overview**
> Harbor task loading no longer backfills `authors` from legacy registry metadata (`author_name` / `author_email` in `[metadata]`). Attribution is taken only from structured `[task].authors`.
> 
> That removes a path where list-shaped legacy metadata could be coerced into scalar `Author` models and fail validation during task parse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0e6ad21d152888aa931484a71d831adb1008142. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove legacy Harbor author metadata fallback in `parse_task`
> Removes the compatibility fallback that constructed an author from legacy metadata fields when a Harbor task had no explicit authors. Authors now come only from the task's explicit author entries; timeout and task metadata handling are unchanged. Risk: Harbor tasks parsed without explicit authors will no longer receive a synthesized author, so any downstream reader relying on a non-null author in `verifiers/v1/tasksets/harbor/taskset.py` may need updating.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c0e6ad2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->