### PR TITLE
feat(v1): carry paired routing weights in single-turn traces

### DIFF
--- a/tests/v1/test_graph.py
+++ b/tests/v1/test_graph.py
@@ -1,9 +1,15 @@
 import base64
+import json
 
+import msgpack
 import numpy as np
+import pytest
+from renderers.client import parse_generate_response
 
 import verifiers.v1 as vf
 from verifiers.v1 import graph
+from verifiers.v1.clients.train import response_from_generate
+from verifiers.v1.routing import RoutingData
 from verifiers.v1.types import TurnTokens
 
 
@@ -32,6 +38,129 @@ def _routed_payload(
         "shape": list(arr.shape),
         "start": start,
     }
+
+
+def _full_routing_response(rows=4, *, prompt=None, completion=None):
+    payload = _routed_payload(rows, 0, 11, top_k=2)
+    weights = np.tile(np.array([0.12345679, 0.8765432], dtype="<f4"), (rows, 2, 1))
+    payload.update(
+        dtype="uint8",
+        format_version=1,
+        weights={
+            "data": base64.b64encode(weights.tobytes()).decode(),
+            "dtype": "float32",
+        },
+    )
+    parsed = parse_generate_response(
+        json.dumps(
+            {"choices": [{"routed_experts": payload}]}, separators=(",", ":")
+        ).encode()
+    )
+    return response_from_generate(
+        {
+            "prompt_ids": [10, 11, 12] if prompt is None else prompt,
+            "completion_ids": [20, 21] if completion is None else completion,
+            "content": "a1",
+            "routed_experts": parsed["choices"][0]["routed_experts"],
+        },
+        "test",
+    )
+
+
+@pytest.mark.parametrize(
+    "rows,completion", [(4, [20, 21]), (3, [20]), (5, [20, 21]), (3, [])]
+)
+def test_full_routing_train_response_graph_and_msgpack_round_trip(rows, completion):
+    trace = vf.Trace(
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
+        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="x")),
+    )
+    response = _full_routing_response(rows, completion=completion)
+    # Exercise the validated carrier as well as the train client's construct-only path.
+    response.tokens = TurnTokens(
+        prompt_ids=response.tokens.prompt_ids,
+        completion_ids=response.tokens.completion_ids,
+        routed_experts=response.tokens.routed_experts,
+    )
+    source = response.tokens.routed_experts
+    graph.prepare_turn(trace, [vf.UserMessage(content="u1")]).commit(response)
+    data = trace.branches[0].routed_experts
+    assert isinstance(data, RoutingData)
+    assert len(data) == len(trace.branches[0].token_ids) == 3 + len(completion)
+    assert data.ids[:rows].tobytes() == base64.b64decode(source["data"])
+    assert data.weights[:rows].tobytes() == base64.b64decode(source["weights"]["data"])
+    assert data.valid[:rows].all()
+    if rows < len(data):
+        assert not data.valid[-1] and not data.weights[-1].any()
+        assert not data.ids[-1].any()
+    dumped = trace.model_dump(mode="python")
+    assert all(
+        node["routed_experts"]["__routing__"]
+        for node in dumped["nodes"]
+        if node["token_ids"]
+    )
+    restored = vf.Trace.model_validate(
+        msgpack.unpackb(msgpack.packb(dumped), raw=False)
+    )
+    for name in ("ids", "weights", "valid"):
+        assert (
+            getattr(restored.branches[0].routed_experts, name).tobytes()
+            == getattr(data, name).tobytes()
+        )
+        for node in restored.nodes:
+            if node.token_ids:
+                with pytest.raises(ValueError):
+                    getattr(node.routed_experts, name).flags.writeable = True
+
+
+@pytest.mark.parametrize(
+    "rows,completion,spans",
+    [(2, [20, 21], None), (6, [20, 21], None), (2, [], None), (4, [20, 21], [(0, 4)])],
+)
+def test_full_routing_invalid_coverage_or_spans_does_not_mutate_graph(
+    rows, completion, spans
+):
+    trace = vf.Trace(
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
+        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="x")),
+    )
+    response = _full_routing_response(rows, completion=completion)
+    response.tokens.message_spans = spans
+    before = trace.model_dump(mode="python")
+    with pytest.raises(ValueError, match="capture must cover|message spans"):
+        graph.prepare_turn(trace, [vf.UserMessage(content="u1")]).commit(response)
+    assert trace.model_dump(mode="python") == before
+
+
+@pytest.mark.parametrize("next_mode", ["full", "legacy", "missing", "parallel"])
+def test_full_routing_reused_prefix_is_rejected_atomically(next_mode):
+    trace = vf.Trace(
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
+        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="x")),
+    )
+    user = vf.UserMessage(content="u1")
+    first = graph.prepare_turn(trace, [user])
+    parallel = graph.prepare_turn(trace, [user])
+    first.commit(_full_routing_response())
+    before = trace.model_dump(mode="python")
+    if next_mode == "parallel":
+        pending, response = parallel, _full_routing_response()
+    else:
+        pending = graph.prepare_turn(
+            trace,
+            [user, vf.AssistantMessage(content="a1"), vf.UserMessage(content="u2")],
+        )
+        response = _full_routing_response(
+            8, prompt=[10, 11, 12, 20, 21, 30, 31], completion=[40, 41]
+        )
+        response.tokens.message_spans = [(0, 3), None, (5, 7)]
+        if next_mode == "legacy":
+            response.tokens.routed_experts = _routed_payload(8, 0, 0)
+        elif next_mode == "missing":
+            response.tokens.routed_experts = None
+    with pytest.raises(ValueError, match="reused-prefix"):
+        pending.commit(response)
+    assert trace.model_dump(mode="python") == before
 
 
 def test_routed_experts_attributed_and_aligned_across_turns():

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -6,6 +6,7 @@ dump without importing the originating taskset."""
 import json
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 
 import verifiers.v1 as vf
@@ -87,6 +88,26 @@ async def test_failed_segment_does_not_reuse_prior_root_reply():
     assert segment.last_reply == "current partial reply"
     assert trace.root_reply is None
     assert trace.last_reply == "current partial reply"
+
+
+@pytest.mark.parametrize(
+    "sampled,mask", [(False, [False, False]), (True, [True]), (True, [True, False])]
+)
+def test_full_routing_invalid_row_requires_sampled_terminal_mask(sampled, mask):
+    node = MessageNode(
+        message=AssistantMessage(content="a"),
+        sampled=sampled,
+        token_ids=[1, 2],
+        mask=mask,
+        routed_experts=vf.RoutingData(
+            np.zeros((2, 1, 1), dtype="uint8"),
+            np.zeros((2, 1, 1), dtype="<f4"),
+            np.array([True, False]),
+        ),
+    )
+    restored = MessageNode.model_validate(node.model_dump(mode="python"))
+    with pytest.raises(ValueError, match="sampled terminal"):
+        _ = vf.Branch(index=0, nodes=[restored]).routed_experts
 
 
 def test_bare_trace_round_trip():

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -72,6 +72,7 @@ from verifiers.v1.mcp import (
     Toolset,
     ToolsetConfig,
 )
+from verifiers.v1.routing import RoutingData
 from verifiers.v1.runtimes import (
     DockerConfig,
     PrimeConfig,
@@ -250,6 +251,7 @@ __all__ = [  # noqa: RUF022 - grouped by public API area
     "Branch",
     "TurnTokens",
     "SamplingMask",
+    "RoutingData",
     "Timing",
     "TimeSpan",
     "TimeSplit",

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -20,7 +20,6 @@ the exact `prompt_ids + completion_ids` the model saw.
 
 from __future__ import annotations
 
-import binascii
 import hashlib
 import json
 import time
@@ -39,6 +38,13 @@ from pydantic import (
 from pydantic.json_schema import SkipJsonSchema
 from renderers.base import MultiModalData, PlaceholderRange, RenderedTokens
 
+from verifiers.v1.routing import (
+    RoutingData,
+    complete_routing_capture,
+    decode_routing_payload,
+    slice_routing,
+    validate_ids,
+)
 from verifiers.v1.semantic import ParentLink
 from verifiers.v1.types import (
     AssistantMessage,
@@ -150,12 +156,11 @@ class MessageNode(BaseModel):
     trainer. `Branch.multi_modal_data` concatenates them along the path into the training
     `mm_kwargs`. Rides the wire as raw bytes (msgpack `bin`) since pydantic can't JSON the numpy;
     kept off disk by the dump-site `exclude` in prime-rl (the tensors bloat the rollout jsonl)."""
-    routed_experts: SkipJsonSchema[np.ndarray | None] = None
-    """This node's slice of the MoE expert-routing array — uint8 `[len(token_ids), layers,
-    top_k]`, the expert ids inference selected for exactly this node's tokens. Attributed from
-    the turn's `generate` payload by `_attribute_routed_experts`; `Branch.routed_experts`
-    concatenates these along the path into the trainer's router-replay input. Rides the wire as
-    a raw-bytes `__nd__` dict; kept off disk by the dump-site `exclude` in prime-rl."""
+    routed_experts: SkipJsonSchema[RoutingData | np.ndarray | None] = None
+    """This node's MoE routing for exactly its token span. Legacy capture is a uint8/uint16
+    ndarray [T,L,K]; full capture is immutable RoutingData with FP32 weights and row validity.
+    Branch.routed_experts concatenates both streams together. Raw bytes ride the msgpack
+    wire; dump-site excludes keep routing off JSON records."""
     sampling_mask: SkipJsonSchema[SamplingMask | None] = None
     """Sampling masks for this node's sampled tokens.
 
@@ -226,18 +231,28 @@ class MessageNode(BaseModel):
         )
 
     @field_serializer("routed_experts")
-    def serialize_ndarray_field(self, arr: np.ndarray | None) -> dict | None:
-        """Integer array -> raw-bytes `__nd__` dict so it rides the wire (numpy can't JSON)."""
-        return None if arr is None else _encode_ndarray(arr)
+    def serialize_routing_field(
+        self, data: RoutingData | np.ndarray | None
+    ) -> dict | None:
+        if data is None:
+            return None
+        return (
+            data.to_wire() if isinstance(data, RoutingData) else _encode_ndarray(data)
+        )
 
     @field_validator("routed_experts", mode="before")
     @classmethod
-    def deserialize_ndarray_field(cls, value: Any) -> np.ndarray | None:
-        if value is None or isinstance(value, np.ndarray):
+    def deserialize_routing_field(cls, value: Any) -> RoutingData | np.ndarray | None:
+        if value is None or isinstance(value, RoutingData):
             return value
+        if isinstance(value, dict) and "__routing__" in value:
+            return RoutingData.from_wire(value)
         if isinstance(value, dict) and value.get("__nd__"):
-            return _decode_ndarray(value)
-        raise TypeError(f"cannot build ndarray field from {type(value).__name__}")
+            value = _decode_ndarray(value)
+        if isinstance(value, np.ndarray):
+            validate_ids(value)
+            return value
+        raise ValueError(f"cannot build routing field from {type(value).__name__}")
 
     @field_serializer("sampling_mask")
     def serialize_sampling_mask(self, mask: SamplingMask | None) -> dict | None:
@@ -610,32 +625,27 @@ def _attribute_routed_experts(
     trace: Trace,
     new_node_ids: list[int],
     path_len: int,
-    payload: Any,
+    capture: tuple[RoutingData | np.ndarray, int] | None,
 ) -> None:
-    """Attach each new node's slice of this turn's MoE expert-routing array. The `generate`
-    payload's array covers the turn's prompt+completion from `payload["start"]` (0 = from token
-    0); the nodes created this turn tile sequence positions `[path_len:]` in creation order, so
-    we hand each node `arr[off : off+len(node.token_ids)]` and advance. Reused-prefix nodes keep
-    the routing attributed when they were first created. A node whose slice falls outside the
-    array (a `start` past `path_len`, e.g. an unexpected prefix-cache delta) is left unset — the
-    branch then reports no routing rather than misaligning."""
-    if payload is None:
+    """Own each new node's routing span. Full captures have already passed coverage and
+    reused-prefix guards. Keep the historical terminal padding rule only for legacy IDs."""
+    if capture is None:
         return
-    raw = binascii.a2b_base64(payload["data"])
-    arr = np.frombuffer(raw, dtype=np.dtype(payload.get("dtype", "uint8"))).reshape(
-        payload["shape"]
-    )
-    off = path_len - int(payload.get("start", 0) or 0)
+    arr, start = capture
+    off = path_len - start
     needed = off + sum(len(trace.nodes[nid].token_ids) for nid in new_node_ids)
     for nid in new_node_ids:
         n = len(trace.nodes[nid].token_ids)
         end = off + n
-        if n and 0 <= off and end <= arr.shape[0]:
-            # Own only this node's rows; a view would retain the turn's full-context array.
-            trace.nodes[nid].routed_experts = arr[off:end].copy()
+        if n and 0 <= off and end <= len(arr):
+            trace.nodes[nid].routed_experts = slice_routing(arr, off, end)
+        elif isinstance(arr, RoutingData):
+            if n:
+                raise ValueError(
+                    "full routing node span is outside captured token coverage"
+                )
         elif n and arr.shape[0] and 0 <= off and end == needed == arr.shape[0] + 1:
-            # The engine omits the turn's final position because no forward pass follows it.
-            # Pad only the final node's suffix instead of copying the full-context array.
+            # Backward-compatible IDs-only behavior. Never used for full coefficients.
             trace.nodes[nid].routed_experts = np.concatenate(
                 [arr[off:], arr[-1:]], axis=0
             )
@@ -660,10 +670,49 @@ def _commit_turn(turn: PendingTurn, response: Response) -> int:
     trace = turn.trace
     prompt = turn.prompt
     tokens = response.tokens
+    # Decode and validate before adding nodes: malformed evidence must not partly commit.
+    capture = (
+        decode_routing_payload(tokens.routed_experts)
+        if tokens is not None and tokens.routed_experts is not None
+        else None
+    )
+    full_capture = capture is not None and isinstance(capture[0], RoutingData)
+    if full_capture:
+        data, start = capture
+        if start != 0:
+            raise ValueError(
+                "full routing replay does not support reused-prefix/delta capture; start must be 0"
+            )
+        # Full routing must stay aligned even on the construct-only train-client
+        # path. Backtracking/out-of-range spans would duplicate tokens and fail
+        # attribution after mutating the graph. Reject them before adding nodes.
+        spans = tokens.message_spans
+        if spans is not None:
+            if len(spans) != len(prompt):
+                raise ValueError("full routing message spans must match the prompt")
+            end = 0
+            for span in spans:
+                if span is None:
+                    continue
+                if not (
+                    isinstance(span, (list, tuple))
+                    and len(span) == 2
+                    and all(type(value) is int for value in span)
+                    and end <= span[0] <= span[1] <= len(tokens.prompt_ids)
+                ):
+                    raise ValueError(
+                        "full routing message spans must be ordered within prompt tokens"
+                    )
+                end = span[1]
+        capture = (
+            complete_routing_capture(
+                data,
+                total_tokens=len(tokens.prompt_ids) + len(tokens.completion_ids),
+                completion_tokens=len(tokens.completion_ids),
+            ),
+            start,
+        )
     multi_modal_data = tokens.multi_modal_data if tokens else None
-    # Constant per renderer, so re-stamping every turn is idempotent.
-    if tokens is not None and tokens.mm_token_type_id_map:
-        trace.mm_token_type_id_map = tokens.mm_token_type_id_map
     prompt_ids = tokens.prompt_ids if tokens else []
     spans = tokens.message_spans if tokens else None
     is_content = tokens.is_content if tokens else None
@@ -735,6 +784,22 @@ def _commit_turn(turn: PendingTurn, response: Response) -> int:
         prefix.append(existing)
         path_len = end
 
+    if prefix and (
+        full_capture
+        or any(
+            isinstance(trace.nodes[nid].routed_experts, RoutingData) for nid in prefix
+        )
+    ):
+        # Token identity does not prove route identity. In particular, a prior turn's
+        # invalid final row becomes live context here. Overlays/provenance are not in MVP.
+        raise ValueError(
+            "full routing replay does not support reused-prefix continuation or forks"
+        )
+
+    # Constant per renderer, so re-stamping every successful turn is idempotent.
+    if tokens is not None and tokens.mm_token_type_id_map:
+        trace.mm_token_type_id_map = tokens.mm_token_type_id_map
+
     num_reused = len(prefix)
     parent = prefix[-1] if prefix else None
     # cursor: in prompt_ids, the end of the previous *new* message's tokens
@@ -798,9 +863,7 @@ def _commit_turn(turn: PendingTurn, response: Response) -> int:
 
     # Attribute this turn's expert-routing array onto the nodes created this turn (new input
     # nodes in creation order, then the assistant node), each getting the routing for its tokens.
-    _attribute_routed_experts(
-        trace, new_node_ids, path_len, tokens.routed_experts if tokens else None
-    )
+    _attribute_routed_experts(trace, new_node_ids, path_len, capture)
 
     # Sampling masks are completion-aligned, so only the sampled node carries them.
     _attribute_sampling_mask(

--- a/verifiers/v1/routing.py
+++ b/verifiers/v1/routing.py
@@ -1,0 +1,294 @@
+"""Immutable paired MoE routing and codecs for the single-turn TRR v1 transport.
+
+Weights are the captured FP32 coefficients, not scores to normalize again. The MVP
+uses Qwen3 normalized top-k weights (route scale 1). A false validity bit denotes
+only a final sampled token which inference has not forwarded yet.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+FORMAT_VERSION = 1
+_ID_DTYPES = {"uint8": np.dtype("u1"), "uint16": np.dtype("<u2")}
+_WEIGHT_DTYPE = np.dtype("<f4")
+
+
+def _shape(value: Any) -> tuple[int, int, int]:
+    if (
+        not isinstance(value, (list, tuple))
+        or len(value) != 3
+        or any(type(n) is not int for n in value)
+        or value[0] < 0
+        or value[1] <= 0
+        or value[2] <= 0
+    ):
+        raise ValueError("routing shape must be [tokens >= 0, layers > 0, top_k > 0]")
+    return tuple(value)
+
+
+def _id_dtype(value: Any) -> np.dtype:
+    if not isinstance(value, str) or value not in _ID_DTYPES:
+        raise ValueError("routing ID dtype must be uint8 or uint16 (little-endian)")
+    return _ID_DTYPES[value]
+
+
+def validate_ids(ids: np.ndarray, num_experts: int | None = None) -> None:
+    if not isinstance(ids, np.ndarray):
+        raise ValueError("routing IDs must be a NumPy array")  # noqa: TRY004 - ingress validation
+    _shape(ids.shape)
+    if ids.dtype not in _ID_DTYPES.values():
+        raise ValueError("routing ID dtype must be uint8 or uint16 (little-endian)")
+    if num_experts is not None:
+        if type(num_experts) is not int or num_experts <= 0:
+            raise ValueError("num_experts must be a positive integer")
+        if ids.shape[2] > num_experts or (ids.size and int(ids.max()) >= num_experts):
+            raise ValueError("routing expert ID/top_k exceeds model expert range")
+
+
+def _array_bytes(arr: np.ndarray) -> bytes:
+    """Reuse only a complete contiguous immutable buffer, never a larger allocation."""
+    owner = arr
+    while isinstance(owner, (np.ndarray, memoryview)):
+        owner = owner.base if isinstance(owner, np.ndarray) else owner.obj
+    if isinstance(owner, bytes) and arr.flags.c_contiguous and len(owner) == arr.nbytes:
+        return owner
+    return arr.tobytes(order="C")
+
+
+def _immutable(arr: np.ndarray) -> np.ndarray:
+    # Read-only alone is insufficient: the owner could enable writes again. Reuse
+    # complete bytes buffers (e.g. freshly decoded HTTP/msgpack), but copy partial
+    # slices so a small graph node cannot pin a full response.
+    return np.frombuffer(_array_bytes(arr), dtype=arr.dtype).reshape(arr.shape)
+
+
+def _joined_array(parts: Sequence[np.ndarray]) -> np.ndarray:
+    # RoutingData fields are contiguous and already have matching dtypes/layouts.
+    # Join directly into immutable storage instead of concatenate -> tobytes.
+    shape = (sum(len(part) for part in parts), *parts[0].shape[1:])
+    raw = b"".join(memoryview(part) for part in parts)
+    return np.frombuffer(raw, dtype=parts[0].dtype).reshape(shape)
+
+
+@dataclass(frozen=True, eq=False)
+class RoutingData:
+    """Read-only IDs/FP32 weights [T,L,K] and captured-row validity [T].
+
+    Mutable inputs and partial slices are copied. Complete immutable byte buffers
+    can be reused. No caller can change array data through the source or by enabling
+    NumPy writes. Model-specific bounds are checked by ``validate(num_experts=...)``.
+    """
+
+    ids: np.ndarray
+    weights: np.ndarray
+    valid: np.ndarray | None = None
+
+    def __post_init__(self) -> None:
+        validate_ids(self.ids)
+        if (
+            not isinstance(self.weights, np.ndarray)
+            or self.weights.dtype != _WEIGHT_DTYPE
+        ):
+            raise ValueError("routing weights dtype must be little-endian float32")
+        if self.weights.shape != self.ids.shape:
+            raise ValueError("routing IDs and weights must have equal [T,L,K] shape")
+        # Scalar reductions avoid full-size temporary masks. NaNs propagate.
+        minimum = self.weights.min(initial=0)
+        maximum = self.weights.max(initial=0)
+        if not (np.isfinite(minimum) and np.isfinite(maximum)):
+            raise ValueError("routing weights must be finite")
+        if minimum < 0 or maximum > 1:
+            raise ValueError("routing weights must be in [0, 1] for TRR v1")
+        valid = self.valid
+        if valid is None:
+            valid = np.frombuffer(b"\x01" * self.ids.shape[0], dtype=np.bool_)
+        if (
+            not isinstance(valid, np.ndarray)
+            or valid.dtype != np.dtype("bool")
+            or valid.shape != (self.ids.shape[0],)
+        ):
+            raise ValueError("routing valid must be bool [T]")
+        if not valid[:-1].all():
+            raise ValueError("only the final routing row may be invalid")
+        if len(valid) and not valid[-1] and np.any(self.weights[-1] != 0):
+            raise ValueError("invalid routing rows must have zero placeholder weights")
+        object.__setattr__(self, "ids", _immutable(self.ids))
+        object.__setattr__(self, "weights", _immutable(self.weights))
+        object.__setattr__(self, "valid", _immutable(valid))
+
+    def __len__(self) -> int:
+        return self.ids.shape[0]
+
+    def __copy__(self) -> RoutingData:
+        return self
+
+    def __deepcopy__(self, memo: dict) -> RoutingData:
+        return self
+
+    def validate(self, *, num_experts: int) -> None:
+        """Check the model-dependent bound not available in HTTP/graph metadata."""
+        validate_ids(self.ids, num_experts)
+
+    def to_wire(self) -> dict[str, Any]:
+        """Encode raw bytes for graph msgpack (not the HTTP base64 envelope)."""
+        return {
+            "__routing__": True,
+            "format_version": FORMAT_VERSION,
+            "data": _array_bytes(self.ids),
+            "shape": list(self.ids.shape),
+            "dtype": str(self.ids.dtype),
+            "weights": {"data": _array_bytes(self.weights), "dtype": "float32"},
+            "valid": _array_bytes(self.valid),
+        }
+
+    @classmethod
+    def from_wire(cls, payload: Mapping[str, Any]) -> RoutingData:
+        if payload.get("__routing__") is not True:
+            raise ValueError("missing graph routing marker")
+        _version(payload, full=True)
+        shape = _shape(payload.get("shape"))
+        dtype = _id_dtype(payload.get("dtype"))
+        count = math.prod(shape)
+        ids = _raw_array(payload.get("data"), dtype, count).reshape(shape)
+        weights = _weights(payload, shape, base64_encoded=False)
+        validity = _raw_array(payload.get("valid"), np.dtype("u1"), shape[0])
+        if np.any(validity > 1):
+            raise ValueError("routing valid bytes must be 0 or 1")
+        return cls(ids, weights, validity.view(np.bool_))
+
+
+def _version(payload: Mapping[str, Any], *, full: bool) -> None:
+    version = payload.get("format_version", 0)
+    if type(version) is not int or version != (FORMAT_VERSION if full else 0):
+        raise ValueError("unsupported routing format_version or missing weights")
+
+
+def _raw_array(data: Any, dtype: np.dtype, count: int) -> np.ndarray:
+    if not isinstance(data, (bytes, bytearray, memoryview)):
+        raise ValueError("routing data must be bytes")  # noqa: TRY004 - ingress validation
+    if memoryview(data).nbytes != count * dtype.itemsize:
+        raise ValueError("routing byte count does not match shape and dtype")
+    return np.frombuffer(data, dtype=dtype, count=count)
+
+
+def _base64_array(data: Any, dtype: np.dtype, count: int) -> np.ndarray:
+    if not isinstance(data, (str, bytes, bytearray, memoryview)):
+        raise ValueError("routing data must be base64 text or bytes")  # noqa: TRY004 - ingress validation
+    size = memoryview(data).nbytes if isinstance(data, memoryview) else len(data)
+    if size != 4 * ((count * dtype.itemsize + 2) // 3):
+        raise ValueError("routing base64 byte count does not match shape and dtype")
+    try:
+        raw = base64.b64decode(data, validate=True)
+    except (ValueError, binascii.Error) as exc:
+        raise ValueError("invalid routing base64 data") from exc
+    return _raw_array(raw, dtype, count)
+
+
+def _weights(
+    payload: Mapping[str, Any], shape: tuple, *, base64_encoded: bool
+) -> np.ndarray:
+    weights = payload.get("weights")
+    if not isinstance(weights, Mapping) or weights.get("dtype") != "float32":
+        raise ValueError("routing weights must include data and dtype=float32")
+    decode = _base64_array if base64_encoded else _raw_array
+    return decode(weights.get("data"), _WEIGHT_DTYPE, math.prod(shape)).reshape(shape)
+
+
+def decode_routing_payload(
+    payload: Mapping[str, Any],
+    *,
+    require_weights: bool = False,
+    num_experts: int | None = None,
+) -> tuple[RoutingData | np.ndarray, int]:
+    """Validate the Prime HTTP envelope and return paired or legacy routing + start.
+
+    Only the legacy format permits omitted dtype/start (historically uint8/0).
+    Absence of weights is legacy, never an implicit zero coefficient stream.
+    """
+    if not isinstance(payload, Mapping):
+        raise ValueError("routing payload must be an object")  # noqa: TRY004 - ingress validation
+    full = "weights" in payload
+    if require_weights and not full:
+        raise ValueError("full routing replay requires captured weights")
+    _version(payload, full=full)
+    shape = _shape(payload.get("shape"))
+    dtype = _id_dtype(payload.get("dtype", None if full else "uint8"))
+    start = payload.get("start", None if full else 0)
+    if type(start) is not int or start < 0:
+        raise ValueError("routing start must be a nonnegative integer")
+    ids = _base64_array(payload.get("data"), dtype, math.prod(shape)).reshape(shape)
+    validate_ids(ids, num_experts)
+    if not full:
+        return ids, start
+    return RoutingData(ids, _weights(payload, shape, base64_encoded=True)), start
+
+
+def slice_routing(
+    data: RoutingData | np.ndarray, start: int, stop: int
+) -> RoutingData | np.ndarray:
+    """Own only a contiguous token span; do not retain a whole response allocation."""
+    if not 0 <= start <= stop <= len(data):
+        raise ValueError("routing token slice is out of range")
+    if isinstance(data, RoutingData):
+        if start == 0 and stop == len(data):
+            return data
+        return RoutingData(
+            data.ids[start:stop], data.weights[start:stop], data.valid[start:stop]
+        )
+    return data[start:stop].copy()
+
+
+def concatenate_routing(
+    parts: Sequence[RoutingData | np.ndarray],
+) -> RoutingData | np.ndarray:
+    if not parts:
+        raise ValueError("cannot concatenate empty routing parts")
+    full = [isinstance(part, RoutingData) for part in parts]
+    if not any(full):
+        return np.concatenate(parts, axis=0)
+    if not all(full):
+        raise ValueError("cannot mix full routing and legacy IDs-only routing")
+    first = parts[0]
+    if len(parts) == 1:
+        return first
+    if any(
+        part.ids.shape[1:] != first.ids.shape[1:] or part.ids.dtype != first.ids.dtype
+        for part in parts
+    ):
+        raise ValueError(
+            "routing parts must have matching layer/top_k layout and ID dtype"
+        )
+    return RoutingData(
+        _joined_array([part.ids for part in parts]),
+        _joined_array([part.weights for part in parts]),
+        _joined_array([part.valid for part in parts]),
+    )
+
+
+def complete_routing_capture(
+    data: RoutingData, *, total_tokens: int, completion_tokens: int
+) -> RoutingData:
+    """Allow only exact capture coverage or one unforwarded final sampled token."""
+    if not data.valid.all():
+        raise ValueError("capture input must contain only real routing rows")
+    if len(data) == total_tokens:
+        return data
+    if completion_tokens <= 0 or len(data) != total_tokens - 1:
+        raise ValueError(
+            "full routing capture must cover P+C or P+C-1 with a final sampled token"
+        )
+    shape = (1, *data.ids.shape[1:])
+    terminal = RoutingData(
+        np.zeros(shape, dtype=data.ids.dtype),
+        np.zeros(shape, dtype=_WEIGHT_DTYPE),
+        np.zeros(1, dtype=np.bool_),
+    )
+    return concatenate_routing([data, terminal])

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -19,6 +19,7 @@ from verifiers.v1 import graph
 from verifiers.v1.configs.agent import AgentConfig, WireAgentConfig
 from verifiers.v1.errors import ProviderError
 from verifiers.v1.graph import RECORD_FLOAT_DECIMALS, MessageNode
+from verifiers.v1.routing import RoutingData, concatenate_routing
 from verifiers.v1.runtimes import RuntimeInfo
 from verifiers.v1.semantic import ACPInfo, ParentLink, SemanticEdgeSet
 from verifiers.v1.state import State, StateT
@@ -332,14 +333,40 @@ class Branch(BaseModel):
         return [mapping.get(t, 0) for t in self.token_ids]
 
     @property
-    def routed_experts(self) -> np.ndarray | None:
-        """uint8 `[tokens, layers, top_k]` routing; partial data returns None."""
+    def routed_experts(self) -> RoutingData | np.ndarray | None:
+        """Routing [T,L,K]. Full mode rejects gaps/mixed modes; legacy partial data is None."""
+        full = any(isinstance(n.routed_experts, RoutingData) for n in self.nodes)
+        if full:
+            for node in self.nodes:
+                data = node.routed_experts
+                if data is None:
+                    continue
+                if not isinstance(data, RoutingData):
+                    raise ValueError(  # noqa: TRY004 - invalid mixed-mode evidence
+                        "cannot mix full routing and legacy IDs-only routing"
+                    )
+                if len(data) != len(node.token_ids):
+                    raise ValueError("full routing node must match its token span")
         nodes = [n for n in self.nodes if n.token_ids]
         if not nodes or any(n.routed_experts is None for n in nodes):
+            if full:
+                raise ValueError("full routing branch has missing routing rows")
             return None
-        merged = np.concatenate([n.routed_experts for n in nodes], axis=0)
+        if full and sum(n.sampled for n in self.nodes) > 1:
+            raise ValueError("full routing replay does not support multi-turn branches")
+        merged = concatenate_routing([n.routed_experts for n in nodes])
         total = sum(len(n.token_ids) for n in nodes)
-        return merged if merged.shape[0] == total else None
+        if isinstance(merged, RoutingData) and len(merged) and not merged.valid[-1]:
+            terminal = nodes[-1]
+            if (
+                not terminal.sampled
+                or len(terminal.mask) != len(terminal.token_ids)
+                or not terminal.mask[-1]
+            ):
+                raise ValueError(
+                    "invalid final routing row must belong to a sampled terminal token"
+                )
+        return merged if len(merged) == total else None
 
     @property
     def sampling_mask(self) -> SamplingMask | None:

--- a/verifiers/v1/types.py
+++ b/verifiers/v1/types.py
@@ -1,9 +1,9 @@
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, NotRequired
 
 import numpy as np
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, StrictInt, StrictStr
 from renderers.base import MultiModalData
 from typing_extensions import TypedDict
 
@@ -176,12 +176,26 @@ class Usage(BaseModel):
         return self.input_tokens + self.completion_tokens
 
 
-class RoutedExperts(TypedDict):
-    """Base64 uint8 `[tokens, layers, top_k]` routing and its prompt offset."""
+class RoutedExpertWeights(TypedDict):
+    """Base64 little-endian FP32 coefficients; shares the outer routing shape/start."""
 
     data: Any
-    shape: list[int]
-    start: int
+    dtype: StrictStr
+
+
+class RoutedExperts(TypedDict):
+    """Prime HTTP routing payload; absent weights preserves legacy ID-only behavior.
+
+    Strict metadata types prevent Pydantic coercion from hiding malformed shapes or
+    versions. Graph ingress also validates construct-only train-client responses.
+    """
+
+    data: Any
+    shape: list[StrictInt]
+    start: NotRequired[StrictInt]
+    dtype: NotRequired[StrictStr]
+    format_version: NotRequired[StrictInt]
+    weights: NotRequired[RoutedExpertWeights]
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Add the verifier transport and trace layer for Total Router Recall (TRR): immutable paired expert IDs and captured FP32 coefficients, with token-row validity. Keep IDs-only routing supported.

- Validate the versioned HTTP payload before graph mutation. Preserve coefficient bytes and expert-slot order.
- Carry paired routing through graph node slices, branch concatenation, and raw-byte msgpack serialization.
- Accept complete capture or one unforwarded final sampled token. Mark that terminal placeholder invalid with zero weights.
- Reject full-coefficient delta capture, reused-prefix continuation, and shared-prefix forks. This MVP supports independent single-turn calls only.
- Extend existing graph/trace tests. No standalone routing test suite is added.

## Validation

Current-main CPU validation, using the prepared renderer companion source:

- `uv run pytest tests/v1/test_graph.py tests/v1/test_trace.py -o addopts= -q`: **37 passed**.
- Audited standalone routing suite, copied unchanged to an ignored external QA location and not included in this PR: **89 passed**.
- Ruff lint/format, `git diff --check`, and `uv run pre-commit run --all-files`: passed.

A broader local-only contributor run was attempted before the final test fix: 79 passed, 15 failed, 1 collection error. Eleven failures and the collection error require omitted example/optional task packages. Four failures came from a new test fixture that dropped the transient routing field; the focused rerun above confirms its fix. The full suite is not claimed as passing.

The original audited implementation reported 111 verifier routing/graph/trace passes. That is prior evidence, not a result from this rebased branch. No live provider, sandbox, GPU, training, throughput, or numerical-equivalence result is claimed. Model expert-count validation remains the trainer loader's responsibility.

## Companions

<!-- trr-dependencies:start -->
- Companion renderers draft: https://github.com/PrimeIntellect-ai/renderers/pull/154
- Companion prime-rl draft: https://github.com/PrimeIntellect-ai/prime-rl/pull/3509
- vLLM coefficient capture is prepared separately; upstream submission is held pending the required human review, testing and DCO sign-off.
<!-- trr-dependencies:end -->

Related #2544 backfills IDs-only turn boundaries; #2408 handles opaque ID decoding. Neither adds coefficient transport or full-coefficient replay.

## AI assistance

AI agents assisted with implementation, review, tests, and preparation of this draft.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `RoutingData` carrier for paired routing weights in single-turn traces
> - Introduces an immutable `RoutingData` dataclass in [routing.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2568/files#diff-508961da01a27b49a63cff039afe5d5044b8e455b784bf4243569ea45b5b713f) carrying FP32 weights, expert IDs, and per-row validity, with wire encode/decode and model-dependent validation.
> - Updates [graph.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2568/files#diff-64c9d635eb215902a512c9e8ab316fd9b9967c36db03d4049aacc812cdfbd740) `_commit_turn` to decode and validate full routing captures before mutation: rejects malformed coverage, unsupported reused-prefix/delta captures, and invalid message-span metadata; valid P+C-1 captures receive a synthetic invalid terminal row.
> - Changes `MessageNode.routed_experts` and `Branch.routed_experts` to accept either legacy ID arrays or `RoutingData`, enforcing single-sampled-node replay and sampled-terminal semantics for full mode while preserving legacy None behavior.
> - Adds HTTP/base64 and graph-wire decoders for legacy IDs-only and versioned full routing envelopes in [routing.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2568/files#diff-508961da01a27b49a63cff039afe5d5044b8e455b784bf4243569ea45b5b713f); exports `RoutingData` from [verifiers/v1/__init__.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2568/files#diff-731a849803c53d001c41b5e0fb1bfcb392eaae7eb4fa4b3ace382768dc40066a) and adds weight typing to [types.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2568/files#diff-88a4e4ee0c58ac5dc7344161a011374082a3767eda2ad32af97c942dca982112).
> - Risk: `_commit_turn` now rejects reused-prefix continuations when existing prefix nodes already carry full routing and rejects mixed full/legacy routing evidence in `concatenate_routing`; callers passing legacy ID arrays must still use supported uint8/uint16 dtypes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 036c828.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
