### PR TITLE
fix: configurable node-local verifier cache

### DIFF
--- a/verifiers/v1/utils/paths.py
+++ b/verifiers/v1/utils/paths.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 from pathlib import Path
 
@@ -10,4 +11,10 @@ def home_dir() -> Path:
         return Path(tempfile.gettempdir())
 
 
-CACHE_DIR = home_dir() / ".cache" / "verifiers"
+def cache_dir() -> Path:
+    if override := os.environ.get("VERIFIERS_CACHE_DIR"):
+        return Path(override).expanduser()
+    return home_dir() / ".cache" / "verifiers"
+
+
+CACHE_DIR = cache_dir()


### PR DESCRIPTION
Support VERIFIERS_CACHE_DIR (including ~ expansion) so large local eval runs can keep verifier cache lookups off shared NFS. The default remains ~/.cache/verifiers; an empty override retains the default.

Validation: Ruff and direct default/absolute-path/tilde-override assertions pass. This is a cache-root selection change, not a concurrency limiter or an NFS filesystem fix.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `VERIFIERS_CACHE_DIR` environment variable override for verifier cache path
> Adds a new `cache_dir` resolver in [paths.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2561/files#diff-7beb5d913a0265762d178d61254e7807858b4f6b42976c8e26de6b37d8bea8e2) that expands `VERIFIERS_CACHE_DIR` when set, otherwise falls back to the existing temporary-home-based default. The module-level `CACHE_DIR` now initializes through this resolver at import time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d4f446e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->