### PR TITLE
fix(v1): preserve runtime overrides for agentic syn-gen

### DIFF
--- a/skills/evaluate-environments/SKILL.md
+++ b/skills/evaluate-environments/SKILL.md
@@ -103,6 +103,22 @@ uv run eval my-task-v1 \
   --env.agent.runtime.memory 8
 ```
 
+### Subprocess and task network policies
+
+The subprocess runtime cannot enforce task-level network restrictions. It rejects
+tasks with a concrete or empty `TaskData.network_allow` list, or a non-empty
+`network_block` list, by default. If running those tasks with inherited host
+networking is an explicit and acceptable tradeoff, opt in through configuration:
+
+```toml
+[env.agent.runtime]
+type = "subprocess"
+ignore_task_network_policy = true
+```
+
+This does not enforce the task's requested policy; it deliberately ignores it.
+Prefer a Docker or Prime runtime when isolation is required.
+
 Sampling:
 
 ```bash

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -81,7 +81,13 @@ def _check_borrowed_placement(
     """A borrowed box is never re-provisioned, so a task's placement fields can't
     be honored. Reject requirements that cannot be applied to the running box; an
     image mismatch on a container only warns, since sharing its world is the point."""
-    task_policy = "*" not in task.data.network_allow or bool(task.data.network_block)
+    ignore_task_policy = (
+        isinstance(base_config, SubprocessConfig)
+        and base_config.ignore_task_network_policy
+    )
+    task_policy = (
+        "*" not in task.data.network_allow or bool(task.data.network_block)
+    ) and not ignore_task_policy
     base_policy = base_config if isinstance(base_config, NetworkPolicyConfig) else None
     if task_policy or (base_policy is not None and base_policy.network_restricted):
         config = runtime.config

--- a/verifiers/v1/runtimes/subprocess.py
+++ b/verifiers/v1/runtimes/subprocess.py
@@ -31,6 +31,12 @@ _BACKGROUND_STOP_TIMEOUT = 5
 
 class SubprocessConfig(BaseConfig):
     type: Literal["subprocess"] = "subprocess"
+    ignore_task_network_policy: bool = False
+    """Run with inherited host networking when a task requests network restrictions.
+
+    Subprocesses cannot enforce framework-aware network policies. Keep this disabled
+    unless unrestricted host networking is an explicit, acceptable tradeoff.
+    """
 
 
 class SubprocessRuntimeInfo(SubprocessConfig, BaseRuntimeInfo):

--- a/verifiers/v1/utils/compile.py
+++ b/verifiers/v1/utils/compile.py
@@ -45,7 +45,11 @@ def resolve_runtime_config(
     task_network_policy = "*" not in task.data.network_allow or bool(
         task.data.network_block
     )
-    if task_network_policy:
+    ignore_task_policy = (
+        isinstance(config, SubprocessConfig)
+        and config.ignore_task_network_policy
+    )
+    if task_network_policy and not ignore_task_policy:
         if not isinstance(config, NetworkPolicyConfig):
             raise ValueError(
                 f"task {task.data.idx!r} requires a network policy, but the "

--- a/verifiers/v1/utils/compile.py
+++ b/verifiers/v1/utils/compile.py
@@ -46,8 +46,7 @@ def resolve_runtime_config(
         task.data.network_block
     )
     ignore_task_policy = (
-        isinstance(config, SubprocessConfig)
-        and config.ignore_task_network_policy
+        isinstance(config, SubprocessConfig) and config.ignore_task_network_policy
     )
     if task_network_policy and not ignore_task_policy:
         if not isinstance(config, NetworkPolicyConfig):

--- a/verifiers/v1/utils/paths.py
+++ b/verifiers/v1/utils/paths.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 from pathlib import Path
 
@@ -10,4 +11,10 @@ def home_dir() -> Path:
         return Path(tempfile.gettempdir())
 
 
-CACHE_DIR = home_dir() / ".cache" / "verifiers"
+def cache_dir() -> Path:
+    if override := os.environ.get("VERIFIERS_CACHE_DIR"):
+        return Path(override).expanduser()
+    return home_dir() / ".cache" / "verifiers"
+
+
+CACHE_DIR = cache_dir()


### PR DESCRIPTION
Supports the research-prod agentic syn-gen stack by retaining two runtime behaviors on current Verifiers main:

- allow subprocess tasks to explicitly ignore task network policy;
- allow `VERIFIERS_CACHE_DIR` to relocate the Verifiers cache.

Current main already includes #2527, so agentic judges omit hidden reasoning and provider state by default.

Validation:
- `uv run pytest tests/v1/test_judges.py -q` (30 passed)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ignore_task_network_policy` opt-in to `SubprocessConfig` and support `VERIFIERS_CACHE_DIR`
> - Adds the `ignore_task_network_policy` boolean field to `SubprocessConfig` (default disabled) so subprocess runtimes can explicitly ignore task-level network restrictions and retain inherited host networking.
> - Updates `resolve_runtime_config` in [compile.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2564/files#diff-c5d7bd0167850a8d2492d083675cba0e1127f6565f85bd87f59dbaf86ac47bc1) to skip applying task network restrictions and suppress the unsupported-policy error when the subprocess runtime opts in.
> - Updates `_check_borrowed_placement` in [agent.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2564/files#diff-f719e773e216506045964fdfb9fad948b7b504ea092359ced06c928ab5148ea2) so borrowed subprocess runtimes with the override no longer reject tasks solely for requesting network restrictions; base network-policy validation still applies when present.
> - Adds a `cache_dir` helper in [paths.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2564/files#diff-7beb5d913a0265762d178d61254e7807858b4f6b42976c8e26de6b37d8bea8e2) that reads `VERIFIERS_CACHE_DIR` (expanding `~`), falling back to the default user cache directory; the module-level `CACHE_DIR` constant now uses this resolver.
> - Documents subprocess network-policy behavior in [SKILL.md](https://github.com/PrimeIntellect-ai/verifiers/pull/2564/files#diff-36d08ee11d380ecaa5beacd5b98cd8bfa0791dfa784b93956b128cafc58dbe0d), recommending Docker or Prime when isolation is required.
> - Behavioral Change: when `ignore_task_network_policy` is enabled on a `SubprocessConfig`, task network restrictions are silently dropped rather than enforced or rejected — tasks that previously failed will now run with inherited host networking.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9003400.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->