### PR TITLE
feat: explicit task-network-policy opt-out for subprocess

### DIFF
--- a/skills/evaluate-environments/SKILL.md
+++ b/skills/evaluate-environments/SKILL.md
@@ -103,6 +103,22 @@ uv run eval my-task-v1 \
   --env.agent.runtime.memory 8
 ```
 
+### Subprocess and task network policies
+
+The subprocess runtime cannot enforce task-level network restrictions. It rejects
+tasks with a concrete or empty `TaskData.network_allow` list, or a non-empty
+`network_block` list, by default. If running those tasks with inherited host
+networking is an explicit and acceptable tradeoff, opt in through configuration:
+
+```toml
+[env.agent.runtime]
+type = "subprocess"
+ignore_task_network_policy = true
+```
+
+This does not enforce the task's requested policy; it deliberately ignores it.
+Prefer a Docker or Prime runtime when isolation is required.
+
 Sampling:
 
 ```bash

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -81,7 +81,13 @@ def _check_borrowed_placement(
     """A borrowed box is never re-provisioned, so a task's placement fields can't
     be honored. Reject requirements that cannot be applied to the running box; an
     image mismatch on a container only warns, since sharing its world is the point."""
-    task_policy = "*" not in task.data.network_allow or bool(task.data.network_block)
+    ignore_task_policy = (
+        isinstance(base_config, SubprocessConfig)
+        and base_config.ignore_task_network_policy
+    )
+    task_policy = (
+        "*" not in task.data.network_allow or bool(task.data.network_block)
+    ) and not ignore_task_policy
     base_policy = base_config if isinstance(base_config, NetworkPolicyConfig) else None
     if task_policy or (base_policy is not None and base_policy.network_restricted):
         config = runtime.config

--- a/verifiers/v1/runtimes/subprocess.py
+++ b/verifiers/v1/runtimes/subprocess.py
@@ -31,6 +31,12 @@ _BACKGROUND_STOP_TIMEOUT = 5
 
 class SubprocessConfig(BaseConfig):
     type: Literal["subprocess"] = "subprocess"
+    ignore_task_network_policy: bool = False
+    """Run with inherited host networking when a task requests network restrictions.
+
+    Subprocesses cannot enforce framework-aware network policies. Keep this disabled
+    unless unrestricted host networking is an explicit, acceptable tradeoff.
+    """
 
 
 class SubprocessRuntimeInfo(SubprocessConfig, BaseRuntimeInfo):

--- a/verifiers/v1/utils/compile.py
+++ b/verifiers/v1/utils/compile.py
@@ -45,7 +45,10 @@ def resolve_runtime_config(
     task_network_policy = "*" not in task.data.network_allow or bool(
         task.data.network_block
     )
-    if task_network_policy:
+    ignore_task_policy = (
+        isinstance(config, SubprocessConfig) and config.ignore_task_network_policy
+    )
+    if task_network_policy and not ignore_task_policy:
         if not isinstance(config, NetworkPolicyConfig):
             raise ValueError(
                 f"task {task.data.idx!r} requires a network policy, but the "


### PR DESCRIPTION
Add SubprocessConfig.ignore_task_network_policy, default false. Trusted host-process runs may explicitly ignore task-level network_allow/network_block requirements, including the borrowed-placement check. Default refusal remains unchanged; container image requirements and container runtime policies are unaffected. Document that this does not enforce network isolation.

Validation: Ruff passes; direct runtime-resolution checks confirm default rejection and explicit opt-in. Existing config/taskset tests ran: 16 passed and 4 failed because optional code_golf, deepwiki, glossary and compact packages are not installed. No dependencies or existing virtual environment changed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ignore_task_network_policy` opt-out to `SubprocessConfig`
> - Adds an opt-in boolean field to `SubprocessConfig` (default `False`) that lets subprocess runtimes ignore task-level network restrictions, since subprocesses cannot enforce framework-aware network policies
> - Updates `resolve_runtime_config` to skip applying task network policy and suppress the unsupported-policy error when the flag is enabled; image requirements still cause rejection
> - Updates `_check_borrowed_placement` so borrowed subprocess runtimes with the flag are not rejected solely for task-level network restrictions, while base runtime restrictions still trigger validation
> - Documents the opt-in behavior and recommends Docker or Prime when isolation is required
> - Risk: tasks requesting network restrictions on a subprocess runtime with `ignore_task_network_policy=True` will run without those restrictions enforced, silently bypassing the requested policy
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1140510.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->