### PR TITLE
Honor explicit runtime workdir overrides

### DIFF
--- a/verifiers/v1/envs/isolated_verifier/env.py
+++ b/verifiers/v1/envs/isolated_verifier/env.py
@@ -91,7 +91,7 @@ class IsolatedVerifierEnv(vf.Env[IsolatedVerifierEnvConfig]):
             if not PurePosixPath(artifact.source).is_absolute()
         ]
         solver = resolve_runtime_config(self.config.agent.runtime, task)
-        solver_workdir = PurePosixPath(getattr(solver, "workdir", "") or "/app")
+        solver_workdir = PurePosixPath(getattr(solver, "workdir", "/") or "/app")
         verifier_workdir = PurePosixPath(config.workdir or "/app")
         if relative and solver_workdir != verifier_workdir:
             raise ValueError(

--- a/verifiers/v1/envs/isolated_verifier/env.py
+++ b/verifiers/v1/envs/isolated_verifier/env.py
@@ -26,32 +26,6 @@ from verifiers.v1.utils.retries import backoff
 logger = logging.getLogger(__name__)
 
 
-class _WorkdirMismatchError(ValueError):
-    """A permanent artifact-placement error that a fresh verifier cannot fix."""
-
-
-def _validate_artifact_workdirs(
-    task: vf.Task, solver_workdir: str | None, verifier_workdir: str | None
-) -> None:
-    """Check known directories; image defaults must wait until runtime startup."""
-    if solver_workdir is None or verifier_workdir is None:
-        return
-    relative = [
-        artifact.source
-        for artifact in task.data.artifacts
-        if not PurePosixPath(artifact.source).is_absolute()
-    ]
-    solver_path = PurePosixPath(solver_workdir)
-    verifier_path = PurePosixPath(verifier_workdir)
-    if relative and solver_path != verifier_path:
-        raise _WorkdirMismatchError(
-            "isolated-verifier cannot transfer relative artifacts "
-            f"{relative!r} between solver workdir {str(solver_path)!r} and "
-            f"verifier workdir {str(verifier_path)!r}; use matching workdirs "
-            "or absolute artifact paths"
-        )
-
-
 class VerifierConfig(vf.BaseConfig):
     runtime: RuntimeConfig | None = None
     """Independent verifier placement and policy. None provisions a fresh runtime
@@ -111,10 +85,21 @@ class IsolatedVerifierEnv(vf.Env[IsolatedVerifierEnvConfig]):
                 "restored safely; configure the agent or verifier runtime as docker, "
                 "prime, or modal"
             )
+        relative = [
+            artifact.source
+            for artifact in task.data.artifacts
+            if not PurePosixPath(artifact.source).is_absolute()
+        ]
         solver = resolve_runtime_config(self.config.agent.runtime, task)
-        _validate_artifact_workdirs(
-            task, getattr(solver, "workdir", None), config.workdir
-        )
+        solver_workdir = PurePosixPath(getattr(solver, "workdir", "") or "/app")
+        verifier_workdir = PurePosixPath(config.workdir or "/app")
+        if relative and solver_workdir != verifier_workdir:
+            raise ValueError(
+                "isolated-verifier cannot transfer relative artifacts "
+                f"{relative!r} between solver workdir {str(solver_workdir)!r} and "
+                f"verifier workdir {str(verifier_workdir)!r}; use matching workdirs "
+                "or absolute artifact paths"
+            )
         return config
 
     async def finalize(self, task: vf.Task, episode: vf.Episode) -> None:
@@ -126,9 +111,6 @@ class IsolatedVerifierEnv(vf.Env[IsolatedVerifierEnvConfig]):
     async def stage_verifier(
         self, task: vf.Task, solution: vf.Trace, runtime: Runtime
     ) -> None:
-        _validate_artifact_workdirs(
-            task, solution.agent.runtime.workdir, runtime.config.workdir
-        )
         artifacts = dict(solution.state.artifacts)
         async with boundary(TaskError, "verifier task setup"):
             await invoke(task.setup, {"trace": solution, "runtime": runtime})
@@ -147,9 +129,6 @@ class IsolatedVerifierEnv(vf.Env[IsolatedVerifierEnvConfig]):
         *,
         scoring_timeout_covers_attempt: bool = False,
     ) -> tuple[Any, vf.Trace]:
-        _validate_artifact_workdirs(
-            task, solution.agent.runtime.workdir, config.workdir
-        )
         timeouts = resolve_rollout_timeouts(self.config.agent.timeout, task)
         last: Exception | None = None
         for attempt in range(self.config.verifier.retries + 1):
@@ -197,8 +176,6 @@ class IsolatedVerifierEnv(vf.Env[IsolatedVerifierEnvConfig]):
                             verifier_task, verifier_solution, runtime
                         )
                     return result, verifier_solution
-            except _WorkdirMismatchError:
-                raise
             except Exception as error:  # noqa: BLE001 - retry the whole fresh box
                 last = error
         assert last is not None

--- a/verifiers/v1/envs/isolated_verifier/env.py
+++ b/verifiers/v1/envs/isolated_verifier/env.py
@@ -26,6 +26,32 @@ from verifiers.v1.utils.retries import backoff
 logger = logging.getLogger(__name__)
 
 
+class _WorkdirMismatchError(ValueError):
+    """A permanent artifact-placement error that a fresh verifier cannot fix."""
+
+
+def _validate_artifact_workdirs(
+    task: vf.Task, solver_workdir: str | None, verifier_workdir: str | None
+) -> None:
+    """Check known directories; image defaults must wait until runtime startup."""
+    if solver_workdir is None or verifier_workdir is None:
+        return
+    relative = [
+        artifact.source
+        for artifact in task.data.artifacts
+        if not PurePosixPath(artifact.source).is_absolute()
+    ]
+    solver_path = PurePosixPath(solver_workdir)
+    verifier_path = PurePosixPath(verifier_workdir)
+    if relative and solver_path != verifier_path:
+        raise _WorkdirMismatchError(
+            "isolated-verifier cannot transfer relative artifacts "
+            f"{relative!r} between solver workdir {str(solver_path)!r} and "
+            f"verifier workdir {str(verifier_path)!r}; use matching workdirs "
+            "or absolute artifact paths"
+        )
+
+
 class VerifierConfig(vf.BaseConfig):
     runtime: RuntimeConfig | None = None
     """Independent verifier placement and policy. None provisions a fresh runtime
@@ -85,6 +111,10 @@ class IsolatedVerifierEnv(vf.Env[IsolatedVerifierEnvConfig]):
                 "restored safely; configure the agent or verifier runtime as docker, "
                 "prime, or modal"
             )
+        solver = resolve_runtime_config(self.config.agent.runtime, task)
+        _validate_artifact_workdirs(
+            task, getattr(solver, "workdir", None), config.workdir
+        )
         return config
 
     async def finalize(self, task: vf.Task, episode: vf.Episode) -> None:
@@ -96,21 +126,9 @@ class IsolatedVerifierEnv(vf.Env[IsolatedVerifierEnvConfig]):
     async def stage_verifier(
         self, task: vf.Task, solution: vf.Trace, runtime: Runtime
     ) -> None:
-        relative = [
-            artifact.source
-            for artifact in task.data.artifacts
-            if not PurePosixPath(artifact.source).is_absolute()
-        ]
-        # Image defaults are known only after each runtime has started.
-        solver_workdir = PurePosixPath(solution.agent.runtime.workdir)
-        verifier_workdir = PurePosixPath(runtime.config.workdir)
-        if relative and solver_workdir != verifier_workdir:
-            raise ValueError(
-                "isolated-verifier cannot transfer relative artifacts "
-                f"{relative!r} between solver workdir {str(solver_workdir)!r} and "
-                f"verifier workdir {str(verifier_workdir)!r}; use matching workdirs "
-                "or absolute artifact paths"
-            )
+        _validate_artifact_workdirs(
+            task, solution.agent.runtime.workdir, runtime.config.workdir
+        )
         artifacts = dict(solution.state.artifacts)
         async with boundary(TaskError, "verifier task setup"):
             await invoke(task.setup, {"trace": solution, "runtime": runtime})
@@ -129,6 +147,9 @@ class IsolatedVerifierEnv(vf.Env[IsolatedVerifierEnvConfig]):
         *,
         scoring_timeout_covers_attempt: bool = False,
     ) -> tuple[Any, vf.Trace]:
+        _validate_artifact_workdirs(
+            task, solution.agent.runtime.workdir, config.workdir
+        )
         timeouts = resolve_rollout_timeouts(self.config.agent.timeout, task)
         last: Exception | None = None
         for attempt in range(self.config.verifier.retries + 1):
@@ -176,6 +197,8 @@ class IsolatedVerifierEnv(vf.Env[IsolatedVerifierEnvConfig]):
                             verifier_task, verifier_solution, runtime
                         )
                     return result, verifier_solution
+            except _WorkdirMismatchError:
+                raise
             except Exception as error:  # noqa: BLE001 - retry the whole fresh box
                 last = error
         assert last is not None

--- a/verifiers/v1/envs/isolated_verifier/env.py
+++ b/verifiers/v1/envs/isolated_verifier/env.py
@@ -85,21 +85,6 @@ class IsolatedVerifierEnv(vf.Env[IsolatedVerifierEnvConfig]):
                 "restored safely; configure the agent or verifier runtime as docker, "
                 "prime, or modal"
             )
-        relative = [
-            artifact.source
-            for artifact in task.data.artifacts
-            if not PurePosixPath(artifact.source).is_absolute()
-        ]
-        solver = resolve_runtime_config(self.config.agent.runtime, task)
-        solver_workdir = PurePosixPath(getattr(solver, "workdir", "") or "/")
-        verifier_workdir = PurePosixPath(config.workdir)
-        if relative and solver_workdir != verifier_workdir:
-            raise ValueError(
-                "isolated-verifier cannot transfer relative artifacts "
-                f"{relative!r} between solver workdir {str(solver_workdir)!r} and "
-                f"verifier workdir {str(verifier_workdir)!r}; use matching workdirs "
-                "or absolute artifact paths"
-            )
         return config
 
     async def finalize(self, task: vf.Task, episode: vf.Episode) -> None:
@@ -111,6 +96,21 @@ class IsolatedVerifierEnv(vf.Env[IsolatedVerifierEnvConfig]):
     async def stage_verifier(
         self, task: vf.Task, solution: vf.Trace, runtime: Runtime
     ) -> None:
+        relative = [
+            artifact.source
+            for artifact in task.data.artifacts
+            if not PurePosixPath(artifact.source).is_absolute()
+        ]
+        # Image defaults are known only after each runtime has started.
+        solver_workdir = PurePosixPath(solution.agent.runtime.workdir)
+        verifier_workdir = PurePosixPath(runtime.config.workdir)
+        if relative and solver_workdir != verifier_workdir:
+            raise ValueError(
+                "isolated-verifier cannot transfer relative artifacts "
+                f"{relative!r} between solver workdir {str(solver_workdir)!r} and "
+                f"verifier workdir {str(verifier_workdir)!r}; use matching workdirs "
+                "or absolute artifact paths"
+            )
         artifacts = dict(solution.state.artifacts)
         async with boundary(TaskError, "verifier task setup"):
             await invoke(task.setup, {"trace": solution, "runtime": runtime})

--- a/verifiers/v1/runtimes/docker/__init__.py
+++ b/verifiers/v1/runtimes/docker/__init__.py
@@ -3,7 +3,6 @@
 import array
 import asyncio
 import contextlib
-import json
 import logging
 import shlex
 import socket
@@ -35,7 +34,7 @@ class DockerConfig(NetworkPolicyConfig):
     type: Literal["docker"] = "docker"
     image: str = "python:3.11-slim"
     workdir: str | None = None
-    """Working directory override; None preserves the image's working directory."""
+    """Working directory override; None uses the task's workdir, or /app."""
     # TaskData.resources uses these units; non-default runtime config values take precedence.
     cpu: float | None = None
     """Pin the container to this many CPU cores (docker `--cpus`). None = unlimited."""
@@ -180,8 +179,8 @@ control.sendmsg([b"listener"], [(socket.SOL_SOCKET, socket.SCM_RIGHTS, array.arr
 class DockerRuntime(Runtime):
     def __init__(self, config: DockerConfig, name: str | None = None) -> None:
         super().__init__(name)
-        self.config = config
-        self.info = DockerRuntimeInfo(**config.model_dump())
+        self.config = config.model_copy(update={"workdir": config.workdir or "/app"})
+        self.info = DockerRuntimeInfo(**self.config.model_dump())
         self._container: str | None = None  # our `--name` (used for exec/rm)
         self._proxy: EgressProxy | None = None
         self._proxy_host_ip: str | None = None
@@ -245,11 +244,8 @@ class DockerRuntime(Runtime):
             *network,
             *limits,
             *env_args,
-            *(
-                ["--workdir", self.config.workdir]
-                if self.config.workdir is not None
-                else []
-            ),
+            "--workdir",
+            self.config.workdir,
             "--entrypoint",
             "sleep",
             "--name",
@@ -262,15 +258,6 @@ class DockerRuntime(Runtime):
         self.info.id = run.stdout.strip()[
             :12
         ]  # `docker run -d` prints the container id
-        if self.config.workdir is None:
-            workdir = await docker(
-                "inspect", "--format", "{{json .Config.WorkingDir}}", self._container
-            )
-            if workdir.exit_code != 0:
-                raise SandboxError(f"docker inspect failed: {workdir.stderr.strip()}")
-            # Resolve before setup so commands, uploads, and relative artifacts agree.
-            self.info.workdir = json.loads(workdir.stdout) or "/"
-            self.config = self.config.model_copy(update={"workdir": self.info.workdir})
         if restricted:
             # Setup is trusted; colocated servers fetch their task from host interception
             # before the final framework routes are known.

--- a/verifiers/v1/runtimes/docker/__init__.py
+++ b/verifiers/v1/runtimes/docker/__init__.py
@@ -3,6 +3,7 @@
 import array
 import asyncio
 import contextlib
+import json
 import logging
 import shlex
 import socket
@@ -33,7 +34,8 @@ logger = logging.getLogger(__name__)
 class DockerConfig(NetworkPolicyConfig):
     type: Literal["docker"] = "docker"
     image: str = "python:3.11-slim"
-    workdir: str = "/app"
+    workdir: str | None = None
+    """Working directory override; None preserves the image's working directory."""
     # TaskData.resources uses these units; non-default runtime config values take precedence.
     cpu: float | None = None
     """Pin the container to this many CPU cores (docker `--cpus`). None = unlimited."""
@@ -243,8 +245,11 @@ class DockerRuntime(Runtime):
             *network,
             *limits,
             *env_args,
-            "--workdir",
-            self.config.workdir,
+            *(
+                ["--workdir", self.config.workdir]
+                if self.config.workdir is not None
+                else []
+            ),
             "--entrypoint",
             "sleep",
             "--name",
@@ -257,6 +262,15 @@ class DockerRuntime(Runtime):
         self.info.id = run.stdout.strip()[
             :12
         ]  # `docker run -d` prints the container id
+        if self.config.workdir is None:
+            workdir = await docker(
+                "inspect", "--format", "{{json .Config.WorkingDir}}", self._container
+            )
+            if workdir.exit_code != 0:
+                raise SandboxError(f"docker inspect failed: {workdir.stderr.strip()}")
+            # Resolve before setup so commands, uploads, and relative artifacts agree.
+            self.info.workdir = json.loads(workdir.stdout) or "/"
+            self.config = self.config.model_copy(update={"workdir": self.info.workdir})
         if restricted:
             # Setup is trusted; colocated servers fetch their task from host interception
             # before the final framework routes are known.

--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -40,7 +40,7 @@ class ModalConfig(BaseConfig):
     type: Literal["modal"] = "modal"
     image: str = "python:3.11-slim"
     workdir: str | None = None
-    """Working directory override; None preserves the sandbox's working directory."""
+    """Working directory override; None uses the task's workdir, or /app."""
     network_access: bool = True
     region: str | None = None
     """Region to provision in (None = provider-chosen)."""
@@ -108,8 +108,8 @@ class ModalRuntime(Runtime):
 
     def __init__(self, config: ModalConfig, name: str | None = None) -> None:
         super().__init__(name)
-        self.config = config
-        self.info = ModalRuntimeInfo(**config.model_dump())
+        self.config = config.model_copy(update={"workdir": config.workdir or "/app"})
+        self.info = ModalRuntimeInfo(**self.config.model_dump())
         self._sandbox = None
 
     @property
@@ -135,18 +135,7 @@ class ModalRuntime(Runtime):
             logger.info(
                 "modal: sandbox %s up (image=%s)", self.info.id, self.config.image
             )
-            if self.config.workdir is not None:
-                await self._sandbox.filesystem.make_directory.aio(self.config.workdir)
-            else:
-                result = await self.run(["pwd", "-P"], {})
-                workdir = result.stdout.removesuffix("\n")
-                if result.exit_code != 0 or not workdir.startswith("/"):
-                    raise SandboxError(
-                        f"could not resolve sandbox workdir: {result.stderr}"
-                    )
-                # Resolve before setup so commands, uploads, and relative artifacts agree.
-                self.info.workdir = workdir
-                self.config = self.config.model_copy(update={"workdir": workdir})
+            await self._sandbox.filesystem.make_directory.aio(self.config.workdir)
         except (
             Exception
         ) as e:  # provisioning failure is one rollout's problem, not the eval's

--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -39,7 +39,8 @@ _APP_NAME = "verifiers-v1"
 class ModalConfig(BaseConfig):
     type: Literal["modal"] = "modal"
     image: str = "python:3.11-slim"
-    workdir: str = "/app"
+    workdir: str | None = None
+    """Working directory override; None preserves the sandbox's working directory."""
     network_access: bool = True
     region: str | None = None
     """Region to provision in (None = provider-chosen)."""
@@ -134,7 +135,18 @@ class ModalRuntime(Runtime):
             logger.info(
                 "modal: sandbox %s up (image=%s)", self.info.id, self.config.image
             )
-            await self._sandbox.filesystem.make_directory.aio(self.config.workdir)
+            if self.config.workdir is not None:
+                await self._sandbox.filesystem.make_directory.aio(self.config.workdir)
+            else:
+                result = await self.run(["pwd", "-P"], {})
+                workdir = result.stdout.removesuffix("\n")
+                if result.exit_code != 0 or not workdir.startswith("/"):
+                    raise SandboxError(
+                        f"could not resolve sandbox workdir: {result.stderr}"
+                    )
+                # Resolve before setup so commands, uploads, and relative artifacts agree.
+                self.info.workdir = workdir
+                self.config = self.config.model_copy(update={"workdir": workdir})
         except (
             Exception
         ) as e:  # provisioning failure is one rollout's problem, not the eval's

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -76,7 +76,8 @@ class PrimeConfig(NetworkPolicyConfig):
     platform auto-builds what the sandbox needs from it (a VM image for `vm` sandboxes,
     ~10 minutes) and caches the result, so later sandboxes on the same ref start in
     seconds."""
-    workdir: str = "/app"
+    workdir: str | None = None
+    """Working directory override; None preserves the sandbox's working directory."""
     vm: bool = True
     """Run as a micro-VM rather than a container (kernel features / stronger isolation)."""
     guaranteed: bool = False
@@ -242,9 +243,20 @@ class PrimeRuntime(Runtime):
             logger.info(
                 "prime: sandbox %s up (image=%s)", self.info.id, self.config.image
             )
-            await self._client.execute_command(
-                self.info.id, f"mkdir -p {shlex.quote(self.config.workdir)}"
-            )
+            if self.config.workdir is not None:
+                await self._client.execute_command(
+                    self.info.id, f"mkdir -p {shlex.quote(self.config.workdir)}"
+                )
+            else:
+                result = await self._client.execute_command(self.info.id, "pwd -P")
+                workdir = result.stdout.removesuffix("\n")
+                if result.exit_code != 0 or not workdir.startswith("/"):
+                    raise SandboxError(
+                        f"could not resolve sandbox workdir: {result.stderr}"
+                    )
+                # Resolve before setup so commands, uploads, and relative artifacts agree.
+                self.info.workdir = workdir
+                self.config = self.config.model_copy(update={"workdir": workdir})
         except (
             Exception
         ) as e:  # provisioning failure is one rollout's problem, not the eval's

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -77,7 +77,7 @@ class PrimeConfig(NetworkPolicyConfig):
     ~10 minutes) and caches the result, so later sandboxes on the same ref start in
     seconds."""
     workdir: str | None = None
-    """Working directory override; None preserves the sandbox's working directory."""
+    """Working directory override; None uses the task's workdir, or /app."""
     vm: bool = True
     """Run as a micro-VM rather than a container (kernel features / stronger isolation)."""
     guaranteed: bool = False
@@ -150,8 +150,8 @@ class PrimeRuntime(Runtime):
     def __init__(self, config: PrimeConfig, name: str | None = None) -> None:
         ensure_prime_auth()
         super().__init__(name)
-        self.config = config
-        self.info = PrimeRuntimeInfo(**config.model_dump())
+        self.config = config.model_copy(update={"workdir": config.workdir or "/app"})
+        self.info = PrimeRuntimeInfo(**self.config.model_dump())
         self._client = None
 
     @property
@@ -243,20 +243,9 @@ class PrimeRuntime(Runtime):
             logger.info(
                 "prime: sandbox %s up (image=%s)", self.info.id, self.config.image
             )
-            if self.config.workdir is not None:
-                await self._client.execute_command(
-                    self.info.id, f"mkdir -p {shlex.quote(self.config.workdir)}"
-                )
-            else:
-                result = await self._client.execute_command(self.info.id, "pwd -P")
-                workdir = result.stdout.removesuffix("\n")
-                if result.exit_code != 0 or not workdir.startswith("/"):
-                    raise SandboxError(
-                        f"could not resolve sandbox workdir: {result.stderr}"
-                    )
-                # Resolve before setup so commands, uploads, and relative artifacts agree.
-                self.info.workdir = workdir
-                self.config = self.config.model_copy(update={"workdir": workdir})
+            await self._client.execute_command(
+                self.info.id, f"mkdir -p {shlex.quote(self.config.workdir)}"
+            )
         except (
             Exception
         ) as e:  # provisioning failure is one rollout's problem, not the eval's


### PR DESCRIPTION
Honor explicit runtime working-directory overrides, including `/app`, without letting a task's directory replace them. Docker, Prime, and Modal use `/app` by default for every image unless the task or runtime explicitly specifies another directory.

Keep omitted overrides distinct during task configuration, then apply `/app` when constructing the runtime so commands, uploads, artifacts, and runtime info share the same directory. Isolated verification compares effective defaults before solving, so incompatible relative-artifact directories fail before provisioning a verifier.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workdir precedence across all container runtimes and isolated verification; callers that read unset `workdir` as `/app` on config models must now apply the fallback themselves.
> 
> **Overview**
> Runtime configs for **Docker**, **Modal**, and **Prime** now treat `workdir` as an optional override (`None`) instead of defaulting to `/app` on the model. That lets `resolve_runtime_config` substitute the task’s workdir only when the override was left unset, while an explicit `/app` (or any other path) is no longer overwritten by the task.
> 
> Each container runtime normalizes the effective directory at construction time by copying the config with `workdir or "/app"`, so exec, uploads, and runtime info still share a concrete path after resolution.
> 
> **Isolated verifier** artifact compatibility checks use the same `/app` fallbacks for solver and verifier workdirs (instead of `/` or empty), reducing false “workdir mismatch” errors when relative artifacts are used with default directories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef889d98510549bc051efb15078d63a2bf90e0b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `workdir` optional in `Docker`, `Modal`, and `Prime` runtime configs
> - Changes `workdir` from a required string defaulting to `/app` to an optional string defaulting to unset in [DockerConfig](https://github.com/PrimeIntellect-ai/verifiers/pull/2559/files#diff-78c81f6d797e8a47a8cfb9bbb435481eb5d3a06c3c043bf690fe1df841f88f8f), [ModalConfig](https://github.com/PrimeIntellect-ai/verifiers/pull/2559/files#diff-a6217d92f043d6050e8609d4341d62b5d097d5db796f6197cd604e09d81683c0), and [PrimeConfig](https://github.com/PrimeIntellect-ai/verifiers/pull/2559/files#diff-d22d61279ff7587a2b14c72ab1a0fc9d3f805a735338a70f8efc7fe19aaa8502). Unset values use the task workdir or `/app`.
> - Runtime constructors now copy their config and replace a falsey `workdir` with `/app` when building `RuntimeInfo`, leaving nonempty overrides unchanged.
> - Updates fallback logic in [IsolatedVerifierEnv](https://github.com/PrimeIntellect-ai/verifiers/pull/2559/files#diff-09416510e196f9cf1daef9c08a714f14d9bb22393b68376b2d775fa679c1b127) so an absent solver `workdir` resolves to `/` while a falsey configured value resolves to `/app`.
> - Behavioral Change: Relative artifact validation in `IsolatedVerifierEnv.verifier_config` now distinguishes absent (`/`) from falsey (`/app`) solver workdirs, which can alter whether verifier configuration raises for relative paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef889d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->