### PR TITLE
Support runtime skill sources through harness skills

### DIFF
--- a/docs/v1/evaluation.md
+++ b/docs/v1/evaluation.md
@@ -66,11 +66,13 @@ The names of these tools are set by the respective harness. Consult the relevant
 
 ## Skills
 
-Harnesses whose program supports SKILL.md skills natively (e.g. Claude Code, Codex) take a `skills` list of local skill folders, each uploaded into the program's skill discovery directory in the agent's runtime as `<skills dir>/<folder name>`:
+Harnesses whose program supports SKILL.md skills natively (e.g. Claude Code, Codex) take a `skills` list. A local skill folder is uploaded to `<skills dir>/<folder name>`. A `{runtime = "..."}` entry copies the contents of a directory already inside the runtime into the program's skill discovery directory:
 
 ```toml
 [env.agent.harness]
-skills = ["path/to/my-skill"]
+skills = [{runtime = "/opt/skills"}, "path/to/my-skill"]
 ```
 
-Setting `skills` on a harness without native skill support fails up front.
+Tasks can supply the same sources through `TaskData.skills`, for example `skills=[vf.RuntimeSkills(runtime="/opt/skills")]`. Task sources are installed first, followed by harness sources; later files override matching earlier files. Sources are resolved after task setup.
+
+Setting `skills` on a task or harness without native harness skill support fails up front.

--- a/docs/v1/evaluation.md
+++ b/docs/v1/evaluation.md
@@ -73,6 +73,6 @@ Harnesses whose program supports SKILL.md skills natively (e.g. Claude Code, Cod
 skills = [{runtime = "/opt/skills"}, "path/to/my-skill"]
 ```
 
-Tasks can supply the same sources through `TaskData.skills`, for example `skills=[vf.RuntimeSkills(runtime="/opt/skills")]`. Task sources are installed first, followed by harness sources; later files override matching earlier files. Sources are resolved after task setup.
+Tasks can supply the same sources through `TaskData.skills`, for example `skills=[vf.RuntimeSkills(runtime="/opt/skills")]`. Task sources are installed first, followed by harness sources; later files override matching earlier files. Each run gets its own installed skills. Sources are resolved after task setup, and missing source directories fail the run.
 
 Setting `skills` on a task or harness without native harness skill support fails up front.

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -16,7 +16,7 @@ from verifiers.v1.clients import (
 from verifiers.v1.configs.agent import AgentConfig
 from verifiers.v1.configs.cli.env import narrowed_env_annotation, resolve_env_field
 from verifiers.v1.configs.env import EnvConfig, default_agent_harness
-from verifiers.v1.configs.harness import HarnessConfig
+from verifiers.v1.configs.harness import HarnessConfig, RuntimeSkills
 from verifiers.v1.configs.judge import JudgeConfig, Judges
 from verifiers.v1.configs.retries import RetryConfig
 from verifiers.v1.configs.serve import (
@@ -219,6 +219,7 @@ __all__ = [  # noqa: RUF022 - grouped by public API area
     "WireTaskData",
     "TaskResources",
     "TaskTimeout",
+    "RuntimeSkills",
     "Trace",
     "TraceTask",
     "WireTrace",

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -19,6 +19,7 @@ from verifiers.v1.clients import (
     ModelContext,
 )
 from verifiers.v1.configs.agent import AgentConfig, TimeoutConfig
+from verifiers.v1.configs.harness import RuntimeSkills
 from verifiers.v1.configs.runtime import NetworkPolicyConfig
 from verifiers.v1.dialects import parse_message
 from verifiers.v1.harness import Harness
@@ -532,6 +533,15 @@ class Agent:
     ) -> dict:
         """Resolve one run's runtime config, pairing checks, timeouts,
         interception — shared by `run` and `interaction`."""
+        harness = self.harness
+        skills = [*task.data.skills, *harness.config.skills]
+        if task.data.skills or any(
+            isinstance(skill, RuntimeSkills) for skill in skills
+        ):
+            # Task and runtime sources vary per run; keep harness state and caches local.
+            harness = type(harness)(
+                harness.config.model_copy(update={"skills": skills})
+            )
         if runtime is not None:
             _check_borrowed_placement(task, runtime, self.runtime_config)
             runtime_config = runtime.config
@@ -542,7 +552,7 @@ class Agent:
             )
             run_is_local = runtime_is_local(runtime_config)
         validate_pairing(
-            self.harness,
+            harness,
             type(task),
             runtime_config,
             tools=[*task.toolsets(task.config), *shared_tools.values()],
@@ -550,7 +560,7 @@ class Agent:
         timeouts = resolve_rollout_timeouts(self.timeout, task)
         return {
             "agent_config": self.config,
-            "harness": self.harness,
+            "harness": harness,
             "ctx": self.ctx,
             "runtime_config": runtime_config,
             "timeouts": replace(

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -19,7 +19,6 @@ from verifiers.v1.clients import (
     ModelContext,
 )
 from verifiers.v1.configs.agent import AgentConfig, TimeoutConfig
-from verifiers.v1.configs.harness import RuntimeSkills
 from verifiers.v1.configs.runtime import NetworkPolicyConfig
 from verifiers.v1.dialects import parse_message
 from verifiers.v1.harness import Harness
@@ -535,10 +534,8 @@ class Agent:
         interception — shared by `run` and `interaction`."""
         harness = self.harness
         skills = [*task.data.skills, *harness.config.skills]
-        if task.data.skills or any(
-            isinstance(skill, RuntimeSkills) for skill in skills
-        ):
-            # Task and runtime sources vary per run; keep harness state and caches local.
+        if skills:
+            # Skill installations can hold run-specific state, such as RLM's package environment.
             harness = type(harness)(
                 harness.config.model_copy(update={"skills": skills})
             )

--- a/verifiers/v1/configs/harness.py
+++ b/verifiers/v1/configs/harness.py
@@ -6,13 +6,29 @@ import os
 from pathlib import Path
 from typing import Annotated
 
-from pydantic import ConfigDict, Field, FiniteFloat
+from pydantic import BaseModel, ConfigDict, Field, FiniteFloat
 from pydantic_config import BaseConfig
 
 from verifiers.v1.types import ID
 
 PinnedVersion = Annotated[str, Field(pattern=r"^[A-Za-z0-9._+-]+$")]
 """A release/tag a harness pins its program install to."""
+
+
+class RuntimeSkills(BaseModel):
+    """A directory of skill folders already present inside the agent runtime."""
+
+    runtime: str
+
+
+SkillSource = Path | RuntimeSkills
+
+
+def skill_destination(skill: SkillSource, dest: str) -> str:
+    """Runtime roots merge into `dest`; host folders keep their resolved name."""
+    return (
+        dest if isinstance(skill, RuntimeSkills) else f"{dest}/{skill.resolve().name}"
+    )
 
 
 class HarnessConfig(BaseConfig):
@@ -26,10 +42,10 @@ class HarnessConfig(BaseConfig):
     tool_timeout: FiniteFloat = Field(600.0, gt=0)
     """Seconds a single MCP tool call may take; raise it for tools that boot a VM."""
     disabled_tools: list[str] | None = None
-    skills: list[Path] = Field(default_factory=list)
-    """Skill folders to upload into the program's skill discovery directory — each
-    lands at `<skills dir>/<folder name>`. Only harnesses whose program discovers
-    skills natively (`SUPPORTS_SKILLS`) accept them."""
+    skills: list[SkillSource] = Field(default_factory=list)
+    """Host skill folders or `{runtime: path}` roots of skills inside the runtime.
+    Sources are installed in order; later files override matching earlier files.
+    Only harnesses with native skill support (`SUPPORTS_SKILLS`) accept them."""
 
     @property
     def name(self) -> str:

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -44,8 +44,8 @@ class Harness(ABC, Generic[ConfigT]):
     where model-directed execution changes the rules: the subprocess-on-host
     warning, the judge env's sandbox requirement."""
     SUPPORTS_SKILLS: ClassVar[bool] = False
-    """Whether the program discovers SKILL.md skills — its `setup` calls
-    `install_skills` with the program's fixed discovery location; configuring
+    """Whether the program discovers SKILL.md skills — it calls
+    `install_skills` with a run-scoped discovery location; configuring
     `skills` on a harness without support is rejected up front."""
     NEEDS_CONTAINER: ClassVar[bool] = True
     """Whether the program must run in a container runtime: True for every harness
@@ -105,7 +105,7 @@ class Harness(ABC, Generic[ConfigT]):
                     [
                         "sh",
                         "-c",
-                        'mkdir -p "$2" && if [ -d "$1" ] && ! [ "$1" -ef "$2" ]; then cp -a "$1/." "$2/"; fi',
+                        '[ -d "$1" ] && mkdir -p "$2" && if ! [ "$1" -ef "$2" ]; then cp -a "$1/." "$2/"; fi',
                         "vf-skills",
                         skill.runtime,
                         target_dir,
@@ -114,7 +114,7 @@ class Harness(ABC, Generic[ConfigT]):
                 )
                 if result.exit_code:
                     raise RuntimeError(
-                        f"installing runtime skills failed: {result.stderr}"
+                        f"installing runtime skills from {skill.runtime!r} failed: {result.stderr}"
                     )
                 continue
             # Resolve so `.`/`..` entries get their real folder name (and can't

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -7,7 +7,7 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar
 
 from verifiers.v1.clients import ModelContext
-from verifiers.v1.configs.harness import HarnessConfig
+from verifiers.v1.configs.harness import HarnessConfig, RuntimeSkills, skill_destination
 from verifiers.v1.errors import HarnessError, SandboxError, boundary
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.task import TaskData
@@ -96,10 +96,27 @@ class Harness(ABC, Generic[ConfigT]):
         """Provision this harness in `runtime` before its execution timeout starts."""
 
     async def install_skills(self, runtime: Runtime, dest: str) -> None:
-        """Upload each `config.skills` folder into `runtime` at `dest/<folder name>` —
-        the program's fixed skill discovery location, which a supporting harness's
-        `setup` passes."""
+        """Install `config.skills` in the program's discovery directory.
+        Runtime roots are copied in place; host skill folders are uploaded."""
         for skill in self.config.skills:
+            target_dir = skill_destination(skill, dest)
+            if isinstance(skill, RuntimeSkills):
+                result = await runtime.run(
+                    [
+                        "sh",
+                        "-c",
+                        'mkdir -p "$2" && if [ -d "$1" ] && ! [ "$1" -ef "$2" ]; then cp -a "$1/." "$2/"; fi',
+                        "vf-skills",
+                        skill.runtime,
+                        target_dir,
+                    ],
+                    {},
+                )
+                if result.exit_code:
+                    raise RuntimeError(
+                        f"installing runtime skills failed: {result.stderr}"
+                    )
+                continue
             # Resolve so `.`/`..` entries get their real folder name (and can't
             # place files outside `dest`).
             skill = skill.resolve()
@@ -109,7 +126,7 @@ class Harness(ABC, Generic[ConfigT]):
             for file in sorted(skill.rglob("*")):
                 if not file.is_file():
                     continue
-                target = f"{dest}/{skill.name}/{file.relative_to(skill).as_posix()}"
+                target = f"{target_dir}/{file.relative_to(skill).as_posix()}"
                 await runtime.write(target, file.read_bytes())
                 if os.access(file, os.X_OK):
                     executables.append(target)

--- a/verifiers/v1/harnesses/claude_code/harness.py
+++ b/verifiers/v1/harnesses/claude_code/harness.py
@@ -15,7 +15,6 @@ ACP_VERSION = "0.67.0"
 CLAUDE_BIN = f"{PACKAGES_DIR}/node_modules/.bin/claude"
 ACP_BIN = f"{PACKAGES_DIR}/node_modules/.bin/claude-agent-acp"
 CLAUDE_CONFIG_ROOT = ".vf-claude"
-SKILLS_DIR = ".claude/skills"
 ACP_INSTALL = r"""
 set -e
 export PATH="/var/tmp/vf-node/bin:$PATH"
@@ -39,7 +38,6 @@ class ClaudeCodeHarness(ACPHarness[ClaudeCodeHarnessConfig]):
     SUPPORTS_SKILLS = True
 
     async def setup(self, runtime: Runtime) -> None:
-        await self.install_skills(runtime, SKILLS_DIR)
         await ensure_node(runtime)
         versions = {"version": self.config.version, "acp_version": ACP_VERSION}
         directory = CLAUDE_ACP_DIR.format(**versions)
@@ -74,6 +72,7 @@ class ClaudeCodeHarness(ACPHarness[ClaudeCodeHarnessConfig]):
     ) -> ACPConfig:
         system_prompt, prompt = self.resolve_prompt(data)
         config_dir = self.config_dir(trace)
+        await self.install_skills(runtime, f"{config_dir}/skills")
         versions = {"version": self.config.version, "acp_version": ACP_VERSION}
         session_meta = {
             "claudeCode": {

--- a/verifiers/v1/harnesses/codex/harness.py
+++ b/verifiers/v1/harnesses/codex/harness.py
@@ -22,7 +22,6 @@ PACKAGES_DIR = f"{CODEX_DIR}/acp"
 ACP_VERSION = "1.2.0"
 CODEX_BIN = f"{PACKAGES_DIR}/node_modules/.bin/codex"
 ACP_BIN = f"{PACKAGES_DIR}/node_modules/.bin/codex-acp"
-SKILLS_DIR = ".agents/skills"
 INSTALL = r"""
 set -e
 export PATH="/var/tmp/vf-node/bin:$PATH"
@@ -48,7 +47,6 @@ class CodexHarness(ACPHarness[CodexHarnessConfig]):
     SUPPORTS_SKILLS = True
 
     async def setup(self, runtime: Runtime) -> None:
-        await self.install_skills(runtime, SKILLS_DIR)
         await ensure_node(runtime)
         logger.info(
             "codex: ensuring Codex %s and codex-acp %s are installed",
@@ -120,6 +118,7 @@ class CodexHarness(ACPHarness[CodexHarnessConfig]):
         mcp_urls: dict[str, str],
     ) -> dict[str, str]:
         home = self.trace_home(trace)
+        await self.install_skills(runtime, f"{home}/skills")
         mcp_config = "features={mcp_2026_07_28=true}\n" + (
             "mcp_servers={"
             + ",".join(

--- a/verifiers/v1/harnesses/kimi_code/harness.py
+++ b/verifiers/v1/harnesses/kimi_code/harness.py
@@ -8,7 +8,7 @@ import tomli_w
 from verifiers.v1.acp import ACPConfig, ACPHarness
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig, PinnedVersion
-from verifiers.v1.harnesses.utils.install import ensure_installed
+from verifiers.v1.harnesses.utils.install import ensure_installed, remove_dir
 from verifiers.v1.runtimes import Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
@@ -125,3 +125,6 @@ class KimiCodeHarness(ACPHarness[KimiCodeHarnessConfig]):
             prompt=prompt,
             system_prompt=system_prompt,
         )
+
+    async def cleanup(self, trace: Trace, runtime: Runtime) -> None:
+        await remove_dir(runtime, f"{KIMI_HOME}/{trace.id}", "Kimi Code state")

--- a/verifiers/v1/harnesses/kimi_code/harness.py
+++ b/verifiers/v1/harnesses/kimi_code/harness.py
@@ -18,7 +18,6 @@ logger = logging.getLogger(__name__)
 BINARY = "/tmp/vf-kimi-code/bin/kimi"
 KIMI_HOME = ".vf-kimi-code"
 ACP_COMMAND = [BINARY, "acp"]
-SKILLS_DIR = f"{KIMI_HOME}/skills"
 
 INSTALL = r"""
 set -e
@@ -52,7 +51,6 @@ class KimiCodeHarness(ACPHarness[KimiCodeHarnessConfig]):
     SUPPORTS_SKILLS = True
 
     async def setup(self, runtime: Runtime) -> None:
-        await self.install_skills(runtime, SKILLS_DIR)
         logger.info(
             "kimi-code: ensuring Kimi Code %s is installed", self.config.version
         )
@@ -77,6 +75,8 @@ class KimiCodeHarness(ACPHarness[KimiCodeHarnessConfig]):
         data: TaskData,
     ) -> ACPConfig:
         kimi_home = f"{KIMI_HOME}/{trace.id}"
+        skills_dir = f"{kimi_home}/skills"
+        await self.install_skills(runtime, skills_dir)
         provider_type = {
             "chat_completions": "openai",
             "responses": "openai_responses",
@@ -88,7 +88,7 @@ class KimiCodeHarness(ACPHarness[KimiCodeHarnessConfig]):
             else endpoint
         )
         config = {
-            "extra_skill_dirs": [SKILLS_DIR] if self.config.skills else [],
+            "extra_skill_dirs": [skills_dir] if self.config.skills else [],
             **(
                 {
                     "permission": {

--- a/verifiers/v1/harnesses/openclaw/harness.py
+++ b/verifiers/v1/harnesses/openclaw/harness.py
@@ -1,9 +1,7 @@
 """Run OpenClaw's Gateway-backed ACP agent against interception."""
 
-import asyncio
 import json
 import logging
-import secrets
 
 from verifiers.v1.acp import ACPConfig, ACPHarness
 from verifiers.v1.clients import ModelContext
@@ -130,22 +128,6 @@ class OpenClawHarness(ACPHarness[OpenClawHarnessConfig]):
     SUPPORTS_SKILLS = True
 
     async def setup(self, runtime: Runtime) -> None:
-        if not hasattr(self, "_staged_skills_dir"):
-            self._staged_skills_dir = (
-                f".vf-openclaw/staged-skills-{secrets.token_hex(8)}"
-            )
-            self._skills_setup_lock = asyncio.Lock()
-        if self.config.skills:
-            async with self._skills_setup_lock:
-                # A complete tree is immutable, so concurrent setups can safely reuse it.
-                ready_path = f"{self._staged_skills_dir}/.ready"
-                ready = await runtime.run(["test", "-f", ready_path], {})
-                if ready.exit_code != 0:
-                    await remove_dir(
-                        runtime, self._staged_skills_dir, "OpenClaw skills"
-                    )
-                    await self.install_skills(runtime, self._staged_skills_dir)
-                    await runtime.write(ready_path, b"")
         directory = OPENCLAW_DIR.format(version=self.config.version)
         binary = OPENCLAW_BIN.format(version=self.config.version)
         logger.info("openclaw: ensuring OpenClaw %s is installed", self.config.version)
@@ -233,14 +215,7 @@ class OpenClawHarness(ACPHarness[OpenClawHarnessConfig]):
             # OpenClaw treats an empty allowlist as all; a no-match key disables the catalog.
             config.setdefault("skills", {})["allowBundled"] = ["__none__"]
         await runtime.write(config_path, json.dumps(config).encode())
-        if self.config.skills:
-            copied = await runtime.run(
-                ["cp", "-R", self._staged_skills_dir, skills_dir], {}
-            )
-            if copied.exit_code != 0:
-                raise RuntimeError(
-                    f"failed to isolate OpenClaw skills: {copied.stderr.strip()[-500:]}"
-                )
+        await self.install_skills(runtime, skills_dir)
 
         env = {
             **self.config.resolved_env,

--- a/verifiers/v1/harnesses/pi/harness.py
+++ b/verifiers/v1/harnesses/pi/harness.py
@@ -21,7 +21,6 @@ KEY_VAR = "PI_INTERCEPT_KEY"
 PI_DIR = "/var/tmp/vf-pi"
 PACKAGES_DIR = f"{PI_DIR}/mcp"
 PI_BIN = f"{PACKAGES_DIR}/node_modules/.bin/pi"
-SKILLS_DIR = ".agents/skills"
 MCP_VERSION = "2.25.0"
 ACP_VERSION = "0.0.33"
 MCP_ADAPTER = f"{PACKAGES_DIR}/node_modules/pi-mcp-adapter/index.ts"
@@ -61,7 +60,6 @@ class PiHarness(ACPHarness[PiHarnessConfig]):
     SUPPORTS_SKILLS = True
 
     async def setup(self, runtime: Runtime) -> None:
-        await self.install_skills(runtime, SKILLS_DIR)
         await ensure_node(runtime)
         logger.info(
             "pi: ensuring Pi %s and pi-acp %s are installed",
@@ -93,6 +91,8 @@ class PiHarness(ACPHarness[PiHarnessConfig]):
     ) -> ACPConfig:
         system_prompt, prompt = self.resolve_prompt(data)
         agent_dir = f".vf-pi-agent-{trace.id}"
+        skills_dir = f"{agent_dir}/skills"
+        await self.install_skills(runtime, skills_dir)
         reasoning = ctx.sampling.reasoning_effort not in (
             None,
             "none",
@@ -159,7 +159,7 @@ class PiHarness(ACPHarness[PiHarnessConfig]):
         skill_args = [
             arg
             for skill in self.config.skills
-            for arg in ("--skill", skill_destination(skill, SKILLS_DIR))
+            for arg in ("--skill", skill_destination(skill, skills_dir))
         ]
         pi_args = [
             PI_BIN,

--- a/verifiers/v1/harnesses/pi/harness.py
+++ b/verifiers/v1/harnesses/pi/harness.py
@@ -9,7 +9,7 @@ from verifiers.v1.acp import ACPConfig, ACPHarness
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig, PinnedVersion, skill_destination
 from verifiers.v1.harnesses.node import NODE_BIN_DIR, ensure_node
-from verifiers.v1.harnesses.utils.install import ensure_installed
+from verifiers.v1.harnesses.utils.install import ensure_installed, remove_dir
 from verifiers.v1.runtimes import Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
@@ -189,3 +189,6 @@ class PiHarness(ACPHarness[PiHarnessConfig]):
             # Pi's extension owns the task-scoped MCP configuration.
             mcp_urls={},
         )
+
+    async def cleanup(self, trace: Trace, runtime: Runtime) -> None:
+        await remove_dir(runtime, f".vf-pi-agent-{trace.id}", "Pi state")

--- a/verifiers/v1/harnesses/pi/harness.py
+++ b/verifiers/v1/harnesses/pi/harness.py
@@ -7,7 +7,7 @@ from typing import Literal
 
 from verifiers.v1.acp import ACPConfig, ACPHarness
 from verifiers.v1.clients import ModelContext
-from verifiers.v1.configs.harness import HarnessConfig, PinnedVersion
+from verifiers.v1.configs.harness import HarnessConfig, PinnedVersion, skill_destination
 from verifiers.v1.harnesses.node import NODE_BIN_DIR, ensure_node
 from verifiers.v1.harnesses.utils.install import ensure_installed
 from verifiers.v1.runtimes import Runtime
@@ -159,8 +159,7 @@ class PiHarness(ACPHarness[PiHarnessConfig]):
         skill_args = [
             arg
             for skill in self.config.skills
-            # Resolve like `install_skills` so the path matches what it wrote.
-            for arg in ("--skill", f"{SKILLS_DIR}/{skill.resolve().name}")
+            for arg in ("--skill", skill_destination(skill, SKILLS_DIR))
         ]
         pi_args = [
             PI_BIN,

--- a/verifiers/v1/harnesses/pool/harness.py
+++ b/verifiers/v1/harnesses/pool/harness.py
@@ -12,7 +12,6 @@ from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
 
 POOL_DIR = "/tmp/vf-pool-{version}"
-SKILLS_DIR = ".poolside/skills"
 INSTALL = r"""
 set -e
 command -v curl >/dev/null || (apt-get update -qq && apt-get install -y -qq curl ca-certificates >/dev/null)
@@ -37,7 +36,6 @@ class PoolHarness(ACPHarness[PoolHarnessConfig]):
     SUPPORTS_SKILLS = True
 
     async def setup(self, runtime: Runtime) -> None:
-        await self.install_skills(runtime, SKILLS_DIR)
         directory = POOL_DIR.format(version=self.config.version)
         binary = f"{directory}/pool"
         script = INSTALL.replace("{version}", self.config.version).replace(
@@ -73,6 +71,7 @@ class PoolHarness(ACPHarness[PoolHarnessConfig]):
             "POOLSIDE_STANDALONE_MODEL": ctx.model,
         }
         pool_home = f".vf-pool/{trace.id}"
+        await self.install_skills(runtime, f"{pool_home}/config/poolside/skills")
         # Values are Pool tool names such as `shell`, `read`, or `edit`.
         tools = {name: {"disabled": True} for name in self.config.disabled_tools or []}
         settings = shlex.quote(json.dumps({"tools": tools}))

--- a/verifiers/v1/harnesses/pool/harness.py
+++ b/verifiers/v1/harnesses/pool/harness.py
@@ -6,7 +6,7 @@ import shlex
 from verifiers.v1.acp import ACPConfig, ACPHarness
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig, PinnedVersion
-from verifiers.v1.harnesses.utils.install import ensure_installed
+from verifiers.v1.harnesses.utils.install import ensure_installed, remove_dir
 from verifiers.v1.runtimes import Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
@@ -93,3 +93,6 @@ class PoolHarness(ACPHarness[PoolHarnessConfig]):
             mcp_urls=mcp_urls,
             system_prompt=system_prompt,
         )
+
+    async def cleanup(self, trace: Trace, runtime: Runtime) -> None:
+        await remove_dir(runtime, f".vf-pool/{trace.id}", "Pool state")

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -190,7 +190,6 @@ class PrimeAgentHarness(ACPHarness[PrimeAgentHarnessConfig]):
         root = self._root(trace)
         agent_dir = f"{root}/agent"
         skills_dir = f"{agent_dir}/skills"
-        await self.install_skills(runtime, skills_dir)
         created = await runtime.run(
             [
                 "mkdir",
@@ -207,6 +206,7 @@ class PrimeAgentHarness(ACPHarness[PrimeAgentHarnessConfig]):
             raise RuntimeError(
                 f"prime-agent state directory failed: {created.stderr.strip()[-500:]}"
             )
+        await self.install_skills(runtime, skills_dir)
         reasoning = ctx.sampling.reasoning_effort not in (
             None,
             "none",

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -25,7 +25,6 @@ PRIME_AGENT_COMMIT: Literal["81ae3cb34d27d38ee37f9e205a1e73694993b344"] = (
 PRIME_AGENT_VERSION = "0.9.1"
 PRIME_AGENT_DIR = "/var/tmp/vf-prime-agent"
 STATE_ROOT = "/tmp/vf-prime-agent-runs"
-SKILLS_DIR = ".agents/skills"
 PROVIDER = "intercept"
 LIFECYCLE_META_NAMESPACE = "ai.primeintellect.prime-agent"
 KEY_VAR = "PRIME_AGENT_INTERCEPT_KEY"
@@ -155,7 +154,6 @@ class PrimeAgentHarness(ACPHarness[PrimeAgentHarnessConfig]):
         statuses.append(status)
 
     async def setup(self, runtime: Runtime) -> None:
-        await self.install_skills(runtime, SKILLS_DIR)
         await ensure_node(runtime)
         logger.info("prime-agent: ensuring commit %s is installed", self.config.commit)
         await ensure_installed(
@@ -191,6 +189,8 @@ class PrimeAgentHarness(ACPHarness[PrimeAgentHarnessConfig]):
 
         root = self._root(trace)
         agent_dir = f"{root}/agent"
+        skills_dir = f"{agent_dir}/skills"
+        await self.install_skills(runtime, skills_dir)
         created = await runtime.run(
             [
                 "mkdir",
@@ -251,7 +251,7 @@ class PrimeAgentHarness(ACPHarness[PrimeAgentHarnessConfig]):
         if self.config.autonomous:
             args.append("--autonomous")
         for skill in self.config.skills:
-            args += ["--skill", skill_destination(skill, SKILLS_DIR)]
+            args += ["--skill", skill_destination(skill, skills_dir)]
         if system_prompt:
             args += ["--append-system-prompt", system_prompt]
 

--- a/verifiers/v1/harnesses/prime_agent/harness.py
+++ b/verifiers/v1/harnesses/prime_agent/harness.py
@@ -7,7 +7,7 @@ from typing import Literal
 
 from verifiers.v1.acp import ACPConfig, ACPHarness, ACPTurn
 from verifiers.v1.clients import ModelContext
-from verifiers.v1.configs.harness import HarnessConfig
+from verifiers.v1.configs.harness import HarnessConfig, skill_destination
 from verifiers.v1.harnesses.node import NODE_BIN_DIR, ensure_node
 from verifiers.v1.harnesses.utils.install import ensure_installed, remove_dir
 from verifiers.v1.runtimes import Runtime
@@ -251,7 +251,7 @@ class PrimeAgentHarness(ACPHarness[PrimeAgentHarnessConfig]):
         if self.config.autonomous:
             args.append("--autonomous")
         for skill in self.config.skills:
-            args += ["--skill", f"{SKILLS_DIR}/{skill.resolve().name}"]
+            args += ["--skill", skill_destination(skill, SKILLS_DIR)]
         if system_prompt:
             args += ["--append-system-prompt", system_prompt]
 

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import logging
+import secrets
 import shlex
 from typing import Any, Literal
 
@@ -18,7 +19,7 @@ from pydantic_config import BaseConfig
 from verifiers.v1.acp import ACPConfig, ACPHarness, ACPTurn, JsonObject
 from verifiers.v1.clients import ModelContext
 from verifiers.v1.configs.harness import HarnessConfig
-from verifiers.v1.harnesses.utils.install import ensure_installed
+from verifiers.v1.harnesses.utils.install import ensure_installed, remove_dir
 from verifiers.v1.runtimes import Runtime
 from verifiers.v1.task import TaskData
 from verifiers.v1.trace import Trace
@@ -114,11 +115,15 @@ class RLMHarness(ACPHarness[RLMHarnessConfig]):
     APPENDS_SYSTEM_PROMPT = True
     SUPPORTS_MCP = True
     SUPPORTS_SKILLS = True
+    _skills_install_dir: str | None = None
 
     async def setup(self, runtime: Runtime) -> None:
-        # Before the installer: install.sh packages the skills it finds.
-        await self.install_skills(runtime, SKILLS_DIR)
+        if self.config.skills:
+            # Editable skill packages and uv's tool environment must belong to this run.
+            self._skills_install_dir = f"{RLM_CACHE_DIR}-skills-{secrets.token_hex(16)}"
         directory = self._install_dir()
+        skills_dir = f"{directory}/skills" if self.config.skills else SKILLS_DIR
+        await self.install_skills(runtime, skills_dir)
         binary = f"{directory}/bin/rlm"
         checkout = f"{directory}/checkout"
         ready = f"{directory}/.ready"
@@ -129,7 +134,9 @@ class RLMHarness(ACPHarness[RLMHarnessConfig]):
             "{ apt-get update -qq && apt-get install -y -qq git; } && "
             f"rm -rf {checkout} && git clone https://{RLM_REPO} {checkout} && "
             f"git -C {checkout} checkout {shlex.quote(self.config.version)} && "
+            f"sed -i 's|/task/rlm-skills|{skills_dir}|g' {checkout}/install.sh && "
             f"UV_INSTALL_DIR={directory}/bin UV_TOOL_BIN_DIR={directory}/bin "
+            f"UV_TOOL_DIR={directory}/tools "
             f"RLM_CHECKOUT_PATH={checkout} bash {checkout}/install.sh && "
             f"touch {ready})"
         )
@@ -240,6 +247,10 @@ class RLMHarness(ACPHarness[RLMHarnessConfig]):
 
     async def cleanup(self, trace: Trace, runtime: Runtime) -> None:
         await runtime.run(["rm", "-rf", f"{RLM_STATE_DIR}/{trace.id}"], {})
+        if self._skills_install_dir is not None:
+            await remove_dir(
+                runtime, self._skills_install_dir, "RLM skill installation"
+            )
 
     @staticmethod
     def _home(trace: Trace) -> str:
@@ -247,4 +258,4 @@ class RLMHarness(ACPHarness[RLMHarnessConfig]):
 
     def _install_dir(self) -> str:
         cache_key = hashlib.sha256(self.config.version.encode()).hexdigest()
-        return f"{RLM_CACHE_DIR}-{cache_key}"
+        return self._skills_install_dir or f"{RLM_CACHE_DIR}-{cache_key}"

--- a/verifiers/v1/task.py
+++ b/verifiers/v1/task.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Generic, Self
 from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import TypeVar
 
+from verifiers.v1.configs.harness import SkillSource
 from verifiers.v1.configs.task import TaskConfig
 from verifiers.v1.errors import TaskError, boundary
 from verifiers.v1.state import StateT
@@ -96,6 +97,9 @@ class TaskData(BaseModel):
     """Optional Docker image to use for the task. Only relevant for tasks that run in a container."""
     workdir: str | None = None
     """Optional working directory to use for the task. Only relevant for tasks that run in a container."""
+
+    skills: list[SkillSource] = Field(default_factory=list)
+    """Skill sources installed before the harness's configured skills for this task."""
 
     network_allow: list[str] = Field(default_factory=lambda: ["*"])
     """Execution-time destinations requested by this task. `*` leaves the runtime

--- a/verifiers/v1/tasksets/harbor/taskset.py
+++ b/verifiers/v1/tasksets/harbor/taskset.py
@@ -32,6 +32,7 @@ from typing import Annotated
 
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, ValidationError
 
+from verifiers.v1.configs.harness import RuntimeSkills
 from verifiers.v1.configs.taskset import TasksetConfig
 from verifiers.v1.errors import SandboxError, TaskError
 from verifiers.v1.runtimes import Runtime
@@ -362,6 +363,7 @@ def verifier_box_data(data: HarborData) -> HarborData:
             "upload_environment": data.upload_environment if fresh else False,
             "env": dict(verifier.env),
             "healthcheck": verifier.healthcheck,
+            "skills": [],
             "network_allow": list(verifier.network_allow),
             "network_block": [],
         }
@@ -583,6 +585,9 @@ def parse_task(task_dir: Path, idx: int, harbor_config: HarborConfig) -> HarborD
         tags=meta.get("tags", []),
         task_dir=str(task_dir),
         upload_environment=upload_environment,
+        skills=[RuntimeSkills(runtime=environment.skills_dir)]
+        if environment.skills_dir
+        else [],
         **environment.model_dump(include={"env", "healthcheck"}, mode="json"),
         verifier_env=parsed.verifier.env,
         artifacts=artifacts,
@@ -699,9 +704,7 @@ def parse_verifier_environment(
             task_dir.name,
         )
     unsupported = [
-        field
-        for field in ("mcp_servers", "skills_dir", "tpu")
-        if getattr(environment, field, None)
+        field for field in ("mcp_servers", "tpu") if getattr(environment, field, None)
     ]
     if environment.os != TaskOS.LINUX or unsupported:
         raise ValueError(


### PR DESCRIPTION
Allow tasks and harnesses to use skills already present in the runtime alongside existing local skill uploads. Harbor's `environment.skills_dir` reaches native harness discovery through the shared skills installer.

`HarnessConfig.skills` and `TaskData.skills` accept local skill folders and runtime directories containing skill folders:

```toml
[env.agent.harness]
skills = [{runtime = "/opt/skills"}, "path/to/my-skill"]
```

Task sources install before harness sources, so configured harness files take precedence when paths overlap. Missing or invalid source directories fail the run.

Each run installs skills in its own native configuration directory or explicit discovery path. RLM installs editable skill packages into a separate uv tool environment for the run and removes that environment during cleanup. Skill-bearing runs use separate harness instances to keep installation state local to the run.

Harbor translates the solver's skills declaration into `TaskData.skills`, clears it from verifier task data, and accepts the redundant agent-skills field in deterministic verifier environments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and where skills are installed across many ACP harnesses and RLM; misconfigured runtime paths or setup timeouts could fail runs that previously succeeded with only host uploads.
> 
> **Overview**
> Adds **runtime-backed skill sources** alongside host skill folder uploads, and wires them through both harness config and per-task data.
> 
> `HarnessConfig.skills` and new `TaskData.skills` accept local folders or `{runtime = "path"}` entries. `Agent._rollout_params` merges task sources first then harness sources (later wins on conflicts) and clones the harness per rollout so skill install state stays run-local. Base `install_skills` copies runtime trees in-place via tar and uploads host folders sequentially into a run-scoped discovery directory (`skill_destination`).
> 
> Skill installation moves out of shared harness `setup()` into session prep for Claude Code, Codex, Kimi, OpenClaw, Pi, Prime Agent, and RLM; OpenClaw drops its shared staged-skills cache. RLM uses a per-run uv install dir when skills are set and cleans it up. Harbor maps `environment.skills_dir` into task skills and clears skills on verifier tasks. Setup timeout now also bounds harness session opening.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65b55e2cfbdf504e59ea620d4b650406936cdd65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add runtime skill sources and per-run harness skill installation
> - Expands `SkillSource` in [verifiers/v1/configs/harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2556/files#diff-c5b409466f272f39cbab9228a91d9b6de6c8a0cdd33ad73f05e7fd690966e478) to accept runtime directories and adds `TaskData.skills` in [verifiers/v1/task.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2556/files#diff-a1b4a5d6915beae41831864087ea497ed41f0b67b9091ad1ee614834cbfd9399) for task-level skills.
> - `Agent._rollout_params` in [verifiers/v1/agent.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2556/files#diff-f719e773e216506045964fdfb9fad948b7b504ea092359ced06c928ab5148ea2) merges task and harness skills, with harness sources applied last.
> - Moves skill installation out of harness `setup` and into session preparation (`prepare_acp`, `build_env`) for Claude Code, Codex, Kimi Code, OpenClaw, Pi, Prime Agent, and RLM.
> - Risk: All harness `setup` methods no longer install skills; installation happens per-run. Runtime sources merge into the destination directory while host sources retain a source-name subdirectory via `skill_destination`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 65b55e2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->