### PR TITLE
fix(v1): refuse a served run whose taskset loads per-case Task subclasses

### DIFF
--- a/tests/v1/fixtures/subclass_task_v1.py
+++ b/tests/v1/fixtures/subclass_task_v1.py
@@ -1,0 +1,44 @@
+"""A taskset whose second case is a per-case `Task` subclass carrying its own reward and
+toolset — the shape a served run cannot carry over the wire."""
+
+import verifiers.v1 as vf
+
+
+class CaseData(vf.TaskData):
+    answer: str
+
+
+class ExtraToolset(vf.Toolset[vf.ToolsetConfig]):
+    TOOL_PREFIX = "extra"
+
+    @vf.tool
+    def ping(self) -> str:
+        """Reply pong."""
+        return "pong"
+
+
+class BaseTask(vf.Task[CaseData]):
+    @vf.reward
+    async def base_match(self, trace: vf.Trace) -> float:
+        return float(trace.last_reply == self.data.answer)
+
+
+class SpecialTask(BaseTask):
+    @classmethod
+    def toolsets(cls, config: vf.TaskConfig) -> list[vf.Toolset]:
+        return [ExtraToolset(vf.ToolsetConfig())]
+
+    @vf.reward
+    async def special_match(self, trace: vf.Trace) -> float:
+        return 1.0
+
+
+class SubclassTaskset(vf.Taskset[BaseTask, vf.TasksetConfig]):
+    def load(self) -> list[BaseTask]:
+        return [
+            BaseTask(CaseData(idx=0, prompt="say a", answer="a"), self.config.task),
+            SpecialTask(CaseData(idx=1, prompt="say b", answer="b"), self.config.task),
+        ]
+
+
+__all__ = ["SubclassTaskset"]

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -10,6 +10,9 @@ import sys
 
 import pytest
 
+from verifiers.v1.cli.eval.runner import run_eval
+from verifiers.v1.configs.cli.eval import EvalConfig
+
 mark = pytest.mark
 
 
@@ -697,6 +700,26 @@ async def main():
 
 asyncio.run(main())
 """
+
+
+async def test_served_run_refuses_per_case_task_subclass(tmp_path):
+    """A served worker rebuilds each task as the taskset's declared `Task` type from wire
+    data, so a per-case subclass would lose its own rewards and toolsets and score wrong
+    without a word. The runner refuses before anything is spawned; `--no-serve` runs it."""
+    config = EvalConfig(  # served: the default `[serve]` pool
+        env={
+            "taskset": {"id": "subclass-task-v1"},
+            "agent": {"harness": {"id": "null"}},
+        },
+        num_tasks=2,
+        rich=None,
+        output_dir=tmp_path,
+        run={"dir": "served"},
+        model="none",
+    )
+    with pytest.raises(ValueError, match="SpecialTask.*served run.*--no-serve"):
+        await run_eval(config)
+    assert not (tmp_path / "served").exists()
 
 
 def test_env_client_close_drains_finished_cancels():

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -152,6 +152,19 @@ async def run_eval(config: EvalConfig) -> list[Episode]:
     if config.num_tasks is not None:
         selected = selected.head(config.num_tasks)
     tasks = list(selected)
+    if env is None:
+        # A served worker rebuilds each task from its wire data as the taskset's declared
+        # `Task` type; a per-case subclass (its own rewards, toolsets, hooks) would come
+        # back as the base class and score silently wrong, so refuse before dispatch.
+        declared = type(taskset).task_type()
+        foreign = sorted({type(t).__name__ for t in tasks if type(t) is not declared})
+        if foreign:
+            raise ValueError(
+                f"{type(taskset).__name__} loads tasks of {', '.join(foreign)}, but a "
+                f"served run rebuilds every task as its declared {declared.__name__} from "
+                "wire data, dropping what only the subclass defines. Dispatch on a "
+                f"TaskData field inside {declared.__name__}, or run in-process with --no-serve"
+            )
     out = output_path(config)
     # One (task, rollouts-to-run) pair per selected task; resume shrinks the counts.
     plan = [(task, config.num_rollouts) for task in tasks]


### PR DESCRIPTION
Fixes the silent half of #2570.

A served run (the default) rebuilds each task inside the env-server worker as the taskset's declared `Task` type from its wire data. A taskset whose `load()` builds some cases as a `Task` subclass loses that subclass's rewards, toolsets and hooks on the served path and scores them silently wrong, while `--no-serve` scores them as authored.

This change makes the runner refuse before dispatch when any loaded task's type is not the taskset's `task_type()`, naming the classes and the two ways out: dispatch on a `TaskData` field inside the declared class, or run in-process with `--no-serve` (which keeps the class; remote tunnel placement still sizes off the base class, see #2570). Nothing is written or spawned before the check. Whether per-case subclasses should become a supported authoring pattern (carrying the class over the wire) is left to #2570.

- `verifiers/v1/cli/eval/runner.py`: the refusal, after task selection.
- `tests/v1/fixtures/subclass_task_v1.py`: a two-case taskset whose second case is a subclass with its own reward and toolset.
- `tests/v1/test_e2e.py`: a deterministic test (no model, no `e2e` mark) asserting the `ValueError` and that no run directory is created.

Validation, model-free: the new test passes; `uv run pytest tests/ -m "not e2e"` 81 passed; ruff check, ruff format and the pre-commit hooks pass; the in-process loader still yields both classes for the fixture. Reproduction of the underlying bug against `EnvServer._build_task` is in #2570.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a pre-dispatch validation on the served eval path only; in-process runs are unchanged and the failure mode is an explicit error instead of silent mis-scoring.
> 
> **Overview**
> **Served eval runs** now fail fast if the taskset’s `load()` returns tasks whose runtime type is not the taskset’s declared `Task` class. On the default served path, workers rebuild tasks from wire data using only that declared type, so per-case subclasses would lose extra rewards, toolsets, and hooks and score incorrectly without an obvious error.
> 
> The check runs in `run_eval` after task selection and **before** any output directory or worker pool is created. The raised `ValueError` names the unexpected class(es) and points authors to branch on `TaskData` inside the declared task type or use **`--no-serve`** for in-process runs that preserve the subclass instances.
> 
> A **`subclass-task-v1`** fixture (base task + `SpecialTask` with its own reward and toolset) and a model-free test assert the refusal message and that no run directory is written.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1514f66eb5f4f29aa1e43562715d454962c55b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refuse served runs when taskset loads per-case `Task` subclasses in `run_eval`
> - Adds validation in `run_eval` ([runner.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2572/files#diff-65be4a576330571f2729a3bbcdbe92ac81bbcba450c313597c1bdca3a1c3f2e4)) that checks whether any selected task's exact type differs from the taskset's declared `Task` type, raising `ValueError` before output setup or dispatch for served runs.
> - In-process runs skip this check and retain their existing path; the error message recommends using a `TaskData` field or `--no-serve`.
> - Adds a `subclass-task-v1` fixture ([subclass_task_v1.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2572/files#diff-a216994fa899026c8fdcab07790294f03e3be66358751d8d2a9fc4dd131c6f41)) and an end-to-end test ([test_e2e.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2572/files#diff-ebbbd919487889487f891b359a756e6c4630e106b16ddaef8ccddc6b900a96e1)) that confirms the `ValueError` mentions `SpecialTask` and `--no-serve` and that no served output directory is created.
> - Risk: served evaluations that previously relied on per-case task subclasses will now fail with `ValueError` instead of proceeding; verify tasksets in `verifiers/v1` for `SubclassTaskset`-style loaders.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a1514f6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->