### PR TITLE
fix(v1): report platform run errors

### DIFF
--- a/verifiers/v1/utils/platform.py
+++ b/verifiers/v1/utils/platform.py
@@ -166,13 +166,13 @@ def _close(
 
 
 def _losses(run: pr.Run) -> str | None:
-    """What the uploader could not store, or `None`. A sink that switched itself off
-    quietly (Prime Traces outside the beta) is not a loss and is not counted here."""
-    parts = [
+    """What the run could not finish or store, or `None`."""
+    parts = list(run.errors)
+    parts.extend(
         f"{count} record(s) not stored by the {sink} sink"
         for sink, count in sorted(run.failed_records.items())
         if count
-    ]
+    )
     if run.dropped_records:
         parts.append(f"{run.dropped_records} record(s) never queued (uploader overrun)")
     return "; ".join(parts) or None


### PR DESCRIPTION
## Summary

- surface contained `prime-runs` update and finalization errors through the existing incomplete upload status
- preserve the current best-effort evaluation and run lifecycle semantics
- keep the change production-only; no test files are included

## Validation

- `uv run pytest tests/ -q` (credential-gated E2E cases skipped)
- `uv run ruff check --fix .`
- `uv run ty check verifiers`
- `uv run pre-commit run --all-files`
- deterministic fake-backend probe confirms a finalization failure renders as incomplete

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to how incomplete upload messages are assembled after `run.finish()`; improves visibility without altering eval or push control flow.
> 
> **Overview**
> **Platform push “incomplete” reporting** now includes **`prime-runs` run-level errors** (e.g. update/finalization failures), not only per-sink failed records and uploader overruns.
> 
> `_losses` builds its message from `run.errors` first, then the existing failed-record and dropped-record details, so a run that **closes successfully** can still show an **incomplete** footer line when the SDK recorded errors during the lifecycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b14aaff65071dcbd0820ef3a445bab65030d649. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Include `run.errors` in platform `_losses` loss description
> Updates the `_losses` utility in [platform.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2577/files#diff-8644072f827be448db5b0010e0969c6c86d9bbf07191ca00a993f416d123235f) to prepend the run's existing errors to the returned semicolon-separated loss message, before failed-record and dropped-record messages. The message still returns `None` when no messages are present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0b14aaf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->