### PR TITLE
Add an interception app configuration hook before startup

### DIFF
--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -742,3 +742,38 @@ async def test_replay_round_trip(run_v1, tmp_path):
     # The wire task keeps its taskset-specific fields in the replay's own output.
     raw = (tmp_path / "replay2" / "traces.jsonl").read_text()
     assert '"answer"' in raw
+
+
+async def test_interception_subclass_routes():
+    """Subclass routes share the normal server startup and shutdown lifecycle."""
+    import httpx
+    from aiohttp import web
+
+    from verifiers.v1.interception.server import InterceptionServer
+
+    configured = []
+
+    class CustomServer(InterceptionServer):
+        def _configure_app(self, app: web.Application) -> None:
+            assert not app.frozen
+            assert not app.router.frozen
+            configured.append(app)
+
+            async def custom(request: web.Request) -> web.Response:
+                return web.json_response({"ok": True})
+
+            app.router.add_get("/custom", custom)
+
+    async with httpx.AsyncClient(trust_env=False, timeout=2) as client:
+        async with CustomServer() as server:
+            response = await client.get(f"{server.base_url}/custom")
+            assert response.status_code == 200
+            assert response.json() == {"ok": True}
+            assert len(configured) == 1
+            assert configured[0] is server.runner.app
+            assert configured[0].router.frozen
+            response = await client.get(f"{server.base_url}/state")
+            assert response.status_code == 401
+
+        with pytest.raises(httpx.ConnectError):
+            await client.get(f"{server.base_url}/custom")

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -322,6 +322,9 @@ class InterceptionServer(Interception):
 
         return handler
 
+    def _configure_app(self, app: web.Application) -> None:
+        """Configure each server application before its router is frozen."""
+
     async def start(self) -> None:
         app = web.Application(client_max_size=MAX_REQUEST_BODY)
         for dialect in DIALECTS:
@@ -337,6 +340,7 @@ class InterceptionServer(Interception):
         # A launched tool server fetches its rollout's task here to run `setup_task` — the task
         # is never passed via env, only over this channel, keyed by the state bearer.
         app.router.add_get("/task", self.handle_task_get)
+        self._configure_app(app)
         self.runner = web.AppRunner(app)
         await self.runner.setup()
         self.stack.push_async_callback(self.runner.cleanup)


### PR DESCRIPTION
`InterceptionServer.start()` freezes its aiohttp router before returning, so a subclass cannot register additional routes after `super().start()`. Add a protected `_configure_app(app)` hook after the built-in routes are registered and before `AppRunner.setup()` freezes the application.

The default hook is a no-op. Server startup, authentication, tunnel exposure and cleanup remain owned by the existing lifecycle.

Validation: a local HTTP regression fails with 404 before the change and passes afterward. It verifies registration before freeze, exactly one hook call, unchanged authorization on `/state`, and listener shutdown. The offline suite passed 83 tests; 76 live tests were excluded. Ruff and all-file pre-commit checks passed.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add interception app configuration hook before startup
> Adds an end-to-end test in [test_e2e.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2560/files#diff-ebbbd919487889487f891b359a756e6c4630e106b16ddaef8ccddc6b900a96e1) that defines an `InterceptionServer` subclass overriding application configuration before startup. The test verifies the subclass route is reachable after startup, the configured application becomes router-frozen, protected state routes still reject requests, and the server stops accepting connections after shutdown.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cd47bf9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->