### PR TITLE
feat(interception): bound concurrent model requests per server

### DIFF
--- a/tests/v1/test_interception.py
+++ b/tests/v1/test_interception.py
@@ -1,0 +1,142 @@
+"""The interception server's request admission: `max_concurrent_requests` bounds the
+upstream model requests in flight across a server's sessions, streamed responses holding
+their slot until the upstream connection closes."""
+
+import asyncio
+import json
+
+import httpx
+import pytest
+
+import verifiers.v1 as vf
+from verifiers.v1.clients import EvalClientConfig, ModelContext
+from verifiers.v1.clients.client import Client, RelayReply
+from verifiers.v1.interception.server import (
+    InterceptionServer,
+    InterceptionServerConfig,
+)
+from verifiers.v1.session import RolloutSession
+
+COMPLETION = {
+    "id": "cmpl",
+    "object": "chat.completion",
+    "created": 0,
+    "model": "m",
+    "choices": [
+        {
+            "index": 0,
+            "message": {"role": "assistant", "content": "ok"},
+            "finish_reason": "stop",
+        }
+    ],
+    "usage": {"prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4},
+}
+CHUNK = {
+    "id": "cmpl",
+    "object": "chat.completion.chunk",
+    "created": 0,
+    "model": "m",
+    "choices": [
+        {
+            "index": 0,
+            "delta": {"role": "assistant", "content": "ok"},
+            "finish_reason": "stop",
+        }
+    ],
+}
+
+
+def sse(data: dict | bytes) -> bytes:
+    payload = data if isinstance(data, bytes) else json.dumps(data).encode()
+    return b"data: " + payload + b"\n\n"
+
+
+class GatedClient(Client):
+    """Counts upstream requests in flight; each holds until `release` is set."""
+
+    def __init__(self) -> None:
+        self.inflight = 0
+        self.peak = 0
+        self.release = asyncio.Event()
+        self.arrived = asyncio.Condition()
+
+    async def _enter(self) -> None:
+        async with self.arrived:
+            self.inflight += 1
+            self.peak = max(self.peak, self.inflight)
+            self.arrived.notify_all()
+
+    async def get_response(
+        self, dialect, body, sampling, session_id=None, turn=None, headers=None
+    ):
+        await self._enter()
+        try:
+            await self.release.wait()
+        finally:
+            self.inflight -= 1
+        response = dialect.parse_response(dialect.validate_response(COMPLETION))
+        response.raw = COMPLETION
+        return response
+
+    async def relay(self, dialect, body, session_id=None, headers=None):
+        await self._enter()
+
+        async def chunks():
+            yield sse(CHUNK)
+            await self.release.wait()
+            yield sse(b"[DONE]")
+
+        async def close() -> None:
+            self.inflight -= 1  # the connection, not the last chunk, ends the request
+
+        return RelayReply(
+            content_type="text/event-stream", chunks=chunks(), close=close
+        )
+
+
+def make_session(idx: int) -> RolloutSession:
+    trace = vf.Trace(
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
+        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=idx, prompt="hi")),
+    )
+    return RolloutSession(
+        ctx=ModelContext(model="m", client=EvalClientConfig()), trace=trace
+    )
+
+
+@pytest.mark.parametrize("stream", [False, True], ids=["rendered", "streamed"])
+async def test_max_concurrent_requests_bounds_upstream(stream):
+    upstream = GatedClient()
+    config = InterceptionServerConfig(max_concurrent_requests=2)
+    async with InterceptionServer(config) as server:
+        sessions = [make_session(idx) for idx in range(5)]
+        secrets = []
+        for session in sessions:
+            model_secret, _ = server.register(session)
+            session.client = upstream
+            secrets.append(model_secret)
+
+        async with httpx.AsyncClient(base_url=server.base_url, timeout=10) as client:
+
+            async def call(secret: str) -> httpx.Response:
+                body = {"model": "m", "messages": [{"role": "user", "content": "hi"}]}
+                return await client.post(
+                    "/v1/chat/completions",
+                    json={**body, "stream": stream},
+                    headers={"Authorization": f"Bearer {secret}"},
+                )
+
+            calls = [asyncio.create_task(call(secret)) for secret in secrets]
+            async with upstream.arrived:
+                await asyncio.wait_for(
+                    upstream.arrived.wait_for(lambda: upstream.inflight >= 2), 5
+                )
+            await asyncio.sleep(0.1)  # the other three must still be queued
+            assert upstream.inflight == 2 and not any(call.done() for call in calls)
+            upstream.release.set()
+            responses = await asyncio.gather(*calls)
+
+    assert [response.status_code for response in responses] == [200] * 5
+    assert upstream.peak == 2
+    assert [len(session.trace.calls) for session in sessions] == [1] * 5
+    assert [session.trace.num_turns for session in sessions] == [1] * 5

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -35,7 +35,7 @@ from typing import Literal
 
 import httpx
 from aiohttp import web
-from pydantic import ValidationError
+from pydantic import PositiveInt, ValidationError
 from pydantic_core import PydanticSerializationError, from_json, to_json
 
 from verifiers.v1 import graph
@@ -218,6 +218,10 @@ class InterceptionServerConfig(BaseInterceptionConfig):
     (`tunnel.type custom`)."""
 
     type: Literal["server"] = "server"
+    max_concurrent_requests: PositiveInt | None = None
+    """Upstream model requests in flight at once across this server's sessions (None =
+    unlimited). A streamed response holds its slot until the upstream connection closes;
+    tool execution and replay-cache hits take none."""
     tunnel: TunnelConfig = PrimeTunnelConfig()
     """How remote consumers reach the server: `prime` (a framework-minted prime_tunnel) or
     `custom` (a pre-started tunnel / reverse proxy / direct bind you provide)."""
@@ -242,6 +246,11 @@ class InterceptionServer(Interception):
         self.state_routes: dict[str, RolloutSession] = {}
         self.state_service_secrets = frozenset(state_service_secrets)
         self.config = config or InterceptionServerConfig()
+        self._request_slots: asyncio.Semaphore | contextlib.nullcontext = (
+            asyncio.Semaphore(self.config.max_concurrent_requests)
+            if self.config.max_concurrent_requests is not None
+            else contextlib.nullcontext()
+        )
         self.tunnel: Tunnel | None = (
             make_tunnel(self.config.tunnel) if requires_tunnel else None
         )
@@ -679,14 +688,15 @@ class InterceptionServer(Interception):
                 try:
                     # What actually goes upstream: the native body with the rollout's model +
                     # sampling imposed — recorded raw on the trace, per call.
-                    call_response = await session.client.get_response(
-                        dialect,
-                        body,
-                        session.ctx.sampling,
-                        headers=upstream_headers,
-                        session_id=session.trace.id,
-                        turn=turn,
-                    )
+                    async with self._request_slots:
+                        call_response = await session.client.get_response(
+                            dialect,
+                            body,
+                            session.ctx.sampling,
+                            headers=upstream_headers,
+                            session_id=session.trace.id,
+                            turn=turn,
+                        )
                     logger.debug(
                         "intercept turn: id=%s tools=%d",
                         session.trace.id,
@@ -803,14 +813,19 @@ class InterceptionServer(Interception):
         node: int | None = None
         error: Exception | None = None
         started = time.time()
+        # The request slot and the upstream connection release together, when the
+        # provider's stream is fully consumed (or abandoned) — not when the handler ends.
+        upstream = contextlib.AsyncExitStack()
         try:
             try:
+                await upstream.enter_async_context(self._request_slots)
                 reply = await session.client.relay(
                     dialect,
                     body,
                     headers=upstream_headers,
                     session_id=session.trace.id,
                 )
+                upstream.push_async_callback(reply.close)
             except RolloutError as e:
                 error = e
                 session.error = e
@@ -875,7 +890,7 @@ class InterceptionServer(Interception):
                     session.error = error
                     return self._fail(session, dialect, error)
                 finally:
-                    await reply.close()
+                    await upstream.aclose()
 
                 if session.released or session.stopped:
                     buffered.close()
@@ -988,7 +1003,7 @@ class InterceptionServer(Interception):
                 if queue.full():
                     queue.get_nowait()
                 await asyncio.gather(producer, return_exceptions=True)
-                await reply.close()
+                await upstream.aclose()
 
             try:
                 if parser_error is not None:
@@ -1025,20 +1040,26 @@ class InterceptionServer(Interception):
                 error = e
             raise
         finally:
-            # The turn's one per-exchange record: settings, timing, outcome, and the
-            # error that ended it (if any).
-            self.record_call(
-                session,
-                dialect,
-                body,
-                started,
-                node=node,
-                finish_reason=response.finish_reason if response is not None else None,
-                usage=response.usage if response is not None else None,
-                error=error,
-                policy_paths=policy_paths,
-                acp=acp,
-            )
+            try:
+                # Idempotent: frees the slot on the paths that reached no close site.
+                await upstream.aclose()
+            finally:
+                # The turn's one per-exchange record: settings, timing, outcome, and the
+                # error that ended it (if any).
+                self.record_call(
+                    session,
+                    dialect,
+                    body,
+                    started,
+                    node=node,
+                    finish_reason=response.finish_reason
+                    if response is not None
+                    else None,
+                    usage=response.usage if response is not None else None,
+                    error=error,
+                    policy_paths=policy_paths,
+                    acp=acp,
+                )
 
     async def handle_aux(
         self, request: web.Request, dialect: Dialect, route: str


### PR DESCRIPTION
## What

`InterceptionServerConfig.max_concurrent_requests: PositiveInt | None = None`. When set, an `asyncio.Semaphore` bounds the upstream model requests in flight across every session registered on that server:

- rendered (non-streaming) calls hold a slot around `client.get_response(...)` only — response interceptors / `@stop`s run after release;
- streamed calls acquire before `client.relay(...)` and release when the upstream connection closes (`reply.close()`), which now sits on one `AsyncExitStack` with the slot so the two always free together, on every exit path (a `finally` in `_stream` closes the stack before `record_call`);
- tool execution, replay-cache hits, coalesced SDK retries, `/v1/models` and aux routes take no slot; `None` keeps today's behavior.

The limit is per server: it applies to the `server` and `static` interception shapes (`static` lists one `InterceptionServerConfig` per server). The `elastic` pool mints servers with the default config and stays unlimited; a pool-wide knob is a separate change.

The same concern was bundled into the closed #2552 with unrelated changes; this reimplements only the request limit on current `main`.

## Why

Rollout concurrency does not bound inference load: a recursive harness (rho in the data-flywheel pipeline, ~90 concurrent rollouts) fans out several model requests per rollout, so the provider sees bursts well past the rollout cap and answers with 429s that then surface as rollout errors. A per-server admission limit puts the bound where every request already passes.

## Validation

- `tests/v1/test_interception.py::test_max_concurrent_requests_bounds_upstream[rendered|streamed]`: a real `InterceptionServer` with `max_concurrent_requests=2`, five sessions sharing a gated stub `Client` that counts in-flight upstream requests (the streamed stub decrements only on `close()`), five concurrent `POST /v1/chat/completions` over HTTP. Asserts exactly two reach upstream while the rest queue, peak in-flight stays 2, and all five complete with a committed turn. With the limit unset the same probe reaches peak 5.
- `uv run pytest tests/v1 -m "not e2e"`: 88 passed. `uv run ruff check`, `uv run pre-commit run --all-files`: clean.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound concurrent upstream model requests in `InterceptionServer`
> - Adds optional `max_concurrent_requests` field (`PositiveInt`) to `InterceptionServerConfig` in [server.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2576/files#diff-84e2f8d027d609e8760ef6d533535ec9d99dfc6384d5ddb6111b4001b2010f35)
> - Acquires an asyncio semaphore in the rendered `sample` handler and streamed relay handler to bound concurrent upstream model requests
> - Streamed responses retain their semaphore slot until the relay's close callback runs
> - Adds `GatedClient` test double and concurrency tests in [test_interception.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2576/files#diff-8a37927b14cde5b1287e9e16d22f188e04e1c710030c997967831559d78c6783) to verify the limit is respected for both rendered and streamed paths
> - Behavioral Change: servers without `max_concurrent_requests` set use a no-op context manager, preserving existing unlimited admission
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 507e414.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes admission control on the central model proxy path; misconfigured limits could throttle or delay rollouts, but default `None` preserves current behavior.
> 
> **Overview**
> Adds optional **`max_concurrent_requests`** on `InterceptionServerConfig` so a single interception server can cap how many upstream model calls are in flight across all registered sessions (`None` keeps unlimited admission).
> 
> Non-streaming turns acquire a semaphore only around `client.get_response`; streamed turns acquire before `client.relay` and hold the slot until upstream teardown by pairing the semaphore with `reply.close()` on an `AsyncExitStack` (with idempotent cleanup on every exit path). Tool routes, replay-cache hits, and aux/model listing paths are unchanged and do not consume slots.
> 
> New integration tests drive five concurrent `/v1/chat/completions` calls against a real server with limit `2`, using a gated stub client to assert queuing, peak in-flight of 2, and successful completion for both rendered and streamed modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 507e4142381ce030d56db6962ebbf7e21b768fdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->