### PR TITLE
Add explicit Braintrust export for native v1 episodes

### DIFF
--- a/verifiers/v1/integrations/README.md
+++ b/verifiers/v1/integrations/README.md
@@ -1,0 +1,90 @@
+# Braintrust episode export
+
+`log_episode` exports a completed native v1 `Episode` to a caller-owned Braintrust
+logger. It also accepts a saved episode loaded with `WireEpisode`. There is no
+runtime monkey-patching, environment-variable auto-enablement, CLI configuration,
+or required Braintrust dependency in verifiers.
+
+Install the SDK separately with `uv pip install braintrust` and authenticate it
+using Braintrust's normal mechanism. Project selection and authentication stay
+outside the episode and eval configuration.
+
+```python
+import braintrust
+
+from verifiers.v1.integrations.braintrust import log_episode
+
+logger = braintrust.init_logger(project="verifiers", set_current=False)
+try:
+    episode = await env.run(task)
+    log_episode(episode, logger)
+finally:
+    logger.flush()
+```
+
+For an async consumer, call `await asyncio.to_thread(log_episode, episode, logger)`
+after saving the episode locally. Export failures propagate; the caller decides
+whether they should fail the run or be reported separately. Flush once after a
+batch, not after each message. SDK delivery/retry behavior remains the SDK's
+responsibility.
+
+## Inspect an existing run
+
+```python
+from pathlib import Path
+
+import braintrust
+
+from verifiers.v1.episode import WireEpisode
+from verifiers.v1.integrations.braintrust import log_episode
+
+logger = braintrust.init_logger(project="verifiers", set_current=False)
+try:
+    with Path("outputs/my-run/traces.jsonl").open() as records:
+        for line in records:
+            if line.strip():
+                log_episode(WireEpisode.model_validate_json(line), logger)
+finally:
+    logger.flush()
+```
+
+Only call this when you intend to send these records to Braintrust. Each invocation
+creates a new export, so retrying a batch can create duplicate traces. This is an
+explicit post-completion export, not live token/turn streaming or an automatic
+`prime eval` integration.
+
+## Recorded structure
+
+- One episode root, one child per agent trace.
+- One point span per native message node. `parent_node` and `semantic_parents`
+  preserve graph edges without expanding shared history into every branch.
+- One LLM span per actual model call, including unsuccessful calls without a
+  committed node. Recorded start/end times are preserved. Message timestamps are
+  commit instants, **not tool execution durations**.
+- Provider usage is logged only on model-call spans to avoid double counting.
+  Braintrust prompt tokens include cache reads; reasoning tokens remain a subset
+  of completion tokens. Judge/off-graph usage is separate trace metadata.
+- The weighted reward is `metrics.verifiers_reward`; named numeric metrics use a
+  `verifiers/` prefix. Raw reward scores and weights remain trace metadata because
+  verifiers rewards are not restricted to Braintrust's `[0, 1]` score range.
+- Episodes without traces become export-time points, labelled `timing_source`.
+  Missing call starts fall back to the trace start and are labelled likewise.
+
+## Content and size
+
+By default, exports include identifiers, model names, graph edges, reward/metric
+names and values, error **types**, and timings, but no message bodies, tool
+arguments/results, error messages, task data, agent configs, or `trace.info`.
+These metadata fields can still be sensitive; this is not an anonymization layer.
+
+`log_episode(episode, logger, include_content=True)` explicitly enables message
+JSON excerpts and error messages. Each excerpt is capped at 16,384 characters;
+message metadata marks `content_truncated`. Truncated JSON is an excerpt, not a
+parseable document. Content may contain credentials, personal information, or
+multimodal URLs, so review/redact it before opting in. Provider replay state,
+token arrays/tensors, task data, agent configs, and `trace.info` are never exported.
+
+Span count and traversal are linear in nodes plus calls, not total expanded branch
+length. There is no attachment upload or full-conversation replay per model call.
+This keeps individual content fields bounded, but does not bound the SDK's batch
+queue or total export size; control concurrency at the consumer.

--- a/verifiers/v1/integrations/__init__.py
+++ b/verifiers/v1/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""Explicit integrations with external observability services."""

--- a/verifiers/v1/integrations/braintrust.py
+++ b/verifiers/v1/integrations/braintrust.py
@@ -1,0 +1,210 @@
+"""Export completed v1 episodes without instrumenting the running environment.
+
+Install Braintrust separately. The caller owns authentication, project selection,
+flush, and export failure policy; importing this module does not import the SDK.
+See the adjacent README for saved-episode and async usage.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import TYPE_CHECKING
+
+from verifiers.v1.episode import Episode
+from verifiers.v1.trace import Error, Trace
+from verifiers.v1.types import Message, Usage
+
+if TYPE_CHECKING:
+    from braintrust import Logger, Span
+
+MAX_CONTENT_CHARS = 16_384
+
+
+def _content(message: Message) -> tuple[str, bool]:
+    """Keep one bounded JSON excerpt, never provider replay state or token arrays."""
+    chunks: list[str] = []
+    remaining = MAX_CONTENT_CHARS
+    for chunk in json.JSONEncoder(ensure_ascii=False).iterencode(
+        message.model_dump(mode="json", exclude={"provider_state"}, exclude_none=True)
+    ):
+        chunks.append(chunk[:remaining])
+        remaining -= len(chunk)
+        if remaining < 0:
+            return "".join(chunks), True
+    return "".join(chunks), False
+
+
+def _errors(errors: list[Error], include_content: bool) -> str | None:
+    if not errors:
+        return None
+    if not include_content:
+        return ", ".join(error.type for error in errors)[:MAX_CONTENT_CHARS]
+    return "\n".join(
+        f"{error.type}: {error.message[:MAX_CONTENT_CHARS]}" for error in errors
+    )[:MAX_CONTENT_CHARS]
+
+
+def _usage(usage: Usage | None) -> dict[str, int | float]:
+    if usage is None:
+        return {}
+    metrics: dict[str, int | float] = {
+        "prompt_tokens": usage.input_tokens,
+        "completion_tokens": usage.completion_tokens,
+        "tokens": usage.total_tokens,
+    }
+    if usage.cached_input_tokens is not None:
+        metrics["prompt_cached_tokens"] = usage.cached_input_tokens
+    if usage.reasoning_tokens is not None:
+        metrics["completion_reasoning_tokens"] = usage.reasoning_tokens
+    if usage.cost is not None:
+        metrics["cost"] = usage.cost
+    return metrics
+
+
+def _bounds(trace: Trace) -> tuple[float, float]:
+    """Measured bounds only: never stretch a historical trace to export time."""
+    stamps = [trace.timing.start]
+    for phase in ("boot", "setup", "agent", "finalize", "scoring"):
+        span = getattr(trace.timing, phase)
+        stamps.extend((span.start, span.end))
+    stamps.extend(node.timestamp for node in trace.nodes)
+    for call in trace.calls:
+        stamps.extend((call.time.start, call.time.end))
+    known = [stamp for stamp in stamps if stamp > 0]
+    if not known:
+        raise ValueError(f"Trace {trace.id} has no recorded timestamps")
+    return min(known), max(known)
+
+
+def log_episode(
+    episode: Episode, logger: Logger, *, include_content: bool = False
+) -> None:
+    """Queue an episode → agent trace → message/model-call span tree in Braintrust.
+
+    Messages are emitted once, not once per root-to-leaf branch. Message timestamps
+    are commit instants, not tool execution durations. Graph edges stay in metadata.
+    Content is opt-in and capped at 16,384 characters per message/error excerpt.
+    Task data, agent config, trace.info, tensors, and provider replay state are never
+    sent. Identifiers, model/tool names, rewards, and numeric metrics ARE sent.
+
+    Export synchronously after completion (or use asyncio.to_thread). Call
+    logger.flush() after a batch. This does not intercept calls, mutate the episode,
+    set current span context, suppress errors, or automatically enable CLI logging.
+    Each invocation is a new export, not a deduplicating upsert.
+    """
+    bounds = [_bounds(trace) for trace in episode.traces]
+    # An episode can fail before producing any trace and has no own timing field.
+    # Represent that case as an export-time point, explicitly labelled as such.
+    now = time.time()
+    start = min((start for start, _ in bounds), default=now)
+    end = max((end for _, end in bounds), default=now)
+    root = logger.start_span(
+        name="verifiers.episode",
+        type="task",
+        start_time=start,
+        set_current=False,
+        metadata={
+            "episode_id": episode.id,
+            "env_id": episode.env.id,
+            "run_id": episode.run.id if episode.run else None,
+            "ok": episode.ok,
+            "timing_source": "recorded" if bounds else "export_time",
+            "include_content": include_content,
+            "num_traces": len(episode.traces),
+        },
+        error=_errors(episode.errors, include_content),
+    )
+    try:
+        for trace, (trace_start, trace_end) in zip(episode.traces, bounds):
+            _log_trace(trace, root, trace_start, trace_end, include_content)
+    finally:
+        root.end(end_time=end)
+
+
+def _log_trace(
+    trace: Trace, root: Span, start: float, end: float, include_content: bool
+) -> None:
+    span = root.start_span(
+        name=f"agent:{trace.agent.name}",
+        type="task",
+        start_time=start,
+        set_current=False,
+        metadata={
+            "trace_id": trace.id,
+            "model": trace.agent.config.model,
+            "ok": trace.ok,
+            "stop_condition": trace.stop_condition,
+            "num_nodes": len(trace.nodes),
+            "num_calls": len(trace.calls),
+            "rewards": {
+                name: reward.model_dump() if reward else None
+                for name, reward in trace.rewards.items()
+            },
+        },
+        # Verifiers rewards need not be in [0, 1]; Braintrust scores must be.
+        # Preserve every weighted reward and metric without inventing normalization.
+        metrics={
+            "verifiers_reward": trace.reward,
+            **{
+                f"verifiers/{key}": value
+                for key, value in trace.metrics.items()
+                if value is not None
+            },
+        },
+        error=_errors(trace.errors, include_content),
+    )
+    try:
+        for index, node in enumerate(trace.nodes):
+            message = node.message
+            metadata = {
+                "node": index,
+                "parent_node": node.parent,
+                "sampled": node.sampled,
+                "timestamp_source": "message_commit",
+                "semantic_parents": [
+                    parent.model_dump() for parent in node.semantic_parents
+                ],
+            }
+            output = None
+            if include_content:
+                output, truncated = _content(message)
+                metadata["content_truncated"] = truncated
+            point = node.timestamp if node.timestamp > 0 else start
+            child = span.start_span(
+                name=f"message:{message.role}",
+                type="task",
+                start_time=point,
+                set_current=False,
+                metadata=metadata,
+                output=output,
+            )
+            child.end(end_time=point)
+        for index, call in enumerate(trace.calls):
+            call_start = call.time.start if call.time.start > 0 else start
+            call_end = max(call_start, call.time.end)
+            child = span.start_span(
+                name="model_call",
+                type="llm",
+                start_time=call_start,
+                set_current=False,
+                metadata={
+                    "call_index": index,
+                    "node": call.node,
+                    "model": call.model,
+                    "finish_reason": call.finish_reason,
+                    "timing_source": "recorded"
+                    if call.time.start > 0
+                    else "trace_start",
+                },
+                metrics=_usage(call.usage),
+                error=_errors([call.error] if call.error else [], include_content),
+            )
+            child.end(end_time=call_end)
+        # Judge/off-graph accounting is separate, never attached to an agent call.
+        if trace.extra_usage:
+            span.log(
+                metadata={"extra_usage": _usage(Usage.aggregate(trace.extra_usage))}
+            )
+    finally:
+        span.end(end_time=end)


### PR DESCRIPTION
## Summary

Add `verifiers.v1.integrations.braintrust.log_episode(episode, logger, include_content=False)` for explicit post-completion tracing from native v1 episodes, including saved `WireEpisode` records.

- Episode → agent trace → message/model-call spans; native graph nodes are emitted once, rather than expanding shared branch history.
- Preserve recorded model-call timing and failed calls without committed nodes; message spans are commit-time points, not fabricated tool execution durations.
- Correct cache/reasoning token accounting; unrestricted rewards remain metrics instead of invalid Braintrust scores.
- Content is excluded by default and explicitly opt-in with bounded excerpts. Task data, agent configuration, trace.info, provider replay state, and tensors are never exported.
- Caller owns the logger, credentials, project, flush, concurrency, and failure policy. No runtime monkey-patching, auto-telemetry, dependency/extra changes, or eval config changes.

Related alternatives: #1333, #1325, #1326. This targets the current native v1 Episode/Trace graph contract and deliberately does not patch harness execution.

## Validation

- 11 offline checks against the real Braintrust SDK with an in-memory sink and socket connections blocked: hierarchy, historical timings, privacy defaults, bounded content, cache accounting, failed calls, multiple agents, no graph expansion/mutation, error propagation, and independent exports.
- `uv run pytest tests/v1/test_trace.py tests/v1/test_graph.py -q` — 22 passed.
- Markdownlint, Ruff check/format, and pre-push ty check passed.
- Temporary SDK smoke script was kept outside the upstream diff, following the repository testing guidance.

## Scope / remaining validation

Draft for API review and live Braintrust delivery verification. This is completed-episode export, not live turn streaming or automatic prime eval integration. Re-export creates a new trace rather than an idempotent upsert. Total SDK queue size remains caller-controlled.

No private trace data, screenshots, credentials, or local viewer files are included or uploaded.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `log_episode` for explicit Braintrust export of native v1 episodes
> - Adds the `verifiers.v1.integrations` package with [braintrust.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2583/files#diff-819d24eed02d471cdafd736cccd70f42c4fcc372855394fb890ea9b403dff44f), providing an opt-in, synchronous `log_episode` function that exports completed episodes to Braintrust without mutating episodes or intercepting calls
> - Exports one episode root span per call, with one agent task span per trace, one message span per native node, and one LLM span per recorded model call including usage metrics, errors, and preserved timestamps
> - Content export is opt-in via `include_content`; message content is capped at 16,384 characters and provider replay state is excluded
> - Timing is derived from earliest and latest positive recorded timestamps; episodes with no traces use export-time; traces with no positive timestamp raise `ValueError`
> - Includes [README.md](https://github.com/PrimeIntellect-ai/verifiers/pull/2583/files#diff-0b4bb24c0c75ec3145787d319be5f18f5369c3a2b2ecb7a6b1a409661803e5ba) documenting SDK setup, usage, span structure, defaults, size limits, and duplicate-export considerations
> - Risk: `log_episode` raises `ValueError` from `_bounds` when a trace has no positive timestamps; export errors propagate only after the root span is ended
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 936b7cf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->