### PR TITLE
Preserve provider filtering when Modal networking is disabled

### DIFF
--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -107,14 +107,12 @@ class Rollout:
             ctx=ctx,
             trace=self.trace,
             network_policy=(
-                runtime_config
+                NetworkPolicyConfig(allow=[])
+                if isinstance(runtime_config, ModalConfig)
+                and not runtime_config.network_access
+                else runtime_config
                 if isinstance(runtime_config, NetworkPolicyConfig)
-                else NetworkPolicyConfig(
-                    allow=[]
-                    if isinstance(runtime_config, ModalConfig)
-                    and not runtime_config.network_access
-                    else ["*"]
-                )
+                else NetworkPolicyConfig()
             ),
             trace_stops=[fn for boundary, fn in stops if boundary is Trace],
             limits=limits,


### PR DESCRIPTION
Keep provider-side network filtering enabled when a Modal runtime is configured with `network_access=false`.

Prioritize Modal's disabled-network setting when selecting the rollout's interception policy. This maps it to a framework-only policy, so hosted web search and remote resource fetching remain filtered. Other configurations continue to use their existing allow/block policies.

Follow-up to #2579.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes execution-time network policy for Modal rollouts and affects egress filtering behavior, though the change narrows access when networking is explicitly disabled.
> 
> **Overview**
> **Fixes rollout interception when Modal has networking disabled.** `ModalConfig` is a `NetworkPolicyConfig`, so the previous `isinstance(runtime_config, NetworkPolicyConfig)` branch reused the Modal config as the session policy and kept the default `allow=["*"]` even when `network_access=false`, while the sandbox blocked egress.
> 
> Rollout session policy selection now **checks Modal first**: `network_access=false` becomes `NetworkPolicyConfig(allow=[])` so hosted web search and remote fetches stay filtered at the framework layer. Explicit `NetworkPolicyConfig` values are unchanged; other runtime configs still fall back to `NetworkPolicyConfig()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a366f875deaa962a262a97437aaea516b5696b45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve provider filtering in `Rollout.__init__` when Modal networking is disabled
> Changes the session network policy construction in [rollout.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2585/files#diff-f886b7f4717cf8fce9270bd4ff4790f3182aa1016abb9efb7f6e57efe18d1bf2). The no-network `ModalConfig` case still creates an empty allow-list policy, existing `NetworkPolicyConfig` instances pass through unchanged, and all other cases now rely on `NetworkPolicyConfig` constructor defaults instead of an explicit wildcard allow-list.
> - Risk: `RolloutSession` now receives a policy based on `NetworkPolicyConfig` constructor defaults for cases not already a `NetworkPolicyConfig` instance (including network-enabled `ModalConfig` values); the exact default values are not visible in this diff and may differ from the previous wildcard behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a366f87.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->