### PR TITLE
Fix bounded file reads on Prime VMs

### DIFF
--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -7,6 +7,7 @@ direction (a program in the sandbox reaching a host service) is the shared host-
 """
 
 import asyncio
+import base64
 import contextlib
 import logging
 import math
@@ -366,6 +367,21 @@ class PrimeRuntime(Runtime):
             raise SandboxError(f"prime background launch failed: {e}") from e
 
     async def _read(self, path: str, max_bytes: int | None = None) -> bytes:
+        if max_bytes is not None and self.config.vm:
+            try:
+                # VM execute_command uses bash and returns the complete output stream.
+                result = await self._client.execute_command(
+                    self.info.id,
+                    f"set -o pipefail; head -c {max_bytes} -- {shlex.quote(path)} | base64",
+                    working_dir=self.config.workdir,
+                    env=self.process_env({}),
+                    timeout=EFFECTIVELY_UNBOUNDED_SECONDS,
+                )
+            except Exception as exc:
+                raise SandboxError(f"read {path!r}: {exc}") from exc
+            if result.exit_code:
+                raise SandboxError(f"read {path!r}: {result.stderr.strip()[-500:]}")
+            return base64.b64decode(result.stdout)
         if max_bytes is not None:
             return await super()._read(path, max_bytes)
         # Avoid background-job log limits and base64 overhead by downloading binary data directly.


### PR DESCRIPTION
Bounded reads on Prime VMs can fail or lose data when file bytes pass through background-job output retrieval. Route capped reads through the SDK's complete command-output stream while retaining the existing byte limit and overflow check.

Use `head` and base64 to preserve binary data, with Bash `pipefail` to propagate file-read failures. The change stays within `PrimeRuntime._read` and uses the existing SDK API without adding runtime interfaces or dependencies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to bounded reads on Prime VMs inside `_read`; uses existing SDK APIs and should reduce data-loss risk rather than broaden behavior.
> 
> **Overview**
> **Prime VM sandboxes** with a byte cap no longer use the inherited `run` / background-job path for `_read`, which could truncate or corrupt output when retrieving file bytes.
> 
> When `max_bytes` is set and `vm` is true, capped reads now go through **`execute_command`** with `head -c`, **base64**, and **`pipefail`**, then decode on the host—same limit semantics, but the full command stdout stream. Non-VM capped reads and full-file downloads are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 027e36d740696b26274f661b557b828f50ee7129. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix bounded file reads on Prime VMs with base64-encoded sandbox command
> Updates `PrimeRuntime._read` so VM reads with a `max_bytes` limit execute inside the VM, read at most the requested bytes, base64-encode the output, and decode it locally. Command failures and nonzero exit codes now raise `SandboxError`. Existing paths for bounded non-VM reads and unbounded reads are unchanged.
> - Risk: VM bounded reads now depend on base64 being available in the sandbox; if the read command fails or exits nonzero, callers receive `SandboxError` instead of raw output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 027e36d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->