### PR TITLE
fix(lean-taskset): audit proof axioms to close the injected-axiom bypass

### DIFF
--- a/tests/v1/test_lean_scoring.py
+++ b/tests/v1/test_lean_scoring.py
@@ -1,0 +1,134 @@
+"""Tests for the Lean taskset's scoring helpers and axiom audit."""
+
+from types import SimpleNamespace
+
+from verifiers.v1.tasksets.lean.scoring import (
+    TRUSTED_AXIOMS,
+    declaration_name,
+    parse_axioms_output,
+    untrusted_axioms,
+)
+
+CHEAT_OUTPUT = (
+    "'fake_irrational' depends on axioms: "
+    "[cheat, propext, Classical.choice, Quot.sound]"
+)
+CLEAN_OUTPUT = (
+    "'real_theorem' depends on axioms: [propext, Classical.choice, Quot.sound]"
+)
+
+
+def test_declaration_name_reads_theorem_and_lemma() -> None:
+    assert (
+        declaration_name("theorem fake_irrational : Irrational (1 : ℝ) := by")
+        == "fake_irrational"
+    )
+    assert declaration_name("lemma my_lemma (x : ℕ) : x = x := by") == "my_lemma"
+    assert declaration_name("import Mathlib\ntheorem foo : True := by") == "foo"
+
+
+def test_declaration_name_returns_empty_when_unparsable() -> None:
+    assert declaration_name("example : True := by") == ""
+    assert declaration_name("") == ""
+
+
+def test_parse_axioms_output_reads_the_axiom_list() -> None:
+    assert parse_axioms_output(CHEAT_OUTPUT) == [
+        "cheat",
+        "propext",
+        "Classical.choice",
+        "Quot.sound",
+    ]
+
+
+def test_parse_axioms_output_handles_no_axioms() -> None:
+    assert parse_axioms_output("'t' does not depend on any axioms") == []
+    assert parse_axioms_output("") == []
+
+
+def test_untrusted_axioms_flags_an_injected_axiom() -> None:
+    """Regression test for the ``axiom cheat : False`` reward bypass."""
+    assert untrusted_axioms(CHEAT_OUTPUT) == ["cheat"]
+
+
+def test_untrusted_axioms_accepts_the_mathlib_baseline() -> None:
+    assert untrusted_axioms(CLEAN_OUTPUT) == []
+    assert set(TRUSTED_AXIOMS) == {"propext", "Classical.choice", "Quot.sound"}
+
+
+def test_untrusted_axioms_matches_the_last_report() -> None:
+    """A printed decoy must not shadow the real audit result.
+
+    Our ``#print axioms`` query is appended last, so anything earlier in the
+    transcript came from the rollout -- the same reasoning ``parse_compile_output``
+    uses for ``EXIT_CODE`` markers.
+    """
+    decoy = (
+        "'fake_irrational' depends on axioms: "
+        "[propext, Classical.choice, Quot.sound]\n" + CHEAT_OUTPUT
+    )
+    assert untrusted_axioms(decoy) == ["cheat"]
+
+
+class _StubResult:
+    def __init__(self, stdout: str) -> None:
+        self.stdout = stdout
+        self.stderr = ""
+
+
+class _StubRuntime:
+    """Serves the proof file and canned ``lake env lean`` transcripts."""
+
+    def __init__(self, axioms_output: str) -> None:
+        self.files = {
+            "/tmp/proof.lean": (
+                b"import Mathlib\naxiom cheat : False\n"
+                b"theorem foo : True := by\n  exact cheat.elim\n"
+            )
+        }
+        self.axioms_output = axioms_output
+
+    async def read(self, path: str, max_bytes: int | None = None) -> bytes:
+        return self.files[path]
+
+    async def write(self, path: str, data: bytes) -> None:
+        self.files[path] = data
+
+    async def run(self, argv: list[str], env: dict[str, str]) -> _StubResult:
+        command = argv[-1]
+        if ".axioms.lean" in command:
+            return _StubResult(self.axioms_output)
+        return _StubResult("EXIT_CODE:0")
+
+
+def _lean_task():
+    from verifiers.v1.tasksets.lean.taskset import LeanData, LeanTask, LeanTaskConfig
+
+    return LeanTask(
+        LeanData(
+            idx=0,
+            prompt="prove it",
+            formal_statement="theorem foo : True := by",
+            protected_signature="theorem foo : True := by",
+        ),
+        LeanTaskConfig(),
+    )
+
+
+async def test_lean_compiled_rejects_a_proof_resting_on_an_injected_axiom() -> None:
+    """A clean compile must not score when the rollout supplied the axiom."""
+    trace = SimpleNamespace(has_error=False, info={})
+    runtime = _StubRuntime(CHEAT_OUTPUT.replace("fake_irrational", "foo"))
+
+    assert await _lean_task().lean_compiled(trace, runtime) == 0.0
+    assert trace.info["lean_compiled"] is True
+    assert trace.info["lean_tampered"] is True
+    assert trace.info["lean_untrusted_axioms"] == ["cheat"]
+
+
+async def test_lean_compiled_still_rewards_a_genuine_proof() -> None:
+    trace = SimpleNamespace(has_error=False, info={})
+    runtime = _StubRuntime(CLEAN_OUTPUT.replace("real_theorem", "foo"))
+
+    assert await _lean_task().lean_compiled(trace, runtime) == 1.0
+    assert trace.info["lean_tampered"] is False

--- a/verifiers/v1/tasksets/lean/scoring.py
+++ b/verifiers/v1/tasksets/lean/scoring.py
@@ -236,6 +236,62 @@ def build_starter_file(
     return wrapped
 
 
+# ── Axiom auditing ───────────────────────────────────────────────────────────
+
+# The axioms Mathlib itself is built on. A proof depending only on these is a
+# genuine proof; anything else means the rollout introduced its own assumption.
+TRUSTED_AXIOMS: frozenset[str] = frozenset(
+    {"propext", "Classical.choice", "Quot.sound"}
+)
+
+
+def declaration_name(expected_signature: str) -> str:
+    """Return the declared name from a ``theorem/lemma/example ... := by`` block.
+
+    Used to build the ``#print axioms <name>`` query. Returns ``""`` when no name
+    can be read (anonymous ``example``, or a signature we cannot parse), which the
+    caller treats as "no audit possible" rather than as a pass.
+    """
+    match = re.search(r"\b(?:theorem|lemma)\s+([^\s:({\[]+)", expected_signature or "")
+    return match.group(1) if match else ""
+
+
+def parse_axioms_output(output: str) -> list[str]:
+    """Extract the axiom list from a ``#print axioms <name>`` transcript.
+
+    Lean prints ``'name' depends on axioms: [a, b, c]`` or, for a proof needing
+    none, ``'name' does not depend on any axioms``. Returns the axiom names in the
+    order Lean reported them; an empty list means either no axioms or no parsable
+    ``depends on axioms`` line.
+
+    Matches the LAST such line, for the same reason ``parse_compile_output``
+    matches the last ``EXIT_CODE`` marker: our query is appended at the end of the
+    file, so anything earlier came from the rollout. Matching the first occurrence
+    would let a model inject
+
+    .. code-block:: lean
+
+        #eval IO.println "'x' depends on axioms: [propext]"
+
+    above its proof and have the audit read that instead of the real result.
+    """
+    matches = list(re.finditer(r"depends on axioms:\s*\[([^\]]*)\]", output))
+    if not matches:
+        return []
+    return [axiom.strip() for axiom in matches[-1].group(1).split(",") if axiom.strip()]
+
+
+def untrusted_axioms(
+    output: str, trusted: frozenset[str] = TRUSTED_AXIOMS
+) -> list[str]:
+    """Axioms in a ``#print axioms`` transcript that fall outside ``trusted``.
+
+    A non-empty result means the proof leans on an assumption the rollout supplied
+    (``axiom cheat : False``), so the goal was never actually proved.
+    """
+    return [axiom for axiom in parse_axioms_output(output) if axiom not in trusted]
+
+
 # ── Compile-output parsing ───────────────────────────────────────────────────
 
 

--- a/verifiers/v1/tasksets/lean/taskset.py
+++ b/verifiers/v1/tasksets/lean/taskset.py
@@ -22,9 +22,11 @@ from verifiers.v1.task import Task, TaskData, TaskResources
 from verifiers.v1.taskset import Taskset
 from verifiers.v1.tasksets.lean.scoring import (
     build_starter_file,
+    declaration_name,
     expected_protected_signature,
     parse_compile_output,
     protected_signature_substring_present,
+    untrusted_axioms,
 )
 from verifiers.v1.trace import Trace
 from verifiers.v1.utils.decorators import reward
@@ -89,6 +91,26 @@ class LeanTask(Task[LeanData, State, LeanTaskConfig]):
         result = await runtime.run(["bash", "-lc", cmd], {})
         return parse_compile_output((result.stdout or "") + (result.stderr or ""))
 
+    async def _print_axioms(self, runtime: Runtime, name: str) -> str:
+        """Compile a copy of the proof file with ``#print axioms <name>`` appended.
+
+        Written to a separate path so the rollout's file is left untouched, and
+        appended last so the real result is the final ``depends on axioms`` line in
+        the transcript.
+        """
+        content = (await runtime.read(self.config.proof_file_path)).decode(
+            "utf-8", "replace"
+        )
+        audit_path = f"{self.config.proof_file_path}.axioms.lean"
+        await runtime.write(audit_path, f"{content}\n#print axioms {name}\n".encode())
+        cmd = (
+            f"cd {shlex.quote(self.config.lean_project_path)} && "
+            f"timeout {self.config.compile_timeout} lake env lean "
+            f"{shlex.quote(audit_path)} 2>&1"
+        )
+        result = await runtime.run(["bash", "-lc", cmd], {})
+        return (result.stdout or "") + (result.stderr or "")
+
     async def setup(self, runtime: Runtime) -> None:
         content = build_starter_file(
             self.data.formal_statement,
@@ -124,7 +146,25 @@ class LeanTask(Task[LeanData, State, LeanTaskConfig]):
         trace.info["lean_compiled"] = compiled
         trace.info["compile_exit_code"] = exit_code
         trace.info["compile_output"] = output[-4000:]
-        return 1.0 if compiled else 0.0
+        if not compiled:
+            return 0.0
+
+        # A clean compile is not a proof if the rollout supplied its own axiom:
+        # ``axiom cheat : False`` above the protected signature compiles silently
+        # and closes any goal. Audit what the declaration actually rests on.
+        name = declaration_name(expected_sig)
+        if name:
+            axioms_output = await self._print_axioms(runtime, name)
+            trace.info["lean_axioms_output"] = axioms_output[-4000:]
+            introduced = untrusted_axioms(axioms_output)
+            if introduced:
+                trace.info["lean_tampered"] = True
+                trace.info["lean_untrusted_axioms"] = introduced
+                trace.info["compile_output"] = (
+                    "proof depends on untrusted axioms: " + ", ".join(introduced)
+                )
+                return 0.0
+        return 1.0
 
     async def validate(self, runtime: Runtime) -> bool | None:
         """Compile the gold proof; rows without one have nothing to preflight."""


### PR DESCRIPTION
Closes #2177

`lean_compiled` awards 1.0 when the protected signature is intact and `lake env lean` exits 0 with no `sorry`. It never checks what the proof depends on, so a rollout can close any goal by supplying its own axiom above the signature:

```lean
import Mathlib
axiom cheat : False
-- DO NOT MODIFY the theorem statement below.
theorem fake_irrational : Irrational (1 : ℝ) := by
  exact cheat.elim
```

`Irrational (1 : ℝ)` is false. The `axiom` sits above the protected region, so the signature guard passes, the compile is silent, and the reward returns 1.0.

#1271 flagged this exact gap as future work ("or axiomatize the goal"); #1480 closed a sibling bypass in the same reward.

## Change

After a clean compile, write the rollout's file to a sibling path with `#print axioms <name>` appended, compile that, and reject any axiom outside Mathlib's trusted base — `propext`, `Classical.choice`, `Quot.sound`. The rollout's own file is left untouched.

The parsing and trust decision are pure functions in `scoring.py`, alongside the existing helpers.

### One detail worth flagging

`parse_axioms_output` matches the **last** `depends on axioms` line, not the first. Our query is appended at the end of the file, so anything earlier came from the rollout — without this, a model could inject

```lean
#eval IO.println "'fake_irrational' depends on axioms: [propext, Classical.choice, Quot.sound]"
```

above its proof and have the audit read the decoy. That is the same failure #1480 fixed for `EXIT_CODE` markers, so I followed the reasoning already documented in `parse_compile_output`. There is a test for it.

`declaration_name` returns `""` for an anonymous `example`, which skips the audit rather than failing the rollout — the pre-existing behaviour for statements the reward cannot pin.

## Tests

`tests/v1/test_lean_scoring.py`, 9 tests:

- the pure helpers: name extraction, axiom-list parsing, the trusted baseline, the injected `cheat` axiom, and the decoy-shadowing case
- the reward itself, driven through a stub runtime: a compiling proof resting on `cheat` scores **0.0** with `lean_untrusted_axioms == ["cheat"]`, and a genuine proof still scores **1.0**

Reverting only the `taskset.py` wiring (keeping the helpers) turns the first reward test into `assert 1.0 == 0.0`, so the test pins the bypass itself rather than the helpers.

`tests/v1` (excluding `test_e2e.py`): 76 passed, up from 67, with the same 11 pre-existing failures in `test_configs.py::test_eval_config_parses` — missing optional taskset packages in my environment, unrelated to this change. `test_color_codeword_tasks.py` does not collect locally for the same reason.

`ruff check` and `ruff format` clean.

I could not run the real Lean toolchain locally, so the audit is verified against recorded `#print axioms` transcripts rather than a live `lake env lean`. The transcripts match the ones in the issue, including `#print axioms fake_irrational → [cheat, propext, Classical.choice, Quot.sound]`. Happy to adjust if the real output differs in shape.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject Lean proofs resting on injected axioms in `lean_compiled`
> - Adds `LeanTask._print_axioms` which writes an audit copy of the proof with a declaration-specific `#axioms` query, runs Lean on it, and returns the combined transcript without touching the original proof file.
> - Adds parsers in [scoring.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2565/files#diff-6df81277181f7dcb921afcca61e1eb6a8630d07219d543c6a6784e0ae7fea305): `declaration_name` extracts the theorem/lemma name from a signature, `parse_axioms_output` selects the last reported axiom list, and `untrusted_axioms` filters names against the `TRUSTED_AXIOMS` Mathlib baseline.
> - `lean_compiled` in [taskset.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2565/files#diff-4e7d754229e5803fddc0fea71640b92984c26d8a2da8fb28aa8c2c86150fa25a) now runs the audit after a successful compile and sets score to zero with tampering info when any untrusted axiom is found.
> - Behavioral Change: a proof that compiles but depends on an axiom outside the three accepted Mathlib baseline names now scores zero and is marked tampered; if no declaration name is found or the audit yields no untrusted axioms, full credit is retained.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 148dfce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->