### PR TITLE
Revert "Simplify Prime background job polling"

### DIFF
--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -295,17 +295,20 @@ class PrimeRuntime(Runtime):
 
     async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
         try:
-            # The shared SDK client coalesces concurrent VM job polls into batches.
-            # Rollout cancellation remains the practical execution timeout; this
-            # long SDK deadline is only a final safety bound.
-            result = await self._client.run_background_job(
+            # Poll directly so rollout cancellation owns the execution timeout.
+            job = await self._client.start_background_job(
                 self.info.id,
                 shlex.join(argv),
-                timeout=EFFECTIVELY_UNBOUNDED_SECONDS,
                 working_dir=self.config.workdir,
                 env=self.process_env(env),
-                poll_interval=1,
             )
+            delay = 0.1
+            while True:
+                result = await self._client.get_background_job(self.info.id, job)
+                if result.completed:
+                    break
+                await asyncio.sleep(delay)
+                delay = min(delay * 2, 3)
         except (
             Exception
         ) as e:  # a sandbox/API failure is one rollout's problem, not the eval's


### PR DESCRIPTION
Reverts #2182 by restoring direct Prime background-job polling, with rollout cancellation owning the execution timeout.

`PrimeRuntime.run()` starts the job and polls until completion, using the original backoff from 0.1 seconds up to 3 seconds. This removes the SDK helper's timeout and polling interval from this path while preserving the current process environment handling, shared client, result conversion, and sandbox error boundary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Prime sandbox command execution waits for completion and interacts with cancellation; it restores prior polling behavior but remains on the core eval execution path.
> 
> **Overview**
> **Reverts the simplified Prime exec path** so `PrimeRuntime.run()` again uses `start_background_job` plus a local poll loop on `get_background_job`, instead of the SDK’s `run_background_job` helper.
> 
> Polling uses exponential backoff from **0.1s up to 3s**. The **`EFFECTIVELY_UNBOUNDED_SECONDS` deadline** and fixed **`poll_interval=1`** are removed from this path so **rollout cancellation** can bound how long execution waits, rather than the SDK’s long-running poll wrapper.
> 
> Process env handling, shared client usage, `ProgramResult` mapping, and the `SandboxError` boundary are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a7626f77c7a2a632aa473357290cc7b805b4ffa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revert simplified `PrimeRuntime.run` polling to explicit start and poll loop
> Replaces the SDK's combined background-job execution and polling call with an explicit start operation followed by repeated get operations in [prime.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2563/files#diff-d22d61279ff7587a2b14c72ab1a0fc9d3f805a735338a70f8efc7fe19aaa8502). Polls immediately with an initial 0.1-second delay that exponentially increases up to 3 seconds, and no longer passes the SDK timeout, poll interval, or deadline. Exception translation and `ProgramResult` construction remain unchanged.
> - Risk: removing the SDK deadline means execution is now bounded only by surrounding coroutine cancellation; callers relying on the SDK-configured final deadline will no longer get automatic timeout enforcement.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6a7626f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->