### PR TITLE
Make Harbor artifact transfer budgets configurable

### DIFF
--- a/docs/v1/harbor.md
+++ b/docs/v1/harbor.md
@@ -109,6 +109,8 @@ tool and provider-held resource remains disabled.
 
 `--env.taskset.artifact-max-bytes` sets the total artifact archive budget per solver runtime (default: 32 MiB), including the `/logs/artifacts/` convention directory. Increase it for tasks that transfer trained checkpoints or VM disk files. The budget also applies when scoring is deferred to a separate verifier.
 
+Prime VM bounded reads stream binary data. Collected archives remain in host memory for grading and are excluded from persisted traces.
+
 `artifacts = [...]` and `[[verifier.collect]]` are read from `task.toml` ([Harbor Docs](https://www.harborframework.com/docs/run-jobs/results-and-artifacts)). Collect hooks run in the agent's box from the task's `finalize`, which is Harbor's own ordering — after the agent phase, before collection — and declared paths plus the `/logs/artifacts/` convention dir are then carried into the grading box and restored at their original paths ("no translation", as in Harbor).
 
 Two deliberate differences from `harbor run`:

--- a/docs/v1/harbor.md
+++ b/docs/v1/harbor.md
@@ -107,6 +107,8 @@ tool and provider-held resource remains disabled.
 
 ## Artifacts and collect hooks
 
+`--env.taskset.artifact-max-bytes` sets the total artifact archive budget per solver runtime (default: 32 MiB), including the `/logs/artifacts/` convention directory. Increase it for tasks that transfer trained checkpoints or VM disk files. The budget also applies when scoring is deferred to a separate verifier.
+
 `artifacts = [...]` and `[[verifier.collect]]` are read from `task.toml` ([Harbor Docs](https://www.harborframework.com/docs/run-jobs/results-and-artifacts)). Collect hooks run in the agent's box from the task's `finalize`, which is Harbor's own ordering — after the agent phase, before collection — and declared paths plus the `/logs/artifacts/` convention dir are then carried into the grading box and restored at their original paths ("no translation", as in Harbor).
 
 Two deliberate differences from `harbor run`:

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -10,6 +10,7 @@ import pytest
 
 import verifiers.v1 as vf
 from verifiers.v1.agent import Interaction
+from verifiers.v1.cli.output import write_episode
 from verifiers.v1.graph import MessageNode
 from verifiers.v1.harnesses.rlm.harness import (
     RLM_SESSION_METADATA_KEY,
@@ -109,13 +110,13 @@ def test_bare_trace_round_trip():
     assert rt.reward == 0.0 and rt.errors == []
 
 
-def test_custom_task_state_round_trip():
+def test_custom_task_state_round_trip(tmp_path):
     # Custom data and state round-trip into the same parameterization. Data fields are
     # typed (not just `model_extra`); `state` is runtime-only and never crosses the wire.
     tr = vf.Trace[MyTask, MyState](
         agent=vf.AgentInfo(config=vf.AgentConfig()),
         task=vf.TraceTask(type="MyTask", data=MyTask(idx=0, prompt="q", answer="gold")),
-        state=MyState(score=7),
+        state=MyState(score=7, artifacts={"/artifact.bin": b"\xff\x00\xfe"}),
         nodes=[
             MessageNode(parent=None, message=UserMessage(content="q"), sampled=False),
             MessageNode(parent=0, message=AssistantMessage(content="a"), sampled=True),
@@ -132,6 +133,10 @@ def test_custom_task_state_round_trip():
     assert rt.task.type == "MyTask"  # the producing class's name survives the wire
     assert rt.num_turns == 1 and rt.num_branches == 1
     assert rt.reward == 0.5  # property recomputed from `rewards`
+    write_episode(tmp_path, vf.Episode(task=tr.task, traces=[tr], ok=True))
+    saved = json.loads((tmp_path / "traces.jsonl").read_bytes())
+    assert "state" not in saved["traces"][0]
+    assert tr.state.artifacts["/artifact.bin"] == b"\xff\x00\xfe"
 
 
 def test_wire_trace_round_trip():

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -476,7 +476,9 @@ class Rollout:
                         )
                         if self._collect_artifacts and not trace.state.artifacts:
                             trace.state.artifacts = await collect(
-                                runtime, self.task.data.artifacts
+                                runtime,
+                                self.task.data.artifacts,
+                                max_bytes=self.task.data.artifact_max_bytes,
                             )
                 now = time.time()
                 trace.timing.finalize.end = now

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -7,8 +7,8 @@ direction (a program in the sandbox reaching a host service) is the shared host-
 """
 
 import asyncio
-import base64
 import contextlib
+import io
 import logging
 import math
 import shlex
@@ -372,19 +372,30 @@ class PrimeRuntime(Runtime):
     async def _read(self, path: str, max_bytes: int | None = None) -> bytes:
         if max_bytes is not None and self.config.vm:
             try:
-                # VM execute_command uses bash and returns the complete output stream.
-                result = await self._client.execute_command(
+                # Stream binary output: execute_command buffers base64 text for the
+                # entire file. Bound the source read and the host buffer independently.
+                process = await self._client.open_process(
                     self.info.id,
-                    f"set -o pipefail; head -c {max_bytes} -- {shlex.quote(path)} | base64",
+                    f"head -c {max_bytes} -- {shlex.quote(path)}",
                     working_dir=self.config.workdir,
                     env=self.process_env({}),
-                    timeout=EFFECTIVELY_UNBOUNDED_SECONDS,
                 )
+                async with contextlib.aclosing(process):
+                    with io.BytesIO() as data:
+                        async for chunk in process.stdout:
+                            if data.tell() + len(chunk) > max_bytes:
+                                raise SandboxError(
+                                    "read stream exceeded its byte limit"
+                                )
+                            data.write(chunk)
+                        stderr = b""
+                        async for chunk in process.stderr:
+                            stderr = (stderr + chunk)[-500:]
+                        if await process.wait():
+                            raise SandboxError(stderr.decode(errors="replace").strip())
+                        return data.getvalue()
             except Exception as exc:
                 raise SandboxError(f"read {path!r}: {exc}") from exc
-            if result.exit_code:
-                raise SandboxError(f"read {path!r}: {result.stderr.strip()[-500:]}")
-            return base64.b64decode(result.stdout)
         if max_bytes is not None:
             return await super()._read(path, max_bytes)
         # Avoid background-job log limits and base64 overhead by downloading binary data directly.

--- a/verifiers/v1/task.py
+++ b/verifiers/v1/task.py
@@ -24,7 +24,7 @@ from verifiers.v1.configs.task import TaskConfig
 from verifiers.v1.errors import TaskError, boundary
 from verifiers.v1.state import StateT
 from verifiers.v1.types import Messages, content_text
-from verifiers.v1.utils.artifacts import Artifact
+from verifiers.v1.utils.artifacts import MAX_ARTIFACT_BYTES, Artifact
 from verifiers.v1.utils.decorators import (
     discover_decorated,
     invoke_all,
@@ -112,6 +112,8 @@ class TaskData(BaseModel):
     on top of the implicitly collected `/logs/artifacts/` convention dir. Declare
     runtime outputs that must cross that boundary. A declared path that is missing at
     collection time fails the rollout."""
+    artifact_max_bytes: int = Field(MAX_ARTIFACT_BYTES, gt=0)
+    """Total byte limit for collected artifact archives, including the convention dir."""
 
     timeout: TaskTimeout = TaskTimeout()
     resources: TaskResources = TaskResources()

--- a/verifiers/v1/tasksets/harbor/taskset.py
+++ b/verifiers/v1/tasksets/harbor/taskset.py
@@ -38,7 +38,7 @@ from verifiers.v1.runtimes import Runtime
 from verifiers.v1.task import Task, TaskData, TaskResources, TaskTimeout
 from verifiers.v1.taskset import Taskset
 from verifiers.v1.trace import Trace
-from verifiers.v1.utils.artifacts import Artifact, collect
+from verifiers.v1.utils.artifacts import MAX_ARTIFACT_BYTES, Artifact, collect
 from verifiers.v1.utils.decorators import reward
 
 logger = logging.getLogger(__name__)
@@ -54,6 +54,8 @@ REWARD_JSON_ADAPTER = TypeAdapter(
 
 
 class HarborConfig(TasksetConfig):
+    artifact_max_bytes: int = Field(MAX_ARTIFACT_BYTES, gt=0)
+    """Total byte limit for artifact archives transferred out of each solver runtime."""
     dataset: str = "harbor/hello-world"
     """A Harbor Hub package id ("org/name" or "org/name@ref"), where ref is a
     tag, integer revision, or sha256 digest. Legacy registries selected with `repo`,
@@ -248,7 +250,9 @@ class HarborTask(Task[HarborData]):
                     f"{hook.command}\n{detail}"
                 )
         if not self.scoring_deferred:
-            trace.state.artifacts = await collect(runtime, self.data.artifacts)
+            trace.state.artifacts = await collect(
+                runtime, self.data.artifacts, max_bytes=self.data.artifact_max_bytes
+            )
 
     async def stage_verifier(self, trace: Trace, runtime: Runtime) -> None:
         if any(
@@ -556,6 +560,7 @@ def parse_task(task_dir: Path, idx: int, harbor_config: HarborConfig) -> HarborD
         )
     return HarborData(
         idx=idx,
+        artifact_max_bytes=harbor_config.artifact_max_bytes,
         name=harbor_task.name,
         description=task.description if task else None,
         prompt=harbor_task.instruction.strip(),

--- a/verifiers/v1/utils/artifacts.py
+++ b/verifiers/v1/utils/artifacts.py
@@ -21,7 +21,7 @@ ARTIFACTS_DIR = "/logs/artifacts"
 """Implicit artifact directory; tasks that write here need no declaration."""
 
 MAX_ARTIFACT_BYTES = 32 * 1024 * 1024
-"""Ceiling per collection. Sized for a delta, not a tree: the grading box boots from the
+"""Default ceiling per collection. Sized for a delta, not a tree: the grading box boots from the
 agent's image, so the repo is already there and only its output has to travel."""
 
 
@@ -35,7 +35,10 @@ class Artifact(BaseModel):
 
 
 async def collect(
-    runtime: Runtime, artifacts: list[Artifact] | None = None
+    runtime: Runtime,
+    artifacts: list[Artifact] | None = None,
+    *,
+    max_bytes: int = MAX_ARTIFACT_BYTES,
 ) -> dict[str, bytes | None]:
     """Tar the convention dir and every declared path out of `runtime`.
 
@@ -114,7 +117,7 @@ async def collect(
         )
         existence.extend(output.splitlines())
     collected: dict[str, bytes | None] = {}
-    budget = MAX_ARTIFACT_BYTES
+    budget = max_bytes
     for artifact, exists in zip(entries, existence, strict=True):
         source = artifact.source
         if exists != "1":


### PR DESCRIPTION
Harbor tasks that produce trained checkpoints or VM disk files can exceed the fixed 32 MiB artifact-transfer cap and fail before separate grading. Add a per-task artifact budget so environments can provide enough space for their declared outputs.

`HarborConfig.artifact_max_bytes` is copied into `TaskData` and passed to the shared collector from both Harbor finalization and deferred rollout collection. The collector applies one total budget across all declared roots and the implicit `/logs/artifacts/` directory, while retaining 32 MiB as the default.

On Prime VMs, bounded reads stream binary chunks into a capped buffer and close the process on success, failure, or cancellation. Artifact payloads remain transient and excluded from persisted traces.

This provides the artifact-budget support required by the Terminal-Bench 4 environment in [prime-envs #800](https://github.com/PrimeIntellect-ai/prime-envs/pull/800) and [PTB Max #4](https://github.com/aisa-group/PostTrainBench-Max-benchmarks/pull/4), whose default budget is 4 GiB.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Raises configurable artifact memory on the host and changes Prime VM read semantics for bounded reads; defaults are unchanged but misconfigured large budgets could increase rollout memory use.
> 
> **Overview**
> Adds a **configurable total artifact archive budget** (default still 32 MiB) so Harbor and generic rollouts can collect larger solver outputs—checkpoints, VM disks—without hitting a hard cap. `HarborConfig` / `TaskData` expose `artifact_max_bytes`, copied into each Harbor task and passed into `collect()` from rollout finalize and Harbor finalize; docs describe `--env.taskset.artifact-max-bytes`.
> 
> **Prime VM bounded reads** no longer pipe files through `base64` + `execute_command`; they stream raw bytes via `open_process` and `head -c`, with independent limits on the sandbox read and host buffer—better suited to artifact collection at higher budgets.
> 
> Tests assert **runtime `state` (including in-memory artifacts) stays off persisted traces** when writing episodes; harbor docs note the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b6e2d80edb3bccf37a70635bf285bb90440e077. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make Harbor artifact transfer byte budget configurable via `artifact_max_bytes`
> - Adds a positive `artifact_max_bytes` field to `TaskData` and `HarborConfig`, defaulting to 32 MiB (`MAX_ARTIFACT_BYTES`), and propagates it through Harbor task parsing and non-deferred/rollout fallback artifact collection calls.
> - Updates the `collect` utility in [artifacts.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2567/files#diff-0d082bad54931be61d7ef55ddce0757034be3013f69ae71cb803cd8416df9138) to accept a keyword-only `max_bytes` budget and subtract each archive's length before collecting the next entry.
> - Rewrites `PrimeRuntime._read` in [prime.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2567/files#diff-d22d61279ff7587a2b14c72ab1a0fc9d3f805a735338a70f8efc7fe19aaa8502) to stream raw binary via `head -c` into a `BytesIO` buffer instead of base64-decoding command output, raising `SandboxError` when the stream exceeds the limit or the process exits non-zero.
> - Extends the trace regression test in [test_trace.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2567/files#diff-ad6d1dda2b40e73baa4de5ad46c7a5a5580402aef93562589170bfc1bf9d1a99) to verify binary artifacts in custom runtime state stay in memory and are excluded from persisted episode JSONL.
> - Behavioral Change: artifact collection now enforces the caller-selected total budget across all entries; callers that omit `max_bytes` retain the 32 MiB default. `PrimeRuntime._read` no longer uses base64 or an effectively-unbounded timeout.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0b6e2d8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
