### PR TITLE
Fix Modal SDK minimum and simplify sandbox creation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ harbor = [
     "harbor==0.21.0 ; python_full_version >= '3.12'",
 ]
 modal = [
-    "modal>=1.4.0",
+    "modal>=1.5.4",
 ]
 openenv = [
     "openenv>=0.4.1",

--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -181,14 +181,6 @@ class ModalRuntime(Runtime):
                 "ModalRuntime requires the Modal SDK; install `verifiers[modal]`."
             ) from e
 
-        if self.network_restricted and not hasattr(
-            modal.Sandbox, "_experimental_set_outbound_network_policy"
-        ):
-            raise SandboxError(
-                "Modal execution-time network policies require a Modal SDK with "
-                "_experimental_set_outbound_network_policy; upgrade verifiers[modal]"
-            )
-
         try:
             app = await modal.App.lookup.aio(_APP_NAME, create_if_missing=True)
             async with (
@@ -219,14 +211,6 @@ class ModalRuntime(Runtime):
 
         # Modal requires both allowlist types at creation before they can be updated.
         # Trusted setup runs open; prepare_execution removes the broad CIDR grant.
-        network = (
-            {
-                "outbound_domain_allowlist": ["*"],
-                "outbound_cidr_allowlist": ["0.0.0.0/0"],
-            }
-            if self.network_restricted
-            else {}
-        )
         self._sandbox = await modal.Sandbox.create.aio(
             "sleep",
             "infinity",  # keep-alive entrypoint; the harness runs via `exec`
@@ -243,7 +227,10 @@ class ModalRuntime(Runtime):
             gpu=self.config.gpu,
             region=self.config.region,
             block_network=not self.config.network_access,
-            **network,
+            outbound_domain_allowlist=["*"] if self.network_restricted else None,
+            outbound_cidr_allowlist=(
+                ["0.0.0.0/0"] if self.network_restricted else None
+            ),
             timeout=24 * 60 * 60,  # Maximum lifetime of any sandbox.
             encrypted_ports=[SERVICE_PORT],
         )


### PR DESCRIPTION
Fix the Modal SDK minimum and simplify sandbox creation. This is a targeted cleanup of the existing networking implementation.

Require Modal 1.5.4, the version already in the lockfile, so the dependency requirement covers the policy-update API used by the runtime. Remove the capability check and pass the network options directly to sandbox creation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Modal sandbox provisioning and egress policy wiring; mis-specified allowlists could affect network-restricted rollouts, though behavior is intended to match the prior dict-based create path.
> 
> **Overview**
> Raises the **`verifiers[modal]`** extra to **`modal>=1.5.4`** so the declared minimum matches the SDK that supports outbound network policy at sandbox creation and the execution-time policy update used in **`prepare_execution`**.
> 
> In **`ModalRuntime`**, drops the **`start()`** guard that failed if **`_experimental_set_outbound_network_policy`** was missing. Sandbox creation now passes **`outbound_domain_allowlist`** and **`outbound_cidr_allowlist`** as first-class **`Sandbox.create`** arguments ( **`None`** when not network-restricted) instead of building and unpacking a separate **`network`** dict.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5629ec63daea7ec7fd6da599408b16d7c93eb0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise `modal` SDK minimum to 1.5.4 and simplify `ModalRuntime` sandbox creation
> - Raises the `modal` optional-dependency minimum from 1.4.0 to 1.5.4 in [pyproject.toml](https://github.com/PrimeIntellect-ai/verifiers/pull/2586/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711).
> - Removes the startup guard in `ModalRuntime.start` that raised `SandboxError` when `_experimental_set_outbound_network_policy` was missing.
> - Passes `outbound_domain_allowlist` and `outbound_cidr_allowlist` directly to `modal.Sandbox.create.aio` in [verifiers/v1/runtimes/modal.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2586/files#diff-a6217d92f043d6050e8609d4341d62b5d097d5db796f6197cd604e09d81683c0).
> - Behavioral Change: Unrestricted network configurations now pass explicit `None` for both allowlist parameters instead of omitting them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b5629ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->