### PR TITLE
Propagate Bash compaction failures

### DIFF
--- a/verifiers/v1/harnesses/utils/core.py
+++ b/verifiers/v1/harnesses/utils/core.py
@@ -14,7 +14,6 @@ from openai import APIStatusError, AsyncOpenAI
 if TYPE_CHECKING:
     # The harness bundles this module into the generated script before execution.
     from verifiers.v1.harnesses.utils.compaction import (  # noqa: TC004
-        CompactionFailed,
         Compactor,
         bound_tool_message,
         compactable,
@@ -226,10 +225,6 @@ async def run_chat_loop(
     while True:
         try:
             completion, messages = await compactor.complete(messages)
-        except CompactionFailed:
-            # The context is exhausted and could not be summarized: end the run
-            # cleanly with what the conversation holds - still a trainable sample.
-            return
         except APIStatusError as error:
             # Null cannot compact, so context exhaustion ends it with the transcript so far.
             if args.bash or not is_context_overflow(error):
@@ -310,10 +305,7 @@ async def run_chat_loop(
             messages.append(tool_message)
             tool_result_tokens += estimated_tokens(str(tool_message["content"]))
         if compactor.reached(completion, tool_result_tokens) and compactable(messages):
-            try:
-                messages = await compactor.compact(messages)
-            except CompactionFailed:
-                return
+            messages = await compactor.compact(messages)
 
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
The bundled Bash chat loop currently catches `CompactionFailed` and exits successfully. A rollout whose checkpoint summaries are all empty or unusable is therefore recorded as `ok=true` with `stop_condition=agent_completed`, leaving incomplete compaction branches eligible for training.

Let `CompactionFailed` propagate from both the pre-turn and post-tool compaction paths. The bundled program then exits nonzero, so Verifiers records a retryable harness failure instead of a completed trajectory.

Validation:
- temporary behavioral check covering both failure paths: 2 passed
- `uv run ruff check --fix .`
- `uv run pytest tests/`: 86 passed, 76 skipped (Prime integration credentials unavailable)
- `uv run pre-commit run --all-files`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout success/failure semantics for Bash compaction paths, which affects which trajectories are marked complete vs retryable for training.
> 
> **Overview**
> Stops treating unrecoverable context compaction as a successful agent completion in the bundled Bash chat harness.
> 
> Previously, `run_chat_loop` caught `CompactionFailed` after `compactor.complete()` and after `compactor.compact()`, then returned normally—so rollouts with failed checkpoint summaries could still finish with `ok=true` and `stop_condition=agent_completed`. Those handlers and the unused `CompactionFailed` import are removed so compaction failures propagate and the bundled process can exit nonzero for a retryable harness failure.
> 
> Context overflow on the completion API is still handled via `APIStatusError` / `is_context_overflow` as before; only explicit compaction failure is no longer swallowed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdd42e2babfc411d0e1ec7e66d0607944a23ad90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Propagate `CompactionFailed` from `run_chat_loop` completion and compaction
> Removes the two `CompactionFailed` catch blocks in the `run_chat_loop` conversation runner that wrapped `compactor.complete(messages)` and `compactor.compact(messages)`. The loop still catches context-overflow `APIStatusError` as before, but a `CompactionFailed` raised by either call now propagates to the caller rather than ending the loop with the current transcript.
> - Risk: callers of `run_chat_loop` in [core.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2584/files#diff-4641f7de541bf21c7f3e30a2d8d49f14c1179c70cf21f3dff5fa19deb9a1e206) must handle `CompactionFailed`; any out-of-tree caller relying on the old normal-return-on-failure behavior will now receive an exception instead of a partial transcript.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fdd42e2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->