### PR TITLE
Fix env-server serialization errors and missing replies

### DIFF
--- a/verifiers/v1/serve/encoding.py
+++ b/verifiers/v1/serve/encoding.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from uuid import UUID
 
 import numpy as np
+from pydantic_core import to_jsonable_python
 
 # Marker key inside the encoded payload so a decoder can recognize a
 # tensor round-trip without disturbing arbitrary user dicts.
@@ -31,14 +32,17 @@ def msgpack_encoder(obj):
     is ONLY called for types msgpack doesn't recognize. This avoids the massive
     performance penalty of recursing through millions of tokens in Python.
 
-    Handles: Path, UUID, Enum, datetime, Pydantic models, numpy scalars,
+    Handles: Path, UUID, sets, Enum, datetime, Pydantic models, numpy scalars,
     numpy arrays, torch tensors, and dataclasses (e.g. renderers'
     ``MultiModalData`` / ``PlaceholderRange``). Tensors and ndarrays are
     encoded as ``{__torch_tensor__: True, dtype, shape, data}``.
+    Other types use Pydantic's JSON conversions; unsupported types still raise.
     Does NOT handle: lists, dicts, basic types (msgpack does this natively in C).
     """
     if isinstance(obj, (Path, UUID)):
         return str(obj)
+    elif isinstance(obj, (set, frozenset)):
+        return list(obj)
     elif isinstance(obj, Enum):
         return obj.value
     elif isinstance(obj, (datetime, date)):
@@ -61,5 +65,4 @@ def msgpack_encoder(obj):
     elif dataclasses.is_dataclass(obj) and not isinstance(obj, type):
         return dataclasses.asdict(obj)
     else:
-        # raise on unknown types to make issues visible
-        raise TypeError(f"Object of type {type(obj)} is not msgpack serializable")
+        return to_jsonable_python(obj)

--- a/verifiers/v1/serve/server.py
+++ b/verifiers/v1/serve/server.py
@@ -136,11 +136,21 @@ class EnvServer:
         ) as e:  # a failed request is data, not a crash — report and keep serving
             logger.warning("request failed: %s", e, exc_info=True)
             response = BaseResponse(success=False, error=f"{type(e).__name__}: {e}")
-        data = msgpack.packb(
-            response.model_dump(mode="python"),
-            default=msgpack_encoder,
-            use_bin_type=True,
-        )
+        try:
+            data = msgpack.packb(
+                response.model_dump(mode="python"),
+                default=msgpack_encoder,
+                use_bin_type=True,
+            )
+        except Exception as e:
+            # Encoding failures must also reply so clients don't wait indefinitely.
+            logger.warning("response encoding failed: %s", e, exc_info=True)
+            data = msgpack.packb(
+                BaseResponse(
+                    success=False, error=f"{type(e).__name__}: {e}"
+                ).model_dump(),
+                use_bin_type=True,
+            )
         try:
             # Let ZMQ retain the packed response instead of copying large traces.
             await self.frontend.send_multipart(


### PR DESCRIPTION
Env-server response serialization can fail after a rollout completes, leaving the client waiting without a result or error. This change supports additional Pydantic field types and returns an error response when serialization fails.

The MessagePack encoder falls back to Pydantic's `to_jsonable_python()` for types such as Decimal, time, and URLs. Sets and frozensets become lists so their contents continue through MessagePack's encoder, preserving binary values alongside the existing tensor handling. The server catches failures from both the Pydantic dump and MessagePack packing and sends a failed response to the client.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wire-format behavior changes for sets and formerly unsupported types, and the encoding fallback path must always produce a packable error response so clients are not left waiting.
> 
> **Overview**
> **Env-server responses** no longer hang when MessagePack serialization fails after a rollout: packing is wrapped in a try/except that logs the failure and still sends a minimal `BaseResponse` with `success=False` and the encoding error (packed without the custom encoder).
> 
> **MessagePack encoder** now serializes `set`/`frozenset` as lists, and unknown leaf types fall back to Pydantic’s `to_jsonable_python()` instead of raising `TypeError` immediately—covering types like `Decimal`, `time`, and URLs in nested response payloads while keeping existing Path, tensor, and dataclass handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c89d2bc47afef1c587c7377fde0cea794e2b1962. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix missing env-server replies and add Pydantic fallback to `msgpack_encoder`
> - [encoding.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2558/files#diff-3cf142d6e5cc729f44408f8131d570a4acd09f552b98e451605c83f7a7525b19): `serve.msgpack_encoder` now serializes `set` and `frozenset` as lists and falls back to Pydantic Core JSON conversion for unsupported types instead of raising `TypeError`.
> - [server.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2558/files#diff-64422f6a8749fcc024415b2756129bc98000e830e74b3b5245de50a555480a22): The `serve.EnvServer` response handler catches response encoding failures and sends a serialized unsuccessful `BaseResponse` containing the error, preventing missing replies to the client.
> - Risk: Unsupported types that Pydantic Core cannot convert will now trigger an error response to the client instead of a server-side exception.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c89d2bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->