### PR TITLE
Fix tool catalog recording and namespaced call identity

### DIFF
--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -276,10 +276,17 @@ async def test_acp_resume_with_tool(run_v1, harness, harness_runtime, tmp_path):
     # Kimi Code is broken upstream: its Responses adapter drops message `phase` on replay.
     if harness.id != "kimi-code":
         assert trace.num_branches == 1
-    # Native MCP tools need not appear in the intercepted model request that
-    # populates trace.tools; the ACP transcript is the source of truth for use.
     assert "tool" in segments[1]["roles"]
     assert segments[1]["tool_outputs"]
+    if harness.id == "codex":
+        recall = next(tool for tool in trace.tools if tool.name.endswith("recall"))
+        assert recall.namespace
+        assert "codeword" in recall.parameters["properties"]
+        assert any(
+            call.namespace == recall.namespace and call.name == recall.name
+            for message in trace.assistant_messages
+            for call in message.tool_calls or []
+        )
     if harness.id == "rlm":
         assert "turns_since_last_compaction" in trace.metrics
         assert all(call.acp is not None for call in trace.calls)

--- a/tests/v1/test_graph.py
+++ b/tests/v1/test_graph.py
@@ -127,6 +127,31 @@ def test_tool_call_hash_matches_v0_content_and_arguments_normalization():
 
     assert graph.message_hash(left) == graph.message_hash(right)
 
+    # Identical call IDs and short names can occur in different agent branches.
+    trace = vf.Trace(
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
+        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0, prompt="lookup")),
+    )
+    user = vf.UserMessage(content="lookup")
+    calls = [
+        vf.AssistantMessage(
+            tool_calls=[
+                vf.ToolCall(id="call_0", name="lookup", namespace=ns, arguments="{}")
+            ]
+        )
+        for ns in (None, "alpha", "beta")
+    ]
+    node_ids = [
+        graph.prepare_turn(trace, [user]).commit(_response(message))
+        for message in calls
+    ]
+    for message, node_id in zip(calls, node_ids, strict=True):
+        turn = graph.prepare_turn(
+            trace,
+            [user, message, vf.ToolMessage(content="result", tool_call_id="call_0")],
+        )
+        assert turn.prefix_node_ids == [0, node_id]
+
 
 def test_reasoning_content_participates_in_graph_prefix_matching():
     task = vf.TaskData(idx=0, prompt="use a tool")
@@ -183,8 +208,11 @@ def test_parallel_commits_reconcile_shared_prompt_prefix():
     # Both model requests leave before either response has committed its prompt.
     pending_a = graph.prepare_turn(trace, [system, user_a])
     pending_b = graph.prepare_turn(trace, [system, user_b])
-    assistant_a_id = pending_a.commit(_response(assistant_a))
-    pending_b.commit(_response(vf.AssistantMessage(content="B1")))
+    tool_a = vf.Tool(name="echo", namespace="a")
+    tool_b = vf.Tool(name="echo", namespace="b")
+    assistant_a_id = pending_a.commit(_response(assistant_a), [tool_a])
+    pending_b.commit(_response(vf.AssistantMessage(content="B1")), [tool_b])
+    assert trace.tools == [tool_a, tool_b]
 
     graph.prepare_turn(
         trace,

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -10,7 +10,8 @@ import pytest
 
 import verifiers.v1 as vf
 from verifiers.v1.agent import Interaction
-from verifiers.v1.graph import MessageNode
+from verifiers.v1.dialects.responses import ResponsesDialect, fold_assistant
+from verifiers.v1.graph import MessageNode, prepare_turn
 from verifiers.v1.harnesses.rlm.harness import (
     RLM_SESSION_METADATA_KEY,
     RLMHarness,
@@ -135,15 +136,53 @@ def test_custom_task_state_round_trip():
 
 
 def test_wire_trace_round_trip():
+    mcp = {
+        "type": "mcp",
+        "server_label": "alpha",
+        "server_url": "https://example.invalid/mcp",
+        "authorization": "trace-test-oauth-token",
+        "headers": {"Authorization": "Bearer trace-test-header-token"},
+    }
+    function = {
+        "type": "function",
+        "name": "echo",
+        "description": "Echo the supplied text.",
+        "parameters": {"type": "object", "properties": {"text": {"type": "string"}}},
+        "strict": False,
+    }
+    request = ResponsesDialect().parse_request(
+        {
+            "tools": [
+                function,
+                {"type": "namespace", "name": "mcp__world", "tools": [function]},
+                {"type": "namespace", "name": "mcp__other", "tools": [function]},
+                {"type": "custom", "name": "patch", "format": {"type": "text"}},
+                {"type": "web_search", "search_context_size": "low"},
+                mcp,
+                mcp | {"server_label": "beta"},
+            ]
+        }
+    )
+    assistant = fold_assistant(
+        [
+            {
+                "type": "function_call",
+                "call_id": "call_0",
+                "name": "echo",
+                "namespace": "mcp__world",
+                "arguments": '{"text":"hello"}',
+            }
+        ]
+    )
     # Two leaves off one root → 2 branches (a compaction-shaped trace), so the round-trip has to
     # carry node `parent` links for `num_branches` to survive.
     tr = vf.Trace[MyTask, vf.State](
         agent=vf.AgentInfo(config=vf.AgentConfig()),
         task=vf.TraceTask(type="MyTask", data=MyTask(idx=0, prompt="q", answer="a")),
-        tools=[vf.Tool(name="echo", description="", parameters={"type": "object"})],
+        tools=request.tools,
         nodes=[
             MessageNode(parent=None, message=UserMessage(content="q"), sampled=False),
-            MessageNode(parent=0, message=AssistantMessage(content="a1"), sampled=True),
+            MessageNode(parent=0, message=assistant, sampled=True),
             MessageNode(parent=0, message=AssistantMessage(content="a2"), sampled=True),
         ],
     )
@@ -153,9 +192,14 @@ def test_wire_trace_round_trip():
     tr.info = {"build": "ok"}
     tr.root_reply = "root answer"
     tr.stop("done")
+    prepare_turn(tr, []).commit_prompt(request.tools)
 
     # the dump is plain pydantic — derived values are properties, so they're not serialized
     data = json.loads(tr.model_dump_json(exclude_none=True))
+    assert "trace-test-oauth-token" not in json.dumps(data)
+    assert "trace-test-header-token" not in json.dumps(data)
+    assert mcp["authorization"] == "trace-test-oauth-token"
+    assert mcp["headers"] == {"Authorization": "Bearer trace-test-header-token"}
     assert "reward" not in data and "is_truncated" not in data
     # exclude_none drops None FIELDS, not None dict values — unscored seeds survive
     assert data["rewards"]["solved"] is None and data["metrics"]["acc"] is None
@@ -174,6 +218,19 @@ def test_wire_trace_round_trip():
     assert (
         rt.tools == tr.tools
     )  # the advertised tools persist (tool-use SFT reads them)
+    assert [tool.namespace for tool in rt.tools[:3]] == [
+        None,
+        "mcp__world",
+        "mcp__other",
+    ]
+    assert all(tool.parameters == function["parameters"] for tool in rt.tools[:3])
+    assert all(tool.strict is False for tool in rt.tools[:3])
+    assert rt.tools[3].type == "custom"
+    assert rt.tools[3].model_extra == {"format": {"type": "text"}}
+    assert rt.tools[4].type == "web_search"
+    assert rt.tools[4].model_extra == {"search_context_size": "low"}
+    assert [tool.name for tool in rt.tools[5:]] == ["alpha", "beta"]
+    assert rt.nodes[1].message.tool_calls[0].namespace == "mcp__world"
     assert rt.task.data.model_extra == {
         "answer": "a"
     }  # taskset extras preserved on WireTaskData

--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -38,6 +38,10 @@ T = TypeVar("T")
 
 
 def tool_to_wire(tool: Tool) -> dict:
+    if tool.type != "function" or tool.namespace:
+        raise NotImplementedError(
+            "The renderer client only supports unnamespaced function tools."
+        )
     function: dict = {
         "name": tool.name,
         "description": tool.description,
@@ -61,6 +65,7 @@ def serialize_completion(response: Response, model: str) -> dict:
                 "type": c.type,
                 c.type: {
                     "name": c.name,
+                    **({"namespace": c.namespace} if c.namespace else {}),
                     "input" if c.type == "custom" else "arguments": c.arguments,
                 },
             }

--- a/verifiers/v1/dialects/anthropic.py
+++ b/verifiers/v1/dialects/anthropic.py
@@ -251,8 +251,9 @@ def parse_messages(body: dict) -> Messages:
                 if isinstance(content, str)
                 else content or []
             )
-            state = [block for block in blocks if block["type"] in THINKING]
-            state.sort(key=lambda block: THINKING.index(block["type"]))
+            state = [
+                block for block in blocks if block["type"] not in ("text", "tool_use")
+            ]
             text = "".join(b.get("text", "") for b in blocks if b.get("type") == "text")
             reasoning = "".join(
                 b.get("thinking", "") for b in blocks if b.get("type") == "thinking"
@@ -261,6 +262,7 @@ def parse_messages(body: dict) -> Messages:
                 ToolCall(
                     id=b.get("id", ""),
                     name=b.get("name", ""),
+                    namespace=b.get("toolset_name"),
                     arguments=json.dumps(b.get("input") or {}),
                 )
                 for b in blocks
@@ -303,8 +305,9 @@ def response_from_wire(message: AnthropicMessage) -> Response:
     reasoning: list[str] = []
     calls: list[ToolCall] = []
     for block in message.content:
-        if block.type in THINKING:
-            state.append(block.model_dump())
+        if block.type not in ("text", "tool_use"):
+            # SDK-inserted defaults are absent when the native response is replayed.
+            state.append(block.model_dump(exclude_unset=True))
         if block.type == "text":
             content.append(block.text)
         elif block.type == "thinking":
@@ -314,10 +317,10 @@ def response_from_wire(message: AnthropicMessage) -> Response:
                 ToolCall(
                     id=block.id,
                     name=block.name,
+                    namespace=block.toolset_name,
                     arguments=json.dumps(block.input or {}),
                 )
             )
-    state.sort(key=lambda block: THINKING.index(block["type"]))
     finish = STOP_REASONS.get(message.stop_reason or "")
     provider_usage = message.usage
     output_details = provider_usage.model_dump().get("output_tokens_details")
@@ -563,13 +566,17 @@ class AnthropicDialect(Dialect[AnthropicMessage]):
 
     def parse_request(self, body: RawRequest) -> Request:
         tools = [
-            Tool(
-                name=t["name"],
-                description=t.get("description", ""),
-                parameters=t.get("input_schema", {}),
+            Tool.model_validate(
+                {k: v for k, v in t.items() if k != "input_schema"}
+                | {
+                    "name": t.get("name") or t.get("mcp_server_name") or t["type"],
+                    "type": "function"
+                    if t.get("type") in (None, "custom")
+                    else t["type"],
+                    "parameters": t.get("input_schema") or {},
+                }
             )
             for t in body.get("tools") or []
-            if "input_schema" in t  # skip server tools (web_search etc.)
         ] or None
         return Request(messages=parse_messages(body), tools=tools)
 

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -122,6 +122,7 @@ def parse_message(raw: dict) -> Message:
                     id=call["id"],
                     type=kind,
                     name=native["name"],
+                    namespace=native.get("namespace"),
                     arguments=native["input" if kind == "custom" else "arguments"],
                 )
             )
@@ -135,21 +136,14 @@ def parse_message(raw: dict) -> Message:
 
 
 def parse_tools(raw: list[dict] | None) -> list[Tool] | None:
-    # `or None` so a tools array with no function entries (e.g. only `custom`/built-in
-    # tools) parses to None, not [] — the same contract as the anthropic/responses
-    # dialects, and what keeps an empty parse from clearing `Trace.tools`.
-    if not raw:
-        return None
-    return [
-        Tool(
-            name=t["function"]["name"],
-            description=t["function"].get("description", ""),
-            parameters=t["function"].get("parameters", {}),
-            strict=t["function"].get("strict"),
+    tools = []
+    for declaration in raw or []:
+        kind = declaration.get("type", "function")
+        tool = declaration.get(kind, declaration)
+        tools.append(
+            Tool.model_validate(tool | {"type": kind, "name": tool.get("name") or kind})
         )
-        for t in raw
-        if t.get("type", "function") == "function"
-    ] or None
+    return tools or None
 
 
 # --- vf -> chat wire ----------------------------------------------------------
@@ -184,6 +178,7 @@ def message_to_wire(message: Message) -> dict:
                     "type": call.type,
                     call.type: {
                         "name": call.name,
+                        **({"namespace": call.namespace} if call.namespace else {}),
                         "input"
                         if call.type == "custom"
                         else "arguments": call.arguments,
@@ -302,8 +297,9 @@ class ChatStreamParser(StreamParser):
                 slot["type"] = kind
                 native = slot.setdefault(kind, {"name": ""})
                 delta_native = tool_call.get(kind) or {}
-                if delta_native.get("name"):
-                    native["name"] = delta_native["name"]
+                for field in ("name", "namespace"):
+                    if delta_native.get(field):
+                        native[field] = delta_native[field]
                 input_field = "input" if kind == "custom" else "arguments"
                 self.tool_inputs.setdefault(index, []).append(
                     delta_native.get(input_field) or ""

--- a/verifiers/v1/dialects/responses.py
+++ b/verifiers/v1/dialects/responses.py
@@ -290,6 +290,7 @@ def fold_assistant(items: list[dict] | None) -> AssistantMessage:
                     id=item.get("call_id", ""),
                     type="custom" if kind == "custom_tool_call" else "function",
                     name=item.get("name", ""),
+                    namespace=item.get("namespace"),
                     arguments=item.get("arguments", item.get("input", "")),
                 )
             )
@@ -589,17 +590,37 @@ class ResponsesDialect(Dialect[OpenAIResponse]):
                 prompt.append(UserMessage(content=parse_content(item.get("content"))))
         if run:
             prompt.append(fold_assistant(run))
-        tools = [
-            Tool(
-                name=t["name"],
-                description=t.get("description") or "",
-                parameters=t.get("parameters") or {},
-                strict=t.get("strict"),
-            )
-            for t in body.get("tools") or []
-            if t.get("type") == "function"
-        ] or None
-        return Request(messages=prompt, tools=tools)
+        tools = []
+        declarations = []
+        for item in items:
+            if item.get("type") in ("additional_tools", "tool_search_output"):
+                declarations.extend(item.get("tools") or [])
+        # Current declarations take precedence over definitions replayed in history.
+        declarations.extend(body.get("tools") or [])
+        for group in declarations:
+            namespace = group["name"] if group.get("type") == "namespace" else None
+            for tool in group["tools"] if namespace else [group]:
+                if tool.get("type") == "mcp":
+                    # Connection credentials belong in the native request, not the trace.
+                    tool = {
+                        key: value
+                        for key, value in tool.items()
+                        if key not in ("authorization", "headers")
+                    }
+                tools.append(
+                    Tool.model_validate(
+                        tool
+                        | {
+                            "name": tool.get("name")
+                            or tool.get("server_label")
+                            or tool["type"],
+                            "namespace": namespace,
+                            "description": tool.get("description") or "",
+                            "parameters": tool.get("parameters") or {},
+                        }
+                    )
+                )
+        return Request(messages=prompt, tools=tools or None)
 
     def parse_response(self, response: OpenAIResponse) -> Response:
         return response_from_wire(response)

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -339,6 +339,7 @@ def message_hash(message: Message) -> str:
             add(tc.type)
             add(tc.id)
             add(tc.name)
+            add(tc.namespace or "")
             add(
                 tc.arguments
                 if tc.type == "custom"
@@ -502,7 +503,12 @@ class PendingTurn:
         """Add this turn to the graph; returns the committed assistant node's id."""
         assistant_id = _commit_turn(self, response)
         if tools:
-            self.trace.tools = tools
+            self.trace.tools = list(
+                {
+                    (tool.namespace, tool.name, tool.type): tool
+                    for tool in [*self.trace.tools, *tools]
+                }.values()
+            )
         return assistant_id
 
     def commit_prompt(self, tools: list[Tool] | None = None) -> None:
@@ -519,7 +525,12 @@ class PendingTurn:
             parent = len(self.trace.nodes) - 1
             index[(previous, message_hash(message))] = parent
         if tools:
-            self.trace.tools = tools
+            self.trace.tools = list(
+                {
+                    (tool.namespace, tool.name, tool.type): tool
+                    for tool in [*self.trace.tools, *tools]
+                }.values()
+            )
 
 
 def prepare_turn(trace: Trace, prompt: list[Message]) -> PendingTurn:

--- a/verifiers/v1/tasksets/nemo_gym/response.py
+++ b/verifiers/v1/tasksets/nemo_gym/response.py
@@ -70,6 +70,7 @@ def trace_to_nemo_response(
                     else "function_call",
                     "call_id": call.id,
                     "name": call.name,
+                    **({"namespace": call.namespace} if call.namespace else {}),
                     ("input" if call.type == "custom" else "arguments"): call.arguments,
                 }
                 for call in message.tool_calls or []

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -401,7 +401,7 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
     agent: AgentInfo[AgentConfigT]
     """The agent (harness x model x runtime) that produced this trace."""
     tools: list[Tool] = Field(default_factory=list)
-    """The tools advertised to the agent, automatically recorded from last intercepted turn."""
+    """Tools observed across requests; the latest definition wins for each identity."""
 
     nodes: list[MessageNode] = Field(default_factory=list)
     """The message graph, including physical and semantic parent links."""
@@ -667,7 +667,8 @@ class Trace(BaseModel, Generic[DataT, StateT, AgentConfigT]):
                 if message.content:
                     lines.append(message.content)
                 lines.extend(
-                    f"[tool_call {call.name}({call.arguments})]"
+                    f"[tool_call {call.namespace + '.' if call.namespace else ''}"
+                    f"{call.name}({call.arguments})]"
                     for call in message.tool_calls or []
                 )
             else:

--- a/verifiers/v1/types.py
+++ b/verifiers/v1/types.py
@@ -68,6 +68,8 @@ class ToolCall(BaseModel):
     id: str
     type: Literal["function", "custom"] = "function"
     name: str
+    namespace: str | None = None
+    """Provider namespace qualifying the tool name, when sent separately."""
     arguments: str
     """Raw function arguments or custom-tool input, exactly as the model emitted it."""
 
@@ -97,9 +99,14 @@ Messages = list[Message]
 
 
 class Tool(BaseModel):
+    # Native declarations carry format, discovery, and provider-specific settings.
+    model_config = ConfigDict(extra="allow")
+
+    type: str = "function"
     name: str
-    description: str
-    parameters: dict[str, Any]
+    namespace: str | None = None
+    description: str = ""
+    parameters: dict[str, Any] = Field(default_factory=dict)
     strict: bool | None = None
 
 


### PR DESCRIPTION
Codex advertises MCP functions inside Responses namespaces, but traces recorded only top-level functions and discarded call namespaces. This change records the tool catalog and preserves call identity through parsing, graph matching, and exports, while leaving native eval request forwarding unchanged.

- Record namespaced, custom, provider-native, and deferred tool declarations across the Responses, Chat Completions, and Anthropic dialects.
- Retain observed tools across requests and branches, prefer current definitions over discovery history, and distinguish remote MCP servers without persisting their authentication tokens or headers.
- Preserve namespaces in calls, graph hashes, transcripts, and serialization. Retain Anthropic native tool state without SDK-added defaults causing spurious replay branches.
- Reject tool declarations unsupported by the training renderer instead of silently omitting them or treating them as ordinary functions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches trace serialization, dialect parsing, and graph deduplication used by eval and training; train rendering explicitly rejects namespaced tools, which may break callers that assumed silent omission.
> 
> **Overview**
> Fixes incomplete tool catalog recording (e.g. Codex MCP tools inside Responses namespaces) by extending **`Tool`/`ToolCall`** with optional **`namespace`** and **`type`**, and teaching **Responses, Chat, and Anthropic** parsers to retain custom, MCP, built-in, and deferred declarations—not only top-level `function` entries.
> 
> **Trace graph** identity now includes call **namespace** in `message_hash`, and **`PendingTurn.commit`** merges tools across turns/branches keyed by `(namespace, name, type)` with latest definitions winning. **Responses** parsing also folds `additional_tools` / `tool_search_output` history but prefers current `tools`, dedupes declarations, and **strips MCP `authorization`/`headers`** from stored traces while leaving native requests untouched.
> 
> Wire paths emit **namespace** on tool calls where supported; **`tool_to_wire`** in the train client **raises** on namespaced or non-function tools rather than silently dropping them. **Anthropic** replay stability improves by sorting all non-text/tool_use blocks (not just thinking) and serializing provider state with **`exclude_unset`**.
> 
> Tests add Codex ACP assertions, namespaced branch prefix matching, parametrized parallel-commit tool roots, and a richer wire round-trip for mixed tool types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc7dbd2aba86ce3048239a3709187e6e098a374a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add namespace to `ToolCall` and `Tool` models and fix tool catalog recording in graph
> - Adds an optional `namespace` field to `ToolCall` and `Tool` in [types.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2597/files#diff-88a4e4ee0c58ac5dc7344161a011374082a3767eda2ad32af97c942dca982112); `Tool` also gains a `type` field and extra provider fields so non-function declarations (custom, built-in, MCP) survive validation.
> - Includes `namespace` in `message_hash` in [graph.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2597/files#diff-64c9d635eb215902a512c9e8ab316fd9b9967c36db03d4049aacc812cdfbd740) so tool calls differing only by namespace get distinct graph nodes instead of colliding.
> - Changes `PendingTurn.commit` and `commit_prompt` in [graph.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2597/files#diff-64c9d635eb215902a512c9e8ab316fd9b9967c36db03d4049aacc812cdfbd740) to merge tools by `namespace`/`name`/`type` across turns instead of replacing the entire tool list, so earlier tool declarations are preserved.
> - Updates all dialect parsers ([anthropic.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2597/files#diff-abc86b3ad07c2d6ab09cd923f50271c4f6c4cb928a9bb82c12f6e97aac17b04d), [chat.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2597/files#diff-5d2fcbf59a03489b63b0626038a853eee89543b591074597161ee29aab901280), [responses.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2597/files#diff-73f89a1b25536fd7a806555e765120f5189cb934eff813f4c7900838efa56b5a)) and wire serializers ([train.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2597/files#diff-c9bcd6c691890b1de6942fe012d2e74678460b22bf335721a8bba5e939d139c3), [response.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2597/files#diff-3596621a20116154128ec5ebaa2355b0ef68430a54b538400f5945a725a5db6b)) to parse, carry, and serialize namespaces and non-function tool declarations, including stripping MCP credentials before model validation.
> - Behavioral Change: `tool_to_wire` in [train.py](https://github.com/PrimeIntellect-ai/verifiers/pull/2597/files#diff-c9bcd6c691890b1de6942fe012d2e74678460b22bf335721a8bba5e939d139c3) now raises `NotImplementedError` for namespaced or non-function tools instead of silently serializing them as unnamespaced function tools; Anthropic `parse_request` now rejects malformed tool arrays and returns `Tool` records for declarations previously skipped for lacking an input schema.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bc7dbd2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->