### PR TITLE
Simplify Modal egress domain-list construction

### DIFF
--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -260,19 +260,9 @@ class ModalRuntime(Runtime):
             if routes is None:
                 domains, cidrs = ["*"], ["0.0.0.0/0"]
             else:
-                domains = list(
-                    dict.fromkeys(
-                        domain
-                        for domain in [
-                            *(
-                                _egress_domain(route, framework=True)
-                                for route in routes
-                            ),
-                            *(_egress_domain(rule) for rule in self.config.allow),
-                        ]
-                        if domain is not None
-                    )
-                )
+                domains = [_egress_domain(route, framework=True) for route in routes]
+                domains.extend(_egress_domain(rule) for rule in self.config.allow)
+                domains = list(dict.fromkeys(d for d in domains if d is not None))
                 cidrs = []
             # Always send both lists: leaving the setup CIDR grant would bypass domains.
             # The awaited RPC applies the policy and closes newly disallowed connections.


### PR DESCRIPTION
Simplify Modal's domain-list construction. This is a readability cleanup of the existing network-policy code.

Replace the nested expression with three statements that collect framework domains, append configured domains, and remove duplicates and loopback entries. Validation, domain ordering, and network-policy behavior stay the same.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Readability-only refactor in egress allowlist assembly; network policy semantics are unchanged.
> 
> **Overview**
> Refactors how `prepare_execution` builds the Modal `outbound_domain_allowlist` when `routes` is set: instead of one nested comprehension, it now collects framework route domains, extends with `config.allow` domains, then deduplicates while dropping `None` (loopback framework URLs).
> 
> **No intended behavior change** — validation still happens in `_egress_domain`, ordering is framework routes then allow rules, and the same RPC call still sends domain and CIDR lists for restricted sandboxes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7633d2f7077dbc680a5c782dde8757094471bb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Simplify Modal egress domain-list construction
> Refactors the outbound domain allowlist in [modal.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2587/files#diff-a6217d92f043d6050e8609d4341d62b5d097d5db796f6197cd604e09d81683c0) from a nested comprehension into explicit route collection, allow-rule extension, filtering, and order-preserving deduplication. The resulting domain ordering and omission of null domains stay equivalent to the prior implementation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e7633d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->