### PR TITLE
feat(v1): streaming tasksets - `Taskset.stream()` and a windowed runner

### DIFF
--- a/docs/v1/evaluation.md
+++ b/docs/v1/evaluation.md
@@ -37,10 +37,11 @@ The output from evaluations are written into `outputs/<env>--<model>--<harness>/
 - `sampling` — generation params passed to the model, e.g. `sampling.temperature`
 - `env.taskset.id` — pick the taskset (or the positional `eval <taskset-id>`)
 - `env.agent.harness.id` — pick the agent's harness (`[env.agent.harness]` in TOML)
-- `num_tasks` — how many tasks to evaluate. Not setting a value means all tasks; an
-  infinite taskset (a procedural generator, e.g. `wordle`) requires it; a streaming
-  taskset (tasks arrive over time) runs until its stream drains, the dashboard's total
-  growing as tasks appear
+- `num_tasks` — how many tasks to evaluate. Not setting a value means all tasks; a
+  taskset without an end of its own requires it: an infinite one (a procedural
+  generator, e.g. `wordle`) and a streaming one (tasks arrive over time — the run takes
+  the next `n` and ends; an eval is bounded, a service that consumes a feed for as long
+  as it runs is built on `run_stream` instead, see [tasksets](tasksets.md#streaming-tasksets))
 - `num_rollouts` — rollouts per task
 - `verbose` — log at debug instead of info
 - `shuffle` — samples the task order (fixed seed); an error on an infinite or a

--- a/docs/v1/evaluation.md
+++ b/docs/v1/evaluation.md
@@ -38,10 +38,13 @@ The output from evaluations are written into `outputs/<env>--<model>--<harness>/
 - `env.taskset.id` — pick the taskset (or the positional `eval <taskset-id>`)
 - `env.agent.harness.id` — pick the agent's harness (`[env.agent.harness]` in TOML)
 - `num_tasks` — how many tasks to evaluate. Not setting a value means all tasks; an
-  infinite taskset (a procedural generator, e.g. `wordle`) requires it
+  infinite taskset (a procedural generator, e.g. `wordle`) requires it; a streaming
+  taskset (tasks arrive over time) runs until its stream drains, the dashboard's total
+  growing as tasks appear
 - `num_rollouts` — rollouts per task
 - `verbose` — log at debug instead of info
-- `shuffle` — samples the task order (fixed seed); an error on an infinite taskset
+- `shuffle` — samples the task order (fixed seed); an error on an infinite or a
+  streaming taskset
 - `serve` — on by default: rollouts run through an elastic env-server worker pool
   (`[serve]` sizes it, e.g. `serve.pool.type`); `--no-serve` runs them in-process
 - `rich` — the live dashboard (default); `--no-rich` streams logs to the console and

--- a/docs/v1/tasksets.md
+++ b/docs/v1/tasksets.md
@@ -140,7 +140,7 @@ Two rules follow from infinity: a run over an infinite taskset must be bounded w
 
 ## Streaming tasksets
 
-A taskset whose tasks appear over time — a queue, a feed of work owed — overrides `stream()` instead of listing them: an async generator that awaits its source, yields each task complete, and returns when the source is drained. The eval runner consumes `stream()` for every taskset (the default streams `iter(self)`); on a streaming one it pulls the next task only while fewer than `max_concurrent` rollouts are in flight, so the feed is read at the pace the run can take, and the run ends with the stream. `-n` bounds it by count; `--shuffle` and `--resume` are errors (no whole set to sample, no keys to resume against). `load()` still exists for what can be listed up front (often nothing: `return []`).
+A taskset whose tasks appear over time — a queue, a feed of work owed — overrides `stream()` instead of listing them: an async generator that awaits its source, yields each task complete, and returns when the source is drained. Every taskset has a `stream()` (the default streams `iter(self)`); the override is the declaration (`taskset.streaming`). `load()` still exists for what can be listed up front (often nothing: `return []`).
 
 ```python
 class TurnTaskset(vf.Taskset[TurnTask, TurnConfig]):
@@ -151,6 +151,23 @@ class TurnTaskset(vf.Taskset[TurnTask, TurnConfig]):
         async for owed in self.feed():  # waits for the next item; returns when drained
             yield TurnTask(TurnData(idx=owed.id, prompt=owed.prompt), self.config.task)
 ```
+
+Two scopes consume it, and the split is deliberate:
+
+- **`vf eval` is bounded.** An eval is a report on a finite set, so on a streaming taskset `-n` is required: the run takes the stream's _next_ `n` tasks (pulling each only while fewer than `-c` rollouts are in flight, so the feed is read at the pace the run can take — and never an `(n+1)`th the feed may still be waiting for), then ends and reports, exactly as on any other taskset. Omitting `-n` is an error, never an open-ended wait. `--shuffle` and `--resume` are errors too (no whole set to sample, no keys to resume against).
+- **Long-running consumption is a service's job — yours.** The eval entrypoint does not wait for new tasks; the primitive it runs on does, and is public: `vf.run_stream(source, run, *, window)` consumes an async iterable under a concurrency window with back-pressure, cancels the rest when one run fails, and closes the source on any exit. The caller decides when the source ends. A service is three statements around it:
+
+```python
+async with env.serving():  # env-level resources (shared tool servers, interception), up for the life of the service
+    ctx = vf.ModelContext(client=client, model=model, sampling=sampling)
+    await vf.run_stream(
+        env.taskset.stream(),
+        lambda task: env.run_slot(vf.RunSlot(task), ctx),
+        window=32,
+    )
+```
+
+`env.run_slot` is what the eval runner calls per rollout (whole-episode retries per `--env.retries`; pass `on_complete=` to persist or publish each episode as it lands), so a service and an eval run the same episode code — the service just owns the loop, its shutdown, and where the results go.
 
 ## Adding Tools
 

--- a/docs/v1/tasksets.md
+++ b/docs/v1/tasksets.md
@@ -138,6 +138,20 @@ class AdditionTaskset(vf.Taskset[AdditionTask, vf.TasksetConfig]):
 
 Two rules follow from infinity: a run over an infinite taskset must be bounded with `num_tasks` (`-n` on the CLI — omitting it is an error), and `shuffle` is an error: there is no whole set to sample from — bound the stream first (`taskset.head(n).shuffle()`). The generator runs once, client-side (the eval entrypoint or the prime-rl orchestrator pulls tasks off it and ships each task's data to the env server), so nothing needs to re-produce the same sequence across processes; keep `load()` deterministic only if you want `--resume` to regenerate the same first `n` tasks (see `alphabet_sort`, `color_codeword`, or the built-in `textarena` taskset).
 
+## Streaming tasksets
+
+A taskset whose tasks appear over time — a queue, a feed of work owed — overrides `stream()` instead of listing them: an async generator that awaits its source, yields each task complete, and returns when the source is drained. The eval runner consumes `stream()` for every taskset (the default streams `iter(self)`); on a streaming one it pulls the next task only while fewer than `max_concurrent` rollouts are in flight, so the feed is read at the pace the run can take, and the run ends with the stream. `-n` bounds it by count; `--shuffle` and `--resume` are errors (no whole set to sample, no keys to resume against). `load()` still exists for what can be listed up front (often nothing: `return []`).
+
+```python
+class TurnTaskset(vf.Taskset[TurnTask, TurnConfig]):
+    def load(self) -> list[TurnTask]:
+        return []
+
+    async def stream(self) -> AsyncIterator[TurnTask]:
+        async for owed in self.feed():  # waits for the next item; returns when drained
+            yield TurnTask(TurnData(idx=owed.id, prompt=owed.prompt), self.config.task)
+```
+
 ## Adding Tools
 
 Some tasksets require custom tools, which are bundled as a `vf.Toolset` (similar to how a `vf.Taskset` bundles `vf.Task`). Tools are exposed as MCP servers to the given harness and thus need a harness which exposes MCP support (via `SUPPORTS_MCP`).

--- a/tests/v1/fixtures/echo_stream_v1.py
+++ b/tests/v1/fixtures/echo_stream_v1.py
@@ -1,0 +1,31 @@
+"""echo-stream: the echo phrases, arriving over time.
+
+A fixture streaming taskset for the v1 e2e suite: `stream()` yields each echo task after
+a short wait, as a feed would, so the runner's windowed pull (and its end when the stream
+drains) is exercised end to end. Resolved by id `echo-stream-v1`.
+"""
+
+import asyncio
+from collections.abc import AsyncIterator
+
+from echo_v1 import EchoConfig, EchoTask, EchoTaskset
+
+import verifiers.v1 as vf
+
+
+class EchoStreamConfig(EchoConfig):
+    gap: float = 0.5
+    """Seconds before each task appears."""
+
+
+class EchoStreamTaskset(vf.Taskset[EchoTask, EchoStreamConfig]):
+    def load(self) -> list[EchoTask]:
+        return []  # nothing to list up front: the tasks arrive through `stream()`
+
+    async def stream(self) -> AsyncIterator[EchoTask]:
+        for task in EchoTaskset(self.config).load():
+            await asyncio.sleep(self.config.gap)
+            yield task
+
+
+__all__ = ["EchoStreamTaskset"]

--- a/tests/v1/fixtures/echo_stream_v1.py
+++ b/tests/v1/fixtures/echo_stream_v1.py
@@ -1,11 +1,14 @@
-"""echo-stream: the echo phrases, arriving over time.
+"""echo-stream: the echo phrases, arriving over time — a feed that never drains.
 
-A fixture streaming taskset for the v1 e2e suite: `stream()` yields each echo task after
-a short wait, as a feed would, so the runner's windowed pull (and its end when the stream
-drains) is exercised end to end. Resolved by id `echo-stream-v1`.
+A fixture streaming taskset for the v1 e2e suite: `stream()` yields an echo task every
+`gap` seconds, cycling the phrases for as long as it is read, as a live feed would. A run
+over it ends only where the caller says — `vf eval -n` takes the next `n` and stops — so
+the runner's windowed pull and its bounded end are exercised end to end (a pull past the
+`n`th would show up as an extra episode). Resolved by id `echo-stream-v1`.
 """
 
 import asyncio
+import itertools
 from collections.abc import AsyncIterator
 
 from echo_v1 import EchoConfig, EchoTask, EchoTaskset
@@ -23,9 +26,10 @@ class EchoStreamTaskset(vf.Taskset[EchoTask, EchoStreamConfig]):
         return []  # nothing to list up front: the tasks arrive through `stream()`
 
     async def stream(self) -> AsyncIterator[EchoTask]:
-        for task in EchoTaskset(self.config).load():
+        phrases = EchoTaskset(self.config).load()
+        for idx, task in enumerate(itertools.cycle(phrases)):
             await asyncio.sleep(self.config.gap)
-            yield task
+            yield EchoTask(task.data.model_copy(update={"idx": idx}), self.config.task)
 
 
 __all__ = ["EchoStreamTaskset"]

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -678,6 +678,38 @@ async def test_multi_agent_env_server(run_v1_server, tmp_path):
         assert trace.metrics["duet"] == 1.0
 
 
+@pytest.mark.e2e
+@pytest.mark.parametrize("runner", ["run_v1", "run_v1_server"])
+async def test_streaming_taskset(runner, request, tmp_path):
+    """A taskset whose tasks arrive over time (`stream()`): the runner pulls each as it
+    appears, runs it, and ends when the stream drains — in-process and served alike."""
+    from verifiers.v1.cli.output import TRACES_FILE
+
+    traces = await request.getfixturevalue(runner)(
+        "echo-stream-v1",
+        harness="null",
+        runtime={"type": "subprocess"},
+        output_dir=tmp_path,
+        num_tasks=None,
+        max_turns=2,
+    )
+    assert len(traces) == 3
+    assert all(trace.ok and trace.reward == 1.0 for trace in traces)
+    assert sorted(trace.task.data.idx for trace in traces) == [0, 1, 2]
+    assert len((tmp_path / TRACES_FILE).read_text().splitlines()) == 3
+
+
+@pytest.mark.parametrize("option", ["shuffle", "resume"])
+async def test_streaming_taskset_refuses_shuffle_and_resume(option):
+    """No whole set to sample and no keys to resume against: refused before any rollout."""
+    from verifiers.v1.cli.eval.runner import run_eval
+    from verifiers.v1.configs.cli.eval import EvalConfig
+
+    config = EvalConfig(env={"taskset": {"id": "echo-stream-v1"}}, **{option: True})
+    with pytest.raises(ValueError, match=f"streams its tasks - cannot {option}"):
+        await run_eval(config)
+
+
 # `_request` parks a cancelled run's fire-and-forget cancel in `_cancel_tasks` with a
 # `discard` done-callback. One loop turn later the sends have finished but the callbacks
 # are still queued behind us, so `close()` meets a set of finished tasks.

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -681,8 +681,9 @@ async def test_multi_agent_env_server(run_v1_server, tmp_path):
 @pytest.mark.e2e
 @pytest.mark.parametrize("runner", ["run_v1", "run_v1_server"])
 async def test_streaming_taskset(runner, request, tmp_path):
-    """A taskset whose tasks arrive over time (`stream()`): the runner pulls each as it
-    appears, runs it, and ends when the stream drains — in-process and served alike."""
+    """A taskset whose tasks arrive over time (`stream()`) under `-n 3`: the runner
+    pulls each as it appears, runs it, and ends after the 3rd — the feed never drains,
+    so a pull past it would land as a 4th episode — in-process and served alike."""
     from verifiers.v1.cli.output import TRACES_FILE
 
     traces = await request.getfixturevalue(runner)(
@@ -690,7 +691,7 @@ async def test_streaming_taskset(runner, request, tmp_path):
         harness="null",
         runtime={"type": "subprocess"},
         output_dir=tmp_path,
-        num_tasks=None,
+        num_tasks=3,
         max_turns=2,
     )
     assert len(traces) == 3
@@ -699,13 +700,26 @@ async def test_streaming_taskset(runner, request, tmp_path):
     assert len((tmp_path / TRACES_FILE).read_text().splitlines()) == 3
 
 
+async def test_streaming_taskset_requires_num_tasks():
+    """An eval is a report on a finite set: without `-n` a stream is refused before
+    any rollout, never waited on open-endedly (that is a service's job, `run_stream`)."""
+    from verifiers.v1.cli.eval.runner import run_eval
+    from verifiers.v1.configs.cli.eval import EvalConfig
+
+    config = EvalConfig(env={"taskset": {"id": "echo-stream-v1"}})
+    with pytest.raises(ValueError, match=r"streams its tasks - bound the run with -n"):
+        await run_eval(config)
+
+
 @pytest.mark.parametrize("option", ["shuffle", "resume"])
 async def test_streaming_taskset_refuses_shuffle_and_resume(option):
     """No whole set to sample and no keys to resume against: refused before any rollout."""
     from verifiers.v1.cli.eval.runner import run_eval
     from verifiers.v1.configs.cli.eval import EvalConfig
 
-    config = EvalConfig(env={"taskset": {"id": "echo-stream-v1"}}, **{option: True})
+    config = EvalConfig(
+        env={"taskset": {"id": "echo-stream-v1"}}, num_tasks=3, **{option: True}
+    )
     with pytest.raises(ValueError, match=f"streams its tasks - cannot {option}"):
         await run_eval(config)
 

--- a/tests/v1/test_taskset.py
+++ b/tests/v1/test_taskset.py
@@ -1,17 +1,14 @@
 """`Taskset` iteration and the `head`/`shuffle` views over list, generator,
-and `INFINITE` `load` implementations; `stream()` and the runner's windowed
+and `INFINITE` `load` implementations; `stream()` and `run_stream`'s windowed
 pull over a taskset whose tasks arrive over time."""
 
 import asyncio
-import contextlib
 import itertools
-from collections.abc import AsyncGenerator
 
 import pytest
 
 import verifiers.v1 as vf
-from verifiers.v1.cli.eval.runner import _plan_stream, _take, run_stream
-from verifiers.v1.env import RunSlot
+from verifiers.v1.cli.eval.runner import _plan_stream, _take
 
 
 class CountTask(vf.Task[vf.TaskData]):
@@ -125,13 +122,6 @@ def queued(*items: int | None) -> QueueTaskset:
     return taskset
 
 
-async def groups(tasks) -> AsyncGenerator[list[RunSlot], None]:
-    """One slot per task, closing the source when closed — the runner's planner."""
-    async with contextlib.aclosing(tasks):
-        async for task in tasks:
-            yield [RunSlot(task)]
-
-
 async def test_default_stream_is_iteration() -> None:
     taskset = FiniteTaskset(vf.TasksetConfig())
     assert taskset.streaming is False
@@ -139,8 +129,22 @@ async def test_default_stream_is_iteration() -> None:
     assert [t.data.idx async for t in _take(taskset.stream(), 3)] == [0, 1, 2]
 
 
-async def test_stream_pulls_only_as_slots_free() -> None:
-    """The window is back-pressure: with `window` slots in flight the next task is
+async def test_take_is_the_next_n_of_a_feed() -> None:
+    """`-n` on a stream: the next `n` tasks, fewer if the feed ends first, and no
+    pull for an (n+1)th; `0` pulls nothing. A started source is closed either way."""
+    taskset = queued(0, 1, 2, 3)  # never ended: the feed is still waiting
+    assert [t.data.idx async for t in _take(taskset.stream(), 2)] == [0, 1]
+    assert taskset.pulled == 2 and taskset.closed
+    taskset = queued(0, 1, None)
+    assert [t.data.idx async for t in _take(taskset.stream(), 5)] == [0, 1]
+    assert taskset.closed
+    taskset = queued(0)
+    assert [t async for t in _take(taskset.stream(), 0)] == []
+    assert taskset.pulled == 0  # never started, so nothing to close
+
+
+async def test_stream_pulls_only_as_runs_free() -> None:
+    """The window is back-pressure: with `window` runs in flight the next task is
     not pulled; `-n` ends the pull without touching the (n+1)th; results keep
     submission order and the source is closed."""
     taskset = queued(0, 1, 2, 3, 4)  # never ended: the feed is still waiting
@@ -148,89 +152,89 @@ async def test_stream_pulls_only_as_slots_free() -> None:
     running = asyncio.Semaphore(0)
     gate = asyncio.Event()
 
-    async def run_slot(slot: RunSlot):
+    async def run(task: CountTask):
         running.release()
         await gate.wait()
-        return slot.task.data.idx
+        return task.data.idx
 
-    run = asyncio.ensure_future(
-        run_stream(groups(_take(taskset.stream(), 4)), run_slot, window=2)
+    result = asyncio.ensure_future(
+        vf.run_stream(_take(taskset.stream(), 4), run, window=2)
     )
     for _ in range(2):
         await running.acquire()
     await asyncio.sleep(0)
-    assert taskset.pulled == 2 and not run.done()
+    assert taskset.pulled == 2 and not result.done()
     gate.set()
-    assert await run == [0, 1, 2, 3]
+    assert await result == [0, 1, 2, 3]
     assert taskset.pulled == 4 and taskset.closed
 
 
 async def test_stream_ends_with_its_source() -> None:
+    """The caller decides when the source ends: the run returns once it has, with
+    every result in submission order."""
     taskset = queued(2, 1, 0, None)
     order: list[int] = []
 
-    async def run_slot(slot: RunSlot):
-        await asyncio.sleep(0.01 * slot.task.data.idx)
-        order.append(slot.task.data.idx)
-        return slot.task.data.idx
+    async def run(task: CountTask):
+        await asyncio.sleep(0.01 * task.data.idx)
+        order.append(task.data.idx)
+        return task.data.idx
 
-    results = await run_stream(groups(taskset.stream()), run_slot, window=None)
+    results = await vf.run_stream(taskset.stream(), run, window=None)
     assert results == [2, 1, 0] and order == [0, 1, 2]
     assert taskset.closed
 
 
-async def test_failing_slot_cancels_the_rest_and_closes_the_stream() -> None:
+async def test_failing_run_cancels_the_rest_and_closes_the_stream() -> None:
     taskset = queued(0, 1, 2, 3)  # never ended
     running = asyncio.Semaphore(0)
     failed = asyncio.Event()
     cancelled: list[int] = []
 
-    async def run_slot(slot: RunSlot):
+    async def run(task: CountTask):
         running.release()
-        if slot.task.data.idx == 1:
+        if task.data.idx == 1:
             await failed.wait()
             raise RuntimeError("boom")
         try:
             await asyncio.sleep(60)
         except asyncio.CancelledError:
-            cancelled.append(slot.task.data.idx)
+            cancelled.append(task.data.idx)
             raise
 
-    run = asyncio.ensure_future(
-        run_stream(groups(taskset.stream()), run_slot, window=3)
-    )
+    result = asyncio.ensure_future(vf.run_stream(taskset.stream(), run, window=3))
     for _ in range(3):
         await running.acquire()
     failed.set()
     with pytest.raises(RuntimeError, match="boom"):
-        await run
+        await result
     assert sorted(cancelled) == [0, 2]
     assert taskset.pulled == 3 and taskset.closed  # the feed's waiter is gone too
 
 
 @pytest.mark.parametrize("window", [2, None])
-async def test_failing_slot_is_seen_while_the_feed_is_quiet(window) -> None:
-    """A slot failing while the runner waits on the feed aborts the run at once: the
-    pull is raced against the slots, so a quiet feed cannot hide the failure."""
+async def test_failing_run_is_seen_while_the_feed_is_quiet(window) -> None:
+    """A run failing while the runner waits on the feed aborts at once: the pull is
+    raced against the runs, so a quiet feed cannot hide the failure."""
     taskset = queued(0)  # one task, then the feed is quiet forever
 
-    async def run_slot(slot: RunSlot):
+    async def run(task: CountTask):
         raise RuntimeError("boom")
 
-    run = run_stream(groups(taskset.stream()), run_slot, window)
+    result = vf.run_stream(taskset.stream(), run, window=window)
     with pytest.raises(RuntimeError, match="boom"):
-        await asyncio.wait_for(run, timeout=2)  # a hang fails as a timeout
+        await asyncio.wait_for(result, timeout=2)  # a hang fails as a timeout
     assert taskset.pulled == 1 and taskset.closed
 
 
 async def test_a_tasks_rollouts_are_windowed_one_by_one() -> None:
     """`-c` bounds slots in flight, not tasks: a task's `-r` rollouts join the
-    display at once but are scheduled one per group, so the window holds them."""
+    display at once but are yielded one by one, so the window holds them."""
     taskset = queued(0, None)
-    display: list[RunSlot] = []
+    display: list[vf.RunSlot] = []
     alive = peak = 0
 
-    async def run_slot(slot: RunSlot):
+    async def run_slot(slot: vf.RunSlot):
         nonlocal alive, peak
         alive += 1
         peak = max(peak, alive)
@@ -238,21 +242,23 @@ async def test_a_tasks_rollouts_are_windowed_one_by_one() -> None:
         alive -= 1
         return slot.task.data.idx
 
-    def plan_slots(task) -> list[RunSlot]:
-        return [RunSlot(task) for _ in range(50)]
+    def plan_slots(task) -> list[vf.RunSlot]:
+        return [vf.RunSlot(task) for _ in range(50)]
 
     stream = _plan_stream(taskset.stream(), plan_slots, display)
-    assert len(await run_stream(stream, run_slot, window=1)) == 50
+    assert len(await vf.run_stream(stream, run_slot, window=1)) == 50
     assert len(display) == 50 and peak == 1 and taskset.closed
 
 
 async def test_cancelling_the_run_closes_a_waiting_stream() -> None:
     taskset = queued()  # nothing yet: `stream()` is parked on the feed
-    run = asyncio.ensure_future(
-        run_stream(groups(taskset.stream()), lambda slot: None, window=None)
-    )
+
+    async def run(task: CountTask) -> None:
+        return None
+
+    result = asyncio.ensure_future(vf.run_stream(taskset.stream(), run, window=None))
     await asyncio.sleep(0)
-    run.cancel()
+    result.cancel()
     with pytest.raises(asyncio.CancelledError):
-        await run
+        await result
     assert taskset.closed

--- a/tests/v1/test_taskset.py
+++ b/tests/v1/test_taskset.py
@@ -10,7 +10,7 @@ from collections.abc import AsyncGenerator
 import pytest
 
 import verifiers.v1 as vf
-from verifiers.v1.cli.eval.runner import _take, run_stream
+from verifiers.v1.cli.eval.runner import _plan_stream, _take, run_stream
 from verifiers.v1.env import RunSlot
 
 
@@ -206,6 +206,44 @@ async def test_failing_slot_cancels_the_rest_and_closes_the_stream() -> None:
         await run
     assert sorted(cancelled) == [0, 2]
     assert taskset.pulled == 3 and taskset.closed  # the feed's waiter is gone too
+
+
+@pytest.mark.parametrize("window", [2, None])
+async def test_failing_slot_is_seen_while_the_feed_is_quiet(window) -> None:
+    """A slot failing while the runner waits on the feed aborts the run at once: the
+    pull is raced against the slots, so a quiet feed cannot hide the failure."""
+    taskset = queued(0)  # one task, then the feed is quiet forever
+
+    async def run_slot(slot: RunSlot):
+        raise RuntimeError("boom")
+
+    run = run_stream(groups(taskset.stream()), run_slot, window)
+    with pytest.raises(RuntimeError, match="boom"):
+        await asyncio.wait_for(run, timeout=2)  # a hang fails as a timeout
+    assert taskset.pulled == 1 and taskset.closed
+
+
+async def test_a_tasks_rollouts_are_windowed_one_by_one() -> None:
+    """`-c` bounds slots in flight, not tasks: a task's `-r` rollouts join the
+    display at once but are scheduled one per group, so the window holds them."""
+    taskset = queued(0, None)
+    display: list[RunSlot] = []
+    alive = peak = 0
+
+    async def run_slot(slot: RunSlot):
+        nonlocal alive, peak
+        alive += 1
+        peak = max(peak, alive)
+        await asyncio.sleep(0)
+        alive -= 1
+        return slot.task.data.idx
+
+    def plan_slots(task) -> list[RunSlot]:
+        return [RunSlot(task) for _ in range(50)]
+
+    stream = _plan_stream(taskset.stream(), plan_slots, display)
+    assert len(await run_stream(stream, run_slot, window=1)) == 50
+    assert len(display) == 50 and peak == 1 and taskset.closed
 
 
 async def test_cancelling_the_run_closes_a_waiting_stream() -> None:

--- a/tests/v1/test_taskset.py
+++ b/tests/v1/test_taskset.py
@@ -1,11 +1,17 @@
 """`Taskset` iteration and the `head`/`shuffle` views over list, generator,
-and `INFINITE` `load` implementations."""
+and `INFINITE` `load` implementations; `stream()` and the runner's windowed
+pull over a taskset whose tasks arrive over time."""
 
+import asyncio
+import contextlib
 import itertools
+from collections.abc import AsyncGenerator
 
 import pytest
 
 import verifiers.v1 as vf
+from verifiers.v1.cli.eval.runner import _take, run_stream
+from verifiers.v1.env import RunSlot
 
 
 class CountTask(vf.Task[vf.TaskData]):
@@ -89,3 +95,126 @@ def test_views_do_not_mutate_the_base_taskset() -> None:
     view = taskset.head(3)
     assert view.INFINITE is False and taskset.INFINITE is True
     assert idxs(taskset.head(2)) == [0, 1]  # base iterates untransformed
+
+
+class QueueTaskset(vf.Taskset[CountTask, vf.TasksetConfig]):
+    """Tasks that arrive over time: `stream()` waits on a queue (`None` ends it) and
+    records what it pulled and whether the runner closed it."""
+
+    queue: asyncio.Queue
+    pulled = 0
+    closed = False
+
+    def load(self):
+        return []
+
+    async def stream(self):
+        try:
+            while (i := await self.queue.get()) is not None:
+                self.pulled += 1
+                yield CountTask(vf.TaskData(idx=i, prompt=f"task {i}"))
+        finally:
+            self.closed = True
+
+
+def queued(*items: int | None) -> QueueTaskset:
+    taskset = QueueTaskset(vf.TasksetConfig())
+    taskset.queue = asyncio.Queue()
+    for item in items:
+        taskset.queue.put_nowait(item)
+    return taskset
+
+
+async def groups(tasks) -> AsyncGenerator[list[RunSlot], None]:
+    """One slot per task, closing the source when closed — the runner's planner."""
+    async with contextlib.aclosing(tasks):
+        async for task in tasks:
+            yield [RunSlot(task)]
+
+
+async def test_default_stream_is_iteration() -> None:
+    taskset = FiniteTaskset(vf.TasksetConfig())
+    assert taskset.streaming is False
+    assert [t.data.idx async for t in taskset.head(2).stream()] == [0, 1]
+    assert [t.data.idx async for t in _take(taskset.stream(), 3)] == [0, 1, 2]
+
+
+async def test_stream_pulls_only_as_slots_free() -> None:
+    """The window is back-pressure: with `window` slots in flight the next task is
+    not pulled; `-n` ends the pull without touching the (n+1)th; results keep
+    submission order and the source is closed."""
+    taskset = queued(0, 1, 2, 3, 4)  # never ended: the feed is still waiting
+    assert taskset.streaming is True
+    running = asyncio.Semaphore(0)
+    gate = asyncio.Event()
+
+    async def run_slot(slot: RunSlot):
+        running.release()
+        await gate.wait()
+        return slot.task.data.idx
+
+    run = asyncio.ensure_future(
+        run_stream(groups(_take(taskset.stream(), 4)), run_slot, window=2)
+    )
+    for _ in range(2):
+        await running.acquire()
+    await asyncio.sleep(0)
+    assert taskset.pulled == 2 and not run.done()
+    gate.set()
+    assert await run == [0, 1, 2, 3]
+    assert taskset.pulled == 4 and taskset.closed
+
+
+async def test_stream_ends_with_its_source() -> None:
+    taskset = queued(2, 1, 0, None)
+    order: list[int] = []
+
+    async def run_slot(slot: RunSlot):
+        await asyncio.sleep(0.01 * slot.task.data.idx)
+        order.append(slot.task.data.idx)
+        return slot.task.data.idx
+
+    results = await run_stream(groups(taskset.stream()), run_slot, window=None)
+    assert results == [2, 1, 0] and order == [0, 1, 2]
+    assert taskset.closed
+
+
+async def test_failing_slot_cancels_the_rest_and_closes_the_stream() -> None:
+    taskset = queued(0, 1, 2, 3)  # never ended
+    running = asyncio.Semaphore(0)
+    failed = asyncio.Event()
+    cancelled: list[int] = []
+
+    async def run_slot(slot: RunSlot):
+        running.release()
+        if slot.task.data.idx == 1:
+            await failed.wait()
+            raise RuntimeError("boom")
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancelled.append(slot.task.data.idx)
+            raise
+
+    run = asyncio.ensure_future(
+        run_stream(groups(taskset.stream()), run_slot, window=3)
+    )
+    for _ in range(3):
+        await running.acquire()
+    failed.set()
+    with pytest.raises(RuntimeError, match="boom"):
+        await run
+    assert sorted(cancelled) == [0, 2]
+    assert taskset.pulled == 3 and taskset.closed  # the feed's waiter is gone too
+
+
+async def test_cancelling_the_run_closes_a_waiting_stream() -> None:
+    taskset = queued()  # nothing yet: `stream()` is parked on the feed
+    run = asyncio.ensure_future(
+        run_stream(groups(taskset.stream()), lambda slot: None, window=None)
+    )
+    await asyncio.sleep(0)
+    run.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await run
+    assert taskset.closed

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -31,7 +31,7 @@ from verifiers.v1.configs.task import (
     TaskConfig,
 )
 from verifiers.v1.configs.taskset import TasksetConfig
-from verifiers.v1.env import Env
+from verifiers.v1.env import Env, RunSlot
 from verifiers.v1.envs.single_agent import SingleAgentEnv, SingleAgentEnvConfig
 from verifiers.v1.episode import (
     EnvInfo,
@@ -133,6 +133,7 @@ from verifiers.v1.types import (
     Usage,
     UserMessage,
 )
+from verifiers.v1.utils.aio import run_stream
 from verifiers.v1.utils.artifacts import (
     ARTIFACTS_DIR,
     Artifact,
@@ -303,6 +304,8 @@ __all__ = [  # noqa: RUF022 - grouped by public API area
     "DockerConfig",
     "PrimeConfig",
     "Env",
+    "RunSlot",
+    "run_stream",
     "SingleAgentEnv",
     "EnvConfig",
     "ServeConfig",

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -88,15 +88,26 @@ async def run_stream(
     in submission order once the stream has ended and the last slot is done. One
     slot failing cancels the rest and waits for them to unwind, so nothing keeps
     uploading into a run the caller is already closing; the stream is `aclose()`d
-    on any exit. Not a `TaskGroup`: that wraps errors in an `ExceptionGroup`, and
-    `main` would no longer see a `KeyboardInterrupt` as Ctrl-C."""
+    on any exit. The pull is its own task, raced against the slots' first failure:
+    a slot that fails while the feed is quiet aborts the run at once, not when the
+    feed next yields (which may be never). Not a `TaskGroup`: that wraps errors in
+    an `ExceptionGroup`, and `main` would no longer see a `KeyboardInterrupt` as
+    Ctrl-C."""
     started: list[asyncio.Task[Episode]] = []
     pending: set[asyncio.Task[Episode]] = set()
+    pull: asyncio.Task[list[RunSlot]] | None = None
+    # Resolved with the first slot to fail (by a done-callback, so the wait on the
+    # pull stays O(1) however many slots a static run has in flight).
+    failed: asyncio.Future[asyncio.Task[Episode]] = (
+        asyncio.get_running_loop().create_future()
+    )
+
+    def watch(task: asyncio.Task[Episode]) -> None:
+        if not task.cancelled() and task.exception() is not None and not failed.done():
+            failed.set_result(task)
+
     try:
-        async for group in groups:
-            for slot in group:
-                started.append(asyncio.ensure_future(run_slot(slot)))
-                pending.add(started[-1])
+        while True:
             # Back-pressure: the next group is pulled only once a slot has freed.
             while window is not None and len(pending) >= window:
                 done, pending = await asyncio.wait(
@@ -104,15 +115,45 @@ async def run_stream(
                 )
                 for task in done:
                     task.result()  # a failed slot raises here: cancel the rest
+            pull = asyncio.ensure_future(anext(groups))
+            await asyncio.wait({pull, failed}, return_when=asyncio.FIRST_COMPLETED)
+            if failed.done():
+                failed.result().result()  # raises the slot's error: cancel the rest
+            try:
+                group = pull.result()
+            except StopAsyncIteration:
+                break
+            for slot in group:
+                started.append(asyncio.ensure_future(run_slot(slot)))
+                started[-1].add_done_callback(watch)
+                pending.add(started[-1])
         return await asyncio.gather(*started)
     except BaseException:
-        for task in started:
+        # The pull too: the stream must not still be running when it is closed.
+        tasks = [*started, pull] if pull is not None else started
+        for task in tasks:
             task.cancel()
         # return_exceptions: wait for every task, not just the first to cancel.
-        await asyncio.gather(*started, return_exceptions=True)
+        await asyncio.gather(*tasks, return_exceptions=True)
         raise
     finally:
         await groups.aclose()
+
+
+async def _plan_stream(
+    tasks: AsyncGenerator[Task, None],
+    plan_slots: Callable[[Task], list[RunSlot]],
+    slots: list[RunSlot],
+) -> AsyncGenerator[list[RunSlot], None]:
+    """Plan each task as it arrives: its slots join the display (`slots`) at once,
+    but are yielded one per group, so the window bounds the slots in flight rather
+    than the tasks — a task's `-r` rollouts wait here, not as live coroutines."""
+    async with contextlib.aclosing(tasks):
+        async for task in tasks:
+            planned = plan_slots(task)
+            slots.extend(planned)  # the display grows with the stream
+            for slot in planned:
+                yield [slot]
 
 
 @contextlib.asynccontextmanager
@@ -319,15 +360,6 @@ async def run_eval(config: EvalConfig) -> list[Episode]:
 
     slots = [RunSlot.finished(episode) for episode in finished]
 
-    async def plan_stream(
-        tasks: AsyncGenerator[Task, None],
-    ) -> AsyncGenerator[list[RunSlot], None]:
-        async with contextlib.aclosing(tasks):
-            async for task in tasks:
-                planned = plan_slots(task, config.num_rollouts)
-                slots.extend(planned)  # the display grows with the stream
-                yield planned
-
     # The run is closed out whatever breaks, backend setup and teardown included.
     try:
         async with backend as run_slot:
@@ -335,7 +367,11 @@ async def run_eval(config: EvalConfig) -> list[Episode]:
                 # Each task is planned as it arrives, pulled only as slots free up: the
                 # feed decides what is owed, `-c` how many run at once, `-n` how many
                 # in total.
-                groups = plan_stream(_take(selected.stream(), config.num_tasks))
+                groups = _plan_stream(
+                    _take(selected.stream(), config.num_tasks),
+                    lambda task: plan_slots(task, config.num_rollouts),
+                    slots,
+                )
                 window = config.max_concurrent
             else:
                 # Every slot exists before the first rollout runs; the semaphore alone

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -5,7 +5,9 @@ elastic — one worker, scaling on demand), the same path prime-rl trains throug
 `--no-serve` runs them in-process instead. Both paths share this runner — task
 selection, resume, persistence, the dashboard — and differ only in how one slot
 becomes one episode: `env.run_slot` in-process, a `run` request to the pool
-otherwise. The dashboard watches the same `RunSlot`s either way; a served slot
+otherwise. Tasks come off the taskset's `stream()`: a static taskset's are all
+planned up front, a streaming one's as they appear, pulled while the concurrency
+window has room. The dashboard watches the same `RunSlot`s either way; a served slot
 has no live traces, so its per-turn detail lands when the episode completes.
 """
 
@@ -13,7 +15,13 @@ import asyncio
 import contextlib
 import logging
 import time
-from collections.abc import AsyncIterator, Awaitable, Callable, Iterable
+from collections.abc import (
+    AsyncGenerator,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Iterable,
+)
 from typing import TypeVar, cast
 
 from verifiers.v1.cli.dashboard import dashboard
@@ -30,6 +38,7 @@ from verifiers.v1.configs.cli.eval import EvalConfig
 from verifiers.v1.configs.serve import ServeConfig
 from verifiers.v1.env import Env, RunSlot
 from verifiers.v1.episode import Episode, EvalRunInfo
+from verifiers.v1.task import Task
 from verifiers.v1.utils.aio import run_shielded
 from verifiers.v1.utils.platform import (
     PushState,
@@ -44,24 +53,66 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
-async def gather_rollouts(rollouts: Iterable[Awaitable[T]]) -> list[T]:
-    """`asyncio.gather`, but one rollout failing cancels the rest and waits for them
-    to unwind, so nothing keeps uploading into a run the caller is already closing.
-    Not a `TaskGroup`: that wraps errors in an `ExceptionGroup`, and `main` would no
-    longer see a `KeyboardInterrupt` as Ctrl-C."""
-    tasks = [asyncio.ensure_future(rollout) for rollout in rollouts]
-    try:
-        return await asyncio.gather(*tasks)
-    except BaseException:
-        for task in tasks:
-            task.cancel()
-        # return_exceptions: wait for every task, not just the first to cancel.
-        await asyncio.gather(*tasks, return_exceptions=True)
-        raise
-
-
 RunSlotFn = Callable[[RunSlot], Awaitable[Episode]]
 OnComplete = Callable[[Episode], Awaitable[None]]
+
+
+async def _aiter(items: Iterable[T]) -> AsyncGenerator[T, None]:
+    for item in items:
+        yield item
+
+
+async def _take(tasks: AsyncIterator[T], n: int | None) -> AsyncGenerator[T, None]:
+    """The first `n` tasks of an async source (all when None), without pulling an
+    (n+1)th the source may still be waiting for; the source is closed after."""
+    taken = 0
+    try:
+        async for task in tasks:
+            yield task
+            taken += 1
+            if taken == n:
+                break
+    finally:
+        # End the source now (its `finally` runs), not when it is collected.
+        if (aclose := getattr(tasks, "aclose", None)) is not None:
+            await aclose()
+
+
+async def run_stream(
+    groups: AsyncGenerator[list[RunSlot], None],
+    run_slot: RunSlotFn,
+    window: int | None,
+) -> list[Episode]:
+    """Run each group of slots as it arrives, pulling the next group only while fewer
+    than `window` slots are in flight (None = pull freely), and return every episode
+    in submission order once the stream has ended and the last slot is done. One
+    slot failing cancels the rest and waits for them to unwind, so nothing keeps
+    uploading into a run the caller is already closing; the stream is `aclose()`d
+    on any exit. Not a `TaskGroup`: that wraps errors in an `ExceptionGroup`, and
+    `main` would no longer see a `KeyboardInterrupt` as Ctrl-C."""
+    started: list[asyncio.Task[Episode]] = []
+    pending: set[asyncio.Task[Episode]] = set()
+    try:
+        async for group in groups:
+            for slot in group:
+                started.append(asyncio.ensure_future(run_slot(slot)))
+                pending.add(started[-1])
+            # Back-pressure: the next group is pulled only once a slot has freed.
+            while window is not None and len(pending) >= window:
+                done, pending = await asyncio.wait(
+                    pending, return_when=asyncio.FIRST_COMPLETED
+                )
+                for task in done:
+                    task.result()  # a failed slot raises here: cancel the rest
+        return await asyncio.gather(*started)
+    except BaseException:
+        for task in started:
+            task.cancel()
+        # return_exceptions: wait for every task, not just the first to cancel.
+        await asyncio.gather(*started, return_exceptions=True)
+        raise
+    finally:
+        await groups.aclose()
 
 
 @contextlib.asynccontextmanager
@@ -175,10 +226,18 @@ async def run_eval(config: EvalConfig) -> list[Episode]:
         raise ValueError(
             f"{type(taskset).__name__} is infinite - bound the run with -n"
         )
+    # A streaming taskset's tasks appear over time: nothing to list up front, so
+    # no whole set to shuffle and no keys to resume against (`-n` still bounds it).
+    streaming = taskset.streaming
+    if streaming and (config.shuffle or config.resume):
+        raise ValueError(
+            f"{type(taskset).__name__} streams its tasks - cannot "
+            f"{'shuffle' if config.shuffle else 'resume'}"
+        )
     selected = taskset.shuffle() if config.shuffle else taskset
     if config.num_tasks is not None:
         selected = selected.head(config.num_tasks)
-    tasks = list(selected)
+    tasks = [] if streaming else list(selected)
     out = output_path(config)
     # One (task, rollouts-to-run) pair per selected task; resume shrinks the counts.
     plan = [(task, config.num_rollouts) for task in tasks]
@@ -216,9 +275,10 @@ async def run_eval(config: EvalConfig) -> list[Episode]:
             if config.serve is not None
             else ""
         )
+        count = config.num_tasks if streaming else len(plan)
         logger.info(
-            "running %dx%d rollouts on %s%s",
-            len(plan),
+            "running %sx%d rollouts on %s%s",
+            "streamed tasks " if count is None else count,
             config.num_rollouts,
             config.model,
             via,
@@ -233,7 +293,9 @@ async def run_eval(config: EvalConfig) -> list[Episode]:
     push_state = PushState()
 
     # Opened before the first rollout so every episode streams as it lands.
-    run = open_run(config, push_state, num_examples=len(tasks))
+    run = open_run(
+        config, push_state, num_examples=config.num_tasks if streaming else len(tasks)
+    )
     # Resumed rollouts are part of this run too.
     log_episodes(run, finished)
 
@@ -247,28 +309,47 @@ async def run_eval(config: EvalConfig) -> list[Episode]:
         if env is not None
         else _server(config, config.serve, semaphore, on_complete)
     )
+
+    # The display slots: in-process ones are the env's own (it fills their live
+    # traces); a served rollout's is a client-side stand-in its worker never sees.
+    def plan_slots(task: Task, n: int) -> list[RunSlot]:
+        if env is not None:
+            return env.slots(task, n)
+        return [RunSlot(task) for _ in range(n)]
+
+    slots = [RunSlot.finished(episode) for episode in finished]
+
+    async def plan_stream(
+        tasks: AsyncGenerator[Task, None],
+    ) -> AsyncGenerator[list[RunSlot], None]:
+        async with contextlib.aclosing(tasks):
+            async for task in tasks:
+                planned = plan_slots(task, config.num_rollouts)
+                slots.extend(planned)  # the display grows with the stream
+                yield planned
+
     # The run is closed out whatever breaks, backend setup and teardown included.
     try:
         async with backend as run_slot:
-            # The display slots: in-process ones are the env's own (it fills their live
-            # traces); a served rollout's is a client-side stand-in its worker never sees.
-            planned = [
-                slot
-                for task, n in plan
-                for slot in (
-                    env.slots(task, n)
-                    if env is not None
-                    else [RunSlot(task) for _ in range(n)]
-                )
-            ]
-            slots = [RunSlot.finished(episode) for episode in finished] + planned
+            if streaming:
+                # Each task is planned as it arrives, pulled only as slots free up: the
+                # feed decides what is owed, `-c` how many run at once, `-n` how many
+                # in total.
+                groups = plan_stream(_take(selected.stream(), config.num_tasks))
+                window = config.max_concurrent
+            else:
+                # Every slot exists before the first rollout runs; the semaphore alone
+                # bounds what runs, so nothing is held back.
+                planned = [plan_slots(task, n) for task, n in plan]
+                slots.extend(slot for group in planned for slot in group)
+                groups, window = _aiter(planned), None
             display = (
                 dashboard(slots, config, start, push=push_state)
                 if config.rich is not None
                 else contextlib.nullcontext()
             )
             async with display:
-                results = await gather_rollouts(run_slot(slot) for slot in planned)
+                results = await run_stream(groups, run_slot, window)
                 episodes = finished + list(results)
                 # Drain and close out off the event loop so the view keeps refreshing.
                 # Shielded: a Ctrl-C here must not cancel the close-out before the

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -7,8 +7,11 @@ selection, resume, persistence, the dashboard — and differ only in how one slo
 becomes one episode: `env.run_slot` in-process, a `run` request to the pool
 otherwise. Tasks come off the taskset's `stream()`: a static taskset's are all
 planned up front, a streaming one's as they appear, pulled while the concurrency
-window has room. The dashboard watches the same `RunSlot`s either way; a served slot
-has no live traces, so its per-turn detail lands when the episode completes.
+window has room — the next `-n` of them, then the run ends: an eval is a report on
+a finite set. Open-ended consumption of a feed is a service's job, built on the
+same primitive, `vf.run_stream`, not this entrypoint's. The
+dashboard watches the same `RunSlot`s either way; a served slot has no live traces,
+so its per-turn detail lands when the episode completes.
 """
 
 import asyncio
@@ -17,6 +20,7 @@ import logging
 import time
 from collections.abc import (
     AsyncGenerator,
+    AsyncIterable,
     AsyncIterator,
     Awaitable,
     Callable,
@@ -39,7 +43,7 @@ from verifiers.v1.configs.serve import ServeConfig
 from verifiers.v1.env import Env, RunSlot
 from verifiers.v1.episode import Episode, EvalRunInfo
 from verifiers.v1.task import Task
-from verifiers.v1.utils.aio import run_shielded
+from verifiers.v1.utils.aio import run_shielded, run_stream
 from verifiers.v1.utils.platform import (
     PushState,
     abort_run,
@@ -62,98 +66,38 @@ async def _aiter(items: Iterable[T]) -> AsyncGenerator[T, None]:
         yield item
 
 
-async def _take(tasks: AsyncIterator[T], n: int | None) -> AsyncGenerator[T, None]:
-    """The first `n` tasks of an async source (all when None), without pulling an
-    (n+1)th the source may still be waiting for; the source is closed after."""
-    taken = 0
+async def _take(tasks: AsyncIterable[T], n: int) -> AsyncGenerator[T, None]:
+    """The first `n` tasks of an async source (fewer if it ends first), without
+    pulling an (n+1)th the source may still be waiting for; the source is closed
+    after — a live feed's `-n`."""
+    source = aiter(tasks)
     try:
-        async for task in tasks:
-            yield task
-            taken += 1
-            if taken == n:
+        for _ in range(n):
+            try:
+                task = await anext(source)
+            except StopAsyncIteration:
                 break
+            yield task
     finally:
         # End the source now (its `finally` runs), not when it is collected.
-        if (aclose := getattr(tasks, "aclose", None)) is not None:
+        if (aclose := getattr(source, "aclose", None)) is not None:
             await aclose()
 
 
-async def run_stream(
-    groups: AsyncGenerator[list[RunSlot], None],
-    run_slot: RunSlotFn,
-    window: int | None,
-) -> list[Episode]:
-    """Run each group of slots as it arrives, pulling the next group only while fewer
-    than `window` slots are in flight (None = pull freely), and return every episode
-    in submission order once the stream has ended and the last slot is done. One
-    slot failing cancels the rest and waits for them to unwind, so nothing keeps
-    uploading into a run the caller is already closing; the stream is `aclose()`d
-    on any exit. The pull is its own task, raced against the slots' first failure:
-    a slot that fails while the feed is quiet aborts the run at once, not when the
-    feed next yields (which may be never). Not a `TaskGroup`: that wraps errors in
-    an `ExceptionGroup`, and `main` would no longer see a `KeyboardInterrupt` as
-    Ctrl-C."""
-    started: list[asyncio.Task[Episode]] = []
-    pending: set[asyncio.Task[Episode]] = set()
-    pull: asyncio.Task[list[RunSlot]] | None = None
-    # Resolved with the first slot to fail (by a done-callback, so the wait on the
-    # pull stays O(1) however many slots a static run has in flight).
-    failed: asyncio.Future[asyncio.Task[Episode]] = (
-        asyncio.get_running_loop().create_future()
-    )
-
-    def watch(task: asyncio.Task[Episode]) -> None:
-        if not task.cancelled() and task.exception() is not None and not failed.done():
-            failed.set_result(task)
-
-    try:
-        while True:
-            # Back-pressure: the next group is pulled only once a slot has freed.
-            while window is not None and len(pending) >= window:
-                done, pending = await asyncio.wait(
-                    pending, return_when=asyncio.FIRST_COMPLETED
-                )
-                for task in done:
-                    task.result()  # a failed slot raises here: cancel the rest
-            pull = asyncio.ensure_future(anext(groups))
-            await asyncio.wait({pull, failed}, return_when=asyncio.FIRST_COMPLETED)
-            if failed.done():
-                failed.result().result()  # raises the slot's error: cancel the rest
-            try:
-                group = pull.result()
-            except StopAsyncIteration:
-                break
-            for slot in group:
-                started.append(asyncio.ensure_future(run_slot(slot)))
-                started[-1].add_done_callback(watch)
-                pending.add(started[-1])
-        return await asyncio.gather(*started)
-    except BaseException:
-        # The pull too: the stream must not still be running when it is closed.
-        tasks = [*started, pull] if pull is not None else started
-        for task in tasks:
-            task.cancel()
-        # return_exceptions: wait for every task, not just the first to cancel.
-        await asyncio.gather(*tasks, return_exceptions=True)
-        raise
-    finally:
-        await groups.aclose()
-
-
 async def _plan_stream(
-    tasks: AsyncGenerator[Task, None],
+    tasks: AsyncIterable[Task],
     plan_slots: Callable[[Task], list[RunSlot]],
     slots: list[RunSlot],
-) -> AsyncGenerator[list[RunSlot], None]:
+) -> AsyncGenerator[RunSlot, None]:
     """Plan each task as it arrives: its slots join the display (`slots`) at once,
-    but are yielded one per group, so the window bounds the slots in flight rather
+    but are yielded one by one, so the window bounds the slots in flight rather
     than the tasks — a task's `-r` rollouts wait here, not as live coroutines."""
-    async with contextlib.aclosing(tasks):
-        async for task in tasks:
+    async with contextlib.aclosing(aiter(tasks)) as source:
+        async for task in source:
             planned = plan_slots(task)
             slots.extend(planned)  # the display grows with the stream
             for slot in planned:
-                yield [slot]
+                yield slot
 
 
 @contextlib.asynccontextmanager
@@ -263,13 +207,17 @@ async def run_eval(config: EvalConfig) -> list[Episode]:
     # workers each load their own, and this process owns just the taskset.
     env = None if config.serve is not None else load_environment(config.env)
     taskset = env.taskset if env is not None else load_taskset(config.env.taskset)
-    if config.num_tasks is None and taskset.INFINITE:
-        raise ValueError(
-            f"{type(taskset).__name__} is infinite - bound the run with -n"
-        )
-    # A streaming taskset's tasks appear over time: nothing to list up front, so
-    # no whole set to shuffle and no keys to resume against (`-n` still bounds it).
+    # An eval is a report on a finite set: a taskset without an end of its own — a
+    # procedural generator, or a stream whose tasks appear over time — is bounded by
+    # `-n` (the stream's next `-n` tasks), never waited on open-endedly. A service
+    # that consumes a feed for as long as it runs is built on `run_stream` instead.
     streaming = taskset.streaming
+    if config.num_tasks is None and (taskset.INFINITE or streaming):
+        what = "streams its tasks" if streaming else "is infinite"
+        raise ValueError(
+            f"{type(taskset).__name__} {what} - bound the run with -n/--num-examples"
+        )
+    # Nothing to list up front: no whole set to shuffle and no keys to resume against.
     if streaming and (config.shuffle or config.resume):
         raise ValueError(
             f"{type(taskset).__name__} streams its tasks - cannot "
@@ -316,10 +264,9 @@ async def run_eval(config: EvalConfig) -> list[Episode]:
             if config.serve is not None
             else ""
         )
-        count = config.num_tasks if streaming else len(plan)
         logger.info(
-            "running %sx%d rollouts on %s%s",
-            "streamed tasks " if count is None else count,
+            "running %dx%d rollouts on %s%s",
+            config.num_tasks if streaming else len(plan),
             config.num_rollouts,
             config.model,
             via,
@@ -335,7 +282,10 @@ async def run_eval(config: EvalConfig) -> list[Episode]:
 
     # Opened before the first rollout so every episode streams as it lands.
     run = open_run(
-        config, push_state, num_examples=config.num_tasks if streaming else len(tasks)
+        config,
+        push_state,
+        # A stream's count is its `-n` (required); fewer land if the feed ends first.
+        num_examples=cast(int, config.num_tasks) if streaming else len(tasks),
     )
     # Resumed rollouts are part of this run too.
     log_episodes(run, finished)
@@ -366,9 +316,10 @@ async def run_eval(config: EvalConfig) -> list[Episode]:
             if streaming:
                 # Each task is planned as it arrives, pulled only as slots free up: the
                 # feed decides what is owed, `-c` how many run at once, `-n` how many
-                # in total.
-                groups = _plan_stream(
-                    _take(selected.stream(), config.num_tasks),
+                # in total — the next `-n`, then the run ends (`_take` never pulls an
+                # (n+1)th the feed may still be waiting for).
+                source = _plan_stream(
+                    _take(taskset.stream(), cast(int, config.num_tasks)),
                     lambda task: plan_slots(task, config.num_rollouts),
                     slots,
                 )
@@ -376,16 +327,16 @@ async def run_eval(config: EvalConfig) -> list[Episode]:
             else:
                 # Every slot exists before the first rollout runs; the semaphore alone
                 # bounds what runs, so nothing is held back.
-                planned = [plan_slots(task, n) for task, n in plan]
-                slots.extend(slot for group in planned for slot in group)
-                groups, window = _aiter(planned), None
+                planned = [slot for task, n in plan for slot in plan_slots(task, n)]
+                slots.extend(planned)
+                source, window = _aiter(planned), None
             display = (
                 dashboard(slots, config, start, push=push_state)
                 if config.rich is not None
                 else contextlib.nullcontext()
             )
             async with display:
-                results = await run_stream(groups, run_slot, window)
+                results = await run_stream(source, run_slot, window=window)
                 episodes = finished + list(results)
                 # Drain and close out off the event loop so the view keeps refreshing.
                 # Shielded: a Ctrl-C here must not cancel the close-out before the

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -10,6 +10,11 @@ the main hook that builds each task:
 `load` may also be a generator for infinite tasksets. There is a one-to-one
 mapping between taskset and task type, i.e. a taskset may only yield one task
 type.
+
+A taskset whose tasks appear over time (a queue, a feed) overrides `stream()`
+instead: an async generator that awaits its source, yields each task complete,
+and returns when the source is drained. The runner consumes `stream()` either
+way — the default streams `iter(self)`.
 """
 
 from __future__ import annotations
@@ -18,7 +23,7 @@ import copy
 import itertools
 import random
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterable, Iterator
+from collections.abc import AsyncIterator, Callable, Iterable, Iterator
 from typing import TYPE_CHECKING, Generic, Self
 
 from typing_extensions import TypeVar
@@ -60,6 +65,20 @@ class Taskset(ABC, Generic[TaskT, TasksetConfigT]):
             for task in self.load()
         )
         yield from self.transform(tasks) if self.transform is not None else tasks
+
+    async def stream(self) -> AsyncIterator[TaskT]:
+        """The tasks as they become available — the read path a runner consumes.
+        The default yields `iter(self)` (system prompt and any `head`/`shuffle`
+        view applied); a taskset whose tasks appear over time overrides this (see
+        module doc) — such a taskset cannot be shuffled or resumed, `-n` bounds
+        it by count."""
+        for task in self:
+            yield task
+
+    @property
+    def streaming(self) -> bool:
+        """Whether `stream()` is overridden (the tasks appear over time)."""
+        return type(self).stream is not Taskset.stream
 
     def view(self, transform: Callable[[Iterator[TaskT]], Iterator[TaskT]]) -> Self:
         """A shallow copy of this taskset iterating through `transform`, composed

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -14,7 +14,9 @@ type.
 A taskset whose tasks appear over time (a queue, a feed) overrides `stream()`
 instead: an async generator that awaits its source, yields each task complete,
 and returns when the source is drained. The runner consumes `stream()` either
-way — the default streams `iter(self)`.
+way — the default streams `iter(self)`. `vf eval` takes a stream's next `-n`
+tasks and ends; consuming it for as long as it runs is a service's job, built on
+`run_stream`.
 """
 
 from __future__ import annotations
@@ -70,8 +72,8 @@ class Taskset(ABC, Generic[TaskT, TasksetConfigT]):
         """The tasks as they become available — the read path a runner consumes.
         The default yields `iter(self)` (system prompt and any `head`/`shuffle`
         view applied); a taskset whose tasks appear over time overrides this (see
-        module doc) — such a taskset cannot be shuffled or resumed, `-n` bounds
-        it by count."""
+        module doc) — such a taskset cannot be shuffled or resumed, and `vf eval`
+        requires `-n`: it takes the next `n` and ends."""
         for task in self:
             yield task
 

--- a/verifiers/v1/utils/aio.py
+++ b/verifiers/v1/utils/aio.py
@@ -1,10 +1,11 @@
 """Asyncio helpers shared across the framework."""
 
 import asyncio
-from collections.abc import Awaitable
+from collections.abc import AsyncIterable, Awaitable, Callable
 from typing import TypeVar
 
 T = TypeVar("T")
+R = TypeVar("R")
 
 
 async def run_shielded(coro: Awaitable[T]) -> T:
@@ -29,3 +30,69 @@ async def run_shielded(coro: Awaitable[T]) -> T:
     if cancelled is not None:
         raise cancelled from (None if task.cancelled() else task.exception())
     return task.result()
+
+
+async def run_stream(
+    source: AsyncIterable[T],
+    run: Callable[[T], Awaitable[R]],
+    *,
+    window: int | None,
+) -> list[R]:
+    """Consume `source` — an async iterable of tasks, typically a feed that waits for
+    its next item — running each through `run` with at most `window` in flight (None:
+    no bound), and return every result in submission order once the source has ended
+    and the last run is done. Back-pressure: the next item is pulled only once a run
+    has freed a place in the window, so a feed is read at the pace the runs can take.
+    One run failing cancels the rest, waits for them to unwind (so nothing keeps
+    uploading into a run the caller is already closing), and re-raises; the source is
+    closed (`aclose()`) on any exit, so a feed's waiter is gone too. The caller decides
+    when the source ends: `vf eval -n` hands in a finite one, a service of your own
+    one that ends when the service does. The pull is its own task raced against the
+    runs' first failure, so a run that fails while the feed is quiet aborts at once,
+    not when the feed next yields (which may be never). Not a `TaskGroup`: that
+    wraps errors in an `ExceptionGroup`, and a CLI's `main` would no longer see a
+    `KeyboardInterrupt` as Ctrl-C."""
+    items = aiter(source)
+    started: list[asyncio.Task[R]] = []
+    pending: set[asyncio.Task[R]] = set()
+    pull: asyncio.Task[T] | None = None
+    # Resolved with the first run to fail (by a done-callback, so the wait on the
+    # pull stays O(1) however many runs a static eval has in flight).
+    failed: asyncio.Future[asyncio.Task[R]] = asyncio.get_running_loop().create_future()
+
+    def watch(task: asyncio.Task[R]) -> None:
+        if not task.cancelled() and task.exception() is not None and not failed.done():
+            failed.set_result(task)
+
+    try:
+        while True:
+            # Back-pressure: the next item is pulled only once a run has freed.
+            while window is not None and len(pending) >= window:
+                done, pending = await asyncio.wait(
+                    pending, return_when=asyncio.FIRST_COMPLETED
+                )
+                for task in done:
+                    task.result()  # a failed run raises here: cancel the rest
+            pull = asyncio.ensure_future(anext(items))
+            await asyncio.wait({pull, failed}, return_when=asyncio.FIRST_COMPLETED)
+            if failed.done():
+                failed.result().result()  # raises the run's error: cancel the rest
+            try:
+                item = pull.result()
+            except StopAsyncIteration:
+                break
+            started.append(asyncio.ensure_future(run(item)))
+            started[-1].add_done_callback(watch)
+            pending.add(started[-1])
+        return await asyncio.gather(*started)
+    except BaseException:
+        # The pull too: the source must not still be running when it is closed.
+        tasks = [*started, pull] if pull is not None else started
+        for task in tasks:
+            task.cancel()
+        # return_exceptions: wait for every task, not just the first to cancel.
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
+    finally:
+        if (aclose := getattr(items, "aclose", None)) is not None:
+            await aclose()

--- a/verifiers/v1/utils/platform.py
+++ b/verifiers/v1/utils/platform.py
@@ -42,13 +42,10 @@ class PushState:
         return self.error is not None or self.url is not None
 
 
-def open_run(
-    config: EvalConfig, state: PushState, *, num_examples: int | None
-) -> pr.Run:
+def open_run(config: EvalConfig, state: PushState, *, num_examples: int) -> pr.Run:
     """Open the run this eval streams into, before the first rollout, and give the
-    config the run's id (`num_examples` is None when a stream's count is not known
-    up front). A run that cannot be opened is logged and replaced by a disabled one;
-    the eval goes on. With `run.attach` the run already exists on the
+    config the run's id. A run that cannot be opened is logged and replaced by a
+    disabled one; the eval goes on. With `run.attach` the run already exists on the
     platform (a hosted evaluation's launcher created it and is waiting on it), so
     there is no local fallback: failing to attach fails the eval."""
     attach = config.run.attach

--- a/verifiers/v1/utils/platform.py
+++ b/verifiers/v1/utils/platform.py
@@ -42,10 +42,13 @@ class PushState:
         return self.error is not None or self.url is not None
 
 
-def open_run(config: EvalConfig, state: PushState, *, num_examples: int) -> pr.Run:
+def open_run(
+    config: EvalConfig, state: PushState, *, num_examples: int | None
+) -> pr.Run:
     """Open the run this eval streams into, before the first rollout, and give the
-    config the run's id. A run that cannot be opened is logged and replaced by a
-    disabled one; the eval goes on. With `run.attach` the run already exists on the
+    config the run's id (`num_examples` is None when a stream's count is not known
+    up front). A run that cannot be opened is logged and replaced by a disabled one;
+    the eval goes on. With `run.attach` the run already exists on the
     platform (a hosted evaluation's launcher created it and is waiting on it), so
     there is no local fallback: failing to attach fails the eval."""
     attach = config.run.attach


### PR DESCRIPTION
## What

`Taskset.stream()` — the read path the eval runner consumes — and the windowed primitive behind it, `vf.run_stream`, public.

```python
class Taskset(ABC, Generic[TaskT, TasksetConfigT]):
    async def stream(self) -> AsyncIterator[TaskT]:
        """The tasks as they become available. Default: `iter(self)` (system prompt, `head`/`shuffle` view applied).
        A taskset whose tasks appear over time overrides this: an async generator that awaits its source,
        yields each task complete, and returns when the source is drained."""

    @property
    def streaming(self) -> bool:
        """Whether `stream()` is overridden."""
```

```python
# verifiers/v1/utils/aio.py — exported as `vf.run_stream`; replaces the runner's one `gather_rollouts(...)` call
async def run_stream(source: AsyncIterable[T], run: Callable[[T], Awaitable[R]], *, window: int | None) -> list[R]:
    """Consume `source` — an async iterable of tasks, typically a feed that waits for its next item — running each
    through `run` with at most `window` in flight (None: no bound); return every result in submission order once the
    source has ended and the last run is done. Back-pressure: the next item is pulled only once a run has freed a
    place. One run failing cancels the rest, waits for them to unwind, re-raises; the source is `aclose()`d on any
    exit. The caller decides when the source ends."""
```

## Scope

**`vf eval` is bounded; long-running consumption is the caller's job.** An eval entrypoint is a report on a finite set — it never waits open-endedly for new tasks. On a streaming taskset `vf eval` therefore requires `-n/--num-examples`: it takes the stream's *next* `n` tasks (pulling each only while fewer than `-c` rollouts are in flight, and never an `(n+1)`th the feed may still be waiting for), then ends and reports like any other run. Without `-n` it refuses (`ValueError` naming the flag — the existing infinite-taskset rule, extended); `--shuffle`/`--resume` are refused too (no whole set to sample, no keys to resume against).

A service that consumes a feed for as long as it runs owns that loop itself — its shutdown, where the results go — and is built on the same primitive the runner uses, not on the entrypoint:

```python
async with env.serving():  # env-level resources, up for the life of the service
    ctx = vf.ModelContext(client=client, model=model, sampling=sampling)
    await vf.run_stream(env.taskset.stream(), lambda task: env.run_slot(vf.RunSlot(task), ctx), window=32)
```

Why the split: the eval entrypoint carries a run (`open_run`/`finish_run`), a dashboard with a total, `--resume`, an exit code — all of which presuppose a finite set. What a service reuses is the runner primitive (bounded concurrency, cancel-the-rest, source close-out) and `env.run_slot` (whole-episode retries, `on_complete`), so those are the public surface; `run_stream` is generic over the item so the in-process path, the served path (one `client.run` per slot) and a service's `env.run_slot` all go through the one implementation. (This is the reshape after review: the first cut let `vf eval` run until a stream drained.)

## Why

Production is a feed: an owed seat turn appears when the records change, not from a list. The data-flywheel environment carries its own scheduler for exactly this — `run.Loop.sweep/schedule/reconcile/_seat`, the `Place`/`Places` capacities, the feed-wait loop, `settle` and `SHUTDOWN_GRACE` — ~330 lines whose only job is "which task is due now, bounded how, stopped how", re-implementing what the runner already owns (bounded concurrency, `run_episode_with_retry`, `append_episode`, shutdown). The runner could not consume a feed because `Taskset.load()` is sync (a feed cannot be awaited without blocking the loop) and `run_eval` materialised the taskset (`tasks = list(selected)`) and planned every slot before the first rollout. An async-capable `load()` was rejected (breaks `__iter__`, `head`/`shuffle`, and every static taskset's contract). `stream()` is a separate hook so `load` stays the small thing AGENTS.md wants, and the override *is* the declaration (no flag that can disagree with the code). With `run_stream` public, the service keeps its loop and drops its scheduler; `vf eval -n 20` on the same taskset is the bounded spot-check.

## What is preserved

- A static taskset (no `stream()` override) takes the same `run_stream` path with **every slot planned up front, before the dashboard's first frame, and `window=None`**: the semaphore alone bounds what runs, exactly as before — same admission order, same dashboard total from the start, same cancel-the-rest / wait-to-unwind semantics `gather_rollouts` had (folded into `run_stream`; it had no other callers). `INFINITE`, `-n`, `--shuffle`, `--resume` behave as today for it.
- `Taskset.load`, `__iter__`, `head`, `shuffle`, `view` unchanged; the default `stream()` yields `iter(self)`, so `head(2).stream()` == `iter(head(2))`.
- The served path is unchanged below the slot: one `client.run` per slot; the streamed taskset lives in the main process as before.
- `open_run(num_examples=)` stays an `int`: a stream's count is its `-n`.
- Public API additions: `vf.run_stream`, `vf.RunSlot` (already the type `Env.run_slot`/`Env.slots` take and return).

## Tests

- `tests/v1/test_taskset.py` (deterministic, no model): a fixture taskset streaming off an `asyncio.Queue`, driven through `vf.run_stream` with tasks directly: the default `stream()` equals iteration (`head(2)` included) and `streaming` is `False`/`True`; `_take(…, n)` yields the next `n`, fewer if the feed ends first, never pulls an `(n+1)`th, and closes a started source; with `window=2` the 3rd task is **not** pulled while two runs are in flight (asserted on the source's cursor with the runs gated); results come back in submission order once the stream ends; a failing run cancels the others, re-raises, and `aclose()`s a stream whose feed is still waiting — also when it fails while the feed is quiet (the pull is raced against the runs' first failure, so a quiet feed cannot hide it); a task's `-r` rollouts are windowed one by one (window=1, 50 rollouts, never more than one alive); cancelling the run while `stream()` is parked on its feed closes it.
- `tests/v1/test_e2e.py::test_streaming_taskset[run_v1|run_v1_server]`: the fixture taskset (`tests/v1/fixtures/echo_stream_v1.py`) is a live feed that **never drains** (the echo phrases every 0.5 s, cycling); with `-n 3` the run ends after the 3rd task, in-process and served → 3 ok episodes, 3 rows in `traces.jsonl` (a pull past the 3rd would land as a 4th episode, not a hang). `test_streaming_taskset_requires_num_tasks` (offline): no `-n` → `ValueError` naming `-n/--num-examples` before any rollout. `test_streaming_taskset_refuses_shuffle_and_resume[shuffle|resume]` (offline): `ValueError` before any rollout.
- Ran locally: `uv run pytest tests/v1 -m "not e2e" -n auto`: 98 passed; the two streaming e2e cases plus `test_single_turn[null-harness-in-subprocess]`, `test_env_id_best_of_n`, `test_multi_agent_env_server` (static path, in-process and served): passed. The documented service pattern (`env.serving()` / `vf.run_stream` / `env.run_slot`) run for real against the fixture feed with `window=2`: 4 ok episodes, each published through `on_complete`. `uv run ruff check`, `ruff format --check`, `pre-commit run --all-files`, `ty check verifiers`: clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core eval scheduling and concurrency for all runs (via `run_stream`), not only streaming tasksets; mistakes in windowing or source closure could affect rollout counts or leave feeds hanging.
> 
> **Overview**
> Adds **streaming tasksets**: subclasses override async **`Taskset.stream()`** (detected by **`streaming`**) so tasks can arrive over time while **`load()`** may stay empty. The public **`vf.run_stream`** helper runs an async source with optional **window** back-pressure, ordered results, fail-fast cancellation, and **`aclose()`** on the feed.
> 
> **`run_eval`** now drives all rollouts through **`stream()`**: streaming runs **`_take(..., -n)` → `_plan_stream` → `run_stream`** (dashboard slots grow as tasks arrive; **`max_concurrent`** is the pull window); static tasksets still plan every slot upfront and use **`window=None`** (semaphore-only, same behavior as the old **`gather_rollouts`** path). Streaming and infinite tasksets **require `-n`**; **`shuffle`** and **`resume`** are rejected on streams.
> 
> Docs cover streaming vs bounded **`eval`** vs long-lived **`run_stream`** services; **`EchoStreamTaskset`** and unit/e2e tests exercise back-pressure, bounds, failures, and config errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 098260455cc771427f81958b8995978eb4d27cd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Taskset.stream()` async hook and windowed `run_stream` runner for v1
> - Adds `Taskset.stream()` default async hook and `Taskset.streaming` property in [taskset.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2582/files#diff-7e5e561017828ff64ab186fa98a8e394675de1971f358af769aa825f7c7997c9); subclasses override `stream()` to emit tasks lazily.
> - Adds `run_stream` concurrency utility in [aio.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2582/files#diff-cff01868a73aed3e28977ebf59b22a6c06a490e9138253edd905e84d965e99c0) that pulls items with back-pressure, limits pending runs via a window, returns results in submission order, and cancels outstanding work plus closes the source on failure or cancellation.
> - Refactors `run_eval` in [runner.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2582/files#diff-65be4a576330571f2729a3bbcdbe92ac81bbcba450c313597c1bdca3a1c3f2e4) to consume the next `num_tasks` streamed tasks via `_take` and `_plan_stream`, execute both static and streaming evals through `run_stream`, and reject missing bounds, shuffle, and resume for streaming tasksets.
> - Exports `RunSlot` and `run_stream` from the `verifiers.v1` public API.
> - Risk: static evaluations now route through `run_stream` instead of the old `gather_rollouts` helper; any out-of-tree callers of `gather_rollouts` will break since it was removed from [runner.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2582/files#diff-65be4a576330571f2729a3bbcdbe92ac81bbcba450c313597c1bdca3a1c3f2e4).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0982604.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
