### PR TITLE
feat(v1): keep boxes between rollouts with Agent.provision(task, reuse=key)

### DIFF
--- a/tests/v1/fixtures/reuse_v1.py
+++ b/tests/v1/fixtures/reuse_v1.py
@@ -1,0 +1,27 @@
+"""reuse: the smallest env that keeps a seat's box across episodes.
+
+The runtime-pool fixture for the v1 e2e suite (resolved by id `reuse-v1`): an `Env`
+whose `run()` provisions the seat's box under a reuse key and plays the task in it —
+with `--env.runtimes` set, every episode of the run lands in one box; without it, each
+episode provisions and tears down its own, exactly as `provision(task)` does."""
+
+from echo_v1 import EchoTaskset
+
+import verifiers.v1 as vf
+
+
+class ReuseEnvConfig(vf.EnvConfig):
+    agent: vf.AgentConfig = vf.AgentConfig()
+
+
+class ReuseEnv(vf.Env[ReuseEnvConfig]):
+    async def run(self, task, agents):
+        async with agents.agent.provision(task, reuse="seat") as box:
+            await agents.agent.run(task, runtime=box)
+
+
+class ReuseTaskset(EchoTaskset):
+    pass
+
+
+__all__ = ["ReuseEnv", "ReuseTaskset"]

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -459,6 +459,57 @@ async def test_multi_agent_env(run_v1, tmp_path):
     assert by_name["b"]["agent"]["trainable"] is False
 
 
+# env x harness runtime for the box-reuse env: the host runtime, and a restricted
+# container whose second episode re-opens egress for setup (`prepare_setup`).
+REUSE_PLACEMENTS = [
+    pytest.param(
+        "null",
+        {"type": "subprocess"},
+        marks=[mark.null, mark.subprocess],
+        id="null-harness-in-subprocess",
+    ),
+    pytest.param(
+        "bash",
+        {"type": "docker", "block": ["example.com"]},
+        marks=[mark.bash, mark.docker],
+        id="bash-harness-in-restricted-docker",
+    ),
+]
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("harness,runtime", REUSE_PLACEMENTS)
+async def test_runtime_pool_keeps_the_box_across_episodes(
+    run_v1, harness, runtime, tmp_path
+):
+    """`--env.runtimes` keeps the box an env `provision(task, reuse=key)`s (reuse-v1)
+    between episodes: both rollouts borrow one box; the same env without the pool
+    provisions a box per episode."""
+    pooled = await run_v1(
+        "reuse-v1",
+        harness=harness,
+        runtime=runtime,
+        env={"runtimes": {"ttl": 60}},
+        n=2,
+        output_dir=tmp_path / "pooled",
+        max_turns=2,
+    )
+    assert len(pooled) == 2
+    assert all(t.ok and t.agent.runtime.borrowed for t in pooled)
+    assert len({t.agent.runtime.id for t in pooled}) == 1  # one box, two episodes
+    plain = await run_v1(
+        "reuse-v1",
+        harness=harness,
+        runtime=runtime,
+        n=2,
+        output_dir=tmp_path / "plain",
+        max_turns=2,
+    )
+    assert len(plain) == 2
+    assert all(t.ok and t.agent.runtime.borrowed for t in plain)
+    assert len({t.agent.runtime.id for t in plain}) == 2  # a box per episode
+
+
 @pytest.mark.e2e
 async def test_env_id_best_of_n(run_v1, tmp_path):
     """`--env.id` pairs a bundled env with an arbitrary taskset: best-of-n over the

--- a/tests/v1/test_runtimes.py
+++ b/tests/v1/test_runtimes.py
@@ -1,8 +1,9 @@
 """`RuntimePool`: the boxes `Agent.provision(task, reuse=key)` keeps between contexts —
-hit/miss on key, config, TTL and liveness (probed under the new env); teardown on error,
-a cancelled probe, caller stop, `discard`, `max_idle` and pool close (a lease queued
-behind it refused); one box per key, its gate dropped when unused. Subprocess runtimes
-(a directory each), no model."""
+hit/miss on key, config, TTL and liveness (probed under the new env); a box started with
+no lease's env, each lease's env its own per-exec overlay; teardown on error, a cancelled
+probe, caller stop, `discard`, `max_idle` and pool close (a lease queued behind it
+refused); one box per key, its gate dropped when unused. Subprocess runtimes (a directory
+each), no model."""
 
 import asyncio
 import gc
@@ -75,6 +76,29 @@ async def test_the_probe_runs_under_the_new_lease_env() -> None:
             assert not await box.alive()  # `true` is unreachable under an empty PATH
         async with runtimes.lease("k", SUBPROCESS, {}) as again:
             assert again is box  # probed under the new env, not the last lease's
+
+
+async def test_a_pooled_box_starts_without_a_lease_env(monkeypatch) -> None:
+    """Docker/prime/modal bake `runtime.env` into the box at creation, and a pooled box
+    hosts later leases: it is started with no lease's env, and each lease's env is the
+    per-exec overlay for that lease alone (parked, the box carries none)."""
+    started_with: list[dict[str, str]] = []
+    real_start = SubprocessRuntime.start
+
+    async def spy_start(self: SubprocessRuntime) -> None:
+        started_with.append(dict(self.env))  # what a container would bake in
+        await real_start(self)
+
+    monkeypatch.setattr(SubprocessRuntime, "start", spy_start)
+    probe = ["sh", "-c", 'echo "${VF_LEASE_A-unset}" "${VF_LEASE_B-unset}"']
+    async with pool() as runtimes:
+        async with runtimes.lease("k", SUBPROCESS, {"VF_LEASE_A": "a"}) as first:
+            assert (await first.run(probe, {})).stdout.split() == ["a", "unset"]
+        assert first.env == {}
+        async with runtimes.lease("k", SUBPROCESS, {"VF_LEASE_B": "b"}) as second:
+            assert second is first
+            assert (await second.run(probe, {})).stdout.split() == ["unset", "b"]
+    assert started_with == [{}]  # one box, started with nothing lease-specific
 
 
 async def test_cancelling_a_lease_mid_probe_stops_the_popped_box(monkeypatch) -> None:

--- a/tests/v1/test_runtimes.py
+++ b/tests/v1/test_runtimes.py
@@ -1,7 +1,8 @@
 """`RuntimePool`: the boxes `Agent.provision(task, reuse=key)` keeps between contexts —
 hit/miss on key, config, TTL and liveness (probed under the new env); teardown on error,
-a cancelled probe, caller stop, `discard`, `max_idle` and pool close; one box per key, its
-gate dropped when unused. Subprocess runtimes (a directory each), no model."""
+a cancelled probe, caller stop, `discard`, `max_idle` and pool close (a lease queued
+behind it refused); one box per key, its gate dropped when unused. Subprocess runtimes
+(a directory each), no model."""
 
 import asyncio
 import gc
@@ -10,7 +11,12 @@ from pathlib import Path
 import pytest
 
 import verifiers.v1 as vf
-from verifiers.v1.runtimes import RuntimePool, RuntimePoolConfig, SubprocessRuntime
+from verifiers.v1.runtimes import (
+    Runtime,
+    RuntimePool,
+    RuntimePoolConfig,
+    SubprocessRuntime,
+)
 from verifiers.v1.runtimes.base import _LIVE, cleanup_at_exit
 from verifiers.v1.runtimes.subprocess import SubprocessConfig
 
@@ -124,9 +130,9 @@ async def test_lease_tears_down_instead_of_keeping() -> None:
         async with runtimes.lease("k", SUBPROCESS, {}) as last:
             pass
     assert last.stopped  # closing the pool
-    async with runtimes.lease("k", SUBPROCESS, {}) as after:
-        pass
-    assert after.stopped  # a release after the pool closed stops, never parks
+    with pytest.raises(RuntimeError, match="runtime pool is closed"):
+        async with runtimes.lease("k", SUBPROCESS, {}):
+            pass  # a lease after the pool closed is refused, never started
 
 
 async def test_idle_boxes_reach_the_atexit_backstop() -> None:
@@ -172,6 +178,45 @@ async def test_one_box_per_key_serialises_leases() -> None:
         await asyncio.gather(first, second)
         assert not runtimes._locks  # nothing holds or waits on the key: gate dropped
     assert order == ["first:in", "first:out", "second:in", "second:out"]
+
+
+async def test_stop_refuses_a_lease_queued_on_a_key(monkeypatch) -> None:
+    started: list[SubprocessRuntime] = []
+    real_start = SubprocessRuntime.start
+
+    async def counting_start(self: SubprocessRuntime) -> None:
+        started.append(self)
+        await real_start(self)
+
+    runtimes = pool()
+    async with runtimes:
+        held, release = asyncio.Event(), asyncio.Event()
+        boxes: list[Runtime] = []
+
+        async def hold() -> None:
+            async with runtimes.lease("k", SUBPROCESS, {}) as box:
+                boxes.append(box)
+                held.set()
+                await release.wait()
+
+        async def queued() -> None:
+            async with runtimes.lease("k", SUBPROCESS, {}):
+                pass
+
+        holder = asyncio.create_task(hold())
+        await held.wait()
+        waiter = asyncio.create_task(queued())
+        await asyncio.sleep(0)
+        assert runtimes._locks["k"].users == 2  # the second lease waits on the gate
+        monkeypatch.setattr(SubprocessRuntime, "start", counting_start)
+        await runtimes.stop()  # closes the pool while the waiter is still queued
+        release.set()
+        await holder
+        with pytest.raises(RuntimeError, match="runtime pool is closed"):
+            await waiter
+    assert boxes[0].stopped  # the live lease's box stops on release, never parks
+    assert started == []  # the queued lease never started a box
+    assert not runtimes._locks
 
 
 def _agent(runtimes: RuntimePool | None) -> vf.Agent:

--- a/tests/v1/test_runtimes.py
+++ b/tests/v1/test_runtimes.py
@@ -1,0 +1,165 @@
+"""`RuntimePool`: the boxes `Agent.provision(task, reuse=key)` keeps between contexts —
+hit/miss on key, config, TTL and liveness; teardown on error, caller stop, `discard`,
+`max_idle` and pool close; one box per key. Subprocess runtimes (a directory each), no model."""
+
+import asyncio
+import gc
+from pathlib import Path
+
+import pytest
+
+import verifiers.v1 as vf
+from verifiers.v1.runtimes import RuntimePool, RuntimePoolConfig, SubprocessRuntime
+from verifiers.v1.runtimes.base import _LIVE, cleanup_at_exit
+from verifiers.v1.runtimes.subprocess import SubprocessConfig
+
+SUBPROCESS = SubprocessConfig()
+
+
+class OtherConfig(SubprocessConfig):
+    """The same fields under another model type: pydantic equality tells them apart, so
+    this is the cheapest "same key, drifted resolved config" a subprocess box can have."""
+
+
+class EnvTask(vf.Task[vf.TaskData]):
+    def runtime_env(self) -> dict[str, str]:
+        return {"TASK": str(self.data.idx)}
+
+
+def pool(**overrides) -> RuntimePool:
+    return RuntimePool(RuntimePoolConfig(**overrides))
+
+
+async def test_lease_reuses_the_box_under_a_key() -> None:
+    async with pool() as runtimes:
+        async with runtimes.lease("k", SUBPROCESS, {"A": "1"}) as first:
+            assert first.env == {"A": "1"} and first.info.id
+        async with runtimes.lease("k", SUBPROCESS, {"A": "2"}) as second:
+            assert second is first and second.env == {"A": "2"}
+        async with runtimes.lease("other", SUBPROCESS, {}) as third:
+            assert third is not first
+    # Closing the pool stops every idle box.
+    assert first.stopped and third.stopped
+
+
+async def test_lease_replaces_a_box_that_no_longer_fits(monkeypatch) -> None:
+    async with pool(ttl=60) as runtimes:
+        async with runtimes.lease("k", SUBPROCESS, {}) as a:
+            pass
+        async with runtimes.lease("k", OtherConfig(), {}) as b:
+            assert b is not a and a.stopped  # the resolved config drifted
+        async with runtimes.lease("k", OtherConfig(), {}) as same:
+            assert same is b
+        runtimes._idle["k"].since -= 61  # idle past `ttl`
+        async with runtimes.lease("k", OtherConfig(), {}) as c:
+            assert c is not b and b.stopped
+        monkeypatch.setattr(SubprocessRuntime, "alive", lambda self: _false())
+        async with runtimes.lease("k", OtherConfig(), {}) as d:
+            assert d is not c and c.stopped  # a dead box is not handed back
+
+
+async def _false() -> bool:
+    return False
+
+
+async def test_sweeper_stops_an_expired_idle_box() -> None:
+    async with pool(ttl=0.05) as runtimes:
+        async with runtimes.lease("k", SUBPROCESS, {}) as box:
+            pass
+        for _ in range(100):  # the sweeper wakes every `ttl / 4`
+            if box.stopped:
+                break
+            await asyncio.sleep(0.01)
+        assert box.stopped and not runtimes._idle
+
+
+async def test_lease_tears_down_instead_of_keeping() -> None:
+    async with pool() as runtimes:
+        with pytest.raises(RuntimeError):
+            async with runtimes.lease("k", SUBPROCESS, {}) as failed:
+                raise RuntimeError("the rollout blew up")
+        assert failed.stopped
+        async with runtimes.lease("k", SUBPROCESS, {}) as released:
+            await released.stop()  # the caller says "do not keep it"
+        async with runtimes.lease("k", SUBPROCESS, {}) as fresh:
+            assert fresh is not released
+        await runtimes.discard("k")
+        assert fresh.stopped
+        await runtimes.discard("k")  # idempotent: nothing under the key
+        async with runtimes.lease("k", SUBPROCESS, {}) as last:
+            pass
+    assert last.stopped  # closing the pool
+    async with runtimes.lease("k", SUBPROCESS, {}) as after:
+        pass
+    assert after.stopped  # a release after the pool closed stops, never parks
+
+
+async def test_idle_boxes_reach_the_atexit_backstop() -> None:
+    async with pool() as runtimes:
+        async with runtimes.lease("k", SUBPROCESS, {}) as box:
+            workdir = Path(box.info.id)
+        del box
+        gc.collect()
+        # The pool's reference keeps the idle box registered for a hard exit.
+        assert any(r.info.id == str(workdir) for r in _LIVE)
+        cleanup_at_exit()
+        assert not workdir.exists()
+
+
+async def test_max_idle_stops_the_oldest_box() -> None:
+    async with pool(max_idle=1) as runtimes:
+        async with runtimes.lease("a", SUBPROCESS, {}) as a:
+            pass
+        async with runtimes.lease("b", SUBPROCESS, {}) as b:
+            pass
+        assert a.stopped and not b.stopped
+
+
+async def test_one_box_per_key_serialises_leases() -> None:
+    order: list[str] = []
+    async with pool() as runtimes:
+
+        async def hold(name: str, gate: asyncio.Event | None) -> None:
+            async with runtimes.lease("k", SUBPROCESS, {}):
+                order.append(f"{name}:in")
+                if gate is not None:
+                    await gate.wait()
+                order.append(f"{name}:out")
+
+        gate = asyncio.Event()
+        first = asyncio.create_task(hold("first", gate))
+        await asyncio.sleep(0)
+        second = asyncio.create_task(hold("second", None))
+        await asyncio.sleep(0.05)
+        assert order == ["first:in"]  # the second lease waits for the first to end
+        gate.set()
+        await asyncio.gather(first, second)
+    assert order == ["first:in", "first:out", "second:in", "second:out"]
+
+
+def _agent(runtimes: RuntimePool | None) -> vf.Agent:
+    config = vf.AgentConfig(
+        model="m", harness=vf.HarnessConfig(id="null"), runtime=SUBPROCESS
+    )
+    return vf.Agent(config, runtimes=runtimes)
+
+
+async def test_provision_reuse_rides_the_agent_pool() -> None:
+    async with pool() as runtimes:
+        agent = _agent(runtimes)
+        task = EnvTask(vf.TaskData(idx=1, prompt="hi"))
+        async with agent.provision(task, reuse="k") as first:
+            assert first.env == {"TASK": "1"}
+        task = EnvTask(vf.TaskData(idx=2, prompt="hi"))
+        async with agent.provision(task, reuse="k") as second:
+            assert second is first and second.env == {"TASK": "2"}
+        async with agent.provision(task) as owned:  # reuse=None: as before
+            assert owned is not first
+        assert owned.stopped and not first.stopped
+    assert first.stopped
+    plain = _agent(None)  # no pool: `reuse` provisions and tears down as before
+    async with plain.provision(task, reuse="k") as box:
+        pass
+    assert box.stopped
+    async with plain.provision(task, reuse="k") as again:
+        assert again is not box

--- a/tests/v1/test_runtimes.py
+++ b/tests/v1/test_runtimes.py
@@ -1,6 +1,7 @@
 """`RuntimePool`: the boxes `Agent.provision(task, reuse=key)` keeps between contexts —
-hit/miss on key, config, TTL and liveness; teardown on error, caller stop, `discard`,
-`max_idle` and pool close; one box per key. Subprocess runtimes (a directory each), no model."""
+hit/miss on key, config, TTL and liveness (probed under the new env); teardown on error,
+a cancelled probe, caller stop, `discard`, `max_idle` and pool close; one box per key, its
+gate dropped when unused. Subprocess runtimes (a directory each), no model."""
 
 import asyncio
 import gc
@@ -60,6 +61,40 @@ async def test_lease_replaces_a_box_that_no_longer_fits(monkeypatch) -> None:
 
 async def _false() -> bool:
     return False
+
+
+async def test_the_probe_runs_under_the_new_lease_env() -> None:
+    async with pool() as runtimes:
+        async with runtimes.lease("k", SUBPROCESS, {"PATH": ""}) as box:
+            assert not await box.alive()  # `true` is unreachable under an empty PATH
+        async with runtimes.lease("k", SUBPROCESS, {}) as again:
+            assert again is box  # probed under the new env, not the last lease's
+
+
+async def test_cancelling_a_lease_mid_probe_stops_the_popped_box(monkeypatch) -> None:
+    probing = asyncio.Event()
+
+    async def _slow_alive(self) -> bool:
+        probing.set()
+        await asyncio.sleep(60)
+        return True
+
+    async with pool() as runtimes:
+        async with runtimes.lease("k", SUBPROCESS, {}) as box:
+            pass
+        monkeypatch.setattr(SubprocessRuntime, "alive", _slow_alive)
+
+        async def take() -> None:
+            async with runtimes.lease("k", SUBPROCESS, {}):
+                pass
+
+        task = asyncio.create_task(take())
+        await probing.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        # Popped before the probe: the cancellation must stop it, not orphan it.
+        assert box.stopped and not runtimes._idle and not runtimes._locks
 
 
 async def test_sweeper_stops_an_expired_idle_box() -> None:
@@ -132,8 +167,10 @@ async def test_one_box_per_key_serialises_leases() -> None:
         second = asyncio.create_task(hold("second", None))
         await asyncio.sleep(0.05)
         assert order == ["first:in"]  # the second lease waits for the first to end
+        assert runtimes._locks["k"].users == 2  # one holding, one waiting
         gate.set()
         await asyncio.gather(first, second)
+        assert not runtimes._locks  # nothing holds or waits on the key: gate dropped
     assert order == ["first:in", "first:out", "second:in", "second:out"]
 
 

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -79,6 +79,8 @@ from verifiers.v1.runtimes import (
     Runtime,
     RuntimeConfig,
     RuntimeInfo,
+    RuntimePool,
+    RuntimePoolConfig,
     RuntimeProcess,
     SubprocessConfig,
 )
@@ -298,6 +300,8 @@ __all__ = [  # noqa: RUF022 - grouped by public API area
     "RuntimeProcess",
     "RuntimeConfig",
     "RuntimeInfo",
+    "RuntimePool",
+    "RuntimePoolConfig",
     "ProgramResult",
     "SubprocessConfig",
     "DockerConfig",

--- a/verifiers/v1/agent.py
+++ b/verifiers/v1/agent.py
@@ -28,6 +28,7 @@ from verifiers.v1.rollout import Rollout, RolloutTimeouts
 from verifiers.v1.runtimes import (
     Runtime,
     RuntimeConfig,
+    RuntimePool,
     SubprocessConfig,
     provision_runtime,
     runtime_is_local,
@@ -254,11 +255,11 @@ class Interaction:
 class Agent:
     """A configured harness + model + runtime policy, runnable on any task.
 
-    Built from an `AgentConfig` alone; `interception=` injects a live resource to
-    borrow — its owner keeps the lifecycle. The endpoint stays config: each rollout
-    builds and closes its own `Client`, so an agent holds no transport. The config's
-    `runtime` is a *policy*: each `run` provisions a fresh box from it, resolved
-    per task; `run(runtime=...)` places the run into an existing box instead
+    Built from an `AgentConfig` alone; `interception=` and `runtimes=` inject live
+    resources to borrow — their owner keeps the lifecycle. The endpoint stays config:
+    each rollout builds and closes its own `Client`, so an agent holds no transport.
+    The config's `runtime` is a *policy*: each `run` provisions a fresh box from it,
+    resolved per task; `run(runtime=...)` places the run into an existing box instead
     (borrowed boxes are never started or torn down by the run)."""
 
     def __init__(
@@ -266,6 +267,7 @@ class Agent:
         config: AgentConfig,
         *,
         interception: Interception | None = None,
+        runtimes: RuntimePool | None = None,
     ) -> None:
         from verifiers.v1.utils.loaders import harness_config_type, load_harness
 
@@ -292,6 +294,7 @@ class Agent:
         self._closed = False
         self.runtime_config: RuntimeConfig = config.runtime
         self.interception = interception
+        self.runtimes = runtimes
         self.limits = RolloutLimits(
             max_turns=config.max_turns,
             max_input_tokens=config.max_input_tokens,
@@ -564,17 +567,30 @@ class Agent:
         }
 
     @asynccontextmanager
-    async def provision(self, task: Task | None = None) -> AsyncIterator[Runtime]:
+    async def provision(
+        self, task: Task | None = None, *, reuse: str | None = None
+    ) -> AsyncIterator[Runtime]:
         """Provision (and on exit tear down) a box from this agent's runtime
-        policy, resolved for `task` when given; share it via `run(..., runtime=box)`."""
+        policy, resolved for `task` when given; share it via `run(..., runtime=box)`.
+        `reuse=key` instead parks the box in the agent's `runtimes` pool when the
+        context closes and gets it back on the next `provision(..., reuse=key)` whose
+        resolved config matches — one box per key: a second holder of a live key
+        waits, and re-entering a key inside its own context deadlocks. With no pool,
+        or `reuse=None`, the box is provisioned and torn down as before. A run placed
+        into the box is a borrowed-box rollout either way (`trace.agent.runtime.borrowed`)."""
         config = (
             resolve_runtime_config(self.runtime_config, task, self._warned_resources)
             if task is not None
             else self.runtime_config
         )
+        # Keep sandbox startup task-neutral: this box may later host another task.
+        env = dict(task.runtime_env()) if task is not None else {}
+        if reuse is not None and self.runtimes is not None:
+            async with self.runtimes.lease(reuse, config, env) as runtime:
+                yield runtime
+            return
         async with provision_runtime(config) as runtime:
-            # Keep sandbox startup task-neutral: this box may later host another task.
-            runtime.env = dict(task.runtime_env()) if task is not None else {}
+            runtime.env = env
             yield runtime
 
 
@@ -592,6 +608,7 @@ class _EpisodeAgent(Agent):
         config: AgentConfig,
         *,
         interception: Interception | None,
+        runtimes: RuntimePool | None,
         name: str,
         shared_tools: Mapping[str, SharedToolServer],
         task_cls: type[Task],
@@ -601,7 +618,7 @@ class _EpisodeAgent(Agent):
         on_discard: Callable[[Trace], None] | None,
         warned_resources: set,
     ) -> None:
-        super().__init__(config, interception=interception)
+        super().__init__(config, interception=interception, runtimes=runtimes)
         # Resource warnings dedupe env-wide, not per episode.
         self._warned_resources = warned_resources
         self._name = name

--- a/verifiers/v1/configs/env.py
+++ b/verifiers/v1/configs/env.py
@@ -11,6 +11,7 @@ from verifiers.v1.configs.harness import HarnessConfig
 from verifiers.v1.configs.retries import RetryConfig
 from verifiers.v1.configs.taskset import TasksetConfig
 from verifiers.v1.interception import ElasticInterceptionPoolConfig, InterceptionConfig
+from verifiers.v1.runtimes import RuntimePoolConfig
 from verifiers.v1.types import ID
 from verifiers.v1.utils.generic import deep_merge
 
@@ -59,6 +60,9 @@ class EnvConfig(BaseConfig):
     in flight."""
     interception: InterceptionConfig = ElasticInterceptionPoolConfig()
     """The interception shape: `elastic` (default), `server`, or `static`."""
+    runtimes: RuntimePoolConfig | None = None
+    """Keep boxes between rollouts for agents that `provision(task, reuse=key)`; None
+    (default) tears every box down with its context — the RL/eval semantics."""
 
     @property
     def env_id(self) -> str:

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -29,7 +29,7 @@ from verifiers.v1.interception import (
     requires_tunnel,
 )
 from verifiers.v1.mcp import SharedToolServer, serve_shared
-from verifiers.v1.runtimes import SubprocessConfig, runtime_is_local
+from verifiers.v1.runtimes import RuntimePool, SubprocessConfig, runtime_is_local
 from verifiers.v1.task import Task
 from verifiers.v1.trace import Error, Trace, TraceTask
 from verifiers.v1.utils.generic import concrete_type, deep_merge
@@ -141,6 +141,9 @@ class Env(ABC, Generic[ConfigT]):
         # Serving resources, live only inside `serving()`; the env's agents borrow them.
         self._shared_tools: dict[str, SharedToolServer] = {}
         self._interception: Interception | None = None
+        self.runtimes: RuntimePool | None = None
+        """The boxes kept between rollouts (`--env.runtimes`), for agents that
+        `provision(task, reuse=key)`; `run()` may `discard(key)` one it is done with."""
         # Resource warnings dedupe env-wide (agents are per-episode).
         self._warned_resources: set = set()
 
@@ -226,6 +229,7 @@ class Env(ABC, Generic[ConfigT]):
             return _EpisodeAgent(
                 resolved,
                 interception=self._interception,
+                runtimes=self.runtimes,
                 name=name,
                 shared_tools=self._shared_tools,
                 task_cls=self._task_cls,
@@ -364,9 +368,13 @@ class Env(ABC, Generic[ConfigT]):
                     if server.state_secret
                 ),
             )
-            async with interception:
+            runtimes = (
+                RuntimePool(self.config.runtimes) if self.config.runtimes else None
+            )
+            async with interception, runtimes or contextlib.nullcontext():
                 self._shared_tools = shared
                 self._interception = interception
+                self.runtimes = runtimes
                 try:
                     await self.start()
                     yield
@@ -377,6 +385,7 @@ class Env(ABC, Generic[ConfigT]):
                     finally:
                         self._shared_tools = {}
                         self._interception = None
+                        self.runtimes = None
 
     def _runs_local(self) -> bool:
         """Whether every role's runtime policy is local (any remote role means tunnels)."""

--- a/verifiers/v1/runtimes/__init__.py
+++ b/verifiers/v1/runtimes/__init__.py
@@ -14,6 +14,7 @@ from verifiers.v1.runtimes.base import (
 )
 from verifiers.v1.runtimes.docker import DockerConfig, DockerRuntime, DockerRuntimeInfo
 from verifiers.v1.runtimes.modal import ModalConfig, ModalRuntime, ModalRuntimeInfo
+from verifiers.v1.runtimes.pool import RuntimePool, RuntimePoolConfig
 from verifiers.v1.runtimes.prime import (
     PrimeConfig,
     PrimeRuntime,
@@ -94,6 +95,8 @@ __all__ = [
     "Runtime",
     "RuntimeConfig",
     "RuntimeInfo",
+    "RuntimePool",
+    "RuntimePoolConfig",
     "RuntimeProcess",
     "SubprocessConfig",
     "SubprocessRuntime",

--- a/verifiers/v1/runtimes/pool.py
+++ b/verifiers/v1/runtimes/pool.py
@@ -1,0 +1,173 @@
+"""Live boxes kept between `Agent.provision(..., reuse=key)` contexts — a cache the env
+owns for the length of `serving()`. A box is a cache entry, never a correctness
+dependency: a miss provisions a fresh box exactly as `provision_runtime` does, and every
+box is torn down with the pool (or by the atexit backstop on a hard exit)."""
+
+import asyncio
+import contextlib
+import logging
+import time
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Self
+
+from pydantic import Field
+from pydantic_config import BaseConfig
+
+from verifiers.v1.runtimes.base import Runtime
+
+if TYPE_CHECKING:
+    # Annotation-only: `RuntimeConfig` is the package's union, and the package
+    # imports this module.
+    from verifiers.v1.runtimes import RuntimeConfig
+
+logger = logging.getLogger(__name__)
+
+
+class RuntimePoolConfig(BaseConfig):
+    """The idle budget of the boxes kept between `Agent.provision(task, reuse=key)` contexts."""
+
+    ttl: float = Field(600, gt=0)
+    """Seconds an idle box is kept after its `provision` context closes, then it is stopped."""
+    max_idle: int | None = Field(16, ge=1)
+    """Idle boxes kept at once (the oldest is stopped first); None = no cap. Leased boxes
+    are bounded by the caller's own concurrency, not here."""
+
+
+@dataclass
+class _Idle:
+    runtime: Runtime
+    config: "RuntimeConfig"
+    since: float
+
+
+class RuntimePool:
+    """Live boxes kept between `Agent.provision(..., reuse=key)` contexts: one box per
+    key, reused while its config still matches, it is alive, and its idle time is under
+    `ttl`. A key is exclusive — a second `lease` of a leased key waits for the first to
+    end, so a box never hosts two rollouts at once (leasing a key inside its own context
+    therefore deadlocks). Idle boxes are held strongly, so `cleanup_at_exit` still frees
+    them on a hard exit; `async with pool:` runs the TTL sweeper and stops every idle box
+    on exit."""
+
+    def __init__(self, config: RuntimePoolConfig | None = None) -> None:
+        self.config = config or RuntimePoolConfig()
+        self._idle: dict[str, _Idle] = {}
+        self._locks: dict[str, asyncio.Lock] = {}
+        self._closed = False
+        self._sweeper: asyncio.Task[None] | None = None
+
+    async def __aenter__(self) -> Self:
+        self._sweeper = asyncio.create_task(self._sweep())
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        await self.stop()
+
+    async def stop(self) -> None:
+        """Stop every idle box now; a lease still live stops its box on release. Idempotent."""
+        self._closed = True
+        if self._sweeper is not None:
+            self._sweeper.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._sweeper
+            self._sweeper = None
+        await self._evict(list(self._idle))
+
+    async def discard(self, key: str) -> None:
+        """Stop the box under `key` now (after its live lease, if any, ends); a no-op if none."""
+        async with self._lock(key):
+            await self._evict([key])
+
+    @asynccontextmanager
+    async def lease(
+        self, key: str, config: "RuntimeConfig", env: Mapping[str, str]
+    ) -> AsyncIterator[Runtime]:
+        """The seam `Agent.provision` rides: the idle box under `key` when its config equals
+        `config`, it is alive, and its idle time is under `ttl`, else a fresh box started
+        from `config` (a stale one stopped first), with `env` as its environment. A normal
+        exit parks the box idle under `key`; an exception (a cancellation included), a box
+        the caller already `stop()`ped, or a closed pool tears it down instead — the
+        outcome `provision_runtime`'s `finally: stop()` gives."""
+        # Lazy: the package imports this module.
+        from verifiers.v1.runtimes import make_runtime
+
+        async with self._lock(key):
+            runtime = await self._take(key, config)
+            if runtime is None:
+                runtime = make_runtime(config)
+                try:
+                    await runtime.start()
+                except BaseException:
+                    await runtime.stop()
+                    raise
+            runtime.env = dict(env)
+            try:
+                yield runtime
+            except BaseException:
+                await runtime.stop()
+                raise
+            if runtime.stopped:  # the caller tore it down itself: not kept
+                return
+            if self._closed:
+                await runtime.stop()
+                return
+            self._idle[key] = _Idle(runtime, config, time.monotonic())
+            await self._trim()
+
+    def _lock(self, key: str) -> asyncio.Lock:
+        return self._locks.setdefault(key, asyncio.Lock())
+
+    def _expired(self, entry: _Idle) -> bool:
+        return time.monotonic() - entry.since >= self.config.ttl
+
+    async def _take(self, key: str, config: "RuntimeConfig") -> Runtime | None:
+        """The idle box under `key` if it still fits, else None (a stale one is stopped)."""
+        entry = self._idle.pop(key, None)
+        if entry is None:
+            return None
+        if (
+            entry.config == config
+            and not entry.runtime.stopped
+            and not self._expired(entry)
+            and await entry.runtime.alive()
+        ):
+            logger.info("runtime pool: reusing box %s for %r", entry.runtime.name, key)
+            return entry.runtime
+        logger.info("runtime pool: replacing box %s for %r", entry.runtime.name, key)
+        await entry.runtime.stop()
+        return None
+
+    async def _trim(self) -> None:
+        """Stop the oldest idle boxes past `max_idle`."""
+        cap = self.config.max_idle
+        if cap is None or len(self._idle) <= cap:
+            return
+        oldest = sorted(self._idle, key=lambda key: self._idle[key].since)
+        await self._evict(oldest[: len(self._idle) - cap])
+
+    async def _evict(self, keys: list[str]) -> None:
+        """Stop the idle boxes under `keys` (each popped first, so a concurrent lease
+        provisions fresh instead of racing the teardown); unknown keys are skipped."""
+        entries = [self._idle.pop(key) for key in keys if key in self._idle]
+        results = await asyncio.gather(
+            *(entry.runtime.stop() for entry in entries), return_exceptions=True
+        )
+        for entry, result in zip(entries, results):
+            if isinstance(result, Exception):
+                logger.warning(
+                    "runtime pool: failed to stop box %s: %s",
+                    entry.runtime.name,
+                    result,
+                )
+
+    async def _sweep(self) -> None:
+        """Stop expired idle boxes on a period; the platform's idle timeout is the backstop."""
+        while True:
+            await asyncio.sleep(min(self.config.ttl / 4, 30))
+            expired = [key for key, entry in self._idle.items() if self._expired(entry)]
+            await self._evict(expired)
+
+
+__all__ = ["RuntimePool", "RuntimePoolConfig"]

--- a/verifiers/v1/runtimes/pool.py
+++ b/verifiers/v1/runtimes/pool.py
@@ -96,12 +96,16 @@ class RuntimePool:
         `config`, it is alive, and its idle time is under `ttl`, else a fresh box started
         from `config` (a stale one stopped first), with `env` as its environment. A normal
         exit parks the box idle under `key`; an exception (a cancellation included), a box
-        the caller already `stop()`ped, or a closed pool tears it down instead — the
-        outcome `provision_runtime`'s `finally: stop()` gives."""
+        the caller already `stop()`ped, or a pool closed meanwhile tears it down instead —
+        the outcome `provision_runtime`'s `finally: stop()` gives. A lease reaching its
+        gate after the pool closed is refused: nothing may start a box `stop` will not see."""
         # Lazy: the package imports this module.
         from verifiers.v1.runtimes import make_runtime
 
         async with self._lock(key):
+            # Queued behind a lease that outlived `stop`, or called after it.
+            if self._closed:
+                raise RuntimeError("runtime pool is closed")
             runtime = await self._take(key, config, env)
             if runtime is None:
                 runtime = make_runtime(config)

--- a/verifiers/v1/runtimes/pool.py
+++ b/verifiers/v1/runtimes/pool.py
@@ -9,7 +9,7 @@ import logging
 import time
 from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Self
 
 from pydantic import Field
@@ -42,6 +42,14 @@ class _Idle:
     since: float
 
 
+@dataclass
+class _Gate:
+    """A key's lock and the number of leases holding or waiting on it."""
+
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    users: int = 0
+
+
 class RuntimePool:
     """Live boxes kept between `Agent.provision(..., reuse=key)` contexts: one box per
     key, reused while its config still matches, it is alive, and its idle time is under
@@ -54,7 +62,7 @@ class RuntimePool:
     def __init__(self, config: RuntimePoolConfig | None = None) -> None:
         self.config = config or RuntimePoolConfig()
         self._idle: dict[str, _Idle] = {}
-        self._locks: dict[str, asyncio.Lock] = {}
+        self._locks: dict[str, _Gate] = {}
         self._closed = False
         self._sweeper: asyncio.Task[None] | None = None
 
@@ -94,15 +102,15 @@ class RuntimePool:
         from verifiers.v1.runtimes import make_runtime
 
         async with self._lock(key):
-            runtime = await self._take(key, config)
+            runtime = await self._take(key, config, env)
             if runtime is None:
                 runtime = make_runtime(config)
+                runtime.env = dict(env)
                 try:
                     await runtime.start()
                 except BaseException:
                     await runtime.stop()
                     raise
-            runtime.env = dict(env)
             try:
                 yield runtime
             except BaseException:
@@ -116,23 +124,43 @@ class RuntimePool:
             self._idle[key] = _Idle(runtime, config, time.monotonic())
             await self._trim()
 
-    def _lock(self, key: str) -> asyncio.Lock:
-        return self._locks.setdefault(key, asyncio.Lock())
+    @asynccontextmanager
+    async def _lock(self, key: str) -> AsyncIterator[None]:
+        """Exclusive (FIFO) use of `key`; its gate is dropped once no lease holds or waits on it."""
+        gate = self._locks.setdefault(key, _Gate())
+        gate.users += 1
+        try:
+            async with gate.lock:
+                yield
+        finally:
+            gate.users -= 1
+            if gate.users == 0:
+                del self._locks[key]
 
     def _expired(self, entry: _Idle) -> bool:
         return time.monotonic() - entry.since >= self.config.ttl
 
-    async def _take(self, key: str, config: "RuntimeConfig") -> Runtime | None:
-        """The idle box under `key` if it still fits, else None (a stale one is stopped)."""
+    async def _take(
+        self, key: str, config: "RuntimeConfig", env: Mapping[str, str]
+    ) -> Runtime | None:
+        """The idle box under `key` if it still fits (probed under `env`), else None (a
+        stale one is stopped)."""
         entry = self._idle.pop(key, None)
         if entry is None:
             return None
-        if (
-            entry.config == config
-            and not entry.runtime.stopped
-            and not self._expired(entry)
-            and await entry.runtime.alive()
-        ):
+        # The probe runs under this lease's env, not whatever the last one left behind.
+        entry.runtime.env = dict(env)
+        try:
+            fits = (
+                entry.config == config
+                and not entry.runtime.stopped
+                and not self._expired(entry)
+                and await entry.runtime.alive()
+            )
+        except BaseException:  # a cancelled probe must not leak the popped box
+            await entry.runtime.stop()
+            raise
+        if fits:
             logger.info("runtime pool: reusing box %s for %r", entry.runtime.name, key)
             return entry.runtime
         logger.info("runtime pool: replacing box %s for %r", entry.runtime.name, key)

--- a/verifiers/v1/runtimes/pool.py
+++ b/verifiers/v1/runtimes/pool.py
@@ -94,9 +94,12 @@ class RuntimePool:
     ) -> AsyncIterator[Runtime]:
         """The seam `Agent.provision` rides: the idle box under `key` when its config equals
         `config`, it is alive, and its idle time is under `ttl`, else a fresh box started
-        from `config` (a stale one stopped first), with `env` as its environment. A normal
-        exit parks the box idle under `key`; an exception (a cancellation included), a box
-        the caller already `stop()`ped, or a pool closed meanwhile tears it down instead —
+        from `config` alone (a stale one stopped first). Either way the box carries `env`
+        as its `runtime.env` for this lease only — applied per exec, never baked into the
+        box at creation, so nothing of one lease's environment (a task's `runtime_env()`
+        secrets) becomes a default the next lease on the box inherits. A normal exit
+        parks the box idle under `key`; an exception (a cancellation included), a box the
+        caller already `stop()`ped, or a pool closed meanwhile tears it down instead —
         the outcome `provision_runtime`'s `finally: stop()` gives. A lease reaching its
         gate after the pool closed is refused: nothing may start a box `stop` will not see."""
         # Lazy: the package imports this module.
@@ -108,13 +111,16 @@ class RuntimePool:
                 raise RuntimeError("runtime pool is closed")
             runtime = await self._take(key, config, env)
             if runtime is None:
+                # Started task-neutral: docker/prime/modal bake `runtime.env` into the
+                # box at creation, and this box may later host another lease. A lease's
+                # env is set afterwards and rides each exec (`process_env`) instead.
                 runtime = make_runtime(config)
-                runtime.env = dict(env)
                 try:
                     await runtime.start()
                 except BaseException:
                     await runtime.stop()
                     raise
+                runtime.env = dict(env)
             try:
                 yield runtime
             except BaseException:
@@ -125,6 +131,7 @@ class RuntimePool:
             if self._closed:
                 await runtime.stop()
                 return
+            runtime.env = {}  # parked: no lease's env is kept on the box
             self._idle[key] = _Idle(runtime, config, time.monotonic())
             await self._trim()
 


### PR DESCRIPTION
## What

`Agent.provision(task, *, reuse: str | None = None)` over an env-owned `RuntimePool`:

- `verifiers/v1/runtimes/pool.py` (new): `RuntimePoolConfig(ttl=600, max_idle=16)` and `RuntimePool` — live boxes kept between `provision` contexts, one box per key. `lease(key, config, env)` (the seam `provision` calls) hands the idle box back when its resolved `RuntimeConfig` equals, it is not stopped, its idle time is under `ttl` and `await runtime.alive()`; otherwise it stops the stale one and does `make_runtime(config)` + `start()` as `provision_runtime` does. A normal exit parks the box idle (the oldest past `max_idle` is stopped); an exception (incl. `CancelledError`), a box the caller already `stop()`ped, or a closed pool stops it — the outcome `provision_runtime`'s `finally: stop()` gives today. Keys are exclusive: a second lease of a live key waits on a per-key `asyncio.Lock` (FIFO), so a box never hosts two rollouts at once — re-entering a key inside its own context therefore deadlocks (documented on the class and on `provision`). `discard(key)` stops the box now (after its live lease, if any), idempotent. `async with pool:` runs a TTL sweeper (`min(ttl / 4, 30)` s, the `ElasticInterceptionPool._warm_task` shape) and stops every idle box on exit; idle boxes are held strongly, so they stay in `_LIVE` and `cleanup_at_exit` frees them on a hard exit.
- `Agent(config, *, interception=None, runtimes=None)` injects a pool the way `interception` is injected (a pool belongs to what spans agents); `provision(task, reuse=key)` rides `self.runtimes.lease(...)` when both are set, else the existing `provision_runtime` path. `_EpisodeAgent` passes it through.
- `EnvConfig.runtimes: RuntimePoolConfig | None = None` (`--env.runtimes.ttl 900 --env.runtimes.max-idle 32`); `Env.serving()` enters a `RuntimePool` beside the interception when set, exposes it as `Env.runtimes` (live only inside `serving()`, so `run()` can `discard(key)`), and closes it on exit. Exported as `vf.RuntimePool` / `vf.RuntimePoolConfig`.

A run placed into the box is a borrowed-box rollout as before: `trace.agent.runtime.borrowed` is `True` and `runtime.id` is equal across the reusing traces; the `Runtime` object is the same `PrimeRuntime` / `DockerRuntime` / … — no wrapper type, no new `RuntimeInfo` field.

```python
class SeatEnv(vf.Env[SeatEnvConfig]):
    async def run(self, task, agents):
        key = f"{task.data.seat}:{task.data.key}"
        async with agents.seat.provision(task, reuse=key) as box:   # the cached box, or a fresh one
            await agents.seat.run(task, runtime=box)
        if task.data.leaves_box and self.runtimes is not None:
            await self.runtimes.discard(key)
```

## Why

A data-flywheel seat turn is one rollout, but the seat's box must outlive it: it carries the prelude, the checked-out repo and the seat's working state, a prime VM cold boot costs 30–60 s per turn while turns arrive every few minutes, and the judge runs K per-solution rollouts on one task's box. Today the env does this by hand — `seat._Instance.provision/release/_leave`, `CLOSE_GRACE`/`REOPEN_BACKOFF`, a `Place` protocol and `platform_outage_s`/`placement_wait_s`/`provision_wait_s` knobs: ~150 lines re-implementing the stopped-check, shielded stop, atexit and TTL that verifiers already owns for its own rollouts. Once the seat becomes `Env.run(task, agents)`, its agents are minted per episode ("no state spans concurrent episodes") and a rollout stops the runtime it provisioned at close, so nothing in an env can hold a box across two episodes without env-owned plumbing — which is a keyed runtime cache. Borrowing is already complete in verifiers (`run(runtime=box)` never starts or stops the box, re-runs `task.setup`/`harness.setup` per rollout, `prepare_setup` re-opens egress "when reusing a restricted runtime"); what was missing is the keyed lookup, a lifetime beyond one `provision` context, an explicit release, and the env-level owner.

## What is preserved

- `reuse=None`, or an agent without a pool (`runtimes=None`, `EnvConfig.runtimes=None` — the default): `provision` takes the untouched `provision_runtime` path; `Rollout` is unchanged.
- Reuse is a cache, never a correctness dependency: a miss provisions fresh; the caller's key asserts "same world" and config equality guards drift (a changed image/resources → fresh box). RL and eval leave `runtimes` unset.
- Served path: each worker holds its own pool and dispatch does not route by key, so cross-episode reuse is best-effort there (documented, not solved; data-flywheel runs `--no-serve`).
- No new dependencies; `docs/` untouched (`provision`/`runtime=` are not described there).

## Tests

- `tests/v1/test_runtimes.py` (new, deterministic, subprocess boxes, no model): same key → same object / `info.id` and the new `env`; drifted config → fresh box, old stopped; idle past `ttl` → replaced; `alive()` False → replaced; the sweeper stops an expired idle box; exception through the context → stopped, not kept; caller `stop()` inside → not kept; `discard` stops and is idempotent; pool close stops idle boxes and a release after close stops; `max_idle=1` stops the oldest; two leases of one key serialise; an idle box stays in `_LIVE` after `gc.collect()` and `cleanup_at_exit()` frees it; `Agent.provision(task, reuse=key)` with a pool reuses, `provision(task)` beside it still tears down, and without a pool `reuse=` provisions and tears down as before.
- `tests/v1/test_e2e.py::test_runtime_pool_keeps_the_box_across_episodes` over a new fixture env `reuse-v1` (`tests/v1/fixtures/reuse_v1.py`, `run()` = `provision(task, reuse="seat")` + `run(task, runtime=box)`): `-r 2` under `env.runtimes.ttl=60` → both traces `agent.runtime.borrowed` with one `runtime.id`; the same eval without `runtimes` → two ids. Rows: `null-harness-in-subprocess` (run here, passes) and `bash-harness-in-restricted-docker` (a `block` policy, so the second episode's setup takes the reused-restricted `prepare_setup` path) — not run here (no docker on this machine); CI's docker job covers it.
- `uv run pytest tests/v1 -m "not e2e" -n auto`: 94 passed. `uv run ruff check`, `uv run ruff format --check`, `uv run pre-commit run --all-files`, `uv run --python 3.13 ty check verifiers`: clean.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `RuntimePool` and `Agent.provision(reuse=key)` to keep boxes across rollouts
> - Adds `RuntimePool` and `RuntimePoolConfig` in [pool.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2581/files#diff-2c00ea54d4b19e0d76d8dc243e6dc96f657e3760df4e502160980b5ce6befcc6) to manage idle runtimes by key, with background expiration sweeping and capacity limits (default TTL 600s, max 16 idle)
> - Updates `Agent.provision` in [agent.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2581/files#diff-f719e773e216506045964fdfb9fad948b7b504ea092359ced06c928ab5148ea2) to lease a runtime by `reuse` key when a pool is available; provisioning without a pool or key falls back to single-context teardown
> - Adds the optional `runtimes` field to `EnvConfig` in [env.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2581/files#diff-f62bb417e4e4b9c81422199ca59c68f3e2b4dbadb2b587736316013cd4418c0f) and starts or stops the pool during the `Env.serving` lifecycle
> - Behavioral Change: `Agent.provision` and `Env` now retain and reuse runtimes when `runtimes` is configured, changing teardown timing for pooled runtimes
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b04e190.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opt-in sandbox reuse changes runtime lifecycle and isolation boundaries; defaults are unchanged but bugs could leak state between rollouts on the same key.
> 
> **Overview**
> Adds an env-owned **`RuntimePool`** so agents can **`provision(task, reuse=key)`** and park the same sandbox between contexts instead of tearing it down every time. **`EnvConfig.runtimes`** (`ttl`, `max_idle`) turns the pool on for **`Env.serving()`**; episode agents receive the pool, and **`discard(key)`** can drop a cached box early.
> 
> **`Agent.provision`** now accepts **`reuse=`**: with a pool it goes through **`RuntimePool.lease`** (config match, liveness under the new lease env, TTL, per-key exclusivity); without a pool or key, behavior stays **`provision_runtime`**. New unit tests cover pool semantics; e2e **`reuse-v1`** asserts one **`runtime.id`** across two episodes when pooled vs one box per episode when not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7030a4868a92a6ec807615de8b5cbb4989408913. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->