### PR TITLE
fix(v1): typed sandbox fault codes

### DIFF
--- a/tests/v1/test_errors.py
+++ b/tests/v1/test_errors.py
@@ -1,0 +1,71 @@
+"""Sandbox fault codes: typed evidence (an exception type, an HTTP status) names the fault, the
+code rides the `SandboxError` onto the trace, and a missing path reads as `not_found`."""
+
+import errno
+
+import httpx
+import pytest
+from prime_sandboxes import APIError, SandboxFileNotFoundError
+
+import verifiers.v1 as vf
+from verifiers.v1.errors import sandbox_fault_code
+from verifiers.v1.runtimes.prime import _fault_code
+from verifiers.v1.runtimes.subprocess import SubprocessConfig, SubprocessRuntime
+
+
+def _http_error(status: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://sandboxes")
+    response = httpx.Response(status, request=request)
+    return httpx.HTTPStatusError("http", request=request, response=response)
+
+
+def _sdk_http_error(status: int) -> APIError:
+    # The SDK's shape: `APIError("HTTP <status>: ...")` raised inside the httpx handler
+    # without `from`, so the typed status is only on `__context__`.
+    try:
+        raise _http_error(status)
+    except httpx.HTTPStatusError:
+        try:
+            raise APIError(f"HTTP {status}: detail")
+        except APIError as e:
+            return e
+
+
+def test_sandbox_error_code_survives_to_trace():
+    tr = vf.Trace(
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
+        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="p")),
+    )
+    tr.record_error(vf.SandboxError("prime exec failed: gone", code="not_found"))
+    assert tr.last_error is not None and tr.last_error.code == "not_found"
+    rt = vf.Trace.model_validate(tr.to_record())
+    assert rt.last_error is not None
+    assert (rt.last_error.type, rt.last_error.code) == ("SandboxError", "not_found")
+    # An untyped fault, and a non-sandbox error, carry no code.
+    tr.record_error(vf.SandboxError("read 'x': exit 1"))
+    assert tr.last_error is not None and tr.last_error.code is None
+    tr.record_error(vf.ProviderError("upstream 502", status_code=502))
+    assert tr.last_error is not None and tr.last_error.code is None
+
+
+def test_fault_codes_come_from_typed_evidence_only():
+    assert sandbox_fault_code(FileNotFoundError(errno.ENOENT, "missing")) == "not_found"
+    assert sandbox_fault_code(OSError(errno.ENOSPC, "full")) == "disk_full"
+    assert sandbox_fault_code(TimeoutError()) == "timeout"
+    assert sandbox_fault_code(_http_error(503)) == "unavailable"
+    assert sandbox_fault_code(RuntimeError("No such file or directory")) is None
+    # prime: SDK types, and the status hidden in a bare `APIError`'s text, read typed.
+    assert _fault_code(SandboxFileNotFoundError("File not found: x")) == "not_found"
+    assert _fault_code(_sdk_http_error(404)) == "not_found"
+    assert _fault_code(_sdk_http_error(402)) == "denied"
+    assert _fault_code(_sdk_http_error(503)) == "unavailable"
+    assert _fault_code(_sdk_http_error(409)) is None
+    assert _fault_code(APIError("Sandbox x is being deleted")) is None
+
+
+async def test_missing_path_reads_as_not_found(tmp_path):
+    runtime = SubprocessRuntime(SubprocessConfig())
+    runtime.workdir = tmp_path
+    with pytest.raises(vf.SandboxError) as info:
+        await runtime.read("missing.txt", max_bytes=16)
+    assert info.value.code == "not_found"

--- a/tests/v1/test_errors.py
+++ b/tests/v1/test_errors.py
@@ -1,11 +1,13 @@
 """Sandbox fault codes: typed evidence (an exception type, an HTTP status) names the fault, the
-code rides the `SandboxError` onto the trace, a missing path reads as `not_found`, and a
-cancelled task's own cancellation is never a sandbox fault."""
+code rides the `SandboxError` onto the trace, a missing path reads as `not_found`, a cancelled
+task's own cancellation is never a sandbox fault, and an `asyncio.timeout` deadline the SDK
+reports the same way is still a timeout."""
 
 import asyncio
 import contextlib
 import errno
 from collections.abc import Callable
+from types import SimpleNamespace
 
 import httpx
 import pytest
@@ -17,6 +19,7 @@ from prime_sandboxes._proto.command_session import command_session_pb2
 
 import verifiers.v1 as vf
 from verifiers.v1.errors import sandbox_fault_code
+from verifiers.v1.runtimes import prime
 from verifiers.v1.runtimes.prime import PrimeConfig, PrimeRuntime, _fault_code
 from verifiers.v1.runtimes.subprocess import SubprocessConfig, SubprocessRuntime
 
@@ -101,8 +104,8 @@ def _bare_swallow(cancel: asyncio.CancelledError) -> APIError:
 
 
 class _FakeSandboxClient:
-    """An SDK client whose RPC parks until the task is cancelled, then reports the cancel as an
-    ordinary error (`swallow`), or fails outright with `error`."""
+    """An SDK client whose RPCs park until the task is cancelled, then report the cancel as an
+    ordinary error (`swallow`), or fail outright with `error`."""
 
     def __init__(
         self,
@@ -113,7 +116,7 @@ class _FakeSandboxClient:
         self.error = error
         self.entered = asyncio.Event()
 
-    async def start_background_job(self, *args, **kwargs):
+    async def _rpc(self):
         if self.error is not None:
             raise self.error
         self.entered.set()
@@ -122,6 +125,15 @@ class _FakeSandboxClient:
         except asyncio.CancelledError as cancel:
             assert self.swallow is not None
             raise self.swallow(cancel) from None
+
+    async def start_background_job(self, *args, **kwargs):
+        return await self._rpc()
+
+    async def set_network(self, *args, **kwargs):
+        return SimpleNamespace(applied=False)
+
+    async def get_network(self, *args, **kwargs):
+        return await self._rpc()
 
 
 def _prime_runtime(monkeypatch, client) -> PrimeRuntime:
@@ -144,6 +156,41 @@ async def test_cancelled_rpc_is_the_cancellation_not_a_sandbox_fault(
     with pytest.raises(asyncio.CancelledError):
         await task
     assert task.cancelled()
+
+
+@pytest.mark.parametrize("swallow", [_rpc_cancelled, _bare_swallow])
+async def test_deadline_inside_the_runtime_is_a_timeout_fault_not_a_cancel(
+    monkeypatch, swallow
+):
+    # `prepare_execution` polls under its own `asyncio.timeout`; the expiry cancels the task
+    # mid-RPC and the SDK reports it exactly like a cancel. It must come out as the timeout
+    # fault, and leave the task uncancelled — not as the cancel of a task nobody cancelled.
+    monkeypatch.setattr(prime, "EGRESS_APPLY_TIMEOUT", 0.5)
+    client = _FakeSandboxClient(swallow=swallow)
+    runtime = _prime_runtime(monkeypatch, client)
+    runtime.config = PrimeConfig(allow=["example.com"])
+    with pytest.raises(vf.SandboxError) as info:
+        await runtime.prepare_execution(None)
+    assert info.value.code == "timeout"
+    assert "not applied within 0.5s" in str(info.value)
+    assert client.entered.is_set()
+    task = asyncio.current_task()
+    assert task is not None and task.cancelling() == 0
+
+
+@pytest.mark.parametrize("swallow", [_rpc_cancelled, _bare_swallow])
+async def test_deadline_around_the_runtime_is_the_callers_timeout(monkeypatch, swallow):
+    # A caller's deadline (a rollout stage budget) over a runtime call: the re-raised cancel
+    # reaches the caller's scope while the task still counts as cancelling, so the scope owns
+    # it and the caller sees its `TimeoutError`, with the task left uncancelled.
+    client = _FakeSandboxClient(swallow=swallow)
+    runtime = _prime_runtime(monkeypatch, client)
+    with pytest.raises(TimeoutError):
+        async with asyncio.timeout(0.05):
+            await runtime.run(["true"], {})
+    assert client.entered.is_set()
+    task = asyncio.current_task()
+    assert task is not None and task.cancelling() == 0
 
 
 async def test_sdk_fault_without_a_cancel_stays_a_sandbox_fault(monkeypatch):

--- a/tests/v1/test_errors.py
+++ b/tests/v1/test_errors.py
@@ -1,15 +1,23 @@
 """Sandbox fault codes: typed evidence (an exception type, an HTTP status) names the fault, the
-code rides the `SandboxError` onto the trace, and a missing path reads as `not_found`."""
+code rides the `SandboxError` onto the trace, a missing path reads as `not_found`, and a
+cancelled task's own cancellation is never a sandbox fault."""
 
+import asyncio
+import contextlib
 import errno
+from collections.abc import Callable
 
 import httpx
 import pytest
-from prime_sandboxes import APIError, SandboxFileNotFoundError
+from connectrpc.code import Code
+from connectrpc.errors import ConnectError
+from prime_sandboxes import APIError, AsyncSandboxProcess, SandboxFileNotFoundError
+from prime_sandboxes import process as sdk_process
+from prime_sandboxes._proto.command_session import command_session_pb2
 
 import verifiers.v1 as vf
 from verifiers.v1.errors import sandbox_fault_code
-from verifiers.v1.runtimes.prime import _fault_code
+from verifiers.v1.runtimes.prime import PrimeConfig, PrimeRuntime, _fault_code
 from verifiers.v1.runtimes.subprocess import SubprocessConfig, SubprocessRuntime
 
 
@@ -61,6 +69,8 @@ def test_fault_codes_come_from_typed_evidence_only():
     assert _fault_code(_sdk_http_error(503)) == "unavailable"
     assert _fault_code(_sdk_http_error(409)) is None
     assert _fault_code(APIError("Sandbox x is being deleted")) is None
+    # A cancel is not a fault code: the runtime re-raises it (below), never names it.
+    assert _fault_code(_rpc_cancelled(asyncio.CancelledError())) is None
 
 
 async def test_missing_path_reads_as_not_found(tmp_path):
@@ -69,3 +79,151 @@ async def test_missing_path_reads_as_not_found(tmp_path):
     with pytest.raises(vf.SandboxError) as info:
         await runtime.read("missing.txt", max_bytes=16)
     assert info.value.code == "not_found"
+
+
+def _rpc_cancelled(cancel: asyncio.CancelledError) -> APIError:
+    # What a cancelled task gets back from a VM RPC: connectrpc turns the `CancelledError`
+    # into `ConnectError(CANCELED)`, the SDK re-wraps that as `APIError`.
+    try:
+        raise ConnectError(Code.CANCELED, "Request was cancelled") from cancel
+    except ConnectError as rpc:
+        try:
+            raise APIError(
+                f"Connect RPC failed ({rpc.code.value}): {rpc.message}"
+            ) from rpc
+        except APIError as e:
+            return e
+
+
+def _bare_swallow(cancel: asyncio.CancelledError) -> APIError:
+    # A swallow that keeps no typed trace of the cancel at all: only `Task.cancelling()` says.
+    return APIError("Request failed")
+
+
+class _FakeSandboxClient:
+    """An SDK client whose RPC parks until the task is cancelled, then reports the cancel as an
+    ordinary error (`swallow`), or fails outright with `error`."""
+
+    def __init__(
+        self,
+        swallow: Callable[[asyncio.CancelledError], BaseException] | None = None,
+        error: BaseException | None = None,
+    ) -> None:
+        self.swallow = swallow
+        self.error = error
+        self.entered = asyncio.Event()
+
+    async def start_background_job(self, *args, **kwargs):
+        if self.error is not None:
+            raise self.error
+        self.entered.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError as cancel:
+            assert self.swallow is not None
+            raise self.swallow(cancel) from None
+
+
+def _prime_runtime(monkeypatch, client) -> PrimeRuntime:
+    monkeypatch.setenv("PRIME_API_KEY", "test")
+    runtime = PrimeRuntime(PrimeConfig())
+    runtime.info.id = "sandbox"
+    runtime._client = client
+    return runtime
+
+
+@pytest.mark.parametrize("swallow", [_rpc_cancelled, _bare_swallow])
+async def test_cancelled_rpc_is_the_cancellation_not_a_sandbox_fault(
+    monkeypatch, swallow
+):
+    client = _FakeSandboxClient(swallow=swallow)
+    runtime = _prime_runtime(monkeypatch, client)
+    task = asyncio.create_task(runtime.run(["true"], {}))
+    await client.entered.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert task.cancelled()
+
+
+async def test_sdk_fault_without_a_cancel_stays_a_sandbox_fault(monkeypatch):
+    runtime = _prime_runtime(
+        monkeypatch, _FakeSandboxClient(error=_sdk_http_error(503))
+    )
+    with pytest.raises(vf.SandboxError) as info:
+        await runtime.run(["true"], {})
+    assert info.value.code == "unavailable"
+
+
+def _event(**fields) -> command_session_pb2.StartResponse:
+    response = command_session_pb2.StartResponse()
+    for name, value in fields.items():
+        setattr(
+            getattr(response.event, name),
+            "pid" if name == "start" else "exit_code",
+            value,
+        )
+    return response
+
+
+class _ClosableClient:
+    async def close(self) -> None:
+        pass
+
+
+async def _live_process(
+    stream, reconnect, reattached: list[bool]
+) -> AsyncSandboxProcess:
+    async def counted(*args):
+        reattached.append(True)
+        async for response in reconnect():
+            yield response
+
+    return await AsyncSandboxProcess._create(
+        _ClosableClient(), stream(), None, None, reconnect=counted
+    )
+
+
+async def test_stream_pump_does_not_reattach_on_its_own_cancel(monkeypatch):
+    monkeypatch.setattr(sdk_process, "_STREAM_RECONNECT_BACKOFF_SECONDS", 0)
+    reattached: list[bool] = []
+
+    async def stream():
+        yield _event(start=7)
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError as cancel:
+            raise ConnectError(Code.CANCELED, "Request was cancelled") from cancel
+
+    async def reconnect():
+        yield _event(start=7)
+        await asyncio.Event().wait()
+
+    process = await _live_process(stream, reconnect, reattached)
+    process._pump_task.cancel()
+    try:
+        # A re-attaching pump streams on forever; a terminal cancel ends it at once.
+        await asyncio.wait_for(asyncio.shield(process._pump_task), 2)
+    finally:
+        process._pump_task.cancel()
+        with contextlib.suppress(BaseException):
+            await process._pump_task
+    assert reattached == []
+    with pytest.raises(APIError, match="canceled"):
+        await process.wait()
+
+
+async def test_stream_pump_still_reattaches_on_a_dropped_link(monkeypatch):
+    monkeypatch.setattr(sdk_process, "_STREAM_RECONNECT_BACKOFF_SECONDS", 0)
+    reattached: list[bool] = []
+
+    async def stream():
+        yield _event(start=7)
+        raise ConnectError(Code.UNAVAILABLE, "link reset")
+
+    async def reconnect():
+        yield _event(end=0)
+
+    process = await _live_process(stream, reconnect, reattached)
+    assert await process.wait() == 0
+    assert reattached == [True]

--- a/verifiers/v1/errors.py
+++ b/verifiers/v1/errors.py
@@ -65,7 +65,9 @@ class SandboxError(RolloutError):
     `not_found` (the path, or the box itself, is gone), `timeout` (the operation or the box's
     lifetime ran out), `disk_full` (ENOSPC), `unavailable` (the provider was unreachable or
     answered 5xx/429), `provisioning` (the box never came up), `denied` (the provider refused:
-    401/402/403). None when nothing typed says."""
+    401/402/403). None when nothing typed says. A cancelled task's own cancellation is never a
+    `SandboxError`: a runtime whose SDK reports it as an ordinary failure re-raises
+    `asyncio.CancelledError`, so a caller that retries on sandbox faults cannot swallow it."""
 
     def __init__(self, message: str = "", *, code: str | None = None) -> None:
         super().__init__(message)

--- a/verifiers/v1/errors.py
+++ b/verifiers/v1/errors.py
@@ -22,8 +22,10 @@ the boundary isn't already clear from it.
 """
 
 import contextlib
+import errno
 from collections.abc import AsyncIterator
 
+import httpx
 from openai import OpenAIError
 
 
@@ -57,7 +59,17 @@ class EnvError(RolloutError):
 
 
 class SandboxError(RolloutError):
-    """A runtime/sandbox operation failed (provisioning, exec, or file I/O)."""
+    """A runtime/sandbox operation failed (provisioning, exec, or file I/O). `code` names the
+    fault when typed evidence (an exception type, an errno, an HTTP/RPC status — never the
+    message text) identifies it, so a consumer branches on it instead of parsing the message:
+    `not_found` (the path, or the box itself, is gone), `timeout` (the operation or the box's
+    lifetime ran out), `disk_full` (ENOSPC), `unavailable` (the provider was unreachable or
+    answered 5xx/429), `provisioning` (the box never came up), `denied` (the provider refused:
+    401/402/403). None when nothing typed says."""
+
+    def __init__(self, message: str = "", *, code: str | None = None) -> None:
+        super().__init__(message)
+        self.code = code
 
 
 class TaskError(RolloutError):
@@ -87,6 +99,35 @@ async def boundary(error_cls: type[RolloutError], what: str) -> AsyncIterator[No
         raise error_cls(f"{what} timed out") from e
     except Exception as e:
         raise error_cls(f"{what}: {type(e).__name__}: {e}") from e
+
+
+def sandbox_fault_code(e: BaseException) -> str | None:
+    """The `SandboxError.code` a Python-level fault identifies — a missing path, a timeout,
+    ENOSPC, or an `httpx` status / transport error — or None when nothing typed does."""
+    if isinstance(e, FileNotFoundError):
+        return "not_found"
+    if isinstance(e, (TimeoutError, httpx.TimeoutException)):
+        return "timeout"
+    if isinstance(e, OSError) and e.errno == errno.ENOSPC:
+        return "disk_full"
+    if isinstance(e, httpx.HTTPStatusError):
+        return _http_fault_code(e.response.status_code)
+    if isinstance(e, httpx.TransportError):
+        return "unavailable"
+    return None
+
+
+def _http_fault_code(status: int) -> str | None:
+    """The `SandboxError.code` an HTTP status from a sandbox provider identifies."""
+    if status == 404:
+        return "not_found"
+    if status in (401, 402, 403):
+        return "denied"
+    if status in (408, 504):
+        return "timeout"
+    if status == 429 or status >= 500:
+        return "unavailable"
+    return None
 
 
 def _provider_status(e: OpenAIError | str) -> int:

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -19,11 +19,25 @@ from pathlib import Path, PurePosixPath
 from typing import Any, ClassVar, Literal
 from urllib.parse import urlsplit
 
+from connectrpc.code import Code
+from connectrpc.errors import ConnectError
+from prime_sandboxes import (
+    APIError,
+    APITimeoutError,
+    CommandTimeoutError,
+    DownloadTimeoutError,
+    PaymentRequiredError,
+    SandboxFileNotFoundError,
+    SandboxImagePullError,
+    SandboxTimeoutError,
+    UnauthorizedError,
+    UploadTimeoutError,
+)
 from prime_sandboxes.models import validate_egress_lists
 from pydantic import Field, model_validator
 
 from verifiers.v1.configs.runtime import NetworkPolicyConfig
-from verifiers.v1.errors import SandboxError
+from verifiers.v1.errors import SandboxError, sandbox_fault_code
 from verifiers.v1.runtimes.base import (
     SERVICE_PORT,
     BaseRuntimeInfo,
@@ -44,6 +58,49 @@ bounded by idle detection or rollout cancellation; 30 days is above any real run
 
 
 BASE_LABELS: list[str] = []
+
+_SDK_TIMEOUTS = (
+    APITimeoutError,
+    CommandTimeoutError,
+    DownloadTimeoutError,
+    UploadTimeoutError,
+    SandboxTimeoutError,
+)
+_RPC_FAULTS = {
+    Code.NOT_FOUND: "not_found",
+    Code.DEADLINE_EXCEEDED: "timeout",
+    Code.UNAVAILABLE: "unavailable",
+    Code.RESOURCE_EXHAUSTED: "unavailable",
+    Code.PERMISSION_DENIED: "denied",
+    Code.UNAUTHENTICATED: "denied",
+}
+
+
+def _fault_code(e: BaseException) -> str | None:
+    """The `SandboxError.code` an SDK failure identifies: its exception type, the Connect RPC
+    code or `httpx` status it wraps, or a Python-level fault (`sandbox_fault_code`). SDK gap:
+    the base `APIError` names the HTTP status only in its text (`"HTTP 503: ..."`) and is
+    raised inside the `httpx` handler without `from`, so the typed status is read from its
+    `__context__` here — the one place that hop is taken, instead of parsing the message."""
+    current: BaseException | None = e
+    while current is not None:
+        if isinstance(current, SandboxFileNotFoundError):
+            return "not_found"
+        if isinstance(current, (UnauthorizedError, PaymentRequiredError)):
+            return "denied"
+        if isinstance(current, _SDK_TIMEOUTS):
+            return "timeout"
+        if isinstance(current, SandboxImagePullError):
+            return "provisioning"
+        if isinstance(current, ConnectError) and current.code in _RPC_FAULTS:
+            return _RPC_FAULTS[current.code]
+        if (code := sandbox_fault_code(current)) is not None:
+            return code
+        if isinstance(current, APIError) and current.__cause__ is None:
+            current = current.__context__
+        else:
+            current = current.__cause__
+    return None
 
 
 @dataclass
@@ -248,7 +305,10 @@ class PrimeRuntime(Runtime):
         except (
             Exception
         ) as e:  # provisioning failure is one rollout's problem, not the eval's
-            raise SandboxError(f"prime sandbox provisioning failed: {e}") from e
+            raise SandboxError(
+                f"prime sandbox provisioning failed: {e}",
+                code=_fault_code(e) or "provisioning",
+            ) from e
 
     async def prepare_execution(self, routes: list[str] | None) -> None:
         """Apply the host policy after setup and wait until the platform enforces it."""
@@ -280,12 +340,15 @@ class PrimeRuntime(Runtime):
             except TimeoutError as e:
                 raise SandboxError(
                     "prime egress policy was not applied within 60s on sandbox "
-                    f"{self.info.id}; refusing to start the agent unrestricted"
+                    f"{self.info.id}; refusing to start the agent unrestricted",
+                    code="timeout",
                 ) from e
         except SandboxError:
             raise
         except Exception as e:
-            raise SandboxError(f"prime egress policy failed: {e}") from e
+            raise SandboxError(
+                f"prime egress policy failed: {e}", code=_fault_code(e)
+            ) from e
         logger.info(
             "prime: egress policy applied on sandbox %s (allow=%s block=%s)",
             self.info.id,
@@ -312,7 +375,7 @@ class PrimeRuntime(Runtime):
         except (
             Exception
         ) as e:  # a sandbox/API failure is one rollout's problem, not the eval's
-            raise SandboxError(f"prime exec failed: {e}") from e
+            raise SandboxError(f"prime exec failed: {e}", code=_fault_code(e)) from e
         return ProgramResult(
             exit_code=result.exit_code or 0,
             stdout=result.stdout or "",
@@ -335,7 +398,9 @@ class PrimeRuntime(Runtime):
                 env=self.process_env(env),
             )
         except Exception as e:
-            raise SandboxError(f"prime live process failed to start: {e}") from e
+            raise SandboxError(
+                f"prime live process failed to start: {e}", code=_fault_code(e)
+            ) from e
         return PrimeProcess(process)
 
     async def expose(self, port: int) -> str | None:
@@ -350,7 +415,8 @@ class PrimeRuntime(Runtime):
             raise SandboxError(
                 "prime port exposure failed — port exposure isn't supported in this sandbox's "
                 "region; pin `tools.runtime.region` to a region that supports it (e.g. `us`), or "
-                f"use a colocated / docker / modal tools.runtime instead. ({e})"
+                f"use a colocated / docker / modal tools.runtime instead. ({e})",
+                code=_fault_code(e),
             ) from e
         logger.info("prime: exposed sandbox port %d at %s", port, exposed.url)
         return exposed.url.rstrip("/")
@@ -367,7 +433,9 @@ class PrimeRuntime(Runtime):
                 env=self.process_env(env),
             )
         except Exception as e:
-            raise SandboxError(f"prime background launch failed: {e}") from e
+            raise SandboxError(
+                f"prime background launch failed: {e}", code=_fault_code(e)
+            ) from e
 
     async def _read(self, path: str, max_bytes: int | None = None) -> bytes:
         if max_bytes is not None and self.config.vm:
@@ -381,7 +449,9 @@ class PrimeRuntime(Runtime):
                     timeout=EFFECTIVELY_UNBOUNDED_SECONDS,
                 )
             except Exception as exc:
-                raise SandboxError(f"read {path!r}: {exc}") from exc
+                raise SandboxError(
+                    f"read {path!r}: {exc}", code=_fault_code(exc)
+                ) from exc
             if result.exit_code:
                 raise SandboxError(f"read {path!r}: {result.stderr.strip()[-500:]}")
             return base64.b64decode(result.stdout)
@@ -400,7 +470,7 @@ class PrimeRuntime(Runtime):
                 await self._client.download_file(self.info.id, target, str(download))
                 return await asyncio.to_thread(download.read_bytes)
         except Exception as e:
-            raise SandboxError(f"read {path!r}: {e}") from e
+            raise SandboxError(f"read {path!r}: {e}", code=_fault_code(e)) from e
 
     async def write(self, path: str, data: bytes) -> None:
         # The gateway creates missing parents and uploads binary data without command-line
@@ -415,7 +485,7 @@ class PrimeRuntime(Runtime):
                 self.info.id, target, data, filename=PurePosixPath(target).name
             )
         except Exception as e:
-            raise SandboxError(f"write {path!r}: {e}") from e
+            raise SandboxError(f"write {path!r}: {e}", code=_fault_code(e)) from e
 
     def cleanup(self) -> None:
         # Synchronous atexit backstop (the async client can't run once the loop is gone): delete

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -61,6 +61,9 @@ bounded by idle detection or rollout cancellation; 30 days is above any real run
 
 BASE_LABELS: list[str] = []
 
+EGRESS_APPLY_TIMEOUT: float = 60
+"""Seconds `prepare_execution` waits for the platform to report an egress policy applied."""
+
 _SDK_TIMEOUTS = (
     APITimeoutError,
     CommandTimeoutError,
@@ -111,33 +114,39 @@ def _fault_code(e: BaseException) -> str | None:
     return None
 
 
-def _cancelled(e: BaseException | None) -> bool:
-    """Whether an SDK failure is really this task's cancellation. connectrpc turns the
-    `CancelledError` raised inside an RPC into `ConnectError(CANCELED, "Request was
-    cancelled")` and the SDK re-wraps that as `APIError`, so a cancelled task comes back from
-    a sandbox call with an ordinary error while `Task.cancelling()` stays set. True when the
-    current task is being cancelled, or when the failure carries the cancel itself (the
-    CANCELED code, or the `CancelledError` chained under it)."""
+def _cancelled() -> bool:
+    """Whether the current task is being cancelled — what tells a swallowed cancel from a
+    fault. connectrpc turns the `CancelledError` raised inside an RPC into
+    `ConnectError(CANCELED, "Request was cancelled")` and the SDK re-wraps that as `APIError`,
+    so a cancelled task comes back from a sandbox call with an ordinary error while
+    `Task.cancelling()` stays set. Only that count is consulted, never the error's chain: an
+    `asyncio.timeout` deadline cancels the task the same way and meets the same rewrite, and
+    only the scope owning the deadline tells the two apart — from the `CancelledError` it is
+    handed while the count is still set. Past the scope the task is uncancelled, and a CANCELED
+    code under an ordinary error is a deadline that already fired (or another task's cancel,
+    batched in by the SDK's coalesced polls), not this task's cancel."""
     task = asyncio.current_task()
-    if task is not None and task.cancelling():
-        return True
-    return e is not None and any(
-        isinstance(current, asyncio.CancelledError)
-        or (isinstance(current, ConnectError) and current.code is Code.CANCELED)
-        for current in _chain(e)
-    )
+    return task is not None and task.cancelling() > 0
 
 
-def _failure(
-    message: str, e: BaseException, *, fallback: str | None = None
-) -> BaseException:
-    """The exception to raise for an SDK failure `e`: the task's cancellation when that is
-    what the SDK reported (`_cancelled`) — a `SandboxError` there would let a caller that
-    retries on sandbox faults swallow the cancel and keep working — else a `SandboxError`
-    carrying the typed fault code (`fallback` when nothing typed says)."""
-    if _cancelled(e):
-        return asyncio.CancelledError()
-    return SandboxError(message, code=_fault_code(e) or fallback)
+@contextlib.contextmanager
+def _faults(what: str, *, fallback: str | None = None) -> Iterator[None]:
+    """Wrap one SDK call. Its failure is re-raised as the task's cancellation when that is what
+    the SDK reported (`_cancelled`) — a `SandboxError` there would let a caller that retries on
+    sandbox faults swallow the cancel and keep working — else as a `SandboxError` carrying the
+    typed fault code (`fallback` when nothing typed says). Sits directly around the call, inside
+    any `asyncio.timeout` scope over it: the cancel must be re-raised while the task still
+    counts as cancelling, where the scope turns its own deadline into `TimeoutError` and lets
+    an external cancel through. Past the scope the swallowed deadline is an ordinary error, and
+    would surface as the cancel of a task nobody cancelled."""
+    try:
+        yield
+    except SandboxError:
+        raise
+    except Exception as e:
+        if _cancelled():
+            raise asyncio.CancelledError() from e
+        raise SandboxError(f"{what}: {e}", code=_fault_code(e) or fallback) from e
 
 
 def _cancel_aware(can_reconnect: Callable[..., bool]) -> Callable[..., bool]:
@@ -145,7 +154,7 @@ def _cancel_aware(can_reconnect: Callable[..., bool]) -> Callable[..., bool]:
 
     @functools.wraps(can_reconnect)
     def wrapper(self: Any, reconnects: int, error: BaseException | None) -> bool:
-        return not _cancelled(error) and can_reconnect(self, reconnects, error)
+        return not _cancelled() and can_reconnect(self, reconnects, error)
 
     return wrapper
 
@@ -314,7 +323,8 @@ class PrimeRuntime(Runtime):
             "gpu_type": gpu_type,
             "region": self.config.region,
         }
-        try:
+        # provisioning failure is one rollout's problem, not the eval's
+        with _faults("prime sandbox provisioning failed", fallback="provisioning"):
             async with (
                 creation_limiter(
                     (self.config.creates_per_min or 0) / 60, "prime-sandbox"
@@ -362,18 +372,12 @@ class PrimeRuntime(Runtime):
             await self._client.execute_command(
                 self.info.id, f"mkdir -p {shlex.quote(self.config.workdir)}"
             )
-        except (
-            Exception
-        ) as e:  # provisioning failure is one rollout's problem, not the eval's
-            raise _failure(
-                f"prime sandbox provisioning failed: {e}", e, fallback="provisioning"
-            ) from e
 
     async def prepare_execution(self, routes: list[str] | None) -> None:
         """Apply the host policy after setup and wait until the platform enforces it."""
         if not self.network_restricted:
             return
-        try:
+        with _faults("prime egress policy failed"):
             if routes is None:
                 policy = {"allow": ["*"]}
             else:
@@ -389,23 +393,22 @@ class PrimeRuntime(Runtime):
                     validate_egress_lists(entries, None)
                     policy = {"allow": entries} if entries else {"deny": ["*"]}
             status = await self._client.set_network(self.info.id, **policy)
-            try:
-                async with asyncio.timeout(60):
-                    delay = 0.1
-                    while not status.applied:
-                        await asyncio.sleep(delay)
-                        delay = min(delay * 2, 3)
+        try:
+            async with asyncio.timeout(EGRESS_APPLY_TIMEOUT):
+                delay = 0.1
+                while not status.applied:
+                    await asyncio.sleep(delay)
+                    delay = min(delay * 2, 3)
+                    # Inside the deadline's scope, so its expiry lands below as `TimeoutError`.
+                    with _faults("prime egress policy failed"):
                         status = await self._client.get_network(self.info.id)
-            except TimeoutError as e:
-                raise SandboxError(
-                    "prime egress policy was not applied within 60s on sandbox "
-                    f"{self.info.id}; refusing to start the agent unrestricted",
-                    code="timeout",
-                ) from e
-        except SandboxError:
-            raise
-        except Exception as e:
-            raise _failure(f"prime egress policy failed: {e}", e) from e
+        except TimeoutError as e:
+            raise SandboxError(
+                "prime egress policy was not applied within "
+                f"{EGRESS_APPLY_TIMEOUT:g}s on sandbox {self.info.id}; refusing to start "
+                "the agent unrestricted",
+                code="timeout",
+            ) from e
         logger.info(
             "prime: egress policy applied on sandbox %s (allow=%s block=%s)",
             self.info.id,
@@ -414,7 +417,8 @@ class PrimeRuntime(Runtime):
         )
 
     async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
-        try:
+        # a sandbox/API failure is one rollout's problem, not the eval's
+        with _faults("prime exec failed"):
             # Poll directly so rollout cancellation owns the execution timeout.
             job = await self._client.start_background_job(
                 self.info.id,
@@ -429,10 +433,6 @@ class PrimeRuntime(Runtime):
                     break
                 await asyncio.sleep(delay)
                 delay = min(delay * 2, 3)
-        except (
-            Exception
-        ) as e:  # a sandbox/API failure is one rollout's problem, not the eval's
-            raise _failure(f"prime exec failed: {e}", e) from e
         return ProgramResult(
             exit_code=result.exit_code or 0,
             stdout=result.stdout or "",
@@ -447,15 +447,13 @@ class PrimeRuntime(Runtime):
                 "persistent harness sessions on Prime require a VM sandbox; "
                 "set runtime.prime.vm=true"
             )
-        try:
+        with _faults("prime live process failed to start"):
             process = await self._client.open_process(
                 self.info.id,
                 shlex.join(argv),
                 working_dir=self.config.workdir,
                 env=self.process_env(env),
             )
-        except Exception as e:
-            raise _failure(f"prime live process failed to start: {e}", e) from e
         return PrimeProcess(process)
 
     async def expose(self, port: int) -> str | None:
@@ -464,15 +462,13 @@ class PrimeRuntime(Runtime):
         # sandbox needs no host tunnel. Port exposure is region-gated: many regions (incl. the
         # backend default, which lands in us-central) 400 it; `us` supports it. TODO: re-enable the
         # prime cases in the e2e `skip_if_unexposable` guard once prime exposes ports in any region.
-        try:
+        # surface prime's exposure constraints actionably
+        with _faults(
+            "prime port exposure failed — port exposure isn't supported in this sandbox's "
+            "region; pin `tools.runtime.region` to a region that supports it (e.g. `us`), or "
+            "use a colocated / docker / modal tools.runtime instead"
+        ):
             exposed = await self._client.expose(self.info.id, port)
-        except Exception as e:  # surface prime's exposure constraints actionably
-            raise _failure(
-                "prime port exposure failed — port exposure isn't supported in this sandbox's "
-                "region; pin `tools.runtime.region` to a region that supports it (e.g. `us`), or "
-                f"use a colocated / docker / modal tools.runtime instead. ({e})",
-                e,
-            ) from e
         logger.info("prime: exposed sandbox port %d at %s", port, exposed.url)
         return exposed.url.rstrip("/")
 
@@ -480,19 +476,17 @@ class PrimeRuntime(Runtime):
         self, argv: list[str], env: dict[str, str], log: str
     ) -> None:
         command = f"exec {shlex.join(argv)} > {shlex.quote(log)} 2>&1"
-        try:
+        with _faults("prime background launch failed"):
             await self._client.start_background_job(
                 self.info.id,
                 command,
                 working_dir=self.config.workdir,
                 env=self.process_env(env),
             )
-        except Exception as e:
-            raise _failure(f"prime background launch failed: {e}", e) from e
 
     async def _read(self, path: str, max_bytes: int | None = None) -> bytes:
         if max_bytes is not None and self.config.vm:
-            try:
+            with _faults(f"read {path!r}"):
                 # VM execute_command uses bash and returns the complete output stream.
                 result = await self._client.execute_command(
                     self.info.id,
@@ -501,8 +495,6 @@ class PrimeRuntime(Runtime):
                     env=self.process_env({}),
                     timeout=EFFECTIVELY_UNBOUNDED_SECONDS,
                 )
-            except Exception as exc:
-                raise _failure(f"read {path!r}: {exc}", exc) from exc
             if result.exit_code:
                 raise SandboxError(f"read {path!r}: {result.stderr.strip()[-500:]}")
             return base64.b64decode(result.stdout)
@@ -515,13 +507,10 @@ class PrimeRuntime(Runtime):
             if path.startswith("/")
             else f"{self.config.workdir.rstrip('/')}/{path}"
         )
-        try:
-            with tempfile.TemporaryDirectory() as directory:
-                download = Path(directory) / "download"
-                await self._client.download_file(self.info.id, target, str(download))
-                return await asyncio.to_thread(download.read_bytes)
-        except Exception as e:
-            raise _failure(f"read {path!r}: {e}", e) from e
+        with _faults(f"read {path!r}"), tempfile.TemporaryDirectory() as directory:
+            download = Path(directory) / "download"
+            await self._client.download_file(self.info.id, target, str(download))
+            return await asyncio.to_thread(download.read_bytes)
 
     async def write(self, path: str, data: bytes) -> None:
         # The gateway creates missing parents and uploads binary data without command-line
@@ -531,12 +520,10 @@ class PrimeRuntime(Runtime):
             if path.startswith("/")
             else f"{self.config.workdir.rstrip('/')}/{path}"
         )
-        try:
+        with _faults(f"write {path!r}"):
             await self._client.upload_bytes(
                 self.info.id, target, data, filename=PurePosixPath(target).name
             )
-        except Exception as e:
-            raise _failure(f"write {path!r}: {e}", e) from e
 
     def cleanup(self) -> None:
         # Synchronous atexit backstop (the async client can't run once the loop is gone): delete

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -9,11 +9,12 @@ direction (a program in the sandbox reaching a host service) is the shared host-
 import asyncio
 import base64
 import contextlib
+import functools
 import logging
 import math
 import shlex
 import tempfile
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable, Iterator
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, ClassVar, Literal
@@ -24,6 +25,7 @@ from connectrpc.errors import ConnectError
 from prime_sandboxes import (
     APIError,
     APITimeoutError,
+    AsyncSandboxProcess,
     CommandTimeoutError,
     DownloadTimeoutError,
     PaymentRequiredError,
@@ -76,14 +78,24 @@ _RPC_FAULTS = {
 }
 
 
-def _fault_code(e: BaseException) -> str | None:
-    """The `SandboxError.code` an SDK failure identifies: its exception type, the Connect RPC
-    code or `httpx` status it wraps, or a Python-level fault (`sandbox_fault_code`). SDK gap:
-    the base `APIError` names the HTTP status only in its text (`"HTTP 503: ..."`) and is
-    raised inside the `httpx` handler without `from`, so the typed status is read from its
-    `__context__` here — the one place that hop is taken, instead of parsing the message."""
+def _chain(e: BaseException) -> Iterator[BaseException]:
+    """`e` and the failures it wraps, outermost first. SDK gap: the base `APIError` names the
+    HTTP status only in its text (`"HTTP 503: ..."`) and is raised inside the `httpx` handler
+    without `from`, so the typed status is reached through its `__context__` here — the one
+    place that hop is taken, instead of parsing the message."""
     current: BaseException | None = e
     while current is not None:
+        yield current
+        if isinstance(current, APIError) and current.__cause__ is None:
+            current = current.__context__
+        else:
+            current = current.__cause__
+
+
+def _fault_code(e: BaseException) -> str | None:
+    """The `SandboxError.code` an SDK failure identifies: its exception type, the Connect RPC
+    code or `httpx` status it wraps, or a Python-level fault (`sandbox_fault_code`)."""
+    for current in _chain(e):
         if isinstance(current, SandboxFileNotFoundError):
             return "not_found"
         if isinstance(current, (UnauthorizedError, PaymentRequiredError)):
@@ -96,11 +108,59 @@ def _fault_code(e: BaseException) -> str | None:
             return _RPC_FAULTS[current.code]
         if (code := sandbox_fault_code(current)) is not None:
             return code
-        if isinstance(current, APIError) and current.__cause__ is None:
-            current = current.__context__
-        else:
-            current = current.__cause__
     return None
+
+
+def _cancelled(e: BaseException | None) -> bool:
+    """Whether an SDK failure is really this task's cancellation. connectrpc turns the
+    `CancelledError` raised inside an RPC into `ConnectError(CANCELED, "Request was
+    cancelled")` and the SDK re-wraps that as `APIError`, so a cancelled task comes back from
+    a sandbox call with an ordinary error while `Task.cancelling()` stays set. True when the
+    current task is being cancelled, or when the failure carries the cancel itself (the
+    CANCELED code, or the `CancelledError` chained under it)."""
+    task = asyncio.current_task()
+    if task is not None and task.cancelling():
+        return True
+    return e is not None and any(
+        isinstance(current, asyncio.CancelledError)
+        or (isinstance(current, ConnectError) and current.code is Code.CANCELED)
+        for current in _chain(e)
+    )
+
+
+def _failure(
+    message: str, e: BaseException, *, fallback: str | None = None
+) -> BaseException:
+    """The exception to raise for an SDK failure `e`: the task's cancellation when that is
+    what the SDK reported (`_cancelled`) — a `SandboxError` there would let a caller that
+    retries on sandbox faults swallow the cancel and keep working — else a `SandboxError`
+    carrying the typed fault code (`fallback` when nothing typed says)."""
+    if _cancelled(e):
+        return asyncio.CancelledError()
+    return SandboxError(message, code=_fault_code(e) or fallback)
+
+
+def _cancel_aware(can_reconnect: Callable[..., bool]) -> Callable[..., bool]:
+    """`AsyncSandboxProcess._can_reconnect` with the pump's own cancellation terminal."""
+
+    @functools.wraps(can_reconnect)
+    def wrapper(self: Any, reconnects: int, error: BaseException | None) -> bool:
+        return not _cancelled(error) and can_reconnect(self, reconnects, error)
+
+    return wrapper
+
+
+# The SDK's live-process stream pump (`AsyncSandboxProcess._pump`, a task of its own) meets the
+# same swallow: cancelled (by `aclose`, or by the loop's shutdown cancelling every task), its
+# stream raises `ConnectError(CANCELED)` rather than `CancelledError`, and `_can_reconnect` — a
+# deny-list of definitive codes — calls that recoverable and re-attaches ("live process stream
+# dropped (Request was cancelled); re-attaching 1/5"), so a cancelled pump streams on until the
+# remote process exits and `asyncio.run` never returns. Until the SDK owns the cancel, the
+# predicate is wrapped here so the pump ends instead; guarded, so an SDK that renames it is
+# left alone.
+_sdk_can_reconnect = getattr(AsyncSandboxProcess, "_can_reconnect", None)
+if _sdk_can_reconnect is not None and not hasattr(_sdk_can_reconnect, "__wrapped__"):
+    AsyncSandboxProcess._can_reconnect = _cancel_aware(_sdk_can_reconnect)
 
 
 @dataclass
@@ -305,9 +365,8 @@ class PrimeRuntime(Runtime):
         except (
             Exception
         ) as e:  # provisioning failure is one rollout's problem, not the eval's
-            raise SandboxError(
-                f"prime sandbox provisioning failed: {e}",
-                code=_fault_code(e) or "provisioning",
+            raise _failure(
+                f"prime sandbox provisioning failed: {e}", e, fallback="provisioning"
             ) from e
 
     async def prepare_execution(self, routes: list[str] | None) -> None:
@@ -346,9 +405,7 @@ class PrimeRuntime(Runtime):
         except SandboxError:
             raise
         except Exception as e:
-            raise SandboxError(
-                f"prime egress policy failed: {e}", code=_fault_code(e)
-            ) from e
+            raise _failure(f"prime egress policy failed: {e}", e) from e
         logger.info(
             "prime: egress policy applied on sandbox %s (allow=%s block=%s)",
             self.info.id,
@@ -375,7 +432,7 @@ class PrimeRuntime(Runtime):
         except (
             Exception
         ) as e:  # a sandbox/API failure is one rollout's problem, not the eval's
-            raise SandboxError(f"prime exec failed: {e}", code=_fault_code(e)) from e
+            raise _failure(f"prime exec failed: {e}", e) from e
         return ProgramResult(
             exit_code=result.exit_code or 0,
             stdout=result.stdout or "",
@@ -398,9 +455,7 @@ class PrimeRuntime(Runtime):
                 env=self.process_env(env),
             )
         except Exception as e:
-            raise SandboxError(
-                f"prime live process failed to start: {e}", code=_fault_code(e)
-            ) from e
+            raise _failure(f"prime live process failed to start: {e}", e) from e
         return PrimeProcess(process)
 
     async def expose(self, port: int) -> str | None:
@@ -412,11 +467,11 @@ class PrimeRuntime(Runtime):
         try:
             exposed = await self._client.expose(self.info.id, port)
         except Exception as e:  # surface prime's exposure constraints actionably
-            raise SandboxError(
+            raise _failure(
                 "prime port exposure failed — port exposure isn't supported in this sandbox's "
                 "region; pin `tools.runtime.region` to a region that supports it (e.g. `us`), or "
                 f"use a colocated / docker / modal tools.runtime instead. ({e})",
-                code=_fault_code(e),
+                e,
             ) from e
         logger.info("prime: exposed sandbox port %d at %s", port, exposed.url)
         return exposed.url.rstrip("/")
@@ -433,9 +488,7 @@ class PrimeRuntime(Runtime):
                 env=self.process_env(env),
             )
         except Exception as e:
-            raise SandboxError(
-                f"prime background launch failed: {e}", code=_fault_code(e)
-            ) from e
+            raise _failure(f"prime background launch failed: {e}", e) from e
 
     async def _read(self, path: str, max_bytes: int | None = None) -> bytes:
         if max_bytes is not None and self.config.vm:
@@ -449,9 +502,7 @@ class PrimeRuntime(Runtime):
                     timeout=EFFECTIVELY_UNBOUNDED_SECONDS,
                 )
             except Exception as exc:
-                raise SandboxError(
-                    f"read {path!r}: {exc}", code=_fault_code(exc)
-                ) from exc
+                raise _failure(f"read {path!r}: {exc}", exc) from exc
             if result.exit_code:
                 raise SandboxError(f"read {path!r}: {result.stderr.strip()[-500:]}")
             return base64.b64decode(result.stdout)
@@ -470,7 +521,7 @@ class PrimeRuntime(Runtime):
                 await self._client.download_file(self.info.id, target, str(download))
                 return await asyncio.to_thread(download.read_bytes)
         except Exception as e:
-            raise SandboxError(f"read {path!r}: {e}", code=_fault_code(e)) from e
+            raise _failure(f"read {path!r}: {e}", e) from e
 
     async def write(self, path: str, data: bytes) -> None:
         # The gateway creates missing parents and uploads binary data without command-line
@@ -485,7 +536,7 @@ class PrimeRuntime(Runtime):
                 self.info.id, target, data, filename=PurePosixPath(target).name
             )
         except Exception as e:
-            raise SandboxError(f"write {path!r}: {e}", code=_fault_code(e)) from e
+            raise _failure(f"write {path!r}: {e}", e) from e
 
     def cleanup(self) -> None:
         # Synchronous atexit backstop (the async client can't run once the loop is gone): delete

--- a/verifiers/v1/runtimes/subprocess.py
+++ b/verifiers/v1/runtimes/subprocess.py
@@ -12,7 +12,7 @@ from typing import ClassVar, Literal
 
 from pydantic_config import BaseConfig
 
-from verifiers.v1.errors import SandboxError
+from verifiers.v1.errors import SandboxError, sandbox_fault_code
 from verifiers.v1.runtimes.base import (
     BaseRuntimeInfo,
     ProgramResult,
@@ -183,7 +183,9 @@ class SubprocessRuntime(Runtime):
         try:
             data = await asyncio.to_thread(read)
         except OSError as exc:
-            raise SandboxError(f"read {path!r}: {exc}") from exc
+            raise SandboxError(
+                f"read {path!r}: {exc}", code=sandbox_fault_code(exc)
+            ) from exc
         return data if data is not None else await super()._read(path, max_bytes)
 
     async def write(self, path: str, data: bytes) -> None:

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 from verifiers.v1 import graph
 from verifiers.v1.configs.agent import AgentConfig, WireAgentConfig
-from verifiers.v1.errors import ProviderError
+from verifiers.v1.errors import ProviderError, SandboxError
 from verifiers.v1.graph import RECORD_FLOAT_DECIMALS, MessageNode
 from verifiers.v1.runtimes import RuntimeInfo
 from verifiers.v1.semantic import ACPInfo, ParentLink, SemanticEdgeSet
@@ -87,6 +87,8 @@ class Error(BaseModel):
     type: str
     message: str
     status_code: int | None = None
+    code: str | None = None
+    """The `SandboxError.code` naming the fault, when typed evidence identified one."""
     traceback: str | None = None
 
 
@@ -734,6 +736,7 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
                 type=type(error).__name__,
                 message=str(error),
                 status_code=getattr(error, "status_code", None),
+                code=error.code if isinstance(error, SandboxError) else None,
                 # Provider errors already carry the actionable upstream diagnostic.
                 # Keep full tracebacks for every other failure.
                 traceback=None


### PR DESCRIPTION
## What

- `SandboxError(message, *, code: str | None = None)`. `code` names the fault from typed evidence only — an exception type, an errno, or an HTTP/RPC status, never the message text: `not_found`, `timeout`, `disk_full`, `unavailable`, `provisioning`, `denied`; `None` when nothing typed says.
- `trace.Error.code: str | None`, recorded by `Trace.record_error` next to `status_code`.
- `errors.sandbox_fault_code(e)` maps the Python-level sources (`FileNotFoundError`, `TimeoutError`, `OSError` with `ENOSPC`, `httpx` status/transport errors).
- `runtimes/prime.py` maps the SDK's exception types and Connect RPC codes in one function, `_fault_code`. The SDK's base `APIError` carries the HTTP status only in its text (`"HTTP 503: ..."`) and is raised inside the `httpx` handler without `from`; that function reads the typed status off the chained `httpx.HTTPStatusError` instead of parsing the message. `start()` falls back to `provisioning`.
- `runtimes/subprocess.py`: a bounded read of a missing path carries `not_found`.

## Cancellation is not a fault

A cancelled task's RPC comes back from the SDK as an ordinary error: connectrpc turns the `CancelledError` raised inside a VM RPC into `ConnectError(CANCELED, "Request was cancelled")`, prime-sandboxes re-wraps it as `APIError`, and the runtime used to wrap that as `SandboxError("prime exec failed: Connect RPC failed (canceled): ...")` — so any caller that retries on sandbox faults (a harness turn, a rollout re-attempt) swallowed the cancel and kept working; a run failed to exit on SIGINT for 11 minutes and leaked 21 sandboxes. The same seam now decides: `_failure(message, e)` re-raises `asyncio.CancelledError` when the current task is being cancelled (`Task.cancelling()`) or the failure carries the cancel (the `CANCELED` code, or the `CancelledError` chained under it), else the `SandboxError` with its typed code. No path returns a `SandboxError` for a cancel, so there is no `canceled` code. The SDK's live-process stream pump (`AsyncSandboxProcess._pump`, its own task) meets the same swallow and re-attaches on it (`live process stream dropped (Request was cancelled); re-attaching 1/5`), so a cancelled pump streamed on until the remote process exited and `asyncio.run` never returned; `_can_reconnect` is wrapped (guarded by `getattr`, a stopgap until the SDK owns the cancel — connectrpc re-raising `CancelledError`, or prime-sandboxes listing `CANCELED` as fatal) so the pump ends instead.

## Why

A pipeline running ~90 concurrent rollouts on prime sandboxes classifies sandbox faults (box gone, API unavailable, disk full, quota) by regex over `SandboxError` text, because the error carries no typed code. The runtime already knows the type of the failure at the point it wraps it; this records it once so consumers branch on `trace.last_error.code` instead of on prose.

## Validation

- `tests/v1/test_errors.py`: the code survives `record_error` and a `to_record` round trip; typed sources map, text-only ones stay `None` (including the SDK's `APIError("HTTP 404: ...")` shape); a runtime read of a missing path raises `SandboxError(code="not_found")`.
- Cancellation: a fake SDK that reports the cancel as the RPC does (`APIError` ← `ConnectError(CANCELED)` ← `CancelledError`), or with no typed trace at all, inside `runtime.run()` while the awaiting task is cancelled → `CancelledError` propagates and the task ends cancelled, not `SandboxError`; a fault without a cancel stays a `SandboxError` with its code. The SDK pump, cancelled while its stream reports `CANCELED`, ends without re-attaching; a dropped link (`UNAVAILABLE`) still re-attaches.
- `uv run pytest tests/v1 -m "not e2e"`, `ruff`, `ty check`, `pre-commit` pass.

Not wired: the modal runtime (its SDK types are not audited here), `harness._check_result`'s "runtime died" `SandboxError` (the alive probe is structural, not an exception type — left `None` for now), and `PrimeProcess.write/terminate/kill`, which never mapped to `SandboxError` and still surface a swallowed cancel as the SDK's raw `APIError`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add typed fault codes to `SandboxError` and Prime runtime error handling
> - Adds an optional `code` field to `SandboxError` and `trace.Error` so sandbox failures carry a named fault code (e.g. `not_found`, `timeout`, `disk_full`, `denied`, `unavailable`) alongside their message
> - Introduces `sandbox_fault_code` and `_http_fault_code` classifiers in [errors.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2574/files#diff-5621d6869aa43b8c83352b3f958fe94b199952c4ae37c042fe2a25106962cb5b) that map typed local `OSError` and HTTP status evidence to codes; unknown exception types and message-only strings produce no code
> - Adds the `_faults` context manager in [prime.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2574/files#diff-d22d61279ff7587a2b14c72ab1a0fc9d3f805a735338a70f8efc7fe19aaa8502) and wraps all Prime runtime operations (`start`, `run`, `read`, `write`, `expose`, `run_background`, `open_process`, `prepare_execution`) so provider failures become coded `SandboxError` and swallowed task cancellation is re-raised as `asyncio.CancelledError`
> - Replaces the SDK `AsyncSandboxProcess._can_reconnect` predicate with a cancellation-aware wrapper so a cancelled stream pump does not attempt reconnection
> - Applies `sandbox_fault_code` to subprocess reads in [subprocess.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2574/files#diff-f36f9994618d7a28baaf498b61eb6f129dcfda77500d165d18537426dfcdd6e2) and records `code` on trace errors in [trace.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2574/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e)
> - Behavioral Change: Prime egress polling now uses `EGRESS_APPLY_TIMEOUT`; deadline expiry raises a `timeout`-coded `SandboxError` instead of propagating as cancellation. The import-time replacement of `AsyncSandboxProcess._can_reconnect` is guarded but modifies a SDK private method at module load.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9671970.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes Prime/async cancellation and error classification across all sandbox RPC paths; misclassification could break retries or leave sandboxes leaking, though behavior is heavily tested.
> 
> **Overview**
> Adds **typed sandbox fault codes** so pipelines can branch on `trace.last_error.code` instead of parsing error messages.
> 
> **`SandboxError`** now accepts an optional `code` (`not_found`, `timeout`, `disk_full`, `unavailable`, `provisioning`, `denied`) derived only from typed evidence. **`sandbox_fault_code`** and Prime’s **`_fault_code`** (walking SDK/Connect/httpx exception chains, including HTTP status on chained `APIError`) classify failures; **`Trace.record_error`** persists `code` on trace errors.
> 
> **Prime runtime** routes SDK calls through **`_faults`**, which re-raises **`asyncio.CancelledError`** when `Task.cancelling()` is set (so retry-on-`SandboxError` cannot swallow SIGINT/cancel) and otherwise raises **`SandboxError`** with the mapped code. Egress apply timeouts explicitly use `code="timeout"`. **`AsyncSandboxProcess._can_reconnect`** is wrapped so a cancelled stream pump does not reconnect forever. **Subprocess** bounded reads attach codes from **`OSError`**.
> 
> New **`tests/v1/test_errors.py`** covers trace round-trips, classification, cancel vs deadline behavior, and stream pump reconnect rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9671970e0cff3aa9a9b9654fc1dd051531ab08da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->